### PR TITLE
fix(verify): wire the test layer into `typecheck` and graduate its TEST_DEBT entry

### DIFF
--- a/packages/verify/package.json
+++ b/packages/verify/package.json
@@ -23,8 +23,7 @@
     "dev": "tsc -w",
     "test": "vitest run",
     "typecheck": "tsc --noEmit && pnpm check:test-typecheck",
-    "check:test-typecheck": "tsx ../../scripts/check-test-typecheck.mts --self-test && tsx ../../scripts/check-test-typecheck.mts --package packages/verify --project tsconfig.test.json",
-    "gen:test-typecheck-debt": "tsx ../../scripts/check-test-typecheck.mts --update --package packages/verify --project tsconfig.test.json"
+    "check:test-typecheck": "tsx ../../scripts/check-test-typecheck.mts --self-test && tsx ../../scripts/check-test-typecheck.mts --package packages/verify --project tsconfig.test.json"
   },
   "dependencies": {
     "@objectstack/core": "workspace:*",

--- a/packages/verify/package.json
+++ b/packages/verify/package.json
@@ -22,7 +22,9 @@
     "build": "tsup --config ../../tsup.config.ts && node ../../scripts/check-dts-emitted.mjs",
     "dev": "tsc -w",
     "test": "vitest run",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit && pnpm check:test-typecheck",
+    "check:test-typecheck": "tsx ../../scripts/check-test-typecheck.mts --self-test && tsx ../../scripts/check-test-typecheck.mts --package packages/verify --project tsconfig.test.json",
+    "gen:test-typecheck-debt": "tsx ../../scripts/check-test-typecheck.mts --update --package packages/verify --project tsconfig.test.json"
   },
   "dependencies": {
     "@objectstack/core": "workspace:*",

--- a/packages/verify/src/harness.host-resolution.test.ts
+++ b/packages/verify/src/harness.host-resolution.test.ts
@@ -31,7 +31,7 @@ import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { bootStack } from './harness';
+import { bootStack } from './harness.js';
 
 /**
  * Stand-in for `@objectstack/organizations`. Mirrors the real plugin's

--- a/packages/verify/src/harness.posture-only.test.ts
+++ b/packages/verify/src/harness.posture-only.test.ts
@@ -20,7 +20,7 @@
 // claim untestable: green whether or not the option actually stands alone.
 
 import { describe, it, expect, afterEach } from 'vitest';
-import { bootStack } from './harness';
+import { bootStack } from './harness.js';
 
 const app = {
   manifest: {

--- a/packages/verify/src/harness.posture.test.ts
+++ b/packages/verify/src/harness.posture.test.ts
@@ -13,7 +13,7 @@
 // integration test.
 
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { bootStack } from './harness';
+import { bootStack } from './harness.js';
 
 class FakeOrganizationsPlugin {
   readonly name = 'fake-organizations';

--- a/packages/verify/tsconfig.test.json
+++ b/packages/verify/tsconfig.test.json
@@ -1,0 +1,62 @@
+// The TEST-layer type-check program (#15145), adopting the #5286 mechanism that
+// #5449 generalised and that 30 sibling configs now use. `tsconfig.json` beside
+// this file is unchanged: it is the BUILD config, its `exclude` of
+// `**/*.test.ts` stays, and this sibling puts the excluded layer in front of
+// tsc. `package.json`'s `typecheck` NAMES this file (via
+// `check:test-typecheck --project`), because a config no script invokes is
+// exactly the phantom this whole mechanism is about.
+//
+// BEFORE THIS FILE, NO tsc PROGRAM COMPILED A SINGLE TEST FILE HERE, and that
+// is measured rather than read off the config. On the tree at 1d67130585 with
+// the workspace closure built first, `tsc --noEmit --listFiles -p tsconfig.json`
+// puts 0 of this package's 10 `src/*.test.ts` files in the program while
+// holding all 9 of its non-test `src/**` files -- so the zero is the `exclude`
+// line and not a probe that sees nothing. The same probe against THIS config,
+// on that same tree, names 10 of 10 (981 program files -> 990).
+//
+// ⚠️ ROUTE (b) WAS AVAILABLE HERE AND WAS NOT TAKEN, which is worth recording
+// because `check-type-check-coverage.mjs` tells the next reader to assume it is
+// not: dropping `**/*.test.ts` from `tsconfig.json`'s `exclude` leaves
+// `pnpm check:type-source-resolution` GREEN for this package (measured under a
+// trap-restored mutation at 1d67130585 -- exit 0, 124 programs across 78
+// packages), unlike the 14 of 18 entries that gate reports as red. It was
+// declined on module semantics, not on availability: vitest executes these
+// files through vite, which resolves extension-less relative specifiers, while
+// `tsconfig.json` inherits `NodeNext` from the repo root and demands `.js` on
+// every one of them. Route (b) would hold the test layer to a resolver that
+// never runs it -- the same config-tier noise the shared gate's header
+// attributes 108 of spec's 842 raw errors to. Matching vitest is fidelity, not
+// laxity, and it is why 28 of the 30 sibling configs override these two keys.
+//
+// ⛔ STRICTNESS IS UNTOUCHED. `strict`, `noUnusedLocals`, `noUnusedParameters`,
+// `noImplicitReturns`, `esModuleInterop` and the rest are inherited from
+// `tsconfig.json` (and through it from the repo root). `rootDir: ".."` and the
+// `@objectstack/core` source `paths` rule are inherited too, deliberately: this
+// program resolves core's types from source for the same #15229 reason the
+// build config does. Nothing here may loosen a type rule; if a test does not
+// compile, that is the finding.
+//
+// MEASURED on the tree at 1d67130585, workspace closure built first (an error
+// count taken against an unbuilt closure is not a reading -- unresolved-import
+// cascades inflate it): this program reports 0 errors over 10 test files, so
+// there is no `test-typecheck-debt.json` beside it and every error any of those
+// 10 files ever gains is red on arrival. 14 of the 30 sibling configs are in
+// that same state. This layer also holds ZERO `@ts-expect-error` directives
+// (grepped with a positive control -- the same grep hits `packages/spec/src`),
+// so no pin was silently dead here; what the gap cost was the other half. The `@objectstack/verify` TEST_DEBT entry in
+// `scripts/check-type-check-coverage.mjs` graduates in this same PR: it recorded
+// TS2835 x3 for three extension-less `./harness` imports, and with those three
+// given their `.js` the gate re-measured the entry at 0 ("TEST_DEBT records 3,
+// and tsc now reports 0 -- graduation candidate").
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/verify/tsconfig.test.json
+++ b/packages/verify/tsconfig.test.json
@@ -43,7 +43,18 @@
 // 10 files ever gains is red on arrival. 14 of the 30 sibling configs are in
 // that same state. This layer also holds ZERO `@ts-expect-error` directives
 // (grepped with a positive control -- the same grep hits `packages/spec/src`),
-// so no pin was silently dead here; what the gap cost was the other half. The `@objectstack/verify` TEST_DEBT entry in
+// so no pin was silently dead here; what the gap cost was the other half.
+//
+// ⛔ AND THEREFORE NO `gen:test-typecheck-debt` SCRIPT EITHER. That pairing is
+// 1:1 across all 30 sibling configs -- 16 with a ledger declare the generator,
+// 14 without one declare nothing -- and it is enforced rather than stylistic:
+// `check:merge-driver` requires every manifest generator to carry a merge
+// disposition in `scripts/regen-artifacts.mjs`, and #14062's note on that file
+// refuses to invent one for a ledger that does not exist. Measured here: adding
+// the script alone reds that gate ("generator(s) with NO recorded merge
+// disposition: gen:test-typecheck-debt [@objectstack/verify]"). If this layer
+// ever measures non-zero, the ledger, the generator and its regen-artifacts row
+// arrive together, in that one PR. The `@objectstack/verify` TEST_DEBT entry in
 // `scripts/check-type-check-coverage.mjs` graduates in this same PR: it recorded
 // TS2835 x3 for three extension-less `./harness` imports, and with those three
 // given their `.js` the gate re-measured the entry at 0 ("TEST_DEBT records 3,

--- a/scripts/check-type-check-coverage.mjs
+++ b/scripts/check-type-check-coverage.mjs
@@ -1033,6 +1033,59 @@ const EXEMPT = {
 // So the shrink-only guarantee did not loosen here; it moved to a strictly
 // sharper instrument, one that also reddens on a wholesale substitution of
 // error IDENTITY at a constant total, which a per-package integer cannot see.
+//
+// ── #15145: `@objectstack/verify` GRADUATED — and this one WAS paid down ───
+//
+// `verify` (3) left this ledger on 2026-09-04. ⛔ Do NOT read it through the
+// blocks above it: those all warn that a deleted entry left its population
+// undiminished, and this one is the other case (`plugin-security` is the
+// nearest precedent, and even it ledgered nothing only because its 9 residual
+// errors were repaired by hand). Here the entry recorded
+// TS2835 x3 for three extension-less `./harness` imports, all three were given
+// their `.js`, and the re-measure then read the entry at ZERO before anything
+// was wired -- this gate's own line, quoted: "@objectstack/verify: TEST_DEBT
+// records 3, and tsc now reports 0 -- graduation candidate". So there is no
+// `packages/verify/test-typecheck-debt.json`: at zero residue a bare
+// `tsc --noEmit -p tsconfig.test.json` is the stronger gate, the call
+// `plugin-security`, `metadata-core`, `metadata-fs` and `trigger-record-change`
+// made before it, and every error any of the package's 10 test files ever gains
+// is red on arrival with no ledger to be added to.
+//
+// ⚠️ MEASURED IN THAT ORDER ON PURPOSE, because the entry's own note predicted
+// the outcome ("the same one-line fix graduates this entry") and a prediction is
+// not a licence. Collapsing a TS2835 cascade EXPOSES errors as well as removing
+// them -- the #8612 lesson this ledger carries twice above -- and the card that
+// filed this had itself watched the entry drift 3 -> 5 (+2 TS7006) the moment
+// two `.then` callbacks were added behind that same unresolved specifier. The
+// honest move on an upward count is to RE-TALLY, not to delete. Here it went
+// down, and only the measurement could say which.
+//
+// THE WIRING IS THE OTHER HALF, and it is what the entry's disappearance now
+// rests on: `packages/verify/tsconfig.test.json` compiles `src/**/*` with
+// vitest-matching module semantics and `package.json`'s `typecheck` NAMES it,
+// so `hidesTests` is false. Measured with the closure built: the build config
+// puts 0 of the package's 10 `src/*.test.ts` in its program (and all 9 non-test
+// `src/**` files); the test config puts 10 of 10. The package's own advertised
+// `typecheck` was green over a layer it had never read -- which is the defect
+// the card was about, and which deleting a ledger entry alone would have left
+// exactly where it was.
+//
+// ⚠️ The pin half reported nothing here in either direction and still does not:
+// this package's test layer holds ZERO `@ts-expect-error` directives (grepped
+// with a positive control -- the same grep hits `packages/spec/src`), so
+// PINS_CHECKED had no subject. The card's sharpest line -- that a
+// `ts-expect-error` in those files is a phantom check -- is a statement about
+// what WOULD happen, not about an existing dead pin, exactly as `cli`'s
+// graduation recorded for its own 115 files.
+//
+// ⚠️ ROUTE (b) WAS AVAILABLE HERE and was still not taken. The #11491 note
+// above names `verify` as one of the 4 entries whose exclusion could be dropped
+// with `check:type-source-resolution` staying green, and that split was
+// re-measured on 2026-09-04 under a trap-restored mutation and still holds for
+// this package (exit 0; 124 programs across 78 packages). It was declined on
+// module semantics: `tsconfig.json` inherits NodeNext from the repo root and
+// would hold the test layer to a resolver vitest never runs it under. Onboard
+// by WIRING, not by widening the build config.
 const TEST_DEBT = {
 // ── #14710: `@objectstack/cli` GRADUATED, and it was not paid down ─────────
 //
@@ -1153,16 +1206,6 @@ const TEST_DEBT = {
       + '(173,52), where the local `ok()` helper pins its second argument to the exact shape of the '
       + 'module-level `VARS` and a partial context cannot satisfy it; the same file already carries a '
       + 'hand-widened copy of that helper (`filterOf`) written for exactly that reason.',
-  },
-  '@objectstack/verify': {
-    errors: 3,
-    note: 'TS2835 x3 -- `harness.host-resolution`, `harness.posture-only` and `harness.posture` each '
-      + 'import `./harness` without the `.js` extension. Re-tallied from the 8 measured at 5ab08428 '
-      + '(TS2835 x4, TS7006 x4) when `derive.test.ts` gained its own extension: that ONE unresolved '
-      + 'import was carrying 1 x TS2835 plus every TS7006 in the file, because a specifier that does '
-      + 'not resolve under NodeNext makes every symbol it names `any` and so every callback parameter '
-      + 'implicitly any. The remainder is the same NodeNext pair from the top-of-ledger note, and the '
-      + 'same one-line fix graduates this entry.',
   },
   '@objectstack/connector-mcp': { errors: 5, note: 'TS2339 x5. Re-measured 5 at 5ab08428, exact.' },
   '@objectstack/connector-openapi': { errors: 5, note: 'TS2339 x5. Re-measured 5 at 5ab08428, exact.' },


### PR DESCRIPTION
Fixes #15145

`packages/verify/tsconfig.json` excludes `**/*.test.ts` and the package's `typecheck` was a bare `tsc --noEmit` against that config, so the script was green over a layer no tsc program read. This wires the layer in the way 30 sibling packages already do, and the `@objectstack/verify` TEST_DEBT entry graduates in the same PR.

## 1. Baseline, then the fix, then the re-measure — in that order

Ruling on the card was that steps 1 and 2 be **measured, not assumed**: the three `TS2835` make every symbol those imports name resolve to `any`, so fixing them can *reveal* diagnostics and the honest move on an upward count is to re-tally, never to delete.

| step | `pnpm check:type-check-debt` verdict, quoted from the gate |
|:--|:--|
| baseline, unmodified tree at `f1d787294f0` | `OK — 13 ledger entr(ies) re-measured in 108.6s, 143 raw tsc error(s) total, none above its recorded number.` / `surplus: none — every entry sits exactly at its measurement` |
| after the three `.js` extensions, at `1d671305858` | `ℹ @objectstack/verify: TEST_DEBT records 3, and tsc now reports 0 -- graduation candidate.` |
| final head `02b1bdcde2d` | `OK — 12 ledger entr(ies) re-measured in 142.9s, 140 raw tsc error(s) total, none above its recorded number.` / `surplus: none` |

**The count went DOWN, to zero.** So ruling 2's first branch applies and the entry is deleted here, not re-tallied. The prediction in the entry's own note ("the same one-line fix graduates this entry") turned out right — but it was a prediction, and only the middle row above could say so.

`check:type-check-coverage` moves consistently with that: `test layer: 9 package(s) still hide their own tests from tsc (118 files hidden ..., 90 frozen raw errors in TEST_DEBT)` becomes `8 package(s) ... (108 files hidden ..., 87 frozen raw errors)`. Minus one package, minus ten files, minus three errors.

## 2. The wiring route, and why route (b) was declined although it was available

Route **(a)**, the #5286 sibling: `packages/verify/tsconfig.test.json` plus `check:test-typecheck --package packages/verify --project tsconfig.test.json` named in the `typecheck` chain. `tsconfig.json` is untouched.

Route (b) — dropping `**/*.test.ts` from `tsconfig.json`'s `exclude` — **was measured available here**, which is worth stating because the gate's own graduation text says to assume it is not ("Measured red on 14 of the 18 entries that have an exclusion to drop, so assume (b) is unavailable until that gate says otherwise"). Under a trap-restored mutation of `tsconfig.json`, `pnpm check:type-source-resolution` came back **exit 0** (`124 tsc program(s) across 78 packages`), and the restore was proved by blob-hash equality against the HEAD blob plus an empty `git diff HEAD`. The #11491 note inside the ledger script already listed `verify` as one of the four that stay green; that still holds.

It was declined on **module semantics**, not availability. `tsconfig.json` inherits `NodeNext` from the repo root, so route (b) would hold the test layer to a resolver vitest never runs it under and demand `.js` on every relative specifier in it — the config-tier noise the shared gate's header attributes 108 of spec's 842 raw errors to. 28 of the 30 sibling configs override `module`/`moduleResolution` for exactly this reason; `packages/runtime` is the closest structural analogue (tests under `src`, tsup build, exclusion in the build config) and this config copies its shape.

## 3. The wiring is not vacuous — two independent proofs

**`--listFiles`**, on the tree at `1d671305858` with the workspace closure built:

| program | `packages/verify/src/*.test.ts` in it | non-test `src/**` in it | total files |
|:--|:--|:--|:--|
| `tsc -p tsconfig.json` (what `typecheck` used to be, alone) | **0 of 10** | 9 of 9 | 981 |
| `tsc -p tsconfig.test.json` | **10 of 10** | 9 of 9 | 990 |

So the zero is the `exclude` line, not a probe that sees nothing.

**Ablation.** A deliberate type error was appended to `src/derive.test.ts` — a file already in both programs, compiled from source by each, so no rebuild leg applies. Predicted direction: the old program stays green, the wired script reddens. Measured, exactly that:

- old program, `tsc --noEmit -p tsconfig.json`: **exit 0, 0 errors**
- wired `pnpm --filter @objectstack/verify typecheck`: **exit 1** — `src/derive.test.ts: 1 type error(s) in a file the ledger does not cover.`

The mutation was proved on disk before either run (injected marker counted 1, injected statement counted 1, `git diff --numstat` 4 added lines) and the restore was proved by blob hash against the HEAD blob and an empty `git diff HEAD`.

## 4. Findings

**Zero phantom pins, and that is the finding.** The card's sharpest line is that any `ts-expect-error` in those files is currently a phantom check. Grepped with a positive control (the same grep hits `packages/spec/src`), this package's test layer holds **zero** `ts-expect-error` and zero `ts-ignore` directives. So no pin was silently dead — the statement was about what *would* happen. That matches what `packages/cli`'s graduation recorded for its own 115 files. What the gap actually cost was the other half: no way to write a type-level pin in this layer at all, and nothing reading it.

**The card's file count was stale.** Re-derived on `origin/main`: **ten** `src/*.test.ts`, not the card's nine. The tenth is `artifact-collections.test.ts`. Triage had already caught this; it is re-derived here rather than carried over.

**Adding `gen:test-typecheck-debt` reds `check:merge-driver`, and the right answer is not to add a disposition.** The first draft declared that generator alongside `check:test-typecheck`, and the gate refused: `generator(s) with NO recorded merge disposition: gen:test-typecheck-debt [@objectstack/verify]`. The pairing is 1:1 across all 30 sibling configs — 16 with a `test-typecheck-debt.json` declare the generator, 14 without one declare nothing — and #14062's note in `scripts/regen-artifacts.mjs` refuses to invent a disposition for a ledger that does not exist. The script was dropped rather than routed. If this layer ever measures non-zero, the ledger, the generator and its `regen-artifacts` row arrive together in that one PR.

## 5. No changeset — `skip-changeset`

Judged from the rule text in `.github/workflows/pr-automation.yml`, Check Changeset step: route 2, "It releases nothing ... tests-only, and the like". This diff is build-config and test-layer wiring plus repo tooling. It adds no exported symbol, no accepted key or value, and no runtime behaviour: `tsconfig.test.json` is not in the package's `files`, the three edited files are tests that tsup never bundles, and `scripts/check-type-check-coverage.mjs` is not published. Under the WHICH LEVEL rule a bump would have to be at least `minor` only for a purely additive widening of a published surface, and there is none — so the label, not a changeset written to be safe.

## 6. Verification

Gate union re-derived from the real changed paths with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` (the tool reads its own change set from the merge base; the first derivation warned STALE and was re-run after merging `origin/main`).

Run to a verdict, all green, on head `02b1bdcde2d` unless noted:

- `check:type-check-coverage`, `check:type-check-debt` — both to a verdict, never left `PREREQUISITE NOT MET`; closure built first with `pnpm exec turbo run build --filter=./packages/* --filter=./packages/*/*`
- `pnpm --filter @objectstack/verify typecheck` — `check:test-typecheck: OK — @objectstack/verify's test layer compiles under packages/verify/tsconfig.test.json; 0 file(s) / 0 error(s) / 0 pinned signature(s)`
- `pnpm --filter @objectstack/verify test` — `Test Files 10 passed (10)` / `Tests 58 passed (58)`
- the derived families: `agent-test-spelling` `bash32-floor` `cli-command-ids` `cross-package-test-inputs` `doc-authoring` `dual-build-cjs-loads` `entry-guard` `logger-receiver-detach` `merge-driver` `objectql-double-limit` `org-identifier` `override-consistency` `page-declaration-shape` `parse-guard` `pnpm-filter-targets` `published-files` `ratchet-remedy-authority` `service-providers` `slot-lookup` `test-source-alias` `turbo-task-graph` `type-source-resolution` `where-matcher` `workspace-manifest-cycles`, plus `spec run check:llms-txt`
- the whole-tree kinds: `nul-bytes` `engine-double-contract` `driver-memory-census` `refd-timer-probe` `watch-hint-literal` `query-options-erasure` `pm-dispatch-gates`
- the artifact-roster families the derivation flagged as scoring silent under a directory one of these paths is in — silence there is not a clearance, so they were run: `published-list-mirrors` (and its self-test) `authz-resolver` `console-injection` `error-code-casing` `filter-alias-parity` `i18n-stale-fill` `published-readme-exports` `single-claim-paths` `partof-closing-keyword` `ci-filter-parity --self-test` `pm-governed-prose`
- `pnpm lint` — the full repo scan, `eslint . --no-inline-config`, exit 0 in 1m20s. No narrowing was needed, so none is claimed.

Exit codes were captured after redirection, never through a pipe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D47qPfEWVPmhguWgBZCi5N)_