### PR TITLE
fix(cli): route resolveConfigPath's refusals to stderr, and pin the pre-boot --json face

### DIFF
--- a/.changeset/config-miss-refusal-to-stderr.md
+++ b/.changeset/config-miss-refusal-to-stderr.md
@@ -1,0 +1,17 @@
+---
+"@objectstack/cli": patch
+---
+
+`os validate|info|diff|lint|compile|build|verify|migrate meta|i18n check|i18n extract --json` no longer print human text on stdout when the config file is missing.
+
+`resolveConfigPath()` emitted both of its refusals — the explicit-path miss and the auto-detect miss — through `printError` and `console.log`, **both of which write to stdout**, and then called `process.exit(1)` directly. Ten published `--json` faces reach that helper, so a missing config file answered them with exit 1, an unparseable stdout and an **empty stderr**: 206 bytes of prose on the one stream `--json` reserves for the machine. And because the exit was called rather than thrown, every command's catch-all `--json` error exit — all of which sit downstream of a throw — never ran.
+
+The diagnostic now goes to stderr, where the rest of this CLI's diagnostics already go. Nothing else moves:
+
+- **the exit code is still 1**, so a consumer branching on exit status sees no change at all;
+- **the wording is unchanged**, hints included, so a human reading a terminal sees the same three lines;
+- **nothing is accepted or rejected differently** — no config that loaded before fails now, and none that failed now loads.
+
+⚠️ **No error payload is invented on this path.** What a `--json` consumer should *receive* when the config file is missing is an envelope question that touches ten published faces at once, and it is deliberately left open here — this change settles only that the machine's channel no longer carries prose. `--json` on this path emits nothing on stdout; a consumer must still read the exit status, exactly as it must today.
+
+A new pin (`config-miss-stdout-purity.e2e.test.ts`) drives all ten faces on both branches of the helper. The existing purity pin could not: it discovers its family as the commands that call `bootSchemaStack`, and these fail before any kernel boots.

--- a/packages/cli/src/utils/config.ts
+++ b/packages/cli/src/utils/config.ts
@@ -7,7 +7,7 @@ import { pathToFileURL } from 'node:url';
 import chalk from 'chalk';
 import { bundleRequire } from 'bundle-require';
 import type { Plugin } from 'esbuild';
