### PR TITLE
docs(rest): the ?type= diagnostics comment describes today's tree, and names the inner gate it sits above

### DIFF
--- a/content/docs/permissions/system-context.mdx
+++ b/content/docs/permissions/system-context.mdx
@@ -158,7 +158,7 @@ The largest single consumer — **17 of the 106 sites**.
 |:--|:---|:---|:---|:---|
 | 48 | Object API-exposure gate bypassed (`apiEnabled` / `apiMethods`) | runtime | Get: internal self-writes ignore exposure declarations — these govern **external** exposure, not engine self-writes | `action-execution.ts:138` |
 | 49 | Action `requiredPermissions` bypassed | runtime | Get: engine self-invocation runs any action | `action-execution.ts:401` |
-| 50 | `manage_metadata` bypassed on metadata writes | runtime, rest | Get: schema writes without the capability | `domains/meta.ts:471`, `:874`, `rest-server.ts:4972`, `:6386`, `:6634`, `:7065`, `:7258` |
+| 50 | `manage_metadata` bypassed on metadata writes | runtime, rest | Get: schema writes without the capability | `domains/meta.ts:471`, `:874`, `rest-server.ts:5016`, `:6430`, `:6678`, `:7109`, `:7302` |
 | 51 | The shared metadata-write verdict itself returns `allowed` | metadata-core | Get: the one function all of row 50's doors consult answers yes before any capability is examined | `meta-write-capability.ts:134` |
 | 52 | Anonymous-deny seam satisfied on the domain dispatchers and the package/federation routes | runtime, rest | Get: passes with no `userId` | `domains/actions.ts:421`, `domains/ai.ts:60`, `domains/automation.ts:989`, `domains/meta.ts:232`, `domains/security.ts:78`, `domains/packages.ts:422`, `external-datasource-routes.ts:302`, `package-routes.ts:97` |
 | 53 | MCP principal check satisfied | runtime | Get: MCP surface reachable with no user | `domains/mcp.ts:61` |

