### PR TITLE
fix(cli): a closed stderr read end exits 2 instead of dying of an uncaught EPIPE (#14858)

### DIFF
--- a/packages/cli/bin/run-dev.js
+++ b/packages/cli/bin/run-dev.js
@@ -200,31 +200,55 @@ keepStderrNonBlocking();
  * still gets this CLI's own exit status instead of a crash. #14858.
  *
  * `process.stderr` is an `EventEmitter`, and an `error` event with nothing
- * listening IS an uncaught exception. Measured on this shim with the parent's
- * read end DESTROYED (`stdio: ['ignore', 'ignore', 'pipe']`, then
- * `child.stderr.destroy()`): oclif's `displayWarnings()` makes the first write,
- * the pipe is already gone, node raises `write EPIPE` on `process.stderr`, and
- * the process dies of an uncaught exception before this file's `.catch()` — and
- * before `writeStderr()` above — has run at all. __REPRO__
+ * listening IS an uncaught exception. With the parent's read end DESTROYED
+ * (`stdio: ['ignore', 'ignore', 'pipe']`, then `child.stderr.destroy()`)
+ * oclif's `displayWarnings()` makes the first write, the pipe is already gone,
+ * node raises `write EPIPE` on `process.stderr`, and this process died of an
+ * uncaught exception — 12 of 12 runs, 938-1174 ms in, well before `run()`
+ * settles and before `writeStderr()` above is ever called. Traced with a
+ * `--import` observer that installs NO listener on this stream and wraps no
+ * write (`uncaughtExceptionMonitor`, which observes without preventing the
+ * default crash — an `uncaughtException` handler would have changed the very
+ * thing being read):
  *
- * Every OTHER reader of the same child answers **2**, the status oclif's
- * `handle()` produces and the one #14715 pinned for the never-read reader.
- * __READERS__ So the closed reader was the single shape that could not tell
- * "the command failed" from "the CLI crashed", on the only channel it had left.
+ *     uncaughtException  code=EPIPE  msg=write EPIPE
+ *           at afterWriteDispatched (node:internal/stream_base_commons:159:15)
+ *     exit  code=1
  *
- * ⛔ Deliberately NOT narrowed to `error.code === 'EPIPE'`, though that is the
- * code the first failure carries. __CODES__ A predicate would therefore have to
- * enumerate the codes a dead pipe produces AFTER the first one, and get that
- * enumeration right forever, to buy a distinction nothing here can act on:
- * every error event on this stream means one thing — a write to stderr failed —
- * and the only channel it could be reported on is the stream that just failed.
+ * Every OTHER reader of the same child answers **2** — drained (1209-1217 ms,
+ * 147699 bytes delivered) and never-read (16178-16471 ms) both did, in the same
+ * conditions. 2 is what oclif's `handle()` produces, and #14715 pinned it for
+ * the never-read reader. So the closed reader was the one shape that could not
+ * tell "the command failed" from "the CLI crashed", on the only channel it had
+ * left.
+ *
+ * ⛔ Deliberately NOT narrowed to `error.code === 'EPIPE'`, even though EPIPE is
+ * the only code this path was measured to raise (4 events per run, no other
+ * code, observed with a listener installed on purpose for that one question).
+ * The reason to tolerate is not WHICH error it is: every event here means one
+ * thing — a write to stderr failed — the only channel it could be reported on
+ * is the stream that just failed, and there is no other action to take. A
+ * predicate would buy no decision and would keep exactly this crash for
+ * whatever code turns up next.
  *
  * ⚠️ What it costs, and it is not nothing. With the write no longer fatal the
- * run continues into `writeStderr()`'s drain, which for this path had never
- * executed at all. Re-measured on this tree, destroyed read end, `bin/run-dev.js`
- * ablated 2x2 (this listener present/absent x the `write` callback kept/removed):
+ * run continues into `writeStderr()`'s drain, which for this path had NEVER
+ * executed at all. Ablated 2x2 on this file, one contiguous run, shared box —
+ * so read the ratios, not the absolutes:
  *
- * __ABLATION__
+ *     this listener   write callback     exit   elapsed
+ *     -------------   ---------------    ----   ---------------
+ *     present         kept (= HEAD)        2    1237-1312 ms
+ *     present         removed              2    16271-16294 ms   the 15 s bound
+ *     absent          kept                 1     983-1028 ms     the defect
+ *     absent          removed              1     843-1031 ms
+ *
+ * Row 1 against row 3 is the whole change, and it is ~250 ms: the child now
+ * ends the way a drained reader's child ends instead of dying on its first
+ * write. (The two runs are comparable because their unfixed rows agree — 938-
+ * 1174 ms above, 983-1028 ms here.) Row 2 is what the drain costs when only the
+ * no-progress bound can end it — a cost that is REACHABLE now and was not
+ * before, because rows 3-4 never got there at all.
  */
 process.stderr.on('error', () => {
   // Nothing to report, and nowhere left to report it.

--- a/packages/cli/bin/run-dev.js
+++ b/packages/cli/bin/run-dev.js
@@ -195,6 +195,41 @@ settings.debug = true;
 // why the re-assert has to sit on the write path rather than run once here.
 keepStderrNonBlocking();
 
+/**
+ * Make a FAILED stderr write non-fatal, so a caller whose read end is gone
+ * still gets this CLI's own exit status instead of a crash. #14858.
+ *
+ * `process.stderr` is an `EventEmitter`, and an `error` event with nothing
+ * listening IS an uncaught exception. Measured on this shim with the parent's
+ * read end DESTROYED (`stdio: ['ignore', 'ignore', 'pipe']`, then
+ * `child.stderr.destroy()`): oclif's `displayWarnings()` makes the first write,
+ * the pipe is already gone, node raises `write EPIPE` on `process.stderr`, and
+ * the process dies of an uncaught exception before this file's `.catch()` — and
+ * before `writeStderr()` above — has run at all. __REPRO__
+ *
+ * Every OTHER reader of the same child answers **2**, the status oclif's
+ * `handle()` produces and the one #14715 pinned for the never-read reader.
+ * __READERS__ So the closed reader was the single shape that could not tell
+ * "the command failed" from "the CLI crashed", on the only channel it had left.
+ *
+ * ⛔ Deliberately NOT narrowed to `error.code === 'EPIPE'`, though that is the
+ * code the first failure carries. __CODES__ A predicate would therefore have to
+ * enumerate the codes a dead pipe produces AFTER the first one, and get that
+ * enumeration right forever, to buy a distinction nothing here can act on:
+ * every error event on this stream means one thing — a write to stderr failed —
+ * and the only channel it could be reported on is the stream that just failed.
+ *
+ * ⚠️ What it costs, and it is not nothing. With the write no longer fatal the
+ * run continues into `writeStderr()`'s drain, which for this path had never
+ * executed at all. Re-measured on this tree, destroyed read end, `bin/run-dev.js`
+ * ablated 2x2 (this listener present/absent x the `write` callback kept/removed):
+ *
+ * __ABLATION__
+ */
+process.stderr.on('error', () => {
+  // Nothing to report, and nowhere left to report it.
+});
+
 const running = run(process.argv.slice(2), import.meta.url);
 
 // ⚠️ ATTACHED AFTER `run()`, and that order is load-bearing rather than style.

--- a/packages/cli/test/run-dev-unbuilt-workspace.e2e.test.ts
+++ b/packages/cli/test/run-dev-unbuilt-workspace.e2e.test.ts
@@ -455,60 +455,57 @@ describe('the mirror direction: a reader that is never coming back', () => {
     expect(Number(String(declared).replaceAll('_', ''))).toBe(SHIM_DRAIN_STALL_MS);
   });
 
-  it('a CLOSED read end ends the child on its own — by an uncaught EPIPE, never by the bound', () => {
-    // ⚠️ This case used to read `elapsedMs < STALL_MS`, and its name used to
-    // say "released at once … EPIPE reaches the callback". BOTH were wrong
-    // about this shape, and the trace that settles it is worth more than the
-    // assertion it replaces.
+  it('a CLOSED read end ends the child on its own, with the status every other reader gets', () => {
+    // ⚠️ THE NUMBER BELOW MOVED FROM 1 TO 2, and this case is why it could not
+    // move quietly. It pinned 1 on purpose — 1 was what the CLI DID, never what
+    // anyone contracted — and #14858 is the card that changed the CLI. ⛔ This
+    // was not a broken test and the flip is not a regression.
     //
-    // What the child ACTUALLY does with its read end destroyed: oclif's
+    // What the child USED TO DO with its read end destroyed: oclif's
     // `displayWarnings()` makes the first stderr write, the pipe is already
     // gone, node raises `write EPIPE` as an `error` event on `process.stderr`,
-    // NOTHING IS LISTENING, and the process dies of an uncaught exception —
-    // exit 1, ~1.4 s in. `writeStderr()` is never called, so the bound this
-    // case was named after is never armed, let alone paid. Traced on one box
-    // with a `--import` observer: the shim's own 415-byte write is #175, at
-    // 9250 ms, behind 174 oclif writes that all EPIPE — 7.8 s after the
-    // unobserved child is already dead.
+    // NOTHING WAS LISTENING, and the process died of an uncaught exception —
+    // exit 1, 938-1174 ms in, 12 of 12 runs, traced with a `--import` observer
+    // that installed no listener here and wrapped no write. `writeStderr()` was
+    // never called at all, so the bound this case was once named after was
+    // never armed, let alone paid. (An earlier version of this case read
+    // `elapsedMs < STALL_MS` and was named for that bound; the wall clock went
+    // because its whole measured term is child cold start, which is elastic,
+    // and because it stayed green through the very ablation it named.)
     //
-    // ⛔ So the wall-clock bound was not merely fragile, it was a PHANTOM: it
-    // could not fail for the reason it named. Ablated on `bin/run-dev.js`,
-    // same box, same probe, with the old bound's verdict in brackets:
+    // `bin/run-dev.js` now attaches a no-op `error` listener to
+    // `process.stderr` before `run()`. A failed stderr write stops being fatal,
+    // the run reaches the CLI's own exit path — oclif's `handle()`, status 2 —
+    // and the closed reader answers what the drained and never-read readers
+    // already answered (#14715 pinned 2 for the never-read one). Re-measured
+    // for that change, one contiguous 2x2 ablation of the shim on one box, the
+    // listener present/absent against the `write` callback kept/removed:
     //
-    //   pristine                                  exit 1, 1387-1711 ms   [green]
-    //   write callback REMOVED, so a closed path
-    //     could only finish on the bound — the
-    //     regression this case named               exit 1, 1517-1633 ms   [GREEN]
-    //   EPIPE made non-fatal, callback kept       exit 2, 8787-8979 ms   [green, 1.2 s spare]
-    //   both, so the path really pays the bound   exit 2, 23601-23712 ms [red]
+    //   listener present, callback kept (as shipped)  exit 2,  1237-1312 ms
+    //   listener present, callback removed            exit 2, 16271-16294 ms
+    //   listener absent,  callback kept (the defect)  exit 1,   983-1028 ms
+    //   listener absent,  callback removed            exit 1,   843-1031 ms
     //
-    // The bound moved only on lines 3 and 4, which change the EXIT CODE too;
-    // against its own regression it stayed green. And its whole measured term
-    // is child cold start, which is elastic — 1.4 s here, 8.9 s the moment
-    // anything lets the child run further — judged against 10 s borrowed from
-    // case 4's parent stall, a number with no relationship to this case.
+    // ⭐ The exit status is still the observation, and it still carries no load
+    // term. 1 means the child died on its first write and never reached the
+    // drain; 2 means it got through to `handle()`, which on this run is only
+    // reachable THROUGH `writeStderr()` — bound paid or not. BOTH rows that
+    // remove the listener flip it back to 1, so this line pins the fix and not
+    // the weather.
     //
-    // ⭐ The exit status IS the observation the wall clock was standing in for,
-    // and it carries no load term at all. 1 means the child died on its first
-    // write and never reached the drain; 2 means it got through to `handle()`,
-    // which is only reachable THROUGH `writeStderr()` — bound paid or not. Every
-    // ablation above that reaches the drain flips it, including the one the old
-    // assertion could not see.
-    //
-    // ⚠️ 1 is what the CLI DOES, not what anyone contracted: a caller whose
-    // stderr is closed gets 1 where every other reader gets 2, and cannot tell a
-    // failed command from a crashed CLI. Filed as #14858. If that is fixed to
-    // exit 2 this case reds, which is the point — the fixing PR flips the number
-    // here and says why. ⛔ Do not "repair" a red by loosening this to
-    // `not.toBeNull()`; that is the phantom check all over again.
+    // ⛔ Do not "repair" a red here by loosening to `not.toBeNull()`; that is
+    // the phantom check the wall clock already was. A red means the child is
+    // dying on a stderr write again — the listener is gone, or something now
+    // writes to stderr ahead of where it is attached.
     const evidence =
       `closed-read-end child ran ${closedEnd.elapsedMs} ms (harness cap ${UNREAD_HARD_CAP_MS} ms); ` +
       `case 1 measured the same child at ${unbuilt.elapsedMs} ms on this runner minutes earlier`;
     expect(closedEnd.signal, `the harness SIGKILLed the child — it was still alive at the ceiling. ${evidence}`).toBeNull();
     expect(
       closedEnd.code,
-      `the child did not die on its first stderr write — it reached the shim's drain, so something now ` +
-        `tolerates EPIPE on stderr (see #14858 and the ablation table above this assertion). ${evidence}`,
-    ).toBe(1);
+      `the child did not reach the CLI's own exit path — it died on a stderr write, so nothing is making ` +
+        `EPIPE non-fatal on \`process.stderr\` any more (see #14858 and the ablation table above this ` +
+        `assertion). ${evidence}`,
+    ).toBe(2);
   });
 });


### PR DESCRIPTION
Fixes #14858

`bin/run-dev.js` now attaches a no-op `error` listener to `process.stderr` before `run()`, so a failed stderr write stops being fatal and a caller whose read end is gone gets the CLI's own exit status (**2**) instead of a crash (**1**).

## The defect, reproduced on the current tree

`process.stderr` is an `EventEmitter`, and an `error` event with nothing listening **is** an uncaught exception. Spawn the shim with `stdio: ['ignore', 'ignore', 'pipe']` and `child.stderr.destroy()`: oclif's `displayWarnings()` makes the first write, the pipe is already gone, node raises `write EPIPE`, and the process dies before reaching any of the CLI's own exit paths — including `writeStderr()`'s drain, which for this path had never executed at all.

Re-measured on `26144c204` (the card's own numbers were taken on a tree that no longer exists, and are **not** carried over), with the card's own instrument: a `--import` observer that appends to a file and installs **no** listener on `process.stderr` and **no** write wrapper. It reads the crash with `uncaughtExceptionMonitor`, which observes without preventing the default action — an `uncaughtException` handler would have changed the very thing being read.

| parent's reader | exit | elapsed | bytes delivered |
|---|---|---|---|
| drained | 2 | 1209-1217 ms | 147699 |
| paused, never read | 2 | 16178-16471 ms | 0 |
| **read end destroyed** | **1** | **938-1174 ms**, 12/12 | 0 |

```
22407  uncaughtException  code=EPIPE  msg=write EPIPE
22407        stack=Error: write EPIPE | at afterWriteDispatched (node:internal/stream_base_commons:159:15)
             | at writeGeneric (node:internal/stream_base_commons:150:3) | at Socket._writeGeneric (node:net:966:11)
22407  exit  code=1  elapsed=823ms
```

2 is what oclif's `handle()` produces and what #14715 pinned for the never-read reader, so the contracted status already existed; this path simply never reached it. Making it agree restores consistency — no contract surface moves.

## The four-row ablation, re-measured with the candidate fix in place

One contiguous run on one box, `bin/run-dev.js` ablated 2x2: this listener present/absent against the `write` callback kept/removed. Every leg proved its mutation on disk by counting **both** the removed text and an injected marker, and every restore was proved by blob-hash equality with the `HEAD` blob **and** an empty `git diff HEAD` **and** zero remaining markers, under a trap with absolute paths.

| this listener | `write` callback | exit | elapsed |
|---|---|---|---|
| present | kept (as shipped) | **2** | 1237-1312 ms |
| present | removed | 2 | 16271-16294 ms — the 15 s no-progress bound |
| absent | kept | 1 | 983-1028 ms — the defect |
| absent | removed | 1 | 843-1031 ms |

Row 1 against row 3 is the whole change and it costs **~250 ms**: the child now ends the way a drained reader's child ends instead of dying on its first write. The two runs are comparable because their unfixed rows agree (938-1174 ms in the table above, 983-1028 ms here).

⚠️ The card's reading that "one `noop` error listener is the difference between exit 1 at 1.4 s and the contracted exit 2 at 8.8 s" **did not survive re-measurement**. On the card's tree the fixed row cost ~7.4 s over the crash; here it costs ~250 ms. What survives is the ratio, not the absolutes: the fixed closed reader now takes about as long as a **drained** reader does, in both conditions (1237-1312 ms vs 1209-1217 ms here; 8.8 s vs 8.3 s there). The absolute gap was contention, not mechanism.

Rows 1-2 together are the second thing the card asked for: `writeStderr()`'s drain is now **reachable** on this path, and row 2 is what it costs when only the no-progress bound can end it. Rows 3-4 never got there at all, which is why the old bound could not fail for the reason it named.

Confirmed with the fix in place, all three reader shapes agree (a slower window on the same box — read the shapes, not the absolutes): drained 5235-5309 ms / exit 2, paused 20181-20205 ms / exit 2, destroyed 5094-5518 ms / exit 2.

No rebuild is involved in any of this, and that is checked rather than assumed: the harness runs `tsx packages/cli/bin/run-dev.js` — the very file being mutated — and that file's only imports are source (`../src/utils/stderr-nonblocking.ts`, `../src/utils/invocation.ts`, `../../../scripts/cli-unbuilt-workspace-lead.mjs`), so no `dist/` sits on the shim's resolution path. The cache-freshness control is in-band: rows 1 and 3 are back-to-back runs of the same path that answer different exit codes.

## Why the listener is not narrowed to EPIPE

Measured with a listener installed on purpose for that one question (⛔ never used for the uncaught-exception reading above, because a probe that installs a listener changes the behaviour under test): the destroyed read end raises **EPIPE and nothing else**, 4 events per run. So a `code === 'EPIPE'` predicate would in fact work today. It is still not what landed: the reason to tolerate is not *which* error it is. Every event on this stream means one thing — a write to stderr failed — the only channel it could be reported on is the stream that just failed, and there is no other action to take. A predicate would buy no decision and would keep exactly this crash for whatever code turns up next.

## The pin this flips, and why it is not a regression

`packages/cli/test/run-dev-unbuilt-workspace.e2e.test.ts:509` pinned `closedEnd.code` to **1** *on purpose* — 1 was what the CLI did, never what anyone contracted — precisely so this could not change silently. This PR flips it to **2** and rewrites the case's rationale to say why, carrying the re-measured ablation table into the comment so the next reader can see that both listener-absent rows flip it back to 1. ⛔ It was not a broken test and this is not a regression.

Reverse verification, run from the committed state: with the listener ablated out of `bin/run-dev.js` (mutation proved on disk, restore proved by blob-hash equality and an empty `git diff HEAD` under a trap) the suite comes back **1 failed | 10 passed** and the one failure is exactly this case — `expected 1 to be 2`, the child having run 1038 ms. So the flipped number pins the fix rather than the weather, and it is the only assertion in the file that moves.

⚠️ That file is also #14822's queue-flake anchor. A red run of this suite is therefore not automatically this PR's regression — tell them apart by the failing arm's identity and a re-run, never by assumption.

## Scope

Out of scope, and named here only so the boundary is explicit: #14832 is a different defect in the same file — an intermittent **hang** of the never-read (paused) reader — and it remains open, untouched by this PR. This PR claims only the deterministic, destroyed-read-end case.

### The published entry `bin/run.js` — measured, reported, not changed here

`bin/run.js` has no stderr `error` listener either, so the same hole is open in the published binary by inspection. **It did not reproduce**, on either probe, on the built tree:

| probe on `bin/run.js` | reader | exit | elapsed | stderr bytes when drained |
|---|---|---|---|---|
| `definitely-not-a-command` | drained | 2 | ~2.3 s | 57 |
| `definitely-not-a-command` | destroyed | 2, 3/3 | ~2.3 s | — |
| `OBJECTSTACK_DEBUG=1` + the unbuilt-spec hook | drained | 2 | 654 ms | 35523 |
| `OBJECTSTACK_DEBUG=1` + the unbuilt-spec hook | destroyed | 2, 3/3 | 657-671 ms | — |

The same `--import` observer recorded **no** `uncaughtException` on any destroyed run there. So the published entry is *not reached* by this failure under these probes, which is not the same as *guarded* — the missing listener is real. Reported for triage rather than fixed, because widening this card to the published binary was explicitly out of scope.

## Verification

- `pnpm --filter @objectstack/cli exec vitest run --maxWorkers=2 test/run-dev-unbuilt-workspace.e2e.test.ts` — **11 passed / 11**, 53.15 s.
- `pnpm --filter @objectstack/cli typecheck` — clean (`tsc --noEmit` plus the test-layer ledger check). The edited test file really is in that program: `tsc -p tsconfig.test.json --listFiles` names it.
- Gate union re-derived from the real changed paths with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack --commands` on a tree the tool did **not** call stale, and run on this PR's head `dd831cce4d5`: **41 derived commands, 40 exit 0**. The artifact-roster families were run too (36 more after de-duplication, 32 exit 0) rather than read as cleared by their silence. Exit codes were captured before any pipe.
- Nothing came back red. Five commands report themselves as NOT MEASURED and say so in their own words — `check:dual-build-cjs-loads` (`PREREQUISITE NOT MET`, wants a full `pnpm build`), `check:published-readme-exports` (13 packages not built), `check:react-declaration-parity` (`MANIFEST is not set … This gate did NOT run`), and the two PR-context guards `check-partof-closing-keyword` / `check-single-claim-paths` (`NOT WIRED`). The first of those two was then run to a real verdict against this body — `PR_BODY="$(cat body.md)" node scripts/check-partof-closing-keyword.mjs` — and passes: *this PR carries no Part-of/closing-keyword contradiction*.

**No changeset, `skip-changeset` instead.** This PR releases nothing: `packages/cli`'s `files` is `["dist", "README.md", "CHANGELOG.md"]` and its `bin` names only `./bin/run.js`, so `npm pack --dry-run` packs exactly one file under `bin/` — `bin/run.js`. `bin/run-dev.js` is not in the tarball, and the other path is a test.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D47qPfEWVPmhguWgBZCi5N