### PR TITLE
fix(driver-sql): a plain unique index over duplicate rows is loud and non-fatal, and `os migrate plan` stops calling it `safe`

### DIFF
--- a/.changeset/plain-unique-index-duplicate-preflight.md
+++ b/.changeset/plain-unique-index-duplicate-preflight.md
@@ -1,0 +1,17 @@
+---
+"@objectstack/driver-sql": patch
+---
+
+A plain unique index over existing duplicate rows no longer kills the boot with the database's raw error, and `os migrate plan` no longer calls that op `safe`.
+
+Declaring a column unique over a table that already holds duplicates had two very different outcomes depending on one branch in the SQL driver, and only one of them was survivable.
+
+- **An organization-scoped unique** (the `unique: 'organization'` default, materialised as the NULL-safe `COALESCE(organization_id, '__global__')` composite) kept the boot up: the driver logged at `error` naming the index, the constraint that is not enforced and the remedy, and the ADR-0120 D4 duplicate pre-flight reported the blocked `create_index` as `category: 'destructive'` / `severity: 'error'` with the conflicting key groups and their row counts.
+- **A plain unique** — no organization key part at all, reached by an object with `tenancy: { enabled: false }` or by any explicit `unique: 'global'` — took the process down: `initObjects` threw the database's own error, which names the index and the column and no rows and no remedy, nothing reached the durability channel, and `detectManagedDrift` (what `os migrate plan` reports) classified the very same op `category: 'safe'`, `severity: 'warning'`, so `os migrate apply` and dev `autoMigrate: 'safe'` walked straight into the raw failure.
+
+The plain path now reaches the same posture as the scoped one:
+
+- **The boot survives and says what is not enforced.** `syncDeclaredIndexes` absorbs a uniqueness violation on a plain unique index the way it already absorbed one on the NULL-safe composite: the failure is logged on the durability channel (`error`) naming the index, the conflicting key groups with their row counts, the constraint that is NOT enforced, and `os migrate plan` as the way out. A non-unique index and any failure that is not a uniqueness violation still surface as before.
+- **The duplicate pre-flight covers it.** The ADR-0120 D4 probe no longer skips ops whose NULL-safe column set is empty, so a plain unique `create_index` over dirty data is reported `destructive` / `error` with the same row report instead of `safe`. Nothing new probes it: the existing probe already groups by the bare columns when there is no NULL-safe key part, so both key shapes share one pre-flight rather than a second copy that can drift from the first.
+
+Consumers of the classification see the op move from the "Safe" group to "Destructive (requires --allow-destructive)" in `os migrate plan` and `os diff`; `os migrate apply` defers it instead of attempting it; the artifact boot gate refuses with a named destructive-drift refusal instead of crashing; and dev `autoMigrate: 'safe'` leaves it alone. Clean data is unaffected — the probe finds nothing and the index is created exactly as before.

--- a/content/docs/deployment/cli.mdx
+++ b/content/docs/deployment/cli.mdx
@@ -680,9 +680,9 @@ occupancy on its own.
 
 | Category | Examples | Applied by |
 |----------|----------|------------|
-| `safe` | relax `NOT NULL` → nullable, widen a `varchar`, create a declared index, replace a legacy installation-wide unique with its per-organization composite | `os migrate apply` (and dev auto-reconcile) |
+| `safe` | relax `NOT NULL` → nullable, widen a `varchar`, create a declared index (a `UNIQUE` one only when its duplicate pre-flight comes back clean), replace a legacy installation-wide unique with its per-organization composite | `os migrate apply` (and dev auto-reconcile) |
 | `needs_confirm` | non-narrowing type change, rebuild a non-unique index whose columns changed | `os migrate apply` — except `manual_widen_varchar_to_text`, which nothing applies |
-| `destructive` | drop an orphaned column or index, tighten `NOT NULL`, narrow a type, rebuild an index as `UNIQUE` | `os migrate apply --allow-destructive` |
+| `destructive` | drop an orphaned column or index, tighten `NOT NULL`, narrow a type, rebuild an index as `UNIQUE`, create a `UNIQUE` index existing rows already violate | `os migrate apply --allow-destructive` |
 
 #### Index drift
 
@@ -690,7 +690,7 @@ occupancy on its own.
 
 | Op | What it means |
 |----|---------------|
-| `create_index` | Metadata declares an index the database does not have |
+| `create_index` | Metadata declares an index the database does not have. A `UNIQUE` one runs the same duplicate pre-flight probe `recreate_index` does: rows that already violate it **block** the op with a report naming the conflicting key groups and their row counts, instead of failing a boot on the database's own error, and the declared constraint stays unenforced until they are resolved |
 | `replace_unique_index` | A field's `unique` used to be enforced installation-wide, but metadata now scopes it per organization — the legacy single-column index is swapped for the NULL-safe `(COALESCE(organization_id, '__global__'), field)` composite. A pure relaxation: it creates before it drops, and cannot fail |
 | `recreate_index` | An index exists under the declared name but with different columns/uniqueness. The additive sync skips it by name, so it must be dropped and rebuilt. This is also how a per-organization unique becomes NULL-safe: a **tightening**, so it runs a duplicate pre-flight probe first — rows the old NULL-distinct index wrongly admitted **block** the op with a report instead of failing a boot, and the old index stays in place until they are resolved |
 | `drop_index` | An index carrying ObjectStack's generated naming (`uniq_…` / `idx_…`) that metadata no longer declares |