--- a/packages/rest/src/rest-server-meta-read-org-scope.test.ts
+++ b/packages/rest/src/rest-server-meta-read-org-scope.test.ts
@@ -567,28 +567,40 @@ describe('#13764 the history seams of this harness honour the org partition', ()
 //
 // ⭐ WHY ONLY THE `?type=` ARM IS REPAIRED, and why the untyped sweep is
 // PINNED AS-IS rather than left unmentioned. `getMetaDiagnostics` reads each
-// swept type through `getMetaItems({ type: t, organizationId })`, and
-// `getMetaItems` applies NO registry gate of its own — the organization it is
-// handed is used for whatever type it is handed. So the scope is per TYPE
-// while the request carries ONE `organizationId`:
+// swept type through `getMetaItems({ type: t, organizationId })`.
+//
+// ⚠️ [#14683, recorded by #15034] `getMetaItems` NOW APPLIES THE REGISTRY GATE
+// ITSELF, after folding the request type. This header used to say it applied
+// none and that the scope was therefore the caller's to decide per type; that
+// sentence is FALSE on today's tree. What survives it is the arm split below,
+// which is about how many types ONE `organizationId` is asked to cover:
 //
 //   • `?type=` ⇒ `targetTypes` is exactly that one type, so
 //     `organizationIdForMetaRead` over it IS the request's whole scope. Correct
 //     by construction, and repaired here.
 //   • no `?type=` ⇒ `targetTypes` is the whole registry, five
-//     `allowOrgOverride: true` types beside every other declared type. One org
-//     id cannot say "org-scoped for those five, env-wide for the rest", and
-//     `getMetaItems` UNIONS the named org's rows onto the env-wide ones — so a
-//     tenant named there would union pre-#6190 phantom rows (org-scoped rows on
-//     types with no per-org read channel, which boot hydration walks past) back
-//     into a governance report. The gap is reported on the card and pinned
-//     below so it cannot widen by accident in either direction.
+//     `allowOrgOverride: true` types beside every other declared type. The arm
+//     names no organization at all, so nothing is folded and nothing is
+//     unioned. ⚠️ The reason it stays that way is no longer "one org id cannot
+//     say org-scoped for those five, env-wide for the rest" — since #14683 the
+//     inner gate folds each `t` separately inside the sweep's own loop, so it
+//     could. It stays because closing it MOVES BEHAVIOUR and is somebody's
+//     decision on a card. The gap is pinned below so it cannot widen by
+//     accident in either direction.
 //
-// The controls are the load-bearing half. `?type=object` proves the predicate
-// is the REGISTRY-GATED one: a phantom org-scoped `object` row is planted
-// directly in the store — the write door cannot produce one, by #6190 — and
-// the sweep must not see it. Swap `organizationIdForMetaRead` for a raw
-// `ctx?.tenantId` at the call site and that assertion, and only it, turns red.
+// ── ⛔ WHAT THIS FILE NO LONGER DISCRIMINATES (#15034, MEASURED) ───────────
+//
+// This header used to end: "Swap `organizationIdForMetaRead` for a raw
+// `ctx?.tenantId` at the call site and that assertion, and only it, turns red."
+// MEASURED on the merged tree, that ablation now leaves this file 30/30 GREEN
+// — `getMetaItems`' own gate re-folds the raw tenant id, phantom control
+// included. Same fate as #14677's ablation B, and for the same reason.
+//
+// ⇒ What this file DOES still discriminate is the organization being DROPPED:
+// remove the `organizationId` the `?type=` arm passes and the six repair cases
+// above turn red (measured: 6 failed / 24 passed). Read the two apart before
+// citing this file as a pin on the door-side predicate — it pins that the arm
+// still FOLDS, never that the fold happens at the door.
 
 /** Rows in the backing store for one `(type, name, org)` slot. */
 function storedRowsFor<T extends { type: string; name: string; organization_id: string | null }>(
@@ -660,9 +672,12 @@ describe('#13753 GET /meta/diagnostics states the org partition on the ?type= ar
             // than written through the door. Rows like it exist in deployments
             // that ran before that ruling; boot hydration walks past them, so
             // they are dead, and a read door that named the org for every type
-            // would serve them again. PREDICTED DIRECTION: replace the
-            // predicate with `ctx?.tenantId` at the call site and the count
-            // below becomes 2.
+            // would serve them again. ⚠️ [#15034] PREDICTED DIRECTION,
+            // CORRECTED: replacing the predicate with `ctx?.tenantId` at the
+            // call site no longer moves this count — `getMetaItems`' own gate
+            // (#14683) re-folds it. What still drives it to 2 is a read door
+            // that reaches the store with the org unfolded, which is why the
+            // control stays.
             const written = await b.put(NON_OVERRIDABLE, 'accounts');
             expect(written.status, 'the control never wrote').toBe(200);
             expect(

--- a/packages/rest/src/rest-server.ts
+++ b/packages/rest/src/rest-server.ts
@@ -4752,15 +4752,22 @@ export class RestServer {
                         // [#13753] STATE THE ORG PARTITION — but only on the
                         // arm where ONE organization is the whole truth.
                         //
-                        // `getMetaDiagnostics` reads each type through
-                        // `getMetaItems({ type: t, organizationId })`, and
-                        // `getMetaItems` applies NO registry gate of its own:
-                        // whatever organization arrives is used for the type it
-                        // is handed, overridable or not (measured — the only
-                        // `organizationIdForMetaRead` call inside
-                        // `metadata-protocol` is the `page` read in
-                        // `protocol.ts`, nothing on this path). The scope is
-                        // therefore decided HERE, per type, by the caller.
+                        // `getMetaDiagnostics` reads each swept type through
+                        // `getMetaItems({ type: t, organizationId })`.
+                        //
+                        // ⚠️ [#14683] `getMetaItems` NOW APPLIES THE REGISTRY GATE
+                        // ITSELF — `organizationIdForMetaRead(request.type,
+                        // request.organizationId)`, one statement after it folds the
+                        // type through `canonicalizeMetaRequestType`. That is the
+                        // ONE inner gate this call site now sits above; the sibling
+                        // gate in the same file guards `getMetaItem` (the singular
+                        // overlay read, #14908), which this arm never reaches.
+                        //
+                        // ⛔ Until #14683 this comment said `getMetaItems` applied NO
+                        // registry gate of its own and the scope was therefore
+                        // decided HERE, per type, by the caller. That sentence is
+                        // FALSE on today's tree — do not reintroduce it, and do not
+                        // reason from it.
                         //
                         // ⇒ The `?type=` arm is exactly one type
                         // (`targetTypes = [request.type]`), so the predicate
@@ -4768,6 +4775,31 @@ export class RestServer {
                         // the answer is correct by construction. That is the
                         // arm Studio's per-type directory drill-down uses, and
                         // it is the arm repaired here.
+                        //
+                        // ── WHY THE FOLD IS DOUBLED, AND STAYS DOUBLED (#15034) ──
+                        //
+                        // The VALUE is redundant, and measured to be. Both sites fold
+                        // the identical string through the identical map — here
+                        // `canonicalMetaUrlType`, inside `getMetaItems` the same
+                        // function reached through `canonicalizeMetaRequestType` →
+                        // `canonicalMetaType` — so `f(t, f(t, o)) === f(t, o)` and the
+                        // inner application is the algebraic no-op. MEASURED: replace
+                        // this predicate with a raw `diagnosticsCtx?.tenantId` and
+                        // `rest-server-meta-read-org-scope.test.ts` stays 30/30 GREEN;
+                        // the inner gate re-folds it, phantom control included.
+                        //
+                        // ⭐ It is KEPT anyway, and the reason is TRUST DOMAIN rather
+                        // than value. `getMetaDiagnostics` is not a member of
+                        // `MetadataProtocol` at all — not required, not optional —
+                        // which is why it is reached through the `(p as any)` cast and
+                        // why the 501 above exists. The inner gate therefore belongs
+                        // to ONE implementation of an UNDECLARED extension, while this
+                        // predicate sits on the REST boundary and holds for every
+                        // `RestProtocol` a host can mount. Delete it and a REST door's
+                        // tenant scope becomes a function of which kernel is mounted —
+                        // and no pin can see that happen, because the harness boots the
+                        // bundled implementation. Defence in depth, on a seam the type
+                        // system does not cover.
                         //
                         // ⛔ The UNTYPED sweep is deliberately left env-wide,
                         // and this is a recorded gap rather than an oversight
@@ -4783,13 +4815,25 @@ export class RestServer {
                         // be read back INTO the governance report as `stats`
                         // counts and diagnostic entries. A dashboard whose job
                         // is reporting what is wrong would report rows that do
-                        // not survive a restart. One org id cannot express a
-                        // per-type scope, and inventing one at this call site
-                        // (a fan-out per overridable type, plus a REST-side
-                        // re-aggregation of `total`/`stats`/`scannedTypes`)
-                        // would make this door a second owner of the sweep's
-                        // arithmetic. The decision belongs where the type is
-                        // known — see the card.
+                        // not survive a restart.
+                        //
+                        // ⚠️ #14683 MOVED THIS ARGUMENT and the gap outlived it, so
+                        // read the two apart. What used to hold the untyped arm shut
+                        // was that one org id could not express a per-type scope from
+                        // here without a fan-out per overridable type and a REST-side
+                        // re-aggregation of `total`/`stats`/`scannedTypes`. That is no
+                        // longer the obstacle: `getMetaDiagnostics` calls
+                        // `getMetaItems` once per `t` INSIDE its own loop, and the
+                        // inner gate folds each `t` separately, so a single
+                        // `organizationId` handed to the untyped arm would already be
+                        // narrowed per type — phantoms of non-overridable types
+                        // included. ⛔ The gap nevertheless stays OPEN and stays
+                        // PINNED: closing it moves observable behaviour and is a
+                        // decision somebody makes on a card, not a side effect of a
+                        // comment repair (#15034 files it). The pin that guards it is
+                        // `the untyped sweep is still env-wide` in
+                        // `rest-server-meta-read-org-scope.test.ts` — if it reddens,
+                        // read that card before making it green.
                         //
                         // ⚠️ NOT a new org-resolution seam: `resolveExecCtx` is
                         // memoised per request (WeakMap keyed by `req`), the


### PR DESCRIPTION
Fixes #15034

Comments only. **No observable behaviour moves, on either branch of the design question** — the whole diff is comment text, proven mechanically below.

## The design question, answered: KEEP — defence in depth

The card's first unit of work is a deliberate answer, not a merge resolution. Answered from two measurements rather than a preference, and the two point in *opposite* directions — which is the finding.

### 1. The VALUE is redundant, and measured to be

Both applications fold the identical string through the identical map:

- the door folds with `canonicalMetaUrlType(diagnosticsType)`;
- `getMetaItems` folds with `canonicalizeMetaRequestType` → `canonicalMetaType` → **the same `canonicalMetaUrlType`**, one statement before its own gate.

`getMetaDiagnostics` sets `targetTypes = [request.type]` on the `?type=` arm and passes that same raw segment down, so `f(t, f(t, o)) === f(t, o)` and the inner application is the algebraic no-op. **There is no path reachable from this arm that hands the inner gate a type the door has not already folded.**

**Ablation M1** — swap the door's predicate for a raw `diagnosticsCtx?.tenantId`. Predicted direction stated first: *stays green*, because the inner gate re-folds.

```
### AFTER: removed-text count = 0, marker count = 1
### MUTATION CONFIRMED ON DISK
 Test Files  1 passed (1)
      Tests  30 passed (30)
```

Green. The door-side predicate buys **nothing at runtime** today.

### 2. But the two gates are not in the same TRUST DOMAIN — and that is why it stays

`getMetaDiagnostics` is **not a member of `MetadataProtocol`** — not required, not optional (`packages/spec/src/api/protocol.zod.ts`, the interface declares `getMetaItems` / `getMetaItem` / `saveMetaItem` plus a list of optional members; this is on neither list). That is exactly why the door reaches it through the `(p as any)` cast and answers 501 `NOT_IMPLEMENTED` when a kernel does not implement it, and why `packages/client` documents it as "501s on kernels without `getMetaDiagnostics`".

⇒ **The inner gate belongs to ONE implementation of an UNDECLARED extension. The door-side predicate sits on the REST boundary and holds for every `RestProtocol` a host can mount.** Delete it and a REST door's tenant scope becomes a function of which kernel is mounted.

⭐ And the sharpest part: **no pin can see that happen**, because the harness boots the bundled implementation — M1 is the proof. So the DELETE branch is worse than the card's cost asymmetry estimated: it is not merely "owes one more pin", it is "owes a pin that cannot be written in this package".

The comment now carries this reason, per the acceptance criterion for the KEEP branch. **No pin change owed.**

## Which site is which — established here, by symbol

The card and the routing notes cite two different anchors and they are two different things. Measured on the merged ref `ba426b0f091`, unedited:

| site | line on `origin/main` | what it is |
| --- | --- | --- |
| `diagnosticsOrganizationId = organizationIdForMetaRead(` | **`:4808`** | the `?type=` **computation** |
| `// getMetaItems applies NO registry gate of its own:` | **`:4757`** | **the falsified comment — THIS CARD** |
| `// organizationIdForMetaRead(canonicalMetaUrlType(` | **`:5536`** | ⚠️ a **different door** — `GET /meta/:type/:name/references` |

Triage's verified anchor for "the comment" was `:5531`, which on today's ref is `:5536` — **the references door, not this card's site.** Both sites quote the same string and both assert the same falsified clause, which is how they came to be conflated. The site this card is about is `:4757`.

Inner gates re-verified on my own merged ref: `packages/metadata-protocol/src/protocol.ts:6958` (plural, #14683) and `:7583` (singular overlay read, #14908).

⭐ **This call site sits above exactly ONE of them, not two.** `getMetaDiagnostics` only ever calls `getMetaItems`; the singular `getMetaItem` gate is under the by-name read door and this arm never reaches it. The comment says so.

## The harness is corrected too, because M1 falsified it as well

`packages/rest/src/rest-server-meta-read-org-scope.test.ts` — the file the card's acceptance criteria name as the ready-made harness — carried the **same** falsified sentence in its header, plus an ablation recipe that M1 measured false:

> Swap `organizationIdForMetaRead` for a raw `ctx?.tenantId` at the call site and that assertion, and only it, turns red.

It does not turn red. Same fate as #14677's ablation B, for the same reason. Its inline `PREDICTED DIRECTION` note said the same thing and is corrected with it.

**Ablation M2** — what the file *does* still discriminate: drop the organization the `?type=` arm passes. Predicted red, and red:

```
 Test Files  1 failed (1)
      Tests  6 failed | 24 passed (30)
       × view: the org-scoped item is counted
       × dashboard: the org-scoped item is counted
       × report: the org-scoped item is counted
       × translation: the org-scoped item is counted
       × email_template: the org-scoped item is counted
       × a plural URL spelling is folded before the scope decision, not after
```

Taken in scope under the bounded in-place rule, all four conditions checked: same defect class and the same sentence; mechanical, with M1 as the pinning evidence; **33/33 open PR heads measured, 0 hits** on this file *or* on `rest-server.ts` (git, against each head's own merge-base — extends the dispatch note's `rest-server.ts`-only scan); same gate family, no new verification surface.

## Ablation hygiene

Both legs: predicted direction stated before running · mutation proven on disk by counting **both** the removed text and an injected marker (a zero-hit edit would have exited 0 and read as a clean run) · restored under a `trap` with **absolute** paths · restore proven by **blob-hash equality against the HEAD blob** *and* an empty `git diff HEAD`, empty hash treated as failure:

```
HEAD blob: 31d5b24f5256516fc39861e565cfbef36bbb03d9
work blob: 31d5b24f5256516fc39861e565cfbef36bbb03d9
RESTORE OK: blob hashes equal
--- git diff HEAD (must be empty) ---
(end)
```

**Resolution path, stated:** `packages/rest`'s vitest config aliases only `plugin-hono-server` and `service-datasource`, so **`@objectstack/metadata-protocol` resolves through `dist/`** — registered in `KNOWN_UNALIASED_TEST_IMPORTS` under `@objectstack/rest`. A source-only mutation of the inner gate would have measured nothing, so the closure was built first and the artifact checked before any reading: `grep -c` over `packages/metadata-protocol/dist/index.js` returns **2** occurrences of `organizationIdForMetaRead(request.type, request.organizationId)` — both inner gates live in the artifact the suite actually resolves. The mutated file itself (`rest-server.ts`) is **source**-resolved through a relative import, so no rebuild was owed for the mutation legs. `typecheck` is on the *other* axis — its tsconfig `paths` redirects the same specifier to **source**.

## Verification

Union re-derived from the real changed paths with `scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` on a tree the tool does **not** call stale (the first derivation reported STALE TREE, 4 commits behind; fast-forwarded to `ba426b0f091` and re-derived). 31 families run; the ratchet families re-run **after that round's final commit, at `d993d6c1e42`**, all exit 0. (The repair round below re-derives and re-runs on the new head — that sentence describes the first round only.)

```
check:nul-bytes  check:doc-authoring  check:route-envelope  check:slot-lookup
check:objectql-double-limit  check:engine-double-contract  check:test-source-alias
check:type-source-resolution  check:authz-resolver  check:error-code-casing
check:filter-alias-parity  check:cross-package-test-inputs  check:keyed-text-bounds
check:undeclared-dep-imports  check:comment-mask-corpus  check:comment-mask-adoption
check:org-identifier  check:tenant-chokepoint  check:single-claim-paths
check:published-files  check:where-matcher  check:page-declaration-shape
check:logger-receiver-detach  check:error-status-conformance  check:overlay-whitelist-table
check:stack-collection-maps  check:console-injection  check:dispatcher-error-vocabulary
check:closing-keyword-parity  check:reference-carrier-shape
```

Artifact-roster families were run rather than read as cleared: `check:error-code-casing` and `check:filter-alias-parity` both score `silent` for every card, and both are green here.

```
pnpm --filter @objectstack/rest test        179 files / 3058 tests passed
pnpm --filter @objectstack/rest typecheck   tsc --noEmit + check:test-typecheck OK
```

⚠️ `typecheck` coverage was **verified, not assumed**: `packages/rest/tsconfig.json` excludes `**/*.test.ts`, so `tsc --noEmit` alone says nothing about the harness edit. `--listFiles` confirms `rest-server.ts` is in the `tsc` program (1 hit) and `rest-server-meta-read-org-scope.test.ts` is in the `tsconfig.test.json` program (1 hit).

**No observable behaviour moves** — mechanically checked, not asserted: every added and removed line in this diff is a comment line.

```
git diff -U0 | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' \
  | grep -vE '^[+-]\s*//' | grep -vE '^[+-]\s*$'
(no output)
```

## Repair round — the census gate's line anchors

The first push was red on one required context, `Lint & Repo Gates`, and on one gate inside it: `check-system-context-census`. Its `--self-test` leg passed; the corpus leg reported **10 problems, all on `packages/rest/src/rest-server.ts`** — five `[anchor-is-not-a-read-site]` (4972, 6386, 6634, 7065, 7258) and five `[site-without-a-row]` (5016, 6430, 6678, 7109, 7302), pairing at a uniform **+44**.

**Cause.** `content/docs/permissions/system-context.mdx` row 50 anchors that file **by line number**, and this PR's comment adds a net 44 lines above every `isSystem` read site in it — hunks `+7`, `+25` and `+12`, all above `:4755`. Every citation below the insertion rotted by exactly 44.

**That it is a pure shift was verified against the tree, not inferred from the log.** The whole census JSON, re-derived at the merge base and at this head, differs in exactly five `line` fields, each +44:

```
json line 539:   4972  →  5016
json line 546:   6386  →  6430
json line 553:   6634  →  6678
json line 560:   7065  →  7109
json line 567:   7258  →  7302
(every other byte of the census JSON identical)
```

Nothing else moved — same sites in the same order, same receivers, same package and file lists, same text counts. No elevation read site arrived or vanished. (Line-content identity alone would not have shown this: four of the five lines are the same string, so the census diff is the load-bearing evidence, not the `sed -n` comparison.)

**Repair: the gate's own `--fix`, never a hand-edited line number.**

```
node scripts/check-system-context-census.mjs --fix
  re-anchored content/docs/permissions/system-context.mdx:161  `rest-server.ts:4972` -> `rest-server.ts:5016`
  re-anchored content/docs/permissions/system-context.mdx:161  `:6386` -> `:6430`
  re-anchored content/docs/permissions/system-context.mdx:161  `:6634` -> `:6678`
  re-anchored content/docs/permissions/system-context.mdx:161  `:7065` -> `:7109`
  re-anchored content/docs/permissions/system-context.mdx:161  `:7258` -> `:7302`
check-system-context-census --fix: 5 anchor(s) rewritten
```

⭐ **`--fix` REFUSED ZERO files.** Per the gate's header that sentence is the whole point: the refusal is the gate's only signal that a site arrived or vanished, so a clean rewrite is what separates a pure re-anchor from a population change that merely happened to be shifted at the same time. The diff is one table row, five numbers, nothing else.

**Gate exit code: 1 before, 0 after.** Both legs green after the repair:

```
node scripts/check-system-context-census.mjs --self-test   exit 0  (all cases passed)
node scripts/check-system-context-census.mjs               exit 0
  OK — 106 elevation read sites in 20 packages across 45 files, all anchored;
       140 anchors resolve, 27 declared non-read.
```

**Union re-derived and re-run on the repair head (`a8cfb760115`).** The first derivation again reported STALE TREE (5 commits behind `origin/main`, 3 of the gate-deriving scripts changed in that range), so the family list was re-derived a second time from a tree at `origin/main` carrying this change set. **Both derivations agree: 73 runnable families, 62 matched by path.** All 73 exit 0 at `a8cfb760115`, exit codes captured after redirection, never through a pipe.

Six needed a second pass and none was a finding:

- `check:doc-formula-expressions`, `check:doc-security-posture`, `check:dual-build-cjs-loads`, `check:type-check-debt` first answered **exit 3 PREREQUISITE NOT MET** — the workspace closure was unbuilt. Re-run after `turbo run build --filter='./packages/*' --filter='./packages/*/*'` (the command lint.yml uses): all four exit 0.
- `check:skill-examples` answered exit 1 for the same reason in different words (`packages/client-react/dist` held no declarations). After the build: exit 0, 257 prose examples type-check.
- `check:docs-audit-scope` answered exit 1 on the pre-existing #15446 / #15328 defect, not on this diff: `check:skill-examples` leaves `packages/spec/.examples-build*/` behind, `walkSourceFiles` skips only `node_modules`, `dist` and `.turbo`, so 233 gitignored byproduct files enter the walk and the live pin "every contract declaration admitted is a packages/spec API declaration" fails. **Proven not ours:** the same commit in a fresh worktree passes 568/568, and the polluted tree passes again once the byproduct directories are removed.

### A standing tax on this file, worth knowing before the next edit

`system-context.mdx` cites `packages/rest/src/rest-server.ts` at **eight** absolute line numbers — `:1553`, `:1582`, `:1585` and row 50's five. The file is **12,864 lines**, so any diff that changes the line count above `:7302` — comments included — rots at least one citation and reds this gate. It has happened before: the gate's own header records `rest-server.ts` displaced `+3/+11` by a merge, and a sibling file's shift "cost a patch round". The repair is one command, not a hand-written row, **provided the diff neither adds nor removes an `isSystem` read site**; if it does, `--fix` refuses by design and a human writes the row.

## Changeset

`skip-changeset`, applied at PR-open time. The rule is `.github/workflows/pr-automation.yml`, Check Changeset step, route 2 — "it releases nothing". This diff is comment text plus a test file plus a docs line-number re-anchor: no public surface, no behaviour, nothing a consumer can observe. `changeset-check` carries no paths filter, so it does **not** skip for this diff on its own; the label is the mechanism. Confirmed still applied on the repair head, and the `Check Changeset` run reports `skipped`.

## Fences honoured

`packages/spec` read only · `packages/rest/src/error-response.ts` untouched (single writer, #14704, held by PR #15452) · `content/docs/releases/` untouched · **`protocol.ts` untouched** — the enumeration finding below is filed, not edited, and PR #15592 is open on that file. The repair round's only new path is `content/docs/permissions/system-context.mdx`, which is hand-written docs and not a governed surface.


---
_Generated by [Claude Code](https://claude.ai/code/session_01D47qPfEWVPmhguWgBZCi5N)_