### PR TITLE
fix(types): recognise an aliased package root by the name its declaration promises

### DIFF
--- a/.changeset/host-importer-aliased-dual-publish-entry.md
+++ b/.changeset/host-importer-aliased-dual-publish-entry.md
@@ -1,0 +1,13 @@
+---
+"@objectstack/types": patch
+---
+
+`createHostImporter` now loads the `import` build of an ALIASED dual-published package, instead of silently keeping its `require` build.
+
+An alias declaration — `{"dependencies": {"foo": "npm:bar@1"}}` — installs a package whose manifest is named `bar` under the key `foo`. On the path where CommonJS resolution SUCCEEDS, the importer re-decides only the CONDITION (it asks the package which entry an `import()` gets, so the caller's ESM chain and this load share one instance). That re-decision recognised the package root by walking up from the resolved entry until it found a manifest named after the DECLARATION KEY — `foo` — while an aliased install's manifest is named `bar`. The walk therefore never matched, the re-decision produced nothing, and the load fell back to whatever the CommonJS resolver had answered: the `require` condition.
+
+For an aliased dual publish that left the process holding two live copies of one package — the CommonJS build behind the host importer, the `import` build in the caller's own chain — which is exactly the split the condition re-decision exists to remove: a plugin registry, a singleton kernel, a module-level cache, one copy each.
+
+The expectation now comes from the host's own declaration (`npm:name@range`, aliased `workspace:name@range`), the same reading the ESM-only fallback finder has used since it learned about aliases. Nothing about the check's strictness moves: an alias naming one package still does not license a directory holding another, and a non-aliased declaration is still verified against its key. Declarations that name a LOCATION rather than a package (`link:`, `file:`) carry no name to expect, so they keep today's behaviour unchanged.
+
+Measured population for the behaviour change: zero aliased declarations exist across this workspace's 875 dependency declarations, and 867 of 867 installed declarations already match their key — no ordinary, non-aliased install reaches this path.

--- a/packages/types/src/node.test.ts
+++ b/packages/types/src/node.test.ts
@@ -1514,3 +1514,318 @@ describe('an aliased install is verified against the name its DECLARATION names 
     expect(hostImportFailureKind(err)).toBe('declared-unresolvable');
   });
 });