--- a/packages/drivers/driver-sql/src/sql-driver-14902-plain-unique-duplicate-preflight.test.ts
+++ b/packages/drivers/driver-sql/src/sql-driver-14902-plain-unique-duplicate-preflight.test.ts
@@ -1,0 +1,316 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { SqlDriver } from '../src/index.js';
+
+/**
+ * #14902 — a PLAIN unique index over existing duplicate rows.
+ *
+ * ## The defect, in the two shapes it was measured side by side
+ *
+ * Same fixture both times: a `crm_quote` table already holding two rows with
+ * the same `quote_number`, then `initObjects` declaring that column unique.
+ *
+ * - **Path A — the NULL-safe organization composite.** The boot CONTINUES: the
+ *   driver logs at `error` naming the index, the unenforced constraint and the
+ *   remedy, and the ADR-0120 D4 pre-flight reports the blocked `create_index`
+ *   as `category: 'destructive'` / `severity: 'error'` with the conflicting key
+ *   groups and their row counts.
+ * - **Path B — a plain unique, no organization key part.** The boot DIED:
+ *   `initObjects` threw the database's own error, which names the index and the
+ *   column and NO rows and NO remedy, nothing reached the durability channel,
+ *   and `detectManagedDrift` — what `os migrate plan` reports — classified the
+ *   very same op `category: 'safe'`, `severity: 'warning'`.
+ *
+ * Three properties stacked, and it is the combination that made it p1: the boot
+ * is DOWN rather than degraded; the message is unactionable; and the instrument
+ * an operator would reach for said `safe` about the op that was about to kill
+ * the boot.
+ *
+ * ## Reachability — precisely, because the wider framing is wrong
+ *
+ * ⛔ NOT "every autonumber field". Since #13894 an `autonumber` field that omits
+ * `unique` defaults to `unique: 'organization'`, and on an object that carries a
+ * tenant column that lands on path A. Path B is reached by an object with
+ * `tenancy: { enabled: false }` (no tenant column at all) or by any explicit
+ * `unique: 'global'`. Narrower — and live: it is the self-hosted upgrade path,
+ * a deployment with legacy duplicate rows and a tenancy-disabled object.
+ *
+ * ## What this suite pins
+ *
+ * Parity, in both halves, plus path A as the CONTROL. A change that quietly
+ * moved path A while making path B loud would otherwise read as success, so the
+ * last block asserts path A's message and classification are still their own —
+ * the `#5030` framing, which is precisely what the plain path must NOT claim
+ * (nothing ever admitted these rows; the constraint is simply newly declared
+ * over data that does not satisfy it).
+ *
+ * ⛔ Nothing here pins the DATABASE's raw error text: the `catch` shape is
+ * dialect-independent, that text is not. Assertions are on our own messages and
+ * on the drift classification.
+ */
+describe('#14902 plain unique index over duplicate rows', () => {
+  let driver: SqlDriver;
+  let logs: Array<{ level: 'warn' | 'info' | 'error'; msg: string }>;
+
+  const makeDriver = (opts: any = {}) =>
+    new SqlDriver({
+      client: 'better-sqlite3',
+      connection: { filename: ':memory:' },
+      useNullAsDefault: true,
+      ...opts,
+    });
+
+  const attachSpy = () => {
+    logs = [];
+    (driver as any).logger = {
+      warn: (msg: string) => logs.push({ level: 'warn', msg }),
+      info: (msg: string) => logs.push({ level: 'info', msg }),
+      error: (msg: string) => logs.push({ level: 'error', msg }),
+    };
+  };
+
+  beforeEach(() => {
+    driver = makeDriver();
+    attachSpy();
+  });
+
+  afterEach(async () => {
+    await driver.disconnect();
+  });
+
+  /**
+   * A pre-existing table, no index on `quote_number` yet — the legacy database
+   * this card is about. `withOrg` selects which path the declaration lands on.
+   */
+  const seed = async (
+    withOrg: boolean,
+    rows: Array<Record<string, unknown>>,
+  ): Promise<any> => {
+    const k = (driver as any).knex;
+    await k.schema.createTable('crm_quote', (t: any) => {
+      t.string('id').primary();
+      t.timestamp('created_at');
+      t.timestamp('updated_at');
+      if (withOrg) t.string('organization_id');
+      t.string('quote_number');
+    });
+    await k('crm_quote').insert(rows);
+    return k;
+  };
+
+  /** The non-PK index names physically present on the table. */
+  const indexNames = async (table: string): Promise<string[]> => {
+    const k = (driver as any).knex;
+    const list: any = await k.raw(`PRAGMA index_list(${table})`);
+    return list.filter((i: any) => i.origin !== 'pk').map((i: any) => i.name);
+  };
+
+  /** Tenancy OFF — the plain single-column unique. */
+  const PLAIN_META = [
+    {
+      name: 'crm_quote',
+      tenancy: { enabled: false },
+      fields: { quote_number: { type: 'autonumber', unique: true } },
+    },
+  ] as any[];
+
+  /** Tenanted object, explicit platform-wide scope — also the plain shape. */
+  const GLOBAL_META = [
+    {
+      name: 'crm_quote',
+      fields: {
+        organization_id: { type: 'string' },
+        quote_number: { type: 'autonumber', unique: 'global' },
+      },
+    },
+  ] as any[];
+
+  const DUP_PLAIN = [
+    { id: 'r1', quote_number: 'QUO-00009' },
+    { id: 'r2', quote_number: 'QUO-00009' },
+  ];
+
+  describe('the boot survives and says what is not enforced', () => {
+    it('does not throw the raw driver error — it logs on the durability channel, naming the rows and the remedy', async () => {
+      await seed(false, DUP_PLAIN);
+
+      // Before this fix: `initObjects` rejected with
+      // "create unique index `uniq_crm_quote_quote_number` … UNIQUE constraint
+      // failed: crm_quote.quote_number" and the whole boot went down.
+      await expect(driver.initObjects(PLAIN_META)).resolves.not.toThrow();
+
+      const durability = logs.filter((l) => l.level === 'error');
+      expect(durability).toHaveLength(1);
+      const msg = durability[0].msg;
+      // Names the index…
+      expect(msg).toContain("'uniq_crm_quote_quote_number'");
+      // …the ROWS, which the database's own error never did…
+      expect(msg).toMatch(/Conflicting group\(s\)/);
+      expect(msg).toContain('quote_number="QUO-00009"');
+      expect(msg).toMatch(/× 2 rows/);
+      // …that the constraint is NOT enforced…
+      expect(msg).toMatch(/NOT enforced/);
+      // …and the remedy.
+      expect(msg).toContain('os migrate plan');
+
+      // The index really is absent: the log is not covering for a silent
+      // success, and a duplicate write is still accepted (that is what "not
+      // enforced" MEANS, and it is why the message is on the durability
+      // channel rather than at `warn`).
+      expect(await indexNames('crm_quote')).not.toContain('uniq_crm_quote_quote_number');
+    });
+
+    it("reaches the same disposition through an explicit unique: 'global' on a tenanted object", async () => {
+      await seed(true, [
+        { id: 'r1', organization_id: 'org_x', quote_number: 'QUO-00009' },
+        { id: 'r2', organization_id: 'org_y', quote_number: 'QUO-00009' },
+      ]);
+
+      await expect(driver.initObjects(GLOBAL_META)).resolves.not.toThrow();
+
+      const durability = logs.filter((l) => l.level === 'error');
+      expect(durability).toHaveLength(1);
+      // The key is the bare column — the organization is NOT part of it, which
+      // is the whole point of `'global'`, and the two rows collide across
+      // organizations.
+      expect(durability[0].msg).toContain('quote_number="QUO-00009"');
+      expect(durability[0].msg).not.toContain('organization_id');
+    });
+
+    it('still creates the index, silently, when the data is clean', async () => {
+      await seed(false, [
+        { id: 'r1', quote_number: 'QUO-00009' },
+        { id: 'r2', quote_number: 'QUO-00010' },
+      ]);
+
+      await driver.initObjects(PLAIN_META);
+
+      expect(await indexNames('crm_quote')).toContain('uniq_crm_quote_quote_number');
+      expect(logs.filter((l) => l.level === 'error')).toHaveLength(0);
+      // Healthy database: converged, zero drift. The pre-flight probes and gets
+      // out of the way — it does not gate clean data.
+      expect(await driver.detectManagedDrift()).toHaveLength(0);
+      await expect(driver.create('crm_quote', { quote_number: 'QUO-00009' })).rejects.toThrow(
+        /UNIQUE constraint failed|duplicate key value/,
+      );
+    });
+  });
+
+  describe("os migrate plan stops calling the blocked op `safe`", () => {
+    it('classifies it destructive/error with the conflicting group and withdraws the safe claim', async () => {
+      await seed(false, DUP_PLAIN);
+      await driver.initObjects(PLAIN_META);
+
+      const drift = await driver.detectManagedDrift();
+      const entry = drift.find((d) => d.op.type === 'create_index');
+      expect(entry).toBeDefined();
+
+      // Before this fix: `category: 'safe'`, `severity: 'warning'`, message
+      // "…the database has no such index — run "os migrate apply" to create
+      // it." — an instrument saying nothing is wrong about the op that had just
+      // taken the boot down.
+      expect(entry!.category).toBe('destructive');
+      expect(entry!.severity).toBe('error');
+      expect(entry!.message).toMatch(/BLOCKED/);
+      expect(entry!.message).toContain('quote_number="QUO-00009"');
+      expect(entry!.message).toMatch(/× 2 rows/);
+      expect(entry!.message).toMatch(/NOT enforced/);
+      expect(entry!.message).toContain('os migrate plan');
+      // ⛔ And it must NOT borrow path A's story: no prior index admitted these
+      // rows, so #5030 is not what happened here.
+      expect(entry!.message).not.toContain('#5030');
+      expect(entry!.message).not.toContain('NULL-safe');
+    });
+
+    it('is not applied by a plain apply, and not created even under --allow-destructive', async () => {
+      await seed(false, DUP_PLAIN);
+      await driver.initObjects(PLAIN_META);
+      const entry = (await driver.detectManagedDrift()).find((d) => d.op.type === 'create_index')!;
+
+      // `destructive` is what keeps `os migrate apply` (and the artifact boot
+      // gate, and dev autoMigrate) from walking into the raw failure.
+      const plain = await driver.applyMigrationEntries([entry], { allowDestructive: false });
+      expect(plain.applied).toHaveLength(0);
+      expect(plain.skipped).toHaveLength(1);
+
+      // …and forcing it does not produce a half-applied schema either: the
+      // create is refused by the data, reported skipped, and no index appears.
+      const forced = await driver.applyMigrationEntries([entry], { allowDestructive: true });
+      expect(forced.applied).toHaveLength(0);
+      expect(forced.skipped).toHaveLength(1);
+      expect(await indexNames('crm_quote')).not.toContain('uniq_crm_quote_quote_number');
+    });
+
+    it("is not auto-applied at boot under dev autoMigrate: 'safe'", async () => {
+      await driver.disconnect();
+      driver = makeDriver({ autoMigrate: 'safe' });
+      attachSpy();
+      await seed(false, DUP_PLAIN);
+
+      await expect(driver.initObjects(PLAIN_META)).resolves.not.toThrow();
+      expect(await indexNames('crm_quote')).not.toContain('uniq_crm_quote_quote_number');
+      expect(logs.some((l) => l.msg.includes('auto-reconciled'))).toBe(false);
+    });
+
+    it('unblocks once the duplicates are gone — the entry re-grades and a plain apply creates it', async () => {
+      const k = await seed(false, DUP_PLAIN);
+      await driver.initObjects(PLAIN_META);
+      expect(
+        (await driver.detectManagedDrift()).find((d) => d.op.type === 'create_index')!.category,
+      ).toBe('destructive');
+
+      await k('crm_quote').where({ id: 'r2' }).delete();
+
+      const entry = (await driver.detectManagedDrift()).find((d) => d.op.type === 'create_index')!;
+      expect(entry.category).toBe('safe');
+      expect(entry.severity).toBe('warning');
+      const res = await driver.applyMigrationEntries([entry], { allowDestructive: false });
+      expect(res.applied).toHaveLength(1);
+      expect(await indexNames('crm_quote')).toContain('uniq_crm_quote_quote_number');
+      expect(await driver.detectManagedDrift()).toHaveLength(0);
+    });
+  });
+
+  describe('CONTROL — path A is untouched', () => {
+    it('still logs its own NULL-safe #5030 message and still reports destructive with the key groups', async () => {
+      await seed(true, [
+        { id: 'r1', organization_id: null, quote_number: 'QUO-00009' },
+        { id: 'r2', organization_id: null, quote_number: 'QUO-00009' },
+        { id: 'r3', organization_id: 'org_x', quote_number: 'QUO-00010' },
+        { id: 'r4', organization_id: 'org_x', quote_number: 'QUO-00010' },
+      ]);
+
+      // `unique: true` on a tenanted object == `unique: 'organization'` — the
+      // #13894 default, and the shape this card must not have disturbed.
+      await expect(
+        driver.initObjects([
+          {
+            name: 'crm_quote',
+            fields: {
+              organization_id: { type: 'string' },
+              quote_number: { type: 'autonumber', unique: true },
+            },
+          },
+        ] as any[]),
+      ).resolves.not.toThrow();
+
+      const durability = logs.filter((l) => l.level === 'error');
+      expect(durability).toHaveLength(1);
+      expect(durability[0].msg).toContain('NULL-safe unique index');
+      expect(durability[0].msg).toContain('#5030');
+      expect(durability[0].msg).toContain('ADR-0120 D4');
+      expect(durability[0].msg).toContain("'organization_id, quote_number'");
+
+      const entry = (await driver.detectManagedDrift()).find((d) => d.op.type === 'create_index')!;
+      expect(entry.category).toBe('destructive');
+      expect(entry.severity).toBe('error');
+      expect(entry.message).toContain('#5030');
+      expect(entry.message).toContain('__global__');
+      // Both key groups, with counts — the NULL-organization bucket and a real
+      // organization, which is what makes the COALESCE key self-describing.
+      expect(entry.message).toContain('(organization_id="__global__", quote_number="QUO-00009")');
+      expect(entry.message).toContain('(organization_id="org_x", quote_number="QUO-00010")');
+    });
+  });
+});

