### PR TITLE
fix(cli): generated migrations give the table's own id the driver's column shape

### DIFF
--- a/.changeset/generated-migration-id-column-shape.md
+++ b/.changeset/generated-migration-id-column-shape.md
@@ -1,0 +1,13 @@
+---
+"@objectstack/cli": patch
+---
+
+`os generate migration` gives a table's own `id` column the shape the platform actually creates.
+
+Both migration generators hardcoded the primary key as a UUID — `"id" UUID PRIMARY KEY DEFAULT gen_random_uuid()` in the SQL format, `table.uuid('id').primary().defaultTo(db.fn.uuid())` in the TypeScript one (the default format). The platform's SQL driver emits `table.string('id').primary()`, which is knex's `varchar(255)`. A platform id is a string, not a uuid, so on Postgres the generated table refused the platform's very first insert with `22P02 invalid input syntax for type uuid`.
+
+The quieter half is the `DEFAULT`, and it is why this was worth correcting rather than working around. The driver emits no database-side default at all — its insert path always supplies the id itself — so `gen_random_uuid()` never fired for a platform write, only for an out-of-band one, handing that row a 36-character uuid this platform's id generator would never mint. One table would then hold two incompatible id shapes, with nothing said.
+
+Both generators now emit the driver's own answer: `"id" VARCHAR(255) PRIMARY KEY` and `table.string('id').primary()`. The correction also closes a contradiction inside the generator file, whose prose already stated that a reference column takes the width of the target's `id` column *because* the driver emits `table.string('id').primary()` — a few hundred lines above the two lines that emitted `uuid`.
+
+`generate-builtin-id-column.pin.test.ts` reads the width from the driver's own `DEFAULT_STRING_VARCHAR_CHARS` rather than transcribing `255`, so the generators cannot drift away from the driver again without a named failure.