+
+/**
+ * ── #15044: the SUCCEEDING leg recognised the package by the DECLARATION KEY ──
+ *
+ * #14278 taught the #14041 FALLBACK finder that `{"foo": "npm:bar@1"}` installs
+ * a package named `bar`. The same blindness survived one leg over, on the path
+ * where the CJS resolve SUCCEEDS — #13330's condition re-decision:
+ * `packageRootOf` walked up from the resolved entry looking for a manifest
+ * named `foo`, and an aliased install's manifest is named `bar`. The walk
+ * therefore never matched, `esmEntryForDeclared` returned `undefined`, and
+ * `?? resolved` handed back the entry the CJS resolver had answered — the
+ * `require` condition.
+ *
+ * ⇒ For an aliased DUAL-PUBLISHED package the host importer silently kept
+ * pre-#13330 behaviour: the CommonJS build loads while the caller's own ESM
+ * chain loads the `import` build. That is the two-instances-of-one-package
+ * split #13330 exists to remove, so what these cases assert is the SHARED
+ * INSTANCE, not the file name — a test that only checked which path was
+ * imported would pass on a fix that loaded the right file into the wrong
+ * instance.
+ *
+ * This leg is NOT #14278's: that one fired only inside `hostRequire.resolve`'s
+ * catch, a hard failure before #14041, so it could not move a working load.
+ * This one moves a load that SUCCEEDS today, which is why the non-aliased
+ * controls below matter more than another aliased assertion — the risk in the
+ * change is a regression in the ordinary case, not the aliased case it fixes.
+ */
+describe('an aliased dual-published package loads its `import` build too (#15044)', () => {
+  /** Keys the HOST writes; none of them is the name of the package installed there. */
+  const REGISTRY_KEY = 'aliased-registry';
+  const DRIVER_KEY = 'aliased-driver';
+  const SUBPATH_KEY = 'aliased-subpaths';
+  /** Manifest names the ALIAS values promise. */
+  const REGISTRY_NAME = '@fixture/alias-dual-registry';
+  const DRIVER_NAME = '@fixture/alias-dual-driver';
+  const SUBPATH_NAME = '@fixture/alias-dual-subpaths';
+  /** An ordinary, NON-aliased dual publish living in the same app. */
+  const PLAIN = '@fixture/plain-dual';
+
+  /** Module-scope state, published as both builds — the `tsup` dual-build shape. */
+  const REGISTRY_ESM = `export const BUILD = 'esm';
+const registered = [];
+export function register(name) { registered.push(name); }
+export function listRegistered() { return [...registered]; }
+`;
+  const REGISTRY_CJS = `const registered = [];
+exports.BUILD = 'cjs';
+exports.register = (name) => { registered.push(name); };
+exports.listRegistered = () => [...registered];
+`;
+  /**
+   * A driver package whose entire contract is the load-time side effect. It
+   * imports the registry by the ALIAS KEY, which is the only spelling an
+   * aliased install makes importable — the alias target's own name resolves
+   * nowhere.
+   */
+  const DRIVER_ESM = `import { register } from '${REGISTRY_KEY}';
+register('probe');
+export const BUILD = 'esm';
+`;
+  const DRIVER_CJS = `const { register } = require('${REGISTRY_KEY}');
+register('probe');
+exports.BUILD = 'cjs';
+`;
+
+  /** Nested, `types` first — the map `tsup` emits, so the walk cannot match a flat string. */
+  const DUAL: unknown = {
+    '.': {
+      import: { types: './dist/index.d.ts', default: './dist/index.js' },
+      require: { types: './dist/index.d.cts', default: './dist/index.cjs' },
+    },
+  };
+
+  const roots: string[] = [];
+
+  afterAll(() => {
+    for (const dir of roots) rmSync(dir, { recursive: true, force: true });
+  });
+
+  /**
+   * Install a package NAMED `manifestName` at `node_modules/<key>` — the
+   * on-disk shape every aliasing package manager produces.
+   */
+  function installAs(
+    root: string,
+    key: string,
+    manifestName: string,
+    exportsField: unknown,
+    files: Record<string, string>,
+  ): void {
+    const dir = join(root, 'node_modules', ...key.split('/'));
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, 'package.json'),
+      JSON.stringify({
+        name: manifestName,
+        version: '0.0.0-fixture',
+        type: 'module',
+        main: 'dist/index.cjs',
+        exports: exportsField,
+      }),
+      'utf8',
+    );
+    for (const rel of Object.keys(files)) {
+      const target = join(dir, rel);
+      mkdirSync(dirname(target), { recursive: true });
+      writeFileSync(target, files[rel] as string, 'utf8');
+    }
+  }
+
+  /**
+   * A fresh app per case. The ESM module cache is keyed by absolute URL, so a
+   * shared fixture directory would let one case's load answer the next one's
+   * question — the failure mode this whole suite exists to detect.
+   */
+  function app(tag: string, extraDependencies: Record<string, string> = {}): string {
+    const root = mkdtempSync(join(tmpdir(), `os-aliased-dual-${tag}-`));
+    roots.push(root);
+    writeFileSync(
+      join(root, 'package.json'),
+      JSON.stringify({
+        name: 'aliased-dual-host-fixture',
+        type: 'module',
+        dependencies: {
+          [REGISTRY_KEY]: `npm:${REGISTRY_NAME}@1`,
+          [DRIVER_KEY]: `npm:${DRIVER_NAME}@1`,
+          [SUBPATH_KEY]: `npm:${SUBPATH_NAME}@^2.0.0`,
+          [PLAIN]: '^1.0.0',
+          ...extraDependencies,
+        },
+      }),
+      'utf8',
+    );
+    installAs(root, REGISTRY_KEY, REGISTRY_NAME, DUAL, {
+      'dist/index.js': REGISTRY_ESM,
+      'dist/index.cjs': REGISTRY_CJS,
+    });
+    installAs(root, DRIVER_KEY, DRIVER_NAME, DUAL, {
+      'dist/index.js': DRIVER_ESM,
+      'dist/index.cjs': DRIVER_CJS,
+    });
+    installAs(
+      root,
+      SUBPATH_KEY,
+      SUBPATH_NAME,
+      {
+        '.': { import: './dist/index.js', require: './dist/index.cjs' },
+        './plugin': { import: './dist/plugin.js', require: './dist/plugin.cjs' },
+      },
+      {
+        'dist/index.js': "export const WHERE = 'root-esm';\n",
+        'dist/index.cjs': "exports.WHERE = 'root-cjs';\n",
+        'dist/plugin.js': "export const WHERE = 'plugin-esm';\n",
+        'dist/plugin.cjs': "exports.WHERE = 'plugin-cjs';\n",
+      },
+    );
+    // NON-aliased, installed under its own name: the ordinary case, in the very
+    // same app, so a change that moved it would redden here.
+    installAs(root, PLAIN, PLAIN, DUAL, {
+      'dist/index.js': "export const BUILD = 'plain-esm';\n",
+      'dist/index.cjs': "exports.BUILD = 'plain-cjs';\n",
+    });
+    return root;
+  }
+
+  /** The instance an ESM consumer chain holds — what the Runtime reads. */
+  function esmInstance(root: string): Promise<{ BUILD: string; listRegistered: () => string[] }> {
+    return import(pathToFileURL(join(root, 'node_modules', REGISTRY_KEY, 'dist', 'index.js')).href);
+  }
+
+  /** The instance a CommonJS load lands in — where the registration used to go. */
+  function cjsInstance(root: string): Promise<{ BUILD: string; listRegistered: () => string[] }> {
+    return import(pathToFileURL(join(root, 'node_modules', REGISTRY_KEY, 'dist', 'index.cjs')).href);
+  }
+
+  // No `fallbackImport`: every fixture here is DECLARED, so the undeclared leg
+  // (the only consumer of that base) is never reached.
+  const importer = (root: string) => createHostImporter(root);
+
+  it('CONTROL: the reader can see BOTH answers, so an empty registry is a reading', async () => {
+    // Every assertion below rests on `listRegistered()` being able to come back
+    // non-empty. A probe that could only ever return `[]` would make the whole
+    // describe pass on a broken fix — so it is proved here, on the same
+    // instrument, before anything is measured with it.
+    const root = app('control');
+    const esm = await esmInstance(root);
+    const cjs = await cjsInstance(root);
+
+    expect(esm.BUILD).toBe('esm');
+    expect(cjs.BUILD).toBe('cjs');
+    expect(esm.listRegistered()).toEqual([]);
+    expect(cjs.listRegistered()).toEqual([]);
+  });
+
+  it('PRECONDITION: the CJS resolve SUCCEEDS here — this is #13330\'s leg, not #14041\'s', () => {
+    // What separates this card from #14278: nothing throws, so the fallback
+    // finder never runs and the load being corrected is one that works today.
+    // If a future Node stopped answering the `require` condition here, this
+    // says so rather than leaving the fix looking like a no-op.
+    const root = app('precondition');
+    expect(createHostRequire(root).resolve(DRIVER_KEY)).toMatch(/dist[/\\]index\.cjs$/);
+  });
+
+  it('THE CARD: an aliased dual publish loads the `import` build, not the `require` one', async () => {
+    const root = app('import-condition');
+    expect((await importer(root)(DRIVER_KEY)).BUILD).toBe('esm');
+  });
+
+  it("a driver's load-time registration lands in the instance an ESM caller reads", async () => {
+    // The defect stated as its consequence — the two-instances split. Before
+    // the fix this stayed `[]`.
+    const root = app('visible');
+    expect((await esmInstance(root)).listRegistered()).toEqual([]);
+    await importer(root)(DRIVER_KEY);
+    expect((await esmInstance(root)).listRegistered()).toEqual(['probe']);
+  });
+
+  it('and no longer lands in the CommonJS instance nothing reads', async () => {
+    // The other direction: the registration MOVED, it was not duplicated.
+    const root = app('cjs-empty');
+    await importer(root)(DRIVER_KEY);
+    expect((await cjsInstance(root)).listRegistered()).toEqual([]);
+    expect((await esmInstance(root)).listRegistered()).toEqual(['probe']);
+  });
+
+  it('the exports SUBPATH is still cut from the KEY, not from the aliased name', async () => {
+    // The two names are different questions (see `esmEntryForDeclared`). The
+    // package ROOT is recognised by the name the declaration promises; the
+    // SUBPATH is what the specifier spells after the key. Using the aliased
+    // name for both would compute a nonsense subpath here.
+    const root = app('subpath');
+    expect((await importer(root)(SUBPATH_KEY)).WHERE).toBe('root-esm');
+    expect((await importer(root)(`${SUBPATH_KEY}/plugin`)).WHERE).toBe('plugin-esm');
+  });
+
+  it('a `workspace:` ALIAS is recognised too; a plain `workspace:` range is a RANGE', async () => {
+    const aliased = app('workspace-alias', { 'ws-dual': 'workspace:@fixture/ws-dual-target@*' });
+    installAs(aliased, 'ws-dual', '@fixture/ws-dual-target', DUAL, {
+      'dist/index.js': "export const BUILD = 'ws-esm';\n",
+      'dist/index.cjs': "exports.BUILD = 'ws-cjs';\n",
+    });
+    expect((await importer(aliased)('ws-dual')).BUILD).toBe('ws-esm');
+
+    // `workspace:*` carries no name, so the key stays the expectation and the
+    // package installed under its own name is recognised exactly as before.
+    const plain = app('workspace-range', { '@fixture/ws-plain-dual': 'workspace:*' });
+    installAs(plain, '@fixture/ws-plain-dual', '@fixture/ws-plain-dual', DUAL, {
+      'dist/index.js': "export const BUILD = 'ws-plain-esm';\n",
+      'dist/index.cjs': "exports.BUILD = 'ws-plain-cjs';\n",
+    });
+    expect((await importer(plain)('@fixture/ws-plain-dual')).BUILD).toBe('ws-plain-esm');
+  });
+
+  it('CONTROL (non-aliased): an ordinary install\'s selected entry does not move', async () => {
+    // The control worth more than another aliased assertion: the risk in this
+    // change is a regression in the ordinary case, which already works. Same
+    // app, same importer, plain range, installed under its own name.
+    const root = app('plain-unmoved');
+    expect((await importer(root)(PLAIN)).BUILD).toBe('plain-esm');
+  });
+
+  it('CONTROL (non-aliased): a package publishing only `require` still loads', async () => {
+    // Narrowness, on the ordinary path: there is no `import` entry to prefer,
+    // so the resolved CJS path is used exactly as before. The fix may not turn
+    // a working load into a failure.
+    const root = app('require-only', { '@fixture/plain-require-only': '^1.0.0' });
+    installAs(root, '@fixture/plain-require-only', '@fixture/plain-require-only', {
+      '.': { require: './dist/index.cjs' },
+    }, { 'dist/index.cjs': "exports.BUILD = 'require-only';\n" });
+    expect((await importer(root)('@fixture/plain-require-only')).BUILD).toBe('require-only');
+  });
+
+  it('TIGHTNESS: an alias naming one package does not license a directory holding another', async () => {
+    // The expectation moved; the comparison did not. The declaration says this
+    // directory holds `@fixture/alias-declared`; it holds something else, so
+    // the walk must NOT recognise it as the declared package's root and the
+    // load stays on the CJS resolver's own answer — today's behaviour for an
+    // unrecognised root, unchanged.
+    const root = app('alias-mismatch', { 'aliased-wrong': 'npm:@fixture/alias-declared@1' });
+    installAs(root, 'aliased-wrong', '@fixture/alias-installed', DUAL, {
+      'dist/index.js': "export const BUILD = 'imposter-esm';\n",
+      'dist/index.cjs': "exports.BUILD = 'imposter-cjs';\n",
+    });
+    expect((await importer(root)('aliased-wrong')).BUILD).toBe('imposter-cjs');
+  });
+
+  it('TIGHTNESS: a NON-aliased declaration is still verified against the KEY', async () => {
+    // The other half of the same property: a plain range declares no alias, so
+    // a directory holding a different package is still not recognised. An
+    // aliased-install green that also greened this one would mean the walk got
+    // looser, not smarter.
+    const root = app('plain-mismatch', { '@fixture/plain-range': '^1.0.0' });
+    installAs(root, '@fixture/plain-range', '@fixture/somebody-else', DUAL, {
+      'dist/index.js': "export const BUILD = 'somebody-else-esm';\n",
+      'dist/index.cjs': "exports.BUILD = 'somebody-else-cjs';\n",
+    });
+    expect((await importer(root)('@fixture/plain-range')).BUILD).toBe('somebody-else-cjs');
+  });
+
+  it('BOUNDARY: a `link:` target whose manifest names something else keeps today\'s load', async () => {
+    // Declared residue, pinned rather than left silent. `link:` / `file:` name
+    // a LOCATION, so no package name can be parsed out of them and the key
+    // stays the expectation — exactly as #14278 ruled for the sibling leg. On
+    // THIS leg the consequence is a load rather than a refusal: the `require`
+    // build keeps loading. Widening it would mean recognising a package root
+    // the host never named, which is the direction the manifest-name check
+    // exists to refuse.
+    const root = app('link-mismatch', { 'linked-other': 'link:../elsewhere' });
+    installAs(root, 'linked-other', '@fixture/some-other-name', DUAL, {
+      'dist/index.js': "export const BUILD = 'linked-esm';\n",
+      'dist/index.cjs': "exports.BUILD = 'linked-cjs';\n",
+    });
+    expect((await importer(root)('linked-other')).BUILD).toBe('linked-cjs');
+  });
+});