--- a/packages/drivers/driver-sql/src/sql-driver-unique-violation-predicate.test.ts
+++ b/packages/drivers/driver-sql/src/sql-driver-unique-violation-predicate.test.ts
@@ -1,10 +1,16 @@
 // Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
 
 /**
- * `syncDeclaredIndexes` judges "did existing rows violate the NULL-safe unique
- * I just tried to create?" — the #5030 branch that keeps a dirty database
- * BOOTING (the constraint is logged as not-enforced and reported by the
- * ADR-0120 D4 drift pre-flight) instead of taking the process down.
+ * `syncDeclaredIndexes` judges "did existing rows violate the unique index I
+ * just tried to create?" — the #5030 branch that keeps a dirty database BOOTING
+ * (the constraint is logged as not-enforced and reported by the ADR-0120 D4
+ * drift pre-flight) instead of taking the process down.
+ *
+ * ⚠️ Since #14902 that branch has two arms, not one: the NULL-safe organization
+ * composite AND the plain unique (`tenancy: { enabled: false }`, or an explicit
+ * `unique: 'global'`), which used to fall through to `throw e`. The
+ * discriminator below is what BOTH arms judge with, so its blind spots are now
+ * twice as expensive.
  *
  * It used to judge that with a private inline regex over the stringified
  * message — `unique constraint failed|duplicate entry|duplicate key value` —
@@ -80,11 +86,17 @@ const NULL_SAFE_INDEX: DeclaredIndexInput = {
   nullSafeColumns: ['organization_id'],
 };
 
-/** The same index with no NULL-safe key part — the `nullSafe.size > 0` guard's false arm. */
+/** The same index with no NULL-safe key part — the plain single-column unique. */
 const PLAIN_INDEX: DeclaredIndexInput = {
   name: 'uniq_product_code',
   fields: ['code'],
   unique: true,
+};
+
+/** Not unique at all — an ACCESS PATH. Its failures are nobody's #5030. */
+const NON_UNIQUE_INDEX: DeclaredIndexInput = {
+  name: 'idx_product_code',
+  fields: ['code'],
 };
 
 const PHYSICAL_COLUMNS = new Set(['id', 'organization_id', 'code']);