-import { printError } from './format.js';
+import { printErrorToStderr } from './format.js';
 
 export interface LoadedConfig {
   config: any;
@@ -43,15 +43,47 @@ export const BUNDLE_REQUIRE_EXTERNALS: (string | RegExp)[] = [
  * Resolve the config file path. Supports:
  * - explicit path (objectstack.config.ts)
  * - auto-detection (searches for objectstack.config.{ts,js,mjs})
+ *
+ * ## Both refusals go to STDERR, and that is not cosmetic (#15547)
+ *
+ * This helper is reached by ten published `--json` faces — `os validate`,
+ * `info`, `diff`, `lint`, `compile`, `build` (a subclass of `compile`),
+ * `verify`, `migrate meta`, `i18n check`, `i18n extract` — and it has no way
+ * to know which run is a `--json` run: the flag is parsed in the command, and
+ * `loadConfig()` passes it nothing. It used to print through `printError` and
+ * `console.log`, **both of which write to stdout**, and then call
+ * `process.exit(1)`.
+ *
+ * That put human text on the one stream `--json` reserves for the machine
+ * (`utils/json-stdout.ts`). Measured on the published entry `bin/run.js` with
+ * `NO_COLOR=1` and the streams captured separately: every one of the ten faces
+ * answered a missing config with **exit 1, an unparseable stdout and an empty
+ * stderr**, on both branches below. And because the exit is called directly,
+ * nothing throws — so every command's catch-all `--json` error exit, which
+ * sits downstream of a throw, never ran.
+ *
+ * ⚠️ Moving the bytes is the whole change. The exit code stays 1, the wording
+ * stays identical, and no payload is invented here: what a `--json` consumer
+ * should receive on this path is an envelope question that touches ten
+ * published faces at once, and it is deliberately left open (see
+ * {@link printErrorToStderr} and the PR for #15547). What is settled is that
+ * the machine's channel no longer carries prose.
+ *
+ * ⛔ Do not "fix" this by making the helper throw without settling that
+ * question first. Measured on the callers: `os verify` has no `try` around its
+ * `loadConfig()` at all, so a throw becomes an oclif crash dump rather than a
+ * payload; and `errorCodeFields()` deliberately mints no `code` for a plain
+ * `Error`, so the other nine would emit a bare `{ error }` — the exact shape
+ * #15549 is an open card about.
  */
 export function resolveConfigPath(source?: string): string {
   if (source) {
     const abs = path.resolve(process.cwd(), source);
     if (!fs.existsSync(abs)) {
-      printError(`Config file not found: ${chalk.white(abs)}`);
-      console.log('');
-      console.log(chalk.dim('  Hint: Run this command from a directory with objectstack.config.ts'));
-      console.log(chalk.dim('  Or specify the path: objectstack <command> path/to/config.ts'));
+      printErrorToStderr(`Config file not found: ${chalk.white(abs)}`);
+      console.error('');
+      console.error(chalk.dim('  Hint: Run this command from a directory with objectstack.config.ts'));
+      console.error(chalk.dim('  Or specify the path: objectstack <command> path/to/config.ts'));
       process.exit(1);
     }
     return abs;
@@ -69,9 +101,9 @@ export function resolveConfigPath(source?: string): string {
     if (fs.existsSync(abs)) return abs;
   }
 
-  printError('No objectstack.config.{ts,js,mjs} found in current directory');
-  console.log('');
-  console.log(chalk.dim('  Hint: Run `objectstack init` to create a new project'));
+  printErrorToStderr('No objectstack.config.{ts,js,mjs} found in current directory');
+  console.error('');
+  console.error(chalk.dim('  Hint: Run `objectstack init` to create a new project'));
   process.exit(1);
 }
 

--- a/packages/cli/src/utils/format.ts
+++ b/packages/cli/src/utils/format.ts
@@ -306,8 +306,36 @@ export function printWarning(msg: string) {
   console.log(chalk.yellow(`  ⚠ ${msg}`));
 }
 
+/** The `  ✗ <msg>` line both error printers render — one glyph, one source. */
+function errorLine(msg: string): string {
+  return chalk.red(`  ✗ ${msg}`);
+}
+
 export function printError(msg: string) {
-  console.log(chalk.red(`  ✗ ${msg}`));
+  console.log(errorLine(msg));
+}
+
+/**
+ * `printError`'s line, on **stderr**.
+ *
+ * For a diagnostic printed by code that CANNOT see whether the run is a
+ * `--json` run. `printError` writes to stdout, which is correct for a command
+ * rendering its own text face and wrong for a shared helper: stdout is what
+ * `--json` reserves for the machine (`utils/json-stdout.ts`), and a helper
+ * called by both faces has no flag to branch on.
+ *
+ * `resolveConfigPath()` is the measured case (#15547). It printed this line
+ * plus two hints to stdout and then `process.exit(1)`, so ten `--json` faces
+ * answered a missing config file with human text on the machine's channel and
+ * an empty stderr — bytes that `JSON.parse` rejects, and no `catch` anywhere
+ * downstream could intervene because nothing was thrown.
+ *
+ * ⚠️ Not a general replacement for `printError`. A command that has already
+ * decided it is rendering the text face should keep writing to stdout; this is
+ * for the shared paths that cannot make that decision.
+ */
+export function printErrorToStderr(msg: string) {
+  console.error(errorLine(msg));
 }
 
 export function printInfo(msg: string) {

--- a/packages/cli/test/config-miss-stdout-purity.e2e.test.ts
+++ b/packages/cli/test/config-miss-stdout-purity.e2e.test.ts
@@ -1,0 +1,293 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * `--json` ⇒ nothing unparseable on stdout when the CONFIG FILE IS MISSING,
+ * for the whole `resolveConfigPath` family (#15547).
+ *
+ * ## The blind spot this exists to close
+ *
+ * `json-stdout-purity.e2e.test.ts` already pins "stdout is exactly one JSON
+ * document" — but it DISCOVERS its family as the commands that call
+ * `bootSchemaStack`. The commands here fail at `resolveConfigPath()`, which
+ * runs **before** any kernel boots, so that pin structurally cannot see this
+ * path and stayed green through the whole defect.
+ *
+ * What it was green through: `resolveConfigPath()` printed its refusal through
+ * `printError` and `console.log` — both stdout — and then called
+ * `process.exit(1)` directly. Ten published `--json` faces therefore answered a
+ * missing config with human text on the machine's channel, an EMPTY stderr, and
+ * no payload; and because nothing was thrown, every command's catch-all
+ * `--json` error exit — all of which sit downstream of a throw — never ran.
+ *
+ * ⇒ The instrument was as broken as the code. A fix that repaired the helper
+ * without widening the discovery would leave the next pre-boot stdout leak just
+ * as invisible, which is why this file exists rather than a fixture edit.
+ *
+ * ## Why the whole family, from one expectation
+ *
+ * Same discipline as the sibling pin: the family is READ OFF THE SOURCE, not
+ * remembered, and reconciled against {@link FAMILY}. Add a command that offers
+ * `--json` and reaches the config helper and this file goes red until it is
+ * listed here and passes; drop one and it goes red until it is removed.
+ *
+ * The discovery has two halves because the reach has two shapes:
+ *
+ *   • DIRECT — the module declares `json: Flags.boolean(` and imports from
+ *     `utils/config.js`.
+ *   • ALIAS — the module's default export `extends` a command in the direct
+ *     set, so it inherits both the flag and the reach without naming either.
+ *     `os build` is exactly this (`class Build extends Compile`), and a
+ *     one-half discovery would have missed it: the original card's static
+ *     reading listed nine modules, and `build` is the tenth face.
+ *
+ * ## What is asserted — and what is deliberately NOT
+ *
+ * ⛔ This file does NOT pin an error-payload shape. Whether `--json` should
+ * emit an envelope on this path is an open question touching ten published
+ * faces at once, entangled with #15549 (`os lint --eval --json`'s bare
+ * `{ error }` with no `code` and no `httpStatus`), and settling it is above
+ * this pin's authority.
+ *
+ * So the assertion is the half that needs no ruling: **stdout carries nothing a
+ * machine cannot read.** Empty passes, one JSON document passes, prose fails.
+ * That holds under the shape shipped today AND under any future envelope, so
+ * whoever settles the question changes the payload without touching this file.
+ *
+ * The other two halves are the ones a "just silence it" regression would break:
+ * the diagnostic must still reach the operator, on **stderr**, and the exit
+ * status must still be 1.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { execFile } from 'node:child_process';
+import { mkdtempSync, rmSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, relative, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { childEnv } from './helpers/serve-process.js';
+
+const HERE = resolve(fileURLToPath(import.meta.url), '..');
+const CLI = resolve(HERE, '../bin/run-dev.js');
+const TSX = resolve(HERE, '../../../node_modules/.bin/tsx');
+const COMMANDS_DIR = resolve(HERE, '../src/commands');
+
+/** A path that cannot exist, driving the EXPLICIT-PATH branch of the helper. */
+const MISSING = './nope-does-not-exist.ts';
+
+/**
+ * The family, and the argv each member needs to reach `resolveConfigPath()`.
+ *
+ * `autoDetect: false` marks the one member with no auto-detect branch to drive:
+ * `os diff` requires two config paths, so there is no bare form that reaches
+ * the helper without one.
+ */
+interface Member {
+  /** argv that reaches the helper with an EXPLICIT missing path. */
+  explicit: string[];
+  /** argv that reaches the helper with NO path, or `null` when there is none. */
+  auto: string[] | null;
+}
+
+const FAMILY: Record<string, Member> = {
+  // `build` is `class Build extends Compile` — the alias half of the discovery.
+  build: { explicit: [MISSING], auto: [] },
+  compile: { explicit: [MISSING], auto: [] },
+  diff: { explicit: [MISSING, MISSING], auto: null },
+  'i18n check': { explicit: [MISSING], auto: [] },
+  'i18n extract': { explicit: [MISSING], auto: [] },
+  info: { explicit: [MISSING], auto: [] },
+  lint: { explicit: [MISSING], auto: [] },
+  // `--from` because `--stored` is its only other way past the flag parser, and
+  // `--stored` boots a kernel — a different family, already pinned elsewhere.
+  'migrate meta': { explicit: [MISSING, '--from', '4'], auto: ['--from', '4'] },
+  validate: { explicit: [MISSING], auto: [] },
+  // The config path is a FLAG here, not a positional.
+  verify: { explicit: ['--app', MISSING], auto: [] },
+};
+
+/** The refusal text, one line per branch — what must be on stderr, never stdout. */
+const REFUSAL = {
+  explicit: 'Config file not found',
+  auto: 'No objectstack.config.{ts,js,mjs} found in current directory',
+} as const;
+
+/** Every `.ts` under `src/commands`, excluding tests. */
+function commandFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const abs = join(dir, entry);
+    if (statSync(abs).isDirectory()) {
+      out.push(...commandFiles(abs));
+      continue;
+    }
+    if (!entry.endsWith('.ts') || entry.endsWith('.test.ts')) continue;
+    out.push(abs);
+  }
+  return out;
+}
+
+/** `src/commands/i18n/check.ts` → `i18n check`, the id oclif dispatches on. */
+function commandId(abs: string): string {
+  const rel = relative(COMMANDS_DIR, abs).replace(/\.ts$/, '');
+  return rel.split(sep).filter((p) => p !== 'index').join(' ');
+}
+
+/**
+ * The family, read off the source rather than remembered: a command belongs iff
+ * it offers a machine-readable mode AND reaches the config helper — directly,
+ * or by extending a command that does.
+ */
+function discoverFamily(): string[] {
+  const files = commandFiles(COMMANDS_DIR);
+  const sources = new Map(files.map((abs) => [abs, readFileSync(abs, 'utf-8')]));
+
+  const direct = new Set<string>();
+  for (const [abs, src] of sources) {
+    if (!/\bjson:\s*Flags\.boolean\(/.test(src)) continue;
+    if (!/from '(?:\.\.\/)+utils\/config\.js'/.test(src)) continue;
+    direct.add(abs);
+  }
+
+  // An alias inherits the flag and the reach from the class it extends, and
+  // names neither itself. Resolve `extends <Ident>` back to the module the
+  // identifier was imported from, and take the member if that module is in the
+  // direct set. One level is enough for the aliases in this tree and a deeper
+  // chain would show up as a discovery mismatch rather than pass silently.
+  const alias = new Set<string>();
+  for (const [abs, src] of sources) {
+    const ext = /export default class \w+ extends (\w+)\b/.exec(src);
+    if (!ext) continue;
+    const imported = new RegExp(`import ${ext[1]} from '(\\.[^']+)\\.js'`).exec(src);
+    if (!imported) continue;
+    const target = resolve(abs, '..', `${imported[1]}.ts`);
+    if (direct.has(target)) alias.add(abs);
+  }
+
+  return [...direct, ...alias].map(commandId).sort();
+}
+
+interface Run {
+  key: string;
+  code: number;
+  stdout: string;
+  stderr: string;
+}
+
+function runCli(argv: string[], cwd: string): Promise<Omit<Run, 'key'>> {
+  return new Promise((resolvePromise) => {
+    execFile(
+      TSX,
+      [CLI, ...argv],
+      { cwd, maxBuffer: 32 * 1024 * 1024, env: childEnv({ NO_COLOR: '1' }) },
+      (err, stdout, stderr) => {
+        resolvePromise({
+          code: err
+            ? (typeof (err as { code?: unknown }).code === 'number'
+                ? (err as unknown as { code: number }).code
+                : 1)
+            : 0,
+          stdout: String(stdout),
+          stderr: String(stderr),
+        });
+      },
+    );
+  });
+}
+
+/**
+ * Whether stdout is something a program can read: nothing at all, or exactly
+ * one JSON document. Prose is the failure — see the header for why the choice
+ * between the two passing shapes is deliberately left open.
+ */
+function stdoutIsMachineReadable(stdout: string): boolean {
+  if (stdout.trim() === '') return true;
+  try {
+    JSON.parse(stdout);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** `[key, argv]` for every branch of every member — 19 runs across 10 faces. */
+function cases(): [string, string[]][] {
+  const out: [string, string[]][] = [];
+  for (const [id, member] of Object.entries(FAMILY)) {
+    const argv = id.split(' ');
+    out.push([`${id} (explicit path)`, [...argv, ...member.explicit, '--json']]);
+    if (member.auto) out.push([`${id} (auto-detect)`, [...argv, ...member.auto, '--json']]);
+  }
+  return out;
+}
+
+let dir: string;
+let runs: Run[];
+
+beforeAll(async () => {
+  // Deliberately EMPTY — no `objectstack.config.*` here, so the auto-detect
+  // branch misses and the explicit branch resolves against a real cwd.
+  dir = mkdtempSync(join(tmpdir(), 'os-config-miss-e2e-'));
+
+  // Sequential: nineteen `tsx` starts at once is the kind of load that makes a
+  // shared box report timeouts instead of verdicts.
+  runs = [];
+  for (const [key, argv] of cases()) {
+    const { code, stdout, stderr } = await runCli(argv, dir);
+    runs.push({ key, code, stdout, stderr });
+  }
+}, 900_000);
+
+afterAll(() => {
+  try { rmSync(dir, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+describe('the family this contract has to hold across', () => {
+  it('is exactly the set listed here — a new member goes red until it is driven too', () => {
+    expect(discoverFamily()).toEqual(Object.keys(FAMILY).sort());
+  });
+
+  it('includes the alias face, which declares neither the flag nor the import', () => {
+    // Guards the alias half specifically: a discovery that regressed to
+    // "grep the module" would still pass the reconciliation above only by
+    // ALSO dropping `build` from FAMILY, and this makes that a second red.
+    expect(discoverFamily()).toContain('build');
+  });
+});
+
+describe.each(cases())('os %s --json, config missing', (key) => {
+  const runOf = () => {
+    const run = runs.find((r) => r.key === key);
+    if (!run) throw new Error(`no run captured for '${key}'`);
+    return run;
+  };
+
+  it('leaves nothing on stdout that a machine cannot read', () => {
+    const run = runOf();
+    // Under the defect this was 206 bytes of `  ✗ Config file not found: …`
+    // plus two hint lines — on the one stream `--json` reserves for the
+    // machine, with stderr completely empty.
+    expect(stdoutIsMachineReadable(run.stdout)).toBe(true);
+  });
+
+  it('keeps the human refusal off stdout entirely', () => {
+    const run = runOf();
+    // Asserted separately from the parse so a regression names its cause
+    // rather than only `Unexpected token`.
+    expect(run.stdout).not.toContain(REFUSAL.explicit);
+    expect(run.stdout).not.toContain(REFUSAL.auto);
+    expect(run.stdout).not.toContain('Hint:');
+  });
+
+  it('still shows the operator the refusal — on stderr', () => {
+    const run = runOf();
+    // Diagnostics are MOVED, never destroyed: a regression toward silencing
+    // this path goes red here.
+    const expected = key.endsWith('(auto-detect)') ? REFUSAL.auto : REFUSAL.explicit;
+    expect(run.stderr).toContain(expected);
+    expect(run.stderr).toContain('Hint:');
+  });
+
+  it('still exits 1', () => {
+    expect(runOf().code).toBe(1);
+  });
+});


### PR DESCRIPTION
Part of #15547

`resolveConfigPath()` printed both of its refusals through `printError` and `console.log` — **both of which write to stdout** — and then called `process.exit(1)` directly. The bytes now go to **stderr**. Nothing else moves.

## The measurement, re-driven

Through the **published** entry `packages/cli/bin/run.js` (not the `bin/run-dev.js` shim), `NO_COLOR=1`, stdout and stderr captured to separate files, exit code read before any pipe.

| | before | after |
|---|---|---|
| explicit-path miss, all 10 faces | exit 1 · stdout **206 B** · stderr 0 B | exit 1 · stdout **0 B** · stderr **206 B** |
| auto-detect miss, all 9 faces | exit 1 · stdout **123 B** · stderr 0 B | exit 1 · stdout **0 B** · stderr **123 B** |

The message bytes are byte-identical; only the stream changed. (206 rather than the card's 286 because the message embeds the absolute path and this container's tmpdir is shorter — same text.)

## Three corrections to the card's own reading, all measured

1. **The population is 10 faces, not 9.** The card's nine modules are exactly right as a list of modules — I re-derived it independently and got the same nine. But `os build` is `export default class Build extends Compile`: it declares neither the `json` flag nor the config import, inherits both, and reproduces the defect. The card drove it without counting it.
2. **Both branches reproduce on all of them.** The card names the auto-detect site but drives only the explicit-path one. Both are in the table above.
3. **`resolveConfigPath` has exactly one in-tree caller** — `loadConfig()`. It is exported, but nothing else calls it, so the blast radius is `loadConfig`'s callers and nothing wider.

## Why the minimal route — measured, not preferred

The alternative was to make the helper **throw** so each command's existing catch-all `--json` exit does the work. I measured that before choosing, and two findings rule it out on its own terms:

- **`os verify` has no `try` around its `loadConfig()` at all** (`verify.ts`, top of `run()`). A throw there does not become a payload; it becomes an oclif crash dump on a different exit path. The fuller route does not fix that face, it changes which way it is broken.
- **`errorCodeFields()` deliberately mints nothing for a locally-thrown plain `Error`** — its own doc says so, and says ADR-0112's ledger is the authority on who may mint a code. So the other nine faces would emit a bare `{ error }` with no `code` and no `httpStatus` — the exact shape #15549 is an open card about. Taking that route would answer #15549 implicitly, in passing. That card is not addressed here and remains open.

A third cost, worth recording: the catch-alls print `printError(error.message)` and nothing else, so the fuller route would silently delete the two hint lines from the **text** face of all ten commands — the majority path.

## What is deliberately NOT settled

⛔ **No error payload is invented.** On this path `--json` still emits nothing on stdout; a consumer must read the exit status, exactly as it must today. What `--json` *should* emit here touches ten published faces at once and is above this PR's authority — that is the half the triage comment said to leave for a ruling, and this is the half it said to land meanwhile:

> Whichever route: the human text must move to stderr regardless. […] If the ruling stalls, land that half.

**Clause ② declared from the delivered diff: NO.** No key is added to any published payload (this path emits none, before or after); no accept/reject set changes — a config that loaded still loads, one that failed still fails, same exit code, same wording. The one new export, `printErrorToStderr`, is package-internal: `packages/cli`'s `exports` map publishes only `.` (a barrel of command classes) and `./console`, `utils/format.js` is neither, and `src/index.ts` does not re-export it.

⚠️ One residual behaviour change for a reviewer to weigh: a wrapper that showed a user only the child's **stdout** now shows nothing on this path. Exit 1 is unchanged, and stderr was empty before, so nothing could have been parsing it.

## The instrument was as blind as the code

`packages/cli/test/json-stdout-purity.e2e.test.ts` pins "stdout is exactly one JSON document", but discovers its family as the commands that call `bootSchemaStack`. These commands fail **before** any kernel boots, so that pin structurally could not see this path and stayed green through the whole defect. Repairing the helper without widening the discovery would leave the next pre-boot stdout leak just as invisible.

`packages/cli/test/config-miss-stdout-purity.e2e.test.ts` is the new pin. It discovers the pre-boot family in **two halves**, because the reach has two shapes — the module that declares `json: Flags.boolean(` and imports `utils/config.js`, and the module whose default export `extends` one that does. A one-half discovery misses `build`, which is why there is a second reconciliation case asserting `build` is in the set.

⛔ The pin does **not** assert a payload shape. It asserts stdout carries nothing a machine cannot read — empty passes, one JSON document passes, prose fails — so it holds under the shape shipped today and under any future envelope, and whoever settles the envelope question changes the payload without touching this file. It also asserts the refusal still reaches the operator on stderr (a "just silence it" regression goes red) and that the exit status is still 1.

## Ablation — direction predicted in writing first, and it was mixed

**No rebuild is part of this ablation, and that is proven rather than assumed:** `packages/cli/dist/utils/config.js` was built *before* the fix and still carried the defect verbatim, yet the new pin passed 78/78 — so the subject resolves through `src/` via tsx, not through `dist/`.

Predicted, before the mutation was made: 19 × "leaves nothing on stdout that a machine cannot read" red, 19 × "keeps the human refusal off stdout entirely" red, 19 × "still shows the operator the refusal — on stderr" red (stderr goes **empty** under the defect), while 19 × "still exits 1" and the 2 discovery cases stay **green** — the exit code is untouched by the defect, which is precisely why the card was graded p2. **⇒ 21 passed, 57 failed.**

Measured: **`Tests 57 failed | 21 passed (78)`**, and the three failing assertion names came back at 19 each. No assertion outside the predicted three failed even once.

Mutation proven on disk before any result was read — removed-text counts `console.error(` 5 ⇒ 0 and `printErrorToStderr` 4 ⇒ 0, injected-marker count 0 ⇒ 1. Restore under an `EXIT INT TERM` trap using an absolute path, proven by blob-hash equality with the HEAD blob (`9a3f0e38b8e05a1569788150f2c65482f399f860`, both sides) plus an empty `git diff HEAD` plus the marker's absence — an empty hash treated as failure, not as "nothing to compare".

## Verification — all at `e13e9862e19`, the final commit

- `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` derived **56 runnable families** (45 by path + 6 by change kind + 7 declared whole-tree, 2 reached both ways). Harvested with `--commands`, so no section or spelling was dropped. **All 56 green**, each exit code captured after redirection, never through a pipe.
  - Two came back `exit 3` first: `check:dual-build-cjs-loads` and `check:i18n-coverage`, both printing `PREREQUISITE NOT MET` / "Nothing was compared" on an unbuilt workspace. Read as **NOT MEASURED**, not as red — the workspace was built and both then returned 0.
- `pnpm lint` (`eslint . --no-inline-config`) — **whole repo, not narrowed** — green.
- `pnpm --filter @objectstack/cli typecheck` green, including `check:test-typecheck`. Confirmed with `--listFiles` that the new test file is actually in the program (the pre-existing 28 ledgered test-layer errors are in three other files; this file contributes zero).
- CLI tests, narrowed and declared: the 23 files that name the changed behaviour, import `utils/format`, or are a stdout-purity pin — **all green** (234 tests across 20 files, plus 116 across the three purity pins). The full 253-file CLI suite is CI's; this is the measured blast radius.
- Pipe check, because the diagnostic is now a stderr write followed immediately by `process.exit(1)`: with a real pipe and a draining reader the 205 bytes arrived intact, 4/4 runs. Bounded claim — this message is ~206 bytes, far under one pipe buffer; the truncation defect `format.ts` documents was ~138 KB.


---
_Generated by [Claude Code](https://claude.ai/code/session_01D47qPfEWVPmhguWgBZCi5N)_