--- a/packages/types/src/node.ts
+++ b/packages/types/src/node.ts
@@ -589,7 +589,75 @@ function exportsSubpathOf(specifier: string, packageName: string): string {
 }
 
 /**
- * The directory of the package named `packageName` that owns `resolvedFile`.
+ * Declaration values whose grammar is `<protocol>:<name>[@<range>]` — the two
+ * spellings in which a host DECLARES that a key is an alias for a package with
+ * a different name (#14278).
+ *
+ * `npm:` always names a package: `npm:bar@1`, `npm:@acme/x@^2`, or `npm:bar`
+ * with no range at all. `workspace:` names one ONLY in its aliased form
+ * (`workspace:bar@*`) — a bare `workspace:*` / `workspace:^1.2.3` is a RANGE,
+ * so the key stays the name. Everything else — a plain range, `link:`,
+ * `file:`, a git or tarball URL — carries no package name to expect: those
+ * name a LOCATION or a version, and the manifest name they install under is
+ * not derivable from the declaration at all.
+ */
+const ALIAS_DECLARATION_PROTOCOLS = [
+  { prefix: 'npm:', rangeRequired: false },
+  { prefix: 'workspace:', rangeRequired: true },
+] as const;
+
+/**
+ * The manifest `name` the host's own declaration promises the package it
+ * declares will carry — the key itself for an ordinary dependency, the ALIASED
+ * package's name for `"foo": "npm:bar@1"` (#14278).
+ *
+ * ⚠️ Read by BOTH legs, which is why it sits above both rather than inside
+ * either. They ask about different directories and it answers the same question
+ * for each — *what name does the host say this key is?*
+ *
+ * - the #14041 fallback ({@link hostInstalledPackageDir}) verifies the one
+ *   directory it consults, `<hostRoot>/node_modules/<key>`;
+ * - the #13330 succeeding leg ({@link packageRootOf}) recognises the package
+ *   root while walking up from the entry the CJS resolver already returned
+ *   (#15044).
+ *
+ * ⚠️ This moves each leg's EXPECTATION, never its strictness. The
+ * manifest-name check is what keeps the fallback strictly tighter than the CJS
+ * resolution it backs up (#14041's property, #4719's gate): a finder that
+ * accepted a directory without confirming it holds the declared package would
+ * be a looser finder, and loosening it would trade a confidently-wrong remedy
+ * for a wrong LOAD — the worse direction. So the expectation is still authored
+ * by the host, read out of the same `package.json` the declaration gate reads;
+ * only the sentence it spells changes, from "the key" to "what the host says
+ * the key is an alias for". An aliased install pointing at one package still
+ * refuses a directory holding another.
+ *
+ * Anything that does not parse as a bare package name yields no expectation to
+ * move to, so the key stays and the pre-#14278 refusal is kept: a `workspace:`
+ * range, a `link:` / `file:` location, an alias value carrying a subpath, a
+ * malformed value. Deliberate — {@link packageNameFromSpecifier} is the one
+ * authority on what a package name is here, and its own documentation blesses
+ * the aliased declaration shape. On the #13330 leg that residue is a load
+ * rather than a refusal: a `link:` target whose manifest names something else
+ * keeps today's `require`-condition entry, unchanged by #15044 and pinned as
+ * such.
+ */
+function declaredManifestName(declaration: HostDeclaration): string {
+  const { packageName, specifier } = declaration;
+  if (specifier === undefined) return packageName;
+  const protocol = ALIAS_DECLARATION_PROTOCOLS.find((p) => specifier.indexOf(p.prefix) === 0);
+  if (protocol === undefined) return packageName;
+  const value = specifier.slice(protocol.prefix.length);
+  // `<name>@<range>`: the LAST `@` separates them, so a scoped name's own
+  // leading `@` (index 0) is never mistaken for the separator.
+  const at = value.lastIndexOf('@');
+  if (at <= 0 && protocol.rangeRequired) return packageName;
+  const name = at > 0 ? value.slice(0, at) : value;
+  return packageNameFromSpecifier(name) === name ? name : packageName;
+}
+
+/**
+ * The directory of the package named `manifestName` that owns `resolvedFile`.
  *
  * Walked up from the resolved entry rather than computed from the specifier,
  * because the resolver's answer is a REALPATH: under pnpm that is inside
@@ -597,8 +665,17 @@ function exportsSubpathOf(specifier: string, packageName: string): string {
  * whose `node_modules` the package's own transitive imports resolve against —
  * and exactly what makes one physical copy shared between the app and the
  * framework.
+ *
+ * ⚠️ `manifestName` is what {@link declaredManifestName} reads out of the
+ * host's declaration, NOT the declaration key (#15044). For an aliased install
+ * — `{"foo": "npm:bar@1"}` — the realpath this walk climbs is `bar`'s own
+ * package directory, whose manifest is named `bar`; matching the key `foo`
+ * never succeeded, so the caller fell back to the CJS resolver's answer and an
+ * aliased dual-published package silently kept loading its `require` build,
+ * beside the `import` build the caller's own ESM chain holds. Matching the
+ * key made the walk unable to recognise the very package it had been handed.
  */