@@ -222,11 +234,64 @@ describe('syncDeclaredIndexes unique-violation discriminator (#6543)', () => {
 
   // ── The site's own business logic, untouched by the migration ─────────────
 
-  it('leaves the `nullSafe.size > 0` guard intact — a plain unique still fails the sync', async () => {
+  /**
+   * ⚠️ RETIRED PIN, re-authored — #14902.
+   *
+   * This block used to assert the opposite: 「leaves the `nullSafe.size > 0`
+   * guard intact — a plain unique still fails the sync」, on the reasoning that
+   * absorbing it 「would silently ship an unenforced constraint **the drift
+   * pre-flight was never told about**」. That reasoning was right, and its
+   * premise is exactly what #14902 removed: the ADR-0120 D4 pre-flight now
+   * probes the plain unique too, so the drift pass IS told, and `os migrate
+   * plan` reports the blocked op `destructive` with the offending rows instead
+   * of calling it `safe`.
+   *
+   * So the invariant the old pin was defending survives verbatim — a plain
+   * unique violation must never be absorbed SILENTLY — and only its
+   * disposition moved: from `throw` (the boot dies carrying the database's own
+   * error, naming no rows and no remedy) to the same loud, non-fatal posture
+   * the NULL-safe arm has had since #5030. What follows asserts the LOUD half,
+   * which is the half that was actually load-bearing.
+   */
+  it('absorbs the plain arm too — but only LOUDLY, naming the rows and the remedy (#14902)', async () => {
     arm(postgresIndexBuildConflict());
+    await realKnex('product').insert([
+      { id: 'r1', organization_id: 'org_a', code: 'DUP' },
+      { id: 'r2', organization_id: 'org_b', code: 'DUP' },
+    ]);
     // The plain arm goes through knex's schema builder rather than the
     // overridden method, and `knex.schema` is a fresh builder on every access
-    // — so the failure is injected by standing in for `knex` itself.
+    // — so the failure is injected by standing in for `knex` itself. Only
+    // `schema` is stood in for: `ref`/`raw` and the query builder stay REAL, so
+    // the duplicate probe in the branch under test runs against the real table
+    // and the row report below is a measurement, not a fixture.
+    (driver as any).getExistingIndexNames = async () => new Set<string>();
+    (driver as any).knex = Object.assign((...args: any[]) => (realKnex as any)(...args), {
+      ref: (id: string) => realKnex.ref(id),
+      raw: (...args: any[]) => realKnex.raw(...args),
+      schema: {
+        alterTable: () => Promise.reject(postgresIndexBuildConflict()),
+      },
+    });
+
+    await expect(sync([PLAIN_INDEX])).resolves.toBeUndefined();
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatch(/cannot create unique index/);
+    expect(errors[0]).toMatch(/uniq_product_code/);
+    expect(errors[0]).toMatch(/NOT enforced/);
+    expect(errors[0]).toMatch(/os migrate plan/);
+    // The rows the database's own error never named.
+    expect(errors[0]).toContain('code="DUP"');
+    expect(errors[0]).toMatch(/× 2 rows/);
+    // ⛔ And it does not borrow the NULL-safe arm's story: no earlier index
+    // admitted these rows, so #5030 is not what happened here.
+    expect(errors[0]).not.toMatch(/#5030/);
+    expect(errors[0]).not.toMatch(/NULL-safe/);
+  });
+
+  it('never absorbs a NON-unique index failure, however much the error reads like a conflict', async () => {
+    arm(postgresIndexBuildConflict());
     (driver as any).getExistingIndexNames = async () => new Set<string>();
     (driver as any).knex = {
       schema: {
@@ -234,10 +299,12 @@ describe('syncDeclaredIndexes unique-violation discriminator (#6543)', () => {
       },
     };
 
-    // A unique violation on a NON-NULL-safe index is not the #5030 case and
-    // must still surface: absorbing it would silently ship an unenforced
-    // constraint the drift pre-flight was never told about.
-    const rejected: any = await sync([PLAIN_INDEX]).then(
+    // A non-unique index exists for an ACCESS PATH — it cannot raise a
+    // uniqueness violation, so a failure that reads as one while creating it is
+    // something else entirely. #14902's `unique` limb is what keeps that
+    // failing loudly instead of being logged away as an unenforced constraint
+    // that was never declared in the first place.
+    const rejected: any = await sync([NON_UNIQUE_INDEX]).then(
       () => undefined,
       (e: unknown) => e,
     );

--- a/packages/drivers/driver-sql/src/sql-driver.ts
+++ b/packages/drivers/driver-sql/src/sql-driver.ts
@@ -4162,6 +4162,26 @@ interface RowWidthContribution {
   bytes: number;
 }
 
+/**
+ * Render the duplicate groups a unique pre-flight probe found, for an operator
+ * message: at most five groups, then a count of the rest.
+ *
+ * Module-local on purpose (#14902). The two sites that report a blocked unique
+ * — the drift entry and the boot-time durability log — must name the SAME rows
+ * in the SAME shape, and a second hand-rolled `.slice(0, 5).join('; ')` is
+ * exactly how the plain and the NULL-safe path drifted apart in the first
+ * place. Not a method, and not exported: `SqlDriver`'s `.d.ts` carries its
+ * protected members, so a new method there would move a published entry point
+ * for a string helper.
+ */
+function formatDuplicateGroups(duplicates: ReadonlyArray<{ key: string; rows: number }>): string {
+  const shown = duplicates
+    .slice(0, 5)
+    .map((g) => `(${g.key}) \u00d7 ${g.rows} rows`)
+    .join('; ');
+  return duplicates.length > 5 ? `${shown}; \u2026and ${duplicates.length - 5} more group(s)` : shown;
+}
+
 export class SqlDriver implements IDataDriver {
   // IDataDriver metadata
   public readonly name: string = 'com.objectstack.driver.sql';
@@ -10686,10 +10706,12 @@ export class SqlDriver implements IDataDriver {
   }
 
   /**
-   * ADR-0120 D4 — duplicate pre-flight for NULL-safe organization uniques.
+   * ADR-0120 D4 — duplicate pre-flight for unique index CREATEs.
    *
-   * Probes every index op that would CREATE a unique index whose organization
-   * key part is the NULL-safe COALESCE form, by grouping over that exact key:
+   * Probes every index op that would create a UNIQUE index over data that
+   * already violates it, grouping by the exact key the index will enforce —
+   * `COALESCE(<org>, '__global__')` for a NULL-safe organization key part, the
+   * bare column otherwise:
    *
    *   - `recreate_index` marked `tightenNullSafeOnly` (the bare composite
    *     tightening into its COALESCE form — same identities, physical fully
@@ -10697,10 +10719,26 @@ export class SqlDriver implements IDataDriver {
    *     `autoMigrate: 'safe'` and a plain `os migrate apply` may apply it; a
    *     dirty probe keeps it blocked (`destructive` + a re-probe refusal in
    *     {@link applyIndexDriftOp}) and reports the offending rows.
-   *   - `create_index` for a unique NULL-safe index: a dirty probe demotes the
-   *     default `safe` to blocked with the same row report — the CREATE could
-   *     only fail at apply time otherwise, with a raw driver error naming no
-   *     rows.
+   *   - `create_index` for a unique index: a dirty probe demotes the default
+   *     `safe` to blocked with the same row report — the CREATE could only
+   *     fail at apply time otherwise, with a raw driver error naming no rows.
+   *
+   * ⚠️ #14902 — the second bullet covers the PLAIN unique too: an index with no
+   * organization key part at all, reached by an object with
+   * `tenancy: { enabled: false }` or by any explicit `unique: 'global'`. The
+   * `nullSafeColumns.length > 0` guard used to exclude it, so `os migrate plan`
+   * classified the one op that was about to take the boot down `safe` — an
+   * instrument reporting nothing wrong about the thing that kills the boot.
+   * Nothing new was needed to probe it:
+   * {@link probeNullSafeUniqueDuplicates} groups by the bare columns when the
+   * NULL-safe set is empty, so the guard MOVED rather than a second copy of the
+   * check appearing beside the first — one pre-flight, two key shapes, no way
+   * for them to drift apart again.
+   *
+   * A PLAIN unique `recreate_index` stays unprobed: it has no
+   * `tightenNullSafeOnly` shape, and `diffManagedIndexes` already categorises a
+   * unique recreate `destructive`, so it never carried the `safe` claim this
+   * pre-flight exists to withdraw.
    *
    * `replace_unique_index` is deliberately NOT probed: the legacy index it
    * retires is a platform-wide unique, strictly stronger than the NULL-safe
@@ -10710,15 +10748,20 @@ export class SqlDriver implements IDataDriver {
     for (const d of entries) {
       const op = d.op;
       if (op.type !== 'recreate_index' && op.type !== 'create_index') continue;
-      if (!op.unique || !op.nullSafeColumns || op.nullSafeColumns.length === 0) continue;
+      if (!op.unique) continue;
+      const nullSafeColumns = op.nullSafeColumns ?? [];
+      const nullSafeKey = nullSafeColumns.length > 0;
       const tighten = op.type === 'recreate_index' && op.tightenNullSafeOnly === true;
       // A generic unique recreate (columns differ beyond the key-part form)
       // keeps its pre-ADR-0120 semantics untouched.
       if (op.type === 'recreate_index' && !tighten) continue;
+      // …and a PLAIN unique has no tightening shape at all, so only its CREATE
+      // reaches the probe (#14902).
+      if (!nullSafeKey && op.type !== 'create_index') continue;
 
       let duplicates: Array<{ key: string; rows: number }>;
       try {
-        duplicates = await this.probeNullSafeUniqueDuplicates(op.table, op.columns, op.nullSafeColumns);
+        duplicates = await this.probeNullSafeUniqueDuplicates(op.table, op.columns, nullSafeColumns);
       } catch (e: any) {
         // Probe failure must fail SAFE: without evidence the data is clean the
         // op may not claim eligibility for auto-apply.
@@ -10743,18 +10786,23 @@ export class SqlDriver implements IDataDriver {
         continue;
       }
 
-      const report = duplicates
-        .slice(0, 5)
-        .map((g) => `(${g.key}) × ${g.rows} rows`)
-        .join('; ');
-      const more = duplicates.length > 5 ? `; …and ${duplicates.length - 5} more group(s)` : '';
+      const report = formatDuplicateGroups(duplicates);
       d.category = 'destructive';
       d.severity = 'error';
-      d.message =
-        `${op.table}: cannot ${tighten ? 'tighten' : 'create'} '${op.indexName}' as ${signature} — existing rows ` +
-        `already violate the NULL-safe unique constraint (duplicates the old index wrongly admitted, #5030): ` +
-        `${report}${more}. The op is BLOCKED: apply re-probes and refuses, and the existing index stays in place ` +
-        `(ADR-0120 D4). Deduplicate the listed rows, then re-run "os migrate plan".`;
+      d.message = nullSafeKey
+        ? `${op.table}: cannot ${tighten ? 'tighten' : 'create'} '${op.indexName}' as ${signature} — existing rows ` +
+          `already violate the NULL-safe unique constraint (duplicates the old index wrongly admitted, #5030): ` +
+          `${report}. The op is BLOCKED: apply re-probes and refuses, and the existing index stays in place ` +
+          `(ADR-0120 D4). Deduplicate the listed rows, then re-run "os migrate plan".`
+        : // #14902: the plain unique has no #5030 history behind it — nothing
+          // ever admitted these rows, the constraint is simply newly declared
+          // over data that does not satisfy it. So the message says what IS
+          // true, and above all withdraws the `safe` claim: this op is not
+          // applied by `os migrate apply` and not auto-applied at boot.
+          `${op.table}: cannot create '${op.indexName}' as ${signature} — existing rows already violate it: ` +
+          `${report}. The op is BLOCKED: neither "os migrate apply" nor dev autoMigrate: 'safe' will create it, ` +
+          `so the constraint is NOT enforced. Deduplicate the listed rows, then re-run "os migrate plan" ` +
+          `(ADR-0120 D4).`;
     }
   }
 
@@ -11708,6 +11756,11 @@ export class SqlDriver implements IDataDriver {
    *   at `error` (a declared constraint is not enforced — the
    *   durability-degradation rule) and surfaces as drift with a row report via
    *   the ADR-0120 D4 pre-flight, instead of failing the whole boot.
+   * - #14902: a PLAIN unique — no organization key part, i.e.
+   *   `tenancy: { enabled: false }` or an explicit `unique: 'global'` — over
+   *   data that already violates it gets the SAME disposition, where it used to
+   *   throw the database's raw error and take the boot down naming no rows and
+   *   no remedy.
    */
   protected async syncDeclaredIndexes(
     tableName: string,
@@ -11873,6 +11926,40 @@ export class SqlDriver implements IDataDriver {
               `violate it (duplicates the previous NULL-distinct index admitted, #5030). The constraint ` +
               `'${columns.join(', ')}' is NOT enforced until the data is deduplicated: run "os migrate plan" ` +
               `for the conflicting rows (ADR-0120 D4).`,
+            msg,
+          );
+          continue;
+        }
+        if (unique && isUniqueViolationError(e)) {
+          // #14902 — the PLAIN unique: no organization key part at all, reached
+          // by `tenancy: { enabled: false }` or by an explicit
+          // `unique: 'global'`. It used to fall through to `throw e`, so the
+          // boot DIED carrying the database's own error, which names the index
+          // and the column and NO rows and NO remedy — while the arm above,
+          // one branch away, kept the boot up and told the operator exactly
+          // what to do. Same defect, same disposition: the declared constraint
+          // is not enforced, say so on the durability channel, name the
+          // conflicting groups, and let the boot continue. The D4 pre-flight
+          // reports the same rows in `os migrate plan`.
+          //
+          // ⚠️ The `unique` limb is load-bearing, not decoration. A NON-unique
+          // index cannot raise a uniqueness violation, so a failure that reads
+          // as one while creating a non-unique index is something else
+          // entirely and must keep failing loudly rather than being absorbed
+          // into a log line here.
+          let report = '';
+          try {
+            const duplicates = await this.probeNullSafeUniqueDuplicates(tableName, columns, []);
+            if (duplicates.length > 0) {
+              report = ` Conflicting group(s): ${formatDuplicateGroups(duplicates)}.`;
+            }
+          } catch {
+            // The probe is a diagnostic; the report below stands without it.
+          }
+          this.logDurabilityFailure(
+            `[sql-driver] cannot create unique index '${name}' on "${tableName}" — existing rows violate ` +
+              `it.${report} The constraint '${columns.join(', ')}' is NOT enforced until the data is ` +
+              `deduplicated: run "os migrate plan" for the conflicting rows.`,
             msg,
           );
           continue;


### PR DESCRIPTION
Closes #14902

A plain unique index over existing duplicate rows no longer kills the boot with the database's raw error, and `os migrate plan` no longer classifies that op `safe`.

## The defect, in the two shapes the card measured side by side

Same fixture both times — a `crm_quote` table already holding two rows with the same `quote_number`, then `initObjects` declaring that column unique.

Both reproduced on today's `origin/main` (`6ed4b811a`, sqlite / `better-sqlite3`) **before a line was written**, so this is not inherited from the card's 2026-09-03 reading.

**Path A — the NULL-safe organization composite. The boot CONTINUES.**

```
[sql-driver] cannot create NULL-safe unique index 'uniq_crm_quote_organization_id_quote_number' on "crm_quote" — existing rows violate it (duplicates the previous NULL-distinct index admitted, #5030). The constraint 'organization_id, quote_number' is NOT enforced until the data is deduplicated: run "os migrate plan" for the conflicting rows (ADR-0120 D4).
```

…and `detectManagedDrift()` — what `os migrate plan` reports — grades it `category: 'destructive'`, `severity: 'error'`, naming both conflicting key groups with their row counts.

**Path B — a PLAIN unique, no organization key part. The boot DIED.**

```
PATH B initObjects threw: create unique index `uniq_crm_quote_quote_number` on `crm_quote` (`quote_number`) - UNIQUE constraint failed: crm_quote.quote_number  (code=SQLITE_CONSTRAINT_UNIQUE)
PATH B logs: []
```

Nothing on the durability channel, no rows, no remedy — and the same op classified as harmless:

```json
{ "kind": "index_mismatch", "expected": "UNIQUE (quote_number)", "actual": "(absent)",
  "severity": "warning", "category": "safe",
  "message": "crm_quote: metadata declares index 'uniq_crm_quote_quote_number' UNIQUE (quote_number) but the database has no such index — run \"os migrate apply\" to create it." }
```

Three properties stack, and it is the combination that graded this p1: the boot is **down**, not degraded; the message is **unactionable**; and the one instrument an operator would reach for says **`safe`** about the op that just killed the boot.

## Reachability — precisely, not the card's own wider framing

⛔ NOT "every autonumber field". Since #13894 an `autonumber` field that omits `unique` defaults to `unique: 'organization'`, and on an object carrying a tenant column that lands on **path A** — loud, non-fatal, rows named. **Path B is reached by an object with `tenancy: { enabled: false }`, or by any explicit `unique: 'global'`.** Narrower than the card says, and live: it is the self-hosted upgrade path — a deployment with legacy duplicate rows and a tenancy-disabled object. Both spellings are pinned.

## The change

Two body-only edits in `packages/drivers/driver-sql/src/sql-driver.ts`, plus one module-local string helper.

- **`syncDeclaredIndexes` absorbs the plain arm the way it already absorbed the NULL-safe one.** A uniqueness violation on a plain unique index is logged on the durability channel (`error`) naming the index, the conflicting key groups with their row counts, the constraint that is NOT enforced, and `os migrate plan` as the way out — instead of `throw e`. The `unique` limb is load-bearing, not decoration: a non-unique index cannot raise a uniqueness violation, so a failure that reads as one while creating one is something else and keeps failing loudly.
- **The ADR-0120 D4 pre-flight covers it.** The guard `nullSafeColumns.length > 0` **moved** rather than a second copy of the check appearing beside the first — `probeNullSafeUniqueDuplicates` already groups by the bare columns when the NULL-safe set is empty, so both key shapes now share **one** pre-flight, which is what stops them drifting apart again. A plain unique `create_index` over dirty data grades `destructive` / `error` with the same row report. A plain unique `recreate_index` stays unprobed and is stated as such in the code: it has no `tightenNullSafeOnly` shape and `diffManagedIndexes` already grades a unique recreate `destructive`, so it never carried the `safe` claim this pre-flight exists to withdraw.

After, same fixture, same tree:

```
PATH B initObjects threw: NO — boot continued
[sql-driver] cannot create unique index 'uniq_crm_quote_quote_number' on "crm_quote" — existing rows violate it. Conflicting group(s): (quote_number="QUO-00009") × 2 rows. The constraint 'quote_number' is NOT enforced until the data is deduplicated: run "os migrate plan" for the conflicting rows.
```
```json
{ "expected": "UNIQUE (quote_number)", "actual": "(absent)", "severity": "error", "category": "destructive",
  "message": "crm_quote: cannot create 'uniq_crm_quote_quote_number' as UNIQUE (quote_number) — existing rows already violate it: (quote_number=\"QUO-00009\") × 2 rows. The op is BLOCKED: neither \"os migrate apply\" nor dev autoMigrate: 'safe' will create it, so the constraint is NOT enforced. Deduplicate the listed rows, then re-run \"os migrate plan\" (ADR-0120 D4)." }
```

The plain message deliberately does **not** borrow path A's story: no earlier index admitted these rows, so `#5030` is not what happened here, and the pins assert its absence.

## Path A is pinned as the CONTROL, and measured unchanged

A change that quietly moved path A while making path B loud would read as success. Path A's log and its drift entry were captured before and after on the same fixture and are **byte-identical** (`md5 9cee6d7603bd154b390b893bf4ab8a82` both runs), and the last block of the new suite asserts path A's own message, its `#5030` / `ADR-0120 D4` framing and both of its key groups.

## A retired pin, re-authored rather than deleted

`sql-driver-unique-violation-predicate.test.ts` carried `leaves the nullSafe.size > 0 guard intact — a plain unique still fails the sync`, on the reasoning that absorbing it "would silently ship an unenforced constraint **the drift pre-flight was never told about**". That reasoning was right, and its premise is exactly what this PR removes — the pre-flight is now told. So the invariant it defended survives verbatim (never absorb SILENTLY) and only its disposition moved; the block now asserts the loud half, against a REAL table so the row report is a measurement, and a new sibling pins that a **non-unique** index failure is still never absorbed.

## Docs round — one page was genuinely falsified, seven were noise

The docs-drift bot listed eight hand-written pages. Audited rather than skipped:

- **Seven dismissed as a group** — `data-modeling/drivers.mdx`, `data-modeling/index.mdx`, `permissions/tenant-audit-census.mdx`, `plugins/packages.mdx`, `protocol/kernel/index.mdx`, `protocol/kernel/lifecycle.mdx`, `protocol/objectql/query-syntax.mdx`. All match on the bare class name `SqlDriver` (1 to 20 hits each) and carry **zero** occurrences of `create_index` between them; `query-syntax.mdx`'s one `category` hit is `category_id` in a filter example, and `drivers.mdx`'s one `NULL-safe` hit is about platform-table index migrations, not this classification.
- **`content/docs/releases/v17.mdx`** is release-owned and read-only. Checked anyway: its `category` hits are all `tool.category`, a retired spec key. Nothing to escalate, and nothing edited there.
- **`content/docs/deployment/cli.mdx` was falsified**, in the page an operator reads before running the command. Three cells changed, table not restructured:
  - the `safe` row listed "create a declared index" flat, promising auto-apply for exactly the case this branch now blocks — carved out to the `UNIQUE` sub-case;
  - `create_index`'s row said only that the index is missing, and now carries the pre-flight sentence, **matched to `recreate_index`'s existing wording one row down** ("block the op with a report instead of failing a boot") rather than given a new shape — the doc edit is the same parity edit as the code;
  - the `destructive` row gains the counterpart example, because that row is where an operator looks to find out why the op they expected to be safe is not.

## Clause ② — enumerated, not assumed

The standing check is "doesn't touch `packages/spec`" is not "doesn't widen the public surface" — enumerate every published package the surface touches and diff its entry point.

- Published packages touched: exactly **one**, `@objectstack/driver-sql`. Its `files` ships `dist` only, so the two test files are not published; `.changeset/*.md` and `content/docs/**` release nothing.
- Entry point: `packages/drivers/driver-sql/dist/index.d.ts`, built from this branch and from `origin/main` `6ed4b811a` and diffed. `SqlDriver`'s `.d.ts` carries its **protected** members, so this was a real risk — which is why the row formatter is a module-local function rather than a method.
- Result: the declaration inventory is **identical**, 830 lines to 830 lines, `diff` clean. The only `.d.ts` delta is JSDoc prose carried through by tsup. The filter that produced that empty result was fired against a deliberately re-signed copy of the same file first, so the emptiness is a measurement and not a dead filter.

⇒ **Clause ② stays `no`.** No published symbol added, removed or re-signed. Draft PR, no `needs:contract-review`.

## What a consumer of the classification now sees

Measured by reading every in-repo consumer of `ManagedDriftEntry.category`, not assumed:

| consumer | before (plain unique over duplicates) | after |
|:---|:---|:---|
| `os migrate plan` / `os diff` (`groupByCategory`, `renderPlan`) | printed green under "Safe (loosening…)" | printed red under "Destructive (requires --allow-destructive)" |
| `os migrate apply` (`intended` / `deferred`) | attempted it, died on the raw driver error | deferred, and even `--allow-destructive` reports it skipped with no index created |
| artifact boot gate (`artifact-boot-migration.ts`) | attempted it | refuses with the named destructive-drift refusal |
| dev `autoMigrate: 'safe'` (`reconcileAndWarnDrift`) | attempted it | leaves it alone |

`os migrate plan` does not set a non-zero exit on destructive entries, so no exit status changes. Clean data is entirely unaffected: the probe finds nothing, the index is created exactly as before, and the pre-flight adds one grouped `SELECT` only for an op that would create a unique index the database does not have.

## Verification

Union re-run on the final commit — `git rev-parse --short HEAD` = **`2721a7e2b`** (`origin/main` merged in twice as this landed).

- `pnpm --filter @objectstack/driver-sql exec vitest run` — **154 passed, 9 skipped, 2357 tests passed**, 0 failed.
- `pnpm --filter @objectstack/driver-sql typecheck` — exit 0, and `tsc --listFiles` confirms all three edited source files are in that program (1 hit each), so "typecheck is clean" actually covers the new tests.
- `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack --commands` derived **73** families once the docs edit landed — up from **46** before it, which is exactly why the derivation was re-run against the real diff rather than trusted from the first pass. Asserted against the Reconciliation line's 73. All 73 run at `2721a7e2b`: **73/73 exit 0**, each exit code captured before any pipe. Two of them (`check:dual-build-cjs-loads`, `check:type-check-debt`) first answered **exit 3 = PREREQUISITE NOT MET = NOT MEASURED**; the closure was built and they were re-run to a real green.
- `pnpm check:durability-log-level` — exit 0, run although the derivation does not name it, because this diff adds a `logDurabilityFailure` call site: "29 durability-critical catch seam(s), all loud".
- `pnpm lint` — the full repo-wide `eslint . --no-inline-config`, exit 0. No narrowing claimed and none needed.
- Ablation: `sql-driver.ts` reverted to `origin/main`'s blob (mutation confirmed on disk by `git hash-object` equality with the base blob and inequality with the pre-mutation hash, plus marker counts falling to 0 against a firing control), the package rebuilt on both legs, **7 of the new assertions turn RED**, then restored — `git diff HEAD` empty, on-disk hash equal to the HEAD blob, rebuilt `dist/index.d.ts` byte-identical to the pre-ablation build. The suite resolves the driver through `../src/index.js`, and the ablation is itself the proof: source-only edits changed the verdict with no rebuild in between.

sqlite (`better-sqlite3`) is a real driver, not a double — the duplicate rows, the failing `CREATE UNIQUE INDEX` and the row report are all measured against a live database. ⛔ Nothing pins the database's raw error text: the `catch` shape is dialect-independent, that text is not.

**Known gap, deliberately not fixed here and filed as #15479:** the MySQL hash-shadow arm of the same `catch` (#11627 / #12998) still guards on `nullSafe.size > 0`, so a plain unique whose shadow `ALTER` finds duplicates keeps taking the boot down. It is the same defect class, but it is reachable only on a live MySQL with a key part over the 768-char ceiling, and this container has none — an unmeasurable change to a durability path is worse than a named gap.