--- a/packages/cli/src/commands/generate-builtin-id-column.pin.test.ts
+++ b/packages/cli/src/commands/generate-builtin-id-column.pin.test.ts
@@ -1,0 +1,217 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * THE #15040 PIN: the `id` column both migration generators emit is the column
+ * `driver-sql` actually creates.
+ *
+ * ## The defect
+ *
+ * `generate.ts` hardcodes the table's own primary key in each of its two
+ * migration generators, and both said `uuid`:
+ *
+ * ```
+ * generateMigrationSql   '  "id" UUID PRIMARY KEY DEFAULT gen_random_uuid(),'
+ * generateMigrationTs    "    table.uuid('id').primary().defaultTo(db.fn.uuid());"
+ * ```
+ *
+ * The platform emits `table.string('id').primary()` — knex's `varchar(255)`,
+ * `SqlDriver.DEFAULT_STRING_VARCHAR_CHARS`. A platform id is not a uuid, so on
+ * Postgres the generated table refuses the platform's first insert outright
+ * with `22P02 invalid input syntax for type uuid`.
+ *
+ * ⭐ The `DEFAULT gen_random_uuid()` half is the one this pin is really for,
+ * because it is the half that is NOT loud. The driver emits no database-side
+ * default at all: its insert path always supplies the id itself (`create()`
+ * takes `_id`, else a caller-supplied `id`, else mints one). So the default
+ * never fires for a platform write and only ever fires for an out-of-band one —
+ * handing that row a 36-character uuid this platform's generator would never
+ * mint, leaving one table holding two incompatible id shapes, silently.
+ *
+ * ## Why the pin reads the driver instead of asserting `varchar(255)`
+ *
+ * The whole shape of this card is "the generator disagrees with the driver". A
+ * pin that transcribed `VARCHAR(255)` would re-create that defect one layer up:
+ * the day the driver's id column moves, the generator would be wrong again and
+ * this file would still be green. So the width is READ from
+ * `DEFAULT_STRING_VARCHAR_CHARS` where it is declared, and the typescript
+ * generator's line is compared against the driver's own call, byte for byte.
+ * Both extractions carry a non-vacuity control — a source reader that matched
+ * nothing would pass while measuring nothing.
+ *
+ * This is the same authority `generate-field-type-vocabulary.pin.test.ts`
+ * already reads for the REFERENCE_VALUE_TYPES width, and for the same reason: a
+ * reference column holds the TARGET's id, so both questions have one answer.
+ * That pin covers the FIELDS; this one covers the builtin column itself, which
+ * is not a vocabulary entry and so had no rule anywhere.
+ *
+ * ## ⚠️ Recorded divergence, NOT a ruling: the audit-stamp columns (#15040)
+ *
+ * The last `it` below records — and deliberately does not correct — a THIRD
+ * disagreement measured in the same pass. It is recorded so it cannot change
+ * shape unnoticed, and so no reader mistakes this file for having decided it.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import { generateMigrationSql, generateMigrationTs } from './generate.js';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const GENERATE_TS = path.resolve(HERE, 'generate.ts');
+const GENERATE_SOURCE = fs.readFileSync(GENERATE_TS, 'utf8');
+
+/** The authority, read where it lives — never transcribed here. */
+const DRIVER_SQL_SRC = path.resolve(HERE, '../../../drivers/driver-sql/src');
+const SQL_DRIVER_SOURCE = fs.readFileSync(path.join(DRIVER_SQL_SRC, 'sql-driver.ts'), 'utf8');
+
+/** The one line the driver emits for a managed table's primary key. */
+const DRIVER_ID_COLUMN = "table.string('id').primary();";
+
+/** `varchar(n)` for a bare `table.string(name)`, read off the driver's constant. */
+function driverDefaultVarcharChars(): number {
+  const m = SQL_DRIVER_SOURCE.match(/DEFAULT_STRING_VARCHAR_CHARS = (\d+);/);
+  if (!m) {
+    throw new Error(
+      'DEFAULT_STRING_VARCHAR_CHARS not found in sql-driver.ts. That constant is the width this ' +
+      'pin reads instead of transcribing, so a rename must fail loudly here rather than leave ' +
+      'the generators unmeasured.',
+    );
+  }
+  return Number(m[1]);
+}
+
+const CONFIG = {
+  objects: {
+    account: {
+      name: 'account',
+      fields: { title: { type: 'text' }, owner: { type: 'lookup' } },
+    },
+  },
+};
+
+/** The `id` line `os generate migration --format sql` emits. */
+function emittedSqlIdLine(): string {
+  const lines = generateMigrationSql(CONFIG as Record<string, unknown>).split('\n');
+  const found = lines.filter((l) => /^\s*"id"\s/.test(l));
+  expect(found, 'the sql generator emitted no id column at all — the reader is broken').toHaveLength(1);
+  return found[0].trim();
+}
+
+/** The `id` line `os generate migration` (typescript, the DEFAULT format) emits. */
+function emittedTsIdLine(): string {
+  const lines = generateMigrationTs(CONFIG as Record<string, unknown>).split('\n');
+  const found = lines.filter((l) => /table\.\w+\('id'\)/.test(l));
+  expect(found, 'the typescript generator emitted no id column at all — the reader is broken').toHaveLength(1);
+  return found[0].trim();
+}
+
+describe('the builtin id column both migration generators emit (#15040)', () => {
+  it('reads a real driver source that still owns the id column (control)', () => {
+    // Non-vacuity for both extractions below.
+    expect(SQL_DRIVER_SOURCE.length).toBeGreaterThan(10_000);
+    expect(
+      SQL_DRIVER_SOURCE,
+      'driver-sql no longer emits `table.string(\'id\').primary()`. This pin corrects the ' +
+      'generators TOWARD the driver, so if the driver moved, re-read #15040 before touching ' +
+      'generate.ts — the authority is the driver, not this file.',
+    ).toContain(DRIVER_ID_COLUMN);
+    expect(driverDefaultVarcharChars()).toBeGreaterThan(0);
+  });
+
+  it('the typescript generator emits the driver\'s own line, byte for byte', () => {
+    expect(emittedTsIdLine()).toBe(DRIVER_ID_COLUMN);
+  });
+
+  it('the sql generator emits the driver\'s width, read from the driver', () => {
+    expect(emittedSqlIdLine()).toBe(`"id" VARCHAR(${driverDefaultVarcharChars()}) PRIMARY KEY,`);
+  });
+
+  it('neither generator gives the id a uuid type', () => {
+    // The loud half: a platform id is not a uuid, and Postgres says so with
+    // `22P02 invalid input syntax for type uuid` on the first insert.
+    expect(emittedSqlIdLine()).not.toMatch(/\bUUID\b/i);
+    expect(emittedTsIdLine()).not.toMatch(/table\.uuid\(/);
+    // Anti-vacuity: the predicates really do fire on the shapes this replaced.
+    expect('"id" UUID PRIMARY KEY DEFAULT gen_random_uuid(),').toMatch(/\bUUID\b/i);
+    expect("table.uuid('id').primary().defaultTo(db.fn.uuid());").toMatch(/table\.uuid\(/);
+  });
+
+  it('neither generator gives the id a database-side default', () => {
+    // The quiet half, and the reason this is p2 rather than p3. The driver
+    // emits no default because `create()` always supplies an id; a default
+    // therefore only ever fires for an out-of-band insert, and mints an id
+    // shape the platform never would.
+    expect(emittedSqlIdLine()).not.toMatch(/\bDEFAULT\b/i);
+    expect(emittedTsIdLine()).not.toMatch(/defaultTo\(/);
+    // The driver's own id line carries no default either — read, not assumed.
+    expect(DRIVER_ID_COLUMN).not.toMatch(/defaultTo\(/);
+    // Anti-vacuity: both predicates fire on what was there before.
+    expect('"id" UUID PRIMARY KEY DEFAULT gen_random_uuid(),').toMatch(/\bDEFAULT\b/i);
+    expect("table.uuid('id').primary().defaultTo(db.fn.uuid());").toMatch(/defaultTo\(/);
+  });
+
+  it('the id column is still emitted by BOTH generators, in each table', () => {
+    // The correction must not be mistaken for a deletion: the primary key is
+    // still there, and still first.
+    const sql = generateMigrationSql(CONFIG as Record<string, unknown>);
+    expect(sql).toContain('CREATE TABLE IF NOT EXISTS "account" (');
+    expect(sql.indexOf('"id"')).toBeLessThan(sql.indexOf('"title"'));
+    const ts = generateMigrationTs(CONFIG as Record<string, unknown>);
+    expect(ts).toContain("await db.schema.createTable('account'");
+    expect(ts.indexOf("table.string('id')")).toBeLessThan(ts.indexOf("table.string('title')"));
+    // Each generator carries exactly ONE hardcoded id line — the shape that let
+    // these two disagree with the driver in the first place, and the reason a
+    // fix to one of them can silently leave the other behind. Counted over the
+    // source so a third copy cannot arrive unmeasured; the literals are the
+    // emitted lines themselves, so this cannot drift from what is asserted above.
+    for (const line of [emittedSqlIdLine(), emittedTsIdLine()]) {
+      expect(GENERATE_SOURCE.split(line), `generate.ts emits \`${line}\` from more than one place`)
+        .toHaveLength(2);
+    }
+  });
+
+  // ── Recorded divergence, NOT coverage, and NOT a ruling ──────────────────
+  //
+  // Measured in the same pass as the id column, on the same two generators.
+  // The audit-stamp columns disagree with the driver too, in a way the id
+  // column did not, and the disagreement is NULLABILITY rather than type:
+  //
+  //   driver-sql   `table.timestamp(name).defaultTo(knex.fn.now())`  (nullable)
+  //   sql gen      `"created_at" TIMESTAMP NOT NULL DEFAULT now()`
+  //   ts gen       `table.timestamps(true, true)` — knex 3.3.0 compiles this
+  //                to `.notNullable().defaultTo(CURRENT_TIMESTAMP)` on both
+  //                columns (`knex/lib/schema/tablebuilder.js`).
+  //
+  // Compiled offline against knex's pg dialect, the two shapes are:
+  //
+  //   driver  "created_at" timestamptz default CURRENT_TIMESTAMP
+  //   ts gen  "created_at" timestamptz not null default CURRENT_TIMESTAMP
+  //
+  // Unlike the id column this is not obviously a wrong value: the driver stamps
+  // both columns on every write, so NOT NULL is arguably the truer constraint —
+  // and the driver's own DDL is dialect-branched (`datetime(3)` on MySQL, a
+  // canonical ISO default on SQLite) in a way a Postgres-flavoured generated
+  // migration does not try to reproduce. Which side moves is not this card's to
+  // decide, so nothing here changes those lines. Asserted only so the
+  // divergence cannot change shape unnoticed.
+  it('#15040 record — the audit-stamp columns diverge from the driver, deliberately unresolved', () => {
+    const sql = generateMigrationSql(CONFIG as Record<string, unknown>);
+    expect(sql).toContain('"created_at" TIMESTAMP NOT NULL DEFAULT now()');
+    expect(sql).toContain('"updated_at" TIMESTAMP NOT NULL DEFAULT now()');
+    expect(generateMigrationTs(CONFIG as Record<string, unknown>)).toContain('table.timestamps(true, true);');
+    // The driver side, read where it lives: one audit-column builder, and its
+    // default arm carries no `.notNullable()`.
+    expect(
+      SQL_DRIVER_SOURCE,
+      'driver-sql\'s audit-column DDL moved — re-read the #15040 record above before trusting it.',
+    ).toContain('table.timestamp(name).defaultTo(this.knex.fn.now());');
+    const auditArm = SQL_DRIVER_SOURCE.slice(
+      SQL_DRIVER_SOURCE.indexOf('protected createAuditTimestampColumn('),
+    ).slice(0, 600);
+    expect(auditArm.length).toBeGreaterThan(100);
+    expect(auditArm).not.toContain('notNullable()');
+  });
+});

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -1171,7 +1171,23 @@ export function generateMigrationSql(config: Record<string, unknown>): string {
     const fields = (obj.fields ?? {}) as Record<string, Record<string, unknown>>;
 
     lines.push(`CREATE TABLE IF NOT EXISTS "${tableName}" (`);
-    lines.push('  "id" UUID PRIMARY KEY DEFAULT gen_random_uuid(),');
+    // #15040 — the table's OWN id, corrected to what `driver-sql` emits for it:
+    // `table.string('id').primary()`, i.e. knex's `varchar(255)`
+    // (`SqlDriver.DEFAULT_STRING_VARCHAR_CHARS`). This is the same derivation
+    // `lookup` / `master_detail` / `user` / `tree` above already state — a
+    // reference column holds the TARGET's id — applied one column to the left,
+    // to the id itself. A platform id is not a uuid, so Postgres refused one in
+    // a `uuid` column with `22P02 invalid input syntax for type uuid` on the
+    // FIRST insert.
+    //
+    // The DEFAULT goes with the type, and it is the quieter half: the driver
+    // emits no database-side default because its own insert path always
+    // supplies the id (`create()` takes `_id`, else a caller-supplied `id`,
+    // else mints one). A `DEFAULT gen_random_uuid()` therefore never fires for
+    // a platform write and only fires for an out-of-band one — handing that row
+    // a 36-character uuid this platform's id generator would never mint, so the
+    // table would end up holding two incompatible id shapes with nothing said.
+    lines.push('  "id" VARCHAR(255) PRIMARY KEY,');
 
     const fieldLines: string[] = [];
     for (const [fieldName, fieldDef] of Object.entries(fields)) {
@@ -1228,7 +1244,12 @@ export function generateMigrationTs(config: Record<string, unknown>): string {
     const fields = (obj.fields ?? {}) as Record<string, Record<string, unknown>>;
 
     lines.push(`  await db.schema.createTable('${tableName}', (table: any) => {`);
-    lines.push("    table.uuid('id').primary().defaultTo(db.fn.uuid());");
+    // #15040 — the driver's own line for this column, emitted verbatim:
+    // `table.string('id').primary()`. See `generateMigrationSql` above for the
+    // derivation and for why the `.defaultTo(db.fn.uuid())` half goes with it
+    // (on Postgres `knex.fn.uuid()` compiles to `(gen_random_uuid())`, so the
+    // two generators were emitting one and the same wrong default).
+    lines.push("    table.string('id').primary();");
 
     for (const [fieldName, fieldDef] of Object.entries(fields)) {
       const fType = String(fieldDef.type || 'text');


### PR DESCRIPTION
Fixes #15040

Both migration generators in `packages/cli/src/commands/generate.ts` hardcoded the table's own primary key as a UUID. The platform's SQL driver emits `table.string('id').primary()` for that column — knex's `varchar(255)`, `SqlDriver.DEFAULT_STRING_VARCHAR_CHARS`. A platform id is a string, not a uuid, so on Postgres the generated table refuses the platform's first insert with `22P02 invalid input syntax for type uuid`.

Two literal lines, one per generator. No restructuring.

## What changed

| | before | after |
|---|---|---|
| `generateMigrationSql` | `"id" UUID PRIMARY KEY DEFAULT gen_random_uuid(),` | `"id" VARCHAR(255) PRIMARY KEY,` |
| `generateMigrationTs` | `table.uuid('id').primary().defaultTo(db.fn.uuid());` | `table.string('id').primary();` |

## The `DEFAULT` half is the quiet one, and it is what the fix is really for

The loud failure announces itself: `22P02` on the first insert, so nobody ships on top of the generated table silently. The default does not.

Measured: `SqlDriver.create()` always supplies the id itself — `_id`, else a caller-supplied `id`, else a minted one — so `DEFAULT gen_random_uuid()` never fires for a platform write. It fires only for an out-of-band insert, and hands that row a 36-character uuid this platform's id generator would never mint. One table would then hold two incompatible id shapes, with nothing anywhere saying so. The driver emits no database-side default for `id` at all, and neither generator does now.

On Postgres `knex.fn.uuid()` compiles to `(gen_random_uuid())`, so the two generators were emitting one and the same wrong default in two spellings.

## The file already contradicted itself

`generate.ts` states, a few hundred lines above the two generators, that a reference column takes the width of the target's `id` column *because* the driver emits `table.string('id').primary()` — the derivation #14828 applied to the `lookup` / `master_detail` / `user` / `tree` rows. Those comments were already right. Only the code was wrong, and this change makes the code agree with prose that had been correct all along; no comment needed correcting.

## Measured, not quoted

The `22P02` refusal itself is **quoted** from `sql-driver.ts`'s own prose, not driven against a live Postgres — there is no database in this container. What is driven here is the emitted **shape**, on both sides, compiled offline through knex's `pg` dialect (`knex.schema.createTable(...).toSQL()`, a pure compile with no connection):

```
driver-sql (postgres arm)   "id" varchar(255)
generateMigrationTs before  "id" uuid default (gen_random_uuid())
generateMigrationTs after   "id" varchar(255)
```

The `after` row is byte-identical to the driver's own id column.

## Third disagreement, measured and NOT folded in: the audit-stamp columns

Triage asked for `created_at` / `updated_at` to be decided in the same pass rather than left half-done. Measured; it **is** a third disagreement, and this PR deliberately does not touch it.

```
driver-sql   table.timestamp(name).defaultTo(knex.fn.now())     -> nullable
sql gen      "created_at" TIMESTAMP NOT NULL DEFAULT now()      -> NOT NULL
ts gen       table.timestamps(true, true)                       -> NOT NULL
```

`table.timestamps(true, true)` compiles to `.notNullable().defaultTo(CURRENT_TIMESTAMP)` on both columns (knex 3.3.0, `knex/lib/schema/tablebuilder.js`). Compiled through the same offline pg probe:

```
driver  "created_at" timestamptz default CURRENT_TIMESTAMP
ts gen  "created_at" timestamptz not null default CURRENT_TIMESTAMP
```

So the disagreement is **nullability**, not type — unlike the `id` column, where the type itself was wrong. It is not obviously a wrong value on either side: the driver stamps both columns on every write, which makes `NOT NULL` arguably the truer constraint, and the driver's DDL is dialect-branched (`datetime(3)` on MySQL, a canonical ISO default on SQLite, per `createAuditTimestampColumn`) in a way a Postgres-flavoured generated migration does not try to reproduce. Which side moves is a decision, not a correction, so nothing here changes those lines. The measurement is recorded as the last case of the new pin, explicitly as a record rather than a ruling, so it cannot change shape unnoticed.

## The pin reads the authority instead of transcribing it

`packages/cli/src/commands/generate-builtin-id-column.pin.test.ts`. A pin asserting `varchar(255)` would re-create this very defect one layer up — the whole shape of this card is "the generator disagrees with the driver". So the width is read from `DEFAULT_STRING_VARCHAR_CHARS` where it is declared, and the typescript generator's emitted line is compared against the driver's own call byte for byte. Both extractions carry non-vacuity controls, and every "must not" assertion carries an anti-vacuity control proving the predicate fires on the shape that was there before.

It needs **no new declared inputs**: `packages/drivers/driver-sql/src/sql-driver.ts` is already listed under `@objectstack/cli#test` in `turbo.json`, and `pnpm check:cross-package-test-inputs` passes unchanged (`26 package(s) read outside themselves, all declared`).

Two legs of ablation, one per generator, because the two lines live in different functions and a pin covering only one would look identical from the outside.

## `Clause-②: no`, re-declared from the delivered diff

A scaffolding generator's emitted DDL is corrected toward what the platform's driver already emits. No exported symbol, no accepted key or value, no schema and no wire shape moves. Changeset is `patch` on that basis: per `Check Changeset`'s WHICH LEVEL prose, `minor` is for a purely additive widening of a published package's public surface, and a `fix(` that changes no public surface stays `patch`.

## Verification

All readings at `bffde48fc99`, on a clean tree, in the worktree `objectstack-issue-15040`. Heavy runs went through `scripts/pm/os-verify-lock.sh`; every verdict below is quoted from the gate's or the lock's own verdict line, never from a bare `$?`.

- **`@objectstack/cli` full suite** — `pnpm --filter @objectstack/cli exec vitest run --maxWorkers=2`. `Test Files 244 passed`, `Tests 2872 passed | 6 expected fail | 11 skipped`, plus the five `*.e2e.test.ts` suites re-run after `turbo run build` satisfied their `requireBuiltCli` prerequisite: `Test Files 5 passed (5)`, `Tests 11 passed (11)`. The first run reported those five as failed suites for one reason — `packages/cli is not built: .../dist/commands/serve.js does not exist` — which is a prerequisite, not a finding, so it was satisfied and re-measured rather than reported.
- **`pnpm --filter @objectstack/cli typecheck`** — `VERDICT command-exit 0`; `check:test-typecheck: OK — @objectstack/cli's test layer compiles under packages/cli/tsconfig.test.json`. The new pin really is in the program: `tsc --noEmit --listFiles` names `generate-builtin-id-column.pin.test.ts` and `commands/generate.ts`, so "typecheck is clean" covers the file this PR adds rather than merely being true.
- **Gate union** — derived with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack --commands` from the change set the script takes itself (3 paths). 49 commands, all exit 0. Four first came back `PREREQUISITE NOT MET` / `NOTHING was measured` (`check:dual-build-cjs-loads`, `check:i18n`, `check:i18n-coverage`, `check:i18n-walk-parity`) — read as NOT MEASURED, satisfied with a workspace build, and re-run green. The five roster families the derivation flags as scoring `silent` for structural reasons with a roster under one of these paths were run too, not read as clearance: `check-changeset-fixed`, `check:authz-resolver`, `check:error-code-casing`, `check:filter-alias-parity`, `check:swallow-census-controls` — all exit 0.
- ⚠️ **Declared limitation.** The derivation printed `STALE TREE` — this branch is behind `origin/main`, and four files the answer derives from changed across that range (`check-dispatcher-error-vocabulary.mjs`, `check-type-check-coverage.mjs`, `engine-double-contract.pinned.json`, `measure-self-test-floor.mjs`). The family list itself was byte-identical when re-derived after a fresh `git fetch origin main`, and three of those four gates ran green here from this tree's copies — but the reading is from this tree, not from `origin/main`. CI runs the farm against the merge and is the stronger reading.

### Ablation — two legs, one per generator, proved on disk

Predicted before running: restoring `uuid` in one generator reds that generator's cases while the other generator's stay green. Both legs behaved that way, and distinctly.

No rebuild is involved and none is owed: the pin imports `./generate.js` relatively, so vitest reads `src/commands/generate.ts` itself rather than anything in `dist/`. That is not an assumption here — each leg mutated only the source and the pin went red without a build, which is what proves the resolution path.

| leg | mutation, proved on disk | red | green |
|---|---|---|---|
| SQL | removed-text count `1 -> 0`, injected marker `1` | `the sql generator emits the driver's width`, `neither generator gives the id a uuid type`, `neither generator gives the id a database-side default` | `the typescript generator emits the driver's own line, byte for byte` |
| TS | removed-text count `1 -> 0`, injected marker `1` | `the typescript generator emits the driver's own line, byte for byte`, and the same two shared cases | `the sql generator emits the driver's width` |

Both legs: `Tests 3 failed | 48 passed (51)`, and in both `Test Files 1 failed | 2 passed` — `generate-field-type-vocabulary.pin.test.ts` and `generate-multiple-json-column.pin.test.ts` stayed **green through both mutations**. That is the case for the new pin existing: the two pins already driving these generators do not cover the builtin `id` column, so either regression could have landed under a green suite.

Restore was `git checkout HEAD -- ABSOLUTE_PATH` from a trap, and is proved rather than assumed: blob hash `06db8cc9cc53cccc3e5aa27ac50417e0717655b1` equal to the `HEAD` blob and `git diff HEAD` empty, checked after each leg. An empty hash is treated as failure, not as "nothing to compare".

---
_Generated by [Claude Code](https://claude.ai/code/session_01D47qPfEWVPmhguWgBZCi5N)_