-function packageRootOf(resolvedFile: string, packageName: string): string | undefined {
+function packageRootOf(resolvedFile: string, manifestName: string): string | undefined {
   let dir = dirname(resolvedFile);
   // Bounded on purpose: a package root is a few segments above its entry, and
   // an unbounded walk on a broken layout would stat every ancestor up to `/`.
@@ -609,7 +686,7 @@ function packageRootOf(resolvedFile: string, packageName: string): string | unde
       };
       // A NESTED manifest — the `{"type":"commonjs"}` marker a dual build drops
       // in `dist/` — carries no name, so it is walked THROUGH, not stopped at.
-      if (manifest.name === packageName) return dir;
+      if (manifest.name === manifestName) return dir;
     } catch {
       // Not a manifest, or not readable. Keep walking.
     }
@@ -624,16 +701,28 @@ function packageRootOf(resolvedFile: string, packageName: string): string | unde
  * The file the `import` condition names for `specifier`, or `undefined` when
  * this seam has nothing to change — see the narrowness list in the #13330 note.
  *
+ * ⚠️ The two names here are different questions and only look alike (#15044).
+ * The package ROOT is recognised by the name the DECLARATION promises
+ * ({@link declaredManifestName}); the exports SUBPATH is cut from the
+ * declaration KEY, because the key is what the specifier is spelled with —
+ * `aliased/plugin` addresses `./plugin` of whatever `aliased` aliases. They
+ * coincide for every ordinary dependency, which is why one name served both
+ * until an aliased install pulled them apart.
+ *
+ * @param declaration What the host's `package.json` says about the key — the
+ * same value the #14041 fallback leg is handed, so both legs read one
+ * expectation from one place.
  * @param cjsResolved What `hostRequire.resolve(specifier)` answered. It is the
  * host-anchored part of the answer and is never second-guessed here; only the
  * CONDITION is re-decided.
  */
 function esmEntryForDeclared(
   specifier: string,
-  packageName: string,
+  declaration: HostDeclaration,
   cjsResolved: string,
 ): string | undefined {
-  const root = packageRootOf(cjsResolved, packageName);
+  const { packageName } = declaration;
+  const root = packageRootOf(cjsResolved, declaredManifestName(declaration));
   if (root === undefined) return undefined;
 
   let exportsField: unknown;
@@ -758,60 +847,6 @@ function hasInvalidExportsSubpathSegments(subpath: string): boolean {
       const segment = raw.toLowerCase();
       return segment === '' || segment === '.' || segment === '..' || segment === 'node_modules';
     });
-}
-
-/**
- * Declaration values whose grammar is `<protocol>:<name>[@<range>]` — the two
- * spellings in which a host DECLARES that a key is an alias for a package with
- * a different name (#14278).
- *
- * `npm:` always names a package: `npm:bar@1`, `npm:@acme/x@^2`, or `npm:bar`
- * with no range at all. `workspace:` names one ONLY in its aliased form
- * (`workspace:bar@*`) — a bare `workspace:*` / `workspace:^1.2.3` is a RANGE,
- * so the key stays the name. Everything else — a plain range, `link:`,
- * `file:`, a git or tarball URL — carries no package name to expect: those
- * name a LOCATION or a version, and the manifest name they install under is
- * not derivable from the declaration at all.
- */
-const ALIAS_DECLARATION_PROTOCOLS = [
-  { prefix: 'npm:', rangeRequired: false },
-  { prefix: 'workspace:', rangeRequired: true },
-] as const;
-
-/**
- * The manifest `name` the host's own declaration says
- * `<hostRoot>/node_modules/<key>` must carry — the key itself for an ordinary
- * dependency, the ALIASED package's name for `"foo": "npm:bar@1"` (#14278).
- *
- * ⚠️ This moves the finder's EXPECTATION, never its strictness. The
- * manifest-name check is what keeps the fallback strictly tighter than the CJS
- * resolution it backs up (#14041's property, #4719's gate): a finder that
- * accepted a directory without confirming it holds the declared package would
- * be a looser finder, and loosening it would trade a confidently-wrong remedy
- * for a wrong LOAD — the worse direction. So the expectation is still authored
- * by the host, read out of the same `package.json` the declaration gate reads;
- * only the sentence it spells changes, from "the key" to "what the host says
- * the key is an alias for". An aliased install pointing at one package still
- * refuses a directory holding another.
- *
- * Anything that does not parse as a bare package name yields no expectation to
- * move to, so the key stays and the pre-#14278 refusal is kept: a `workspace:`
- * range, an alias value carrying a subpath, a malformed value. Deliberate —
- * {@link packageNameFromSpecifier} is the one authority on what a package name
- * is here, and its own documentation blesses the aliased declaration shape.
- */
-function declaredManifestName(declaration: HostDeclaration): string {
-  const { packageName, specifier } = declaration;
-  if (specifier === undefined) return packageName;
-  const protocol = ALIAS_DECLARATION_PROTOCOLS.find((p) => specifier.indexOf(p.prefix) === 0);
-  if (protocol === undefined) return packageName;
-  const value = specifier.slice(protocol.prefix.length);
-  // `<name>@<range>`: the LAST `@` separates them, so a scoped name's own
-  // leading `@` (index 0) is never mistaken for the separator.
-  const at = value.lastIndexOf('@');
-  if (at <= 0 && protocol.rangeRequired) return packageName;
-  const name = at > 0 ? value.slice(0, at) : value;
-  return packageNameFromSpecifier(name) === name ? name : packageName;
 }
 
 /**
@@ -1059,7 +1094,14 @@ export function createHostImporter(
       // stays the authority on WHERE the package is; this asks that package
       // which entry an `import()` gets, so the caller's ESM chain and this
       // load share one instance of everything the package brings with it.
-      const entry = esmEntryForDeclared(pkg, declaration.packageName, resolved) ?? resolved;
+      //
+      // #15044: the whole DECLARATION goes in, not just the key. Recognising
+      // the package root by the key made an aliased install unrecognisable to
+      // its own re-decision — the walk failed, the `?? resolved` here caught
+      // it, and the load silently stayed on the `require` build #13330 exists
+      // to move it off. The fallback below the catch has taken the same
+      // declaration since #14278; the two legs now expect one name.
+      const entry = esmEntryForDeclared(pkg, declaration, resolved) ?? resolved;
       return import(pathToFileURL(entry).href);
     }
 


### PR DESCRIPTION
Fixes #15044

`createHostImporter`'s declared leg re-decides the **condition** for a package the CommonJS resolver has already located (the #13330 contract): it asks that package which entry an `import()` gets, so the caller's ESM chain and this load share one instance. That re-decision recognised the package root by walking up from the resolved entry until it found a `package.json` whose `name` equals the **declaration key**.

An aliased install — `{"dependencies": {"foo": "npm:bar@1"}}` — puts a manifest named `bar` under the key `foo`. The walk therefore never matched, `esmEntryForDeclared` returned `undefined`, and the `?? resolved` at the call site handed back the entry CommonJS resolution had answered: the `require` condition. For an aliased **dual-published** package the process was left holding two live copies of one package — the CommonJS build behind the host importer, the `import` build in the caller's own chain — which is exactly the split #13330 exists to remove.

## The population measurement, first

Triage fenced this card: *if the affected population is not narrow — ordinary installs reach this path too, or an in-tree package is dual-published and aliased — stop and report.* Measured before the fix, on `origin/main`. **The fence holds.**

| Measurement | Result |
|:---|:---|
| Alias declarations (`npm:`, aliased `workspace:NAME@RANGE`) across 81 workspace manifests / 875 dependency declarations | **0** — 400 plain-range, 475 `workspace:` range |
| Alias specifiers in `pnpm-lock.yaml` | **0** (6 `npm:` hits are all `engines:` maps and one dependency literally named `npm`; positive control: 855 `version:` hits) |
| In-tree dual-published packages (exports naming both an `import` and a `require` condition) | **66** |
| In-tree dual-published packages that are aliased anywhere | **0** — the cross-set is empty |
| Installed declarations whose `node_modules/KEY/package.json` name equals the key — i.e. the walk matches, build-independent | **867 of 867**; 8 not installed at that root |
| Declarations resolvable from their own root today, run through a verbatim replica of `packageRootOf` | **315 of 315 matched, 0 mismatches** |

Positive control for the zero: the same sweep pointed at a synthetic host declaring `{"foo": "npm:bar@1"}` reports **1 mismatch of 2 declarations**, flagged dual-published. The instrument can report a mismatch; the repo has none.

⇒ No ordinary, non-aliased install reaches this path. The `p3` grading and the "restores a contract, does not widen a surface" call both stand.

## The change

`esmEntryForDeclared` now takes the whole `HostDeclaration`, exactly as the #14041 fallback leg has since #14278, and recognises the package root by `declaredManifestName(declaration)` — the name the host's own declaration promises. That helper moved above both legs rather than staying inside the fallback section, because both now read it.

**Two names, two questions.** The package **root** is recognised by the name the declaration promises; the exports **subpath** is still cut from the declaration **key**, because the key is what the specifier is spelled with — `aliased/plugin` addresses `./plugin` of whatever `aliased` aliases. They coincide for every ordinary dependency, which is why one name served both until an alias pulled them apart. A regression test pins it.

**Only the expectation moves, never the strictness.** An alias naming one package still does not license a directory holding another; a non-aliased declaration is still verified against its key; `link:` / `file:` name a location rather than a package, so no name can be parsed out of them and they keep today's behaviour — pinned as a declared residue rather than left silent.

Nothing is exported. `packageRootOf` is module-private, called at one site, and named by neither subpath export of `@objectstack/types`, so the signature change is unreachable by any consumer.

## Before / after, shown rather than described

Ablation on the committed tree at `eb613ef6366`: `packageRootOf`'s argument reverted to the declaration key, mutation confirmed on disk by counting **both** the removed text (1 to 0) and an injected marker (0 to 1), plus a worktree blob-hash change.

Predicted direction, stated before the run: **red — exactly the 5 aliased cases, with all 7 non-aliased / tightness / boundary controls staying green.** Observed: `Tests 5 failed | 65 passed (70)`, and the 5 are precisely the predicted ones.

```
× THE CARD: an aliased dual publish loads the `import` build, not the `require` one
    AssertionError: expected 'cjs' to be 'esm'
× a driver's load-time registration lands in the instance an ESM caller reads
    AssertionError: expected [] to deeply equal [ 'probe' ]
× and no longer lands in the CommonJS instance nothing reads
× the exports SUBPATH is still cut from the KEY, not from the aliased name
    AssertionError: expected 'root-cjs' to be 'root-esm'
× a `workspace:` ALIAS is recognised too; a plain `workspace:` range is a RANGE
```

Restore proved by blob-hash equality with the HEAD blob (`97d373138e422e5e011596a33655eeb7314dd619`), an empty `git diff HEAD`, an empty `git status --porcelain`, and an absent-marker count of 0.

**Which resolution path the suite is on: source.** `src/node.test.ts` imports `./node.js` relatively and the package's vitest config declares no alias — and the ablation proves it rather than asserting it: `packages/types/dist/node.js` and `dist/node.mjs` existed at the time of the run (the whole workspace closure was built for the ratchet gates) and were never touched, yet a source-only mutation reddened the suite. A dist-resolving harness would have stayed green.

## The controls that matter more than the fix

The risk here is not the aliased case being corrected — it is a regression in the ordinary case that already works. Four controls, all in the same host app as the aliased fixtures, all green before and after:

- an ordinary plain-range dual publish still loads its `import` build;
- an ordinary package publishing only a `require` condition still loads;
- a plain-range key whose directory holds a different package is still not recognised;
- a `link:` target whose manifest names something else keeps today's `require`-condition load.

Plus the reader control the #13330 suite established: an empty registry is proved to be a reading, not an instrument that can only ever answer empty.

No ADR-0112 envelope is asserted because none is produced: this path never throws, before or after — the change moves which entry a working load returns, and can turn no working load into a failure.

## Verification

All run on `eb613ef6366`, the head of this branch; exit codes captured before any pipe.

- `pnpm --filter @objectstack/types test` — **19 files, 573 tests passed** (`src/node.test.ts` alone: 70 passed, 12 of them new)
- `pnpm --filter @objectstack/types typecheck` — exit 0; `tsc --noEmit --listFiles` confirms **both** `src/node.ts` and `src/node.test.ts` are in the program, so the green covers the new tests
- **Gate union: all 48 families** re-derived from the real changed paths by `scripts/pm/dispatch-gates.mjs` at this commit (36 by path + 7 by change kind + 7 declared whole-tree, 2 reached twice). 46 green on the first pass; `check:dual-build-cjs-loads` and `check:type-check-debt` answered `PREREQUISITE NOT MET` (exit 3, "this is NOT a pass") until the workspace closure was built, then both green — `check:dual-build-cjs-loads`: *103 published require entry points across 66 packages load*; `check:type-check-debt --re-measure`: *13 ledger entries re-measured, 143 raw errors, none above its recorded number*
- `pnpm lint` (repo-wide `eslint . --no-inline-config`) — exit 0, no narrowing claimed
- Control-byte self-scan of every touched file — clean, with a live positive control

## Changeset

`patch`, for `@objectstack/types`. The Check Changeset rule reserves `minor` for *a purely additive widening of a published package's public surface (a new exported symbol on an index, a new accepted key or value)*. This exports no new symbol, accepts no new key and no new value; it changes which entry a working `import()` returns for a population measured at zero in this workspace, restoring the condition contract the declared leg already promises. That is a bug fix in a released package, which takes `patch`. Not breaking — nothing an author can write is removed or renamed — so no ADR-0087 disposition marker is owed.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

_Generated by [Claude Code](https://claude.ai/code/session_01D47qPfEWVPmhguWgBZCi5N)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01D47qPfEWVPmhguWgBZCi5N)_