### PR TITLE
fix(core): drop a session's unbacked organization claim under a wall-enforcing posture

### DIFF
--- a/.changeset/session-unbacked-org-claim-dropped.md
+++ b/.changeset/session-unbacked-org-claim-dropped.md
@@ -1,0 +1,9 @@
+---
+'@objectstack/core': patch
+---
+
+A session whose active organization is no longer one the user belongs to now resolves with no active organization instead of that one's data.
+
+Under a wall-enforcing tenancy posture (`isolated` / `group`), `resolveAuthzContext` took a browser session's stored `activeOrganizationId` as the request tenant without ever comparing it to the user's current memberships — the framework's only such comparison was gated on an API-key principal. A session whose owner had been removed from an organization therefore kept reading that organization's rows and writing into it until the session expired on its own (7 days by default), including when the removal went through the product's own offboarding path.
+
+That claim is now vetted: if it is not in the caller's `accessible_org_ids`, it is dropped and the context resolves with no active organization at all, which the tenant wall already fails closed on (reads resolve to nothing; a tenant-scoped write is refused by ADR-0123 D2). The principal is **not** refused — a session is a person who may hold memberships elsewhere, so they stay signed in and can switch to an organization they are actually in. The API-key arm is unchanged: a key is its organization binding and is still refused outright. The wire is unchanged; the drop is reported to the operator as a single server-side `warn`.

--- a/packages/core/src/security/resolve-authz-context.test.ts
+++ b/packages/core/src/security/resolve-authz-context.test.ts
@@ -1543,3 +1543,243 @@ describe('the in-memory ObjectQL double honours `limit` (#10978)', () => {
     expect(found.every((r: any) => r.organization_id === 'o1')).toBe(true);
   });
 });
+
+
+// ── [#15409] The SESSION arm of the organization claim ─────────────────────
+
+/**
+ * [#15409 — maintainer ruling 2026-09-05, option B] A browser session whose
+ * `activeOrganizationId` names an organization its owner has LEFT.
+ *
+ * ## What was measured, before the guard existed
+ *
+ * On a live `isolated` boot with the real cloud-private `Organizations` plugin
+ * and a file-backed sqlite store, a session whose owner had been removed
+ * through better-auth's OWN `/organization/remove-member` — driven by the org
+ * owner, 200, the `sys_member` row really deleted — went on READING that
+ * organization's rows (`GET 200`, total 4, every row `@org_alpha`) and WRITING
+ * into it (`POST 201`), the written row read back out of the sqlite file with
+ * the server stopped carrying `organization_id: org_alpha` and the removed
+ * user as `created_by`. Nothing revoked, nothing expired: `revoked_at` was
+ * still `null` and the default session lifetime is 7 days.
+ *
+ * The resolver already HELD the fact. `get-session` returned positions
+ * `["user","org_member"]` while the membership was intact and `["user"]` on
+ * the very next request — off the same `sys_member` read that builds
+ * `accessible_org_ids` — while still serving that organization's rows. The
+ * only tenant-claim-vs-membership comparison in the framework was
+ * `keyPrincipal`-gated, so a session never reached it.
+ *
+ * ## What is pinned here, and what is deliberately NOT
+ *
+ * Option B, ruled: the claim is DROPPED, the principal is NOT refused. So the
+ * assertions below are about `ctx.tenantId` going away while `ctx.userId`
+ * STAYS — the one pair that would go red if someone later "simplified" B into
+ * the API-key arm's option A. Refusing the whole credential is right for an API
+ * key, which IS its organization binding; a session is a person who may hold
+ * legitimate memberships elsewhere.
+ *
+ * ⛔ No new refusal mechanism is pinned because none was added: with no active
+ * organization, Layer 0 already fails closed — `!organizationId ⇒
+ * RLS_DENY_FILTER` in `plugin-security/src/tenant-layer.ts` for reads, and
+ * ADR-0123 D2's write refusal for writes. Those two are pinned where they live.
+ * The end-to-end consequence — reads nothing, write does not land, read back
+ * from the STORE — is pinned in
+ * `packages/rest/src/single-kernel-isolated-session-org-claim-matrix.test.ts`.
+ */
+describe('[#15409] a session organization claim that no membership backs', () => {
+  /** The `sys_session` token — the credential. It must never reach a log line. */
+  const SESSION_TOKEN = 'sess_token_never_log_me';
+
+  /**
+   * A session as better-auth returns it: the ROW `id` and the `token` are
+   * separate columns, which is why the log line can name one and never the
+   * other.
+   */
+  const sessionAs = (userId: string, org: string | null, id = 'ses_probe') =>
+    async () => ({
+      user: { id: userId, email: `${userId}@x.com` },
+      session: { id, token: SESSION_TOKEN, userId, activeOrganizationId: org },
+    });
+
+  /**
+   * `u_ex` was removed from `org_alpha` and is still a member of `org_beta` —
+   * the shape that makes "still authenticated elsewhere" measurable rather than
+   * asserted. `u_ex2` is a fellow member of `org_alpha`, seeded so the
+   * fellow-org peer list has something to leak if the drop is incomplete.
+   */
+  const tables = () => ({
+    sys_user: [{ id: 'u_ex', email: 'u_ex@x.com' }, { id: 'u_ex2', email: 'u_ex2@x.com' }],
+    sys_member: [
+      { user_id: 'u_ex', organization_id: 'org_beta', role: 'member' },
+      { user_id: 'u_ex2', organization_id: 'org_alpha', role: 'member' },
+    ],
+    sys_user_position: [],
+    sys_user_permission_set: [],
+  });
+
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  beforeEach(() => { warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {}); });
+  afterEach(() => { warnSpy.mockRestore(); });
+  const dropLines = () =>
+    warnSpy.mock.calls
+      .map((c: unknown[]) => c.map(String).join(' '))
+      .filter((l) => l.includes('Session organization claim dropped'));
+
+  it('CONTROL · a BACKED claim is adopted untouched — the guard is not a blanket', async () => {
+    const ql = makeQl(tables());
+    const ctx = await resolveAuthzContext({
+      ql, headers: H(), getSession: sessionAs('u_ex', 'org_beta'), tenancyPosture: 'isolated',
+    });
+    expect(ctx.userId).toBe('u_ex');
+    expect(ctx.tenantId).toBe('org_beta');
+    expect(dropLines()).toHaveLength(0);
+  });
+
+  it('THE SUBJECT: an UNBACKED claim resolves with NO active organization', async () => {
+    const ql = makeQl(tables());
+    const ctx = await resolveAuthzContext({
+      ql, headers: H(), getSession: sessionAs('u_ex', 'org_alpha'), tenancyPosture: 'isolated',
+    });
+    expect(ctx.tenantId).toBeUndefined();
+    // …and the key is GONE, not present-and-undefined: a downstream
+    // `'tenantId' in ctx` must read the same as a session that never picked one.
+    expect(Object.prototype.hasOwnProperty.call(ctx, 'tenantId')).toBe(false);
+  });
+
+  /**
+   * ⭐ B, NOT A. The assertion that goes red if the session arm is ever
+   * "simplified" into the API-key arm's refusal: the principal is still
+   * authenticated, still carries its own identity and its real membership set.
+   */
+  it('B, not A: the PRINCIPAL survives — still authenticated, still a member where it really is', async () => {
+    const ql = makeQl(tables());
+    const ctx = await resolveAuthzContext({
+      ql, headers: H(), getSession: sessionAs('u_ex', 'org_alpha'), tenancyPosture: 'isolated',
+    });
+    expect(ctx.userId).toBe('u_ex');
+    expect(ctx.email).toBe('u_ex@x.com');
+    // The organization they ARE in is still reachable — this is what lets them
+    // switch to it instead of being signed out of everything.
+    expect(ctx.accessible_org_ids).toEqual(['org_beta']);
+    // ⛔ And it is NOT the API-key refusal: no principal was refused.
+    expect(ctx.authRefusal).toBeUndefined();
+  });
+
+  /**
+   * The drop is not a field edit — the envelope is RE-RESOLVED with no tenant.
+   * `org_user_ids` is the one that would give it away: computed under the
+   * rejected claim it enumerates the members of the organization the user left,
+   * and Layer 1 scopes identity tables with it.
+   */
+  it('the envelope carries no residue of the rejected claim — the fellow-org peer list is not the left org\'s', async () => {
+    const ql = makeQl(tables());
+    const ctx = await resolveAuthzContext({
+      ql, headers: H(), getSession: sessionAs('u_ex', 'org_alpha'), tenancyPosture: 'isolated',
+    });
+    expect(ctx.org_user_ids).toEqual(['u_ex']);
+    expect(ctx.org_user_ids).not.toContain('u_ex2');
+  });
+
+  it('the same claim under `group` is dropped too — the wall is membership-derived there as well', async () => {
+    const ql = makeQl(tables());
+    const ctx = await resolveAuthzContext({
+      ql, headers: H(), getSession: sessionAs('u_ex', 'org_alpha'), tenancyPosture: 'group',
+    });
+    expect(ctx.userId).toBe('u_ex');
+    expect(ctx.tenantId).toBeUndefined();
+    expect(dropLines()).toHaveLength(1);
+  });
+
+  /**
+   * Under `single` there is no organization boundary to cross, and a deployment
+   * with no membership rows at all would otherwise lose every session's active
+   * organization. Same scoping the API-key arm carries, same reason.
+   */
+  it('does NOT apply under `single` — no wall, nothing to justify a claim against', async () => {
+    const ql = makeQl(tables());
+    const ctx = await resolveAuthzContext({
+      ql, headers: H(), getSession: sessionAs('u_ex', 'org_alpha'), tenancyPosture: 'single',
+    });
+    expect(ctx.tenantId).toBe('org_alpha');
+    expect(dropLines()).toHaveLength(0);
+  });
+
+  /**
+   * An unwired caller is never made WORSE, only less strict — the doctrine
+   * `ResolveAuthzInput.tenancyPosture` already states for the two API-key
+   * refusals. A transport that supplies no posture keeps its old behaviour.
+   */
+  it('does NOT apply when the transport supplies no posture', async () => {
+    const ql = makeQl(tables());
+    const ctx = await resolveAuthzContext({
+      ql, headers: H(), getSession: sessionAs('u_ex', 'org_alpha'),
+    });
+    expect(ctx.tenantId).toBe('org_alpha');
+    expect(dropLines()).toHaveLength(0);
+  });
+
+  it('a session with NO claim at all is not a drop — nothing was claimed', async () => {
+    const ql = makeQl(tables());
+    const ctx = await resolveAuthzContext({
+      ql, headers: H(), getSession: sessionAs('u_ex', null), tenancyPosture: 'isolated',
+    });
+    expect(ctx.userId).toBe('u_ex');
+    expect(ctx.tenantId).toBeUndefined();
+    expect(dropLines()).toHaveLength(0);
+  });
+
+  it('a membership whose ADR-0091 window has lapsed does not back a claim', async () => {
+    const ql = makeQl({
+      ...tables(),
+      sys_member: [{ user_id: 'u_ex', organization_id: 'org_alpha', role: 'member', valid_until: '2000-01-01T00:00:00Z' }],
+    });
+    const ctx = await resolveAuthzContext({
+      ql, headers: H(), getSession: sessionAs('u_ex', 'org_alpha'), tenancyPosture: 'isolated',
+    });
+    expect(ctx.userId).toBe('u_ex');
+    expect(ctx.tenantId).toBeUndefined();
+    expect(dropLines()).toHaveLength(1);
+  });
+
+  /**
+   * [#15256 / 2A, mirrored] The operator's only exit. The wire is unchanged, so
+   * without this line an offboarded member's live session naming the
+   * organization they left is invisible to everyone.
+   */
+  it('says it OUT LOUD, once, naming session / principal / organization / reason — and ⛔ never the token', async () => {
+    const ql = makeQl(tables());
+    await resolveAuthzContext({
+      ql, headers: H(), getSession: sessionAs('u_ex', 'org_alpha', 'ses_victim'), tenancyPosture: 'isolated',
+    });
+    const lines = dropLines();
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain('organization_membership_ended');
+    expect(lines[0]).toContain('session=ses_victim');
+    expect(lines[0]).toContain('principal=u_ex');
+    expect(lines[0]).toContain('organization=org_alpha');
+    // ⛔ THE CREDENTIAL. `sys_session.token` is replay-proven impersonation —
+    // its own field comment says so. It must never appear in a log line.
+    expect(lines[0]).not.toContain(SESSION_TOKEN);
+  });
+
+  /**
+   * The API-key arm is UNCHANGED (#15256 decision 1A stands): a key IS its
+   * organization binding, so it keeps refusing the principal outright. The
+   * session line must not fire for it — one credential, one decision point.
+   */
+  it('the API-key arm is untouched: an ex-member KEY is still refused, and says so in ITS own words', async () => {
+    const raw = 'osk_15409_exmember';
+    const ql = makeQl({
+      ...tables(),
+      sys_api_key: [{ id: 'key_ex', key: hashApiKey(raw), revoked: false, user_id: 'u_ex', active_organization_id: 'org_alpha' }],
+    });
+    const ctx = await resolveAuthzContext({
+      ql, headers: { 'x-api-key': raw }, tenancyPosture: 'isolated',
+    });
+    expect(ctx.userId).toBeUndefined();
+    expect(ctx.authRefusal?.reason).toBe('organization_membership_ended');
+    // ⛔ Not degraded into the session's drop: the key is REFUSED, not trimmed.
+    expect(dropLines()).toHaveLength(0);
+  });
+});

--- a/packages/core/src/security/resolve-authz-context.test.ts
+++ b/packages/core/src/security/resolve-authz-context.test.ts
@@ -1624,7 +1624,7 @@ describe('[#15409] a session organization claim that no membership backs', () =>
   const dropLines = () =>
     warnSpy.mock.calls
       .map((c: unknown[]) => c.map(String).join(' '))
-      .filter((l) => l.includes('Session organization claim dropped'));
+      .filter((l: string) => l.includes('Session organization claim dropped'));
 
   it('CONTROL · a BACKED claim is adopted untouched — the guard is not a blanket', async () => {
     const ql = makeQl(tables());

--- a/packages/core/src/security/resolve-authz-context.ts
+++ b/packages/core/src/security/resolve-authz-context.ts
@@ -76,6 +76,15 @@ import { isRowActive } from './row-active.js';
 /** The transport-agnostic authorization envelope produced from a request. */
 export interface ResolvedAuthzContext {
   userId?: string;
+  /**
+   * The ACTIVE organization this request operates in.
+   *
+   * ⚠️ [#15409] For a session principal under a wall-enforcing posture this is
+   * a VETTED value, never the stored `activeOrganizationId` as read: a claim
+   * that is not in {@link accessible_org_ids} is dropped and the context
+   * resolves with no active organization at all. Absent here is the fail-closed
+   * state, not a missing lookup — Layer 0 denies on it.
+   */
   tenantId?: string;
   email?: string;
   accessToken?: string;
@@ -210,6 +219,57 @@ function warnApiKeyRefusal(details: {
   );
 }
 
+/**
+ * [#15409 — maintainer ruling 2026-09-05, option B] Say a DROPPED session
+ * organization claim out loud, on the SERVER side, where the drop is decided —
+ * the session mirror of {@link warnApiKeyRefusal} (#15256 / 2A).
+ *
+ * ## Why the operator needs this and the caller must not get it
+ *
+ * The drop is deliberately INVISIBLE on the wire: the principal stays
+ * authenticated, no status code moves, no response field is added and no reason
+ * travels. What the user sees is a session with no active organization — Layer
+ * 0's existing fail-closed branch (`!organizationId ⇒ RLS_DENY_FILTER` in
+ * `plugin-security/src/tenant-layer.ts`) — which is indistinguishable from
+ * never having selected one. That is right for the caller and useless for the
+ * operator, who otherwise has no way to learn that an offboarded member's live
+ * session was still naming the organization they left.
+ *
+ * ## What may appear here
+ *
+ * The `sys_session` ROW id, the owner, the claimed organization, the reason.
+ * ⛔ NEVER `sys_session.token` — that column's own field comment records a
+ * replay-proven impersonation (a leaked token is `Authorization: Bearer` for
+ * that user), so it is the one value this line must never carry. The row `id`
+ * is a separate column and is derived from neither the token nor its hash.
+ *
+ * ## Volume
+ *
+ * One line per request that drops a claim — bounded by real sessions whose
+ * membership ended, not by traffic. An anonymous or bogus cookie never reaches
+ * here (no `userId`, no claim), so a prober writes nothing. Deliberately not
+ * rate-limited: the burst — every request of a removed member's still-live
+ * session, for up to the session's remaining lifetime — is exactly what the
+ * operator needs to see.
+ *
+ * `console.warn` and not an injected logger, for the same reason the API-key
+ * line is: this resolver is kernel-agnostic and takes no host wiring.
+ */
+function warnSessionOrganizationClaimDropped(details: {
+  reason: 'organization_membership_ended';
+  sessionId?: string;
+  userId?: string;
+  organizationId?: string;
+}): void {
+  const { reason, sessionId, userId, organizationId } = details;
+  console.warn(
+    `[security] Session organization claim dropped (${reason}): `
+    + `session=${sessionId ?? '<unknown>'} principal=${userId ?? '<unknown>'} `
+    + `organization=${organizationId ?? '<none>'}. `
+    + 'The session stays authenticated with NO active organization — the wire is unchanged.',
+  );
+}
+
 async function tryFind(
   ql: any,
   object: string,
@@ -324,6 +384,12 @@ export async function resolveAuthzContext(input: ResolveAuthzInput): Promise<Res
 
   let userId: string | undefined;
   let tenantId: string | undefined;
+  /**
+   * [#15409] The `sys_session` ROW id, kept only so a dropped organization
+   * claim can name the session it was dropped from. ⛔ Never
+   * `sessionData.session.token` — see {@link warnSessionOrganizationClaimDropped}.
+   */
+  let sessionId: string | undefined;
 
   // 1. API key (explicit opt-in via header) takes precedence over session.
   const admission = await resolveApiKeyAdmission(ql, headers, input.nowMs, input.tenancyPosture);
@@ -359,6 +425,10 @@ export async function resolveAuthzContext(input: ResolveAuthzInput): Promise<Res
       const sessionData = await input.getSession(headers);
       userId = sessionData?.user?.id ?? sessionData?.session?.userId;
       tenantId = tenantId ?? sessionData?.session?.activeOrganizationId;
+      // [#15409] Identity of the session, for the dropped-claim log line below.
+      // ⛔ The ROW id, never `session.token` — the token is the credential.
+      const rawSessionId = sessionData?.session?.id;
+      sessionId = typeof rawSessionId === 'string' && rawSessionId ? rawSessionId : undefined;
       ctx.accessToken = sessionData?.session?.token ?? ctx.accessToken;
       if (sessionData?.user?.email) ctx.email = String(sessionData.user.email);
     } catch {
@@ -379,7 +449,7 @@ export async function resolveAuthzContext(input: ResolveAuthzInput): Promise<Res
   // `sys_member` / `sys_user_position` / `sys_*_permission_set`, so a non-HTTP
   // surface that already knows the user id (a `runAs:'user'` automation run,
   // #3356) can build the SAME envelope without re-implementing any of it.
-  const grants = await resolveUserAuthzGrants(ql, userId, {
+  let grants = await resolveUserAuthzGrants(ql, userId, {
     tenantId,
     nowMs: input.nowMs,
     seedPermissions: ctx.permissions,
@@ -430,6 +500,87 @@ export async function resolveAuthzContext(input: ResolveAuthzInput): Promise<Res
         },
       };
     }
+  }
+
+  // ── [#15409 — maintainer ruling 2026-09-05, option B] The SESSION arm ─────
+  //
+  // The block above asks "is this stamped organization still backed by a
+  // membership?" and, until this card, asked it ONLY of an API key. A browser
+  // session's `activeOrganizationId` reached `ctx.tenantId` unread: measured on
+  // a live `isolated` boot with the real cloud-private `Organizations` plugin,
+  // a session whose owner had been removed through better-auth's OWN
+  // `/organization/remove-member` (driven by the org owner, 200, the
+  // `sys_member` row really deleted) went on READING that organization's rows
+  // and WRITING into it — the written row read back out of the sqlite file
+  // carrying the left organization and the removed user as author, for up to
+  // the session's remaining lifetime (7 days by default).
+  //
+  // The resolver already HELD the fact: `get-session` reported positions
+  // `["user","org_member"]` while the membership was intact and `["user"]` on
+  // the very next request — off the same `sys_member` read that builds
+  // `accessible_org_ids`. Nothing was missing but this comparison.
+  //
+  // ⚠️ Why the claim is DROPPED and the principal is NOT refused (option B,
+  // ruled; ⛔ not option A, which is the API-key arm's shape):
+  //
+  //   An API key IS its organization binding, so refusing the whole credential
+  //   is right there (#15256, decision 1A). A session is a PERSON, who may hold
+  //   legitimate memberships elsewhere. Refusing the principal would sign them
+  //   out of every organization because one stored claim went stale; dropping
+  //   the claim leaves them signed in, with no active organization, free to
+  //   switch to one they are actually in.
+  //
+  // ⛔ No second refusal mechanism is added: with no active organization, Layer
+  // 0 is ALREADY fail-closed — `!input.organizationId ⇒ RLS_DENY_FILTER` in
+  // `plugin-security/src/tenant-layer.ts`'s `isolated` branch, and an empty
+  // `accessible_org_ids` denies under `group`. This uses the branch that exists.
+  //
+  // ⛔ And no session revocation: revoking on a membership change is an EVENT
+  // trigger, covering exactly the removal paths someone remembered to wire — a
+  // direct row delete, a seed replay, a bulk or control-plane operation fails
+  // it OPEN, silently. This test runs on EVERY request, at the point the
+  // decision is made, so it covers every removal path by construction. Session
+  // revocation is filed separately, as the courtesy an admin expects when they
+  // click "Remove member", never as the wall.
+  //
+  // Free, like its API-key sibling: `resolveUserAuthzGrants` has just read
+  // `sys_member` for this user, so the test itself is a set membership check on
+  // data in hand. The RE-resolution below is not free, but it is reached only
+  // by a request that presented an unbacked claim — never on a healthy one.
+  //
+  // Re-resolved rather than hand-edited on purpose: "resolves with NO active
+  // organization" is an existing, well-defined state (a session that has not
+  // selected one), and the honest way to reach it is to ask the same resolver
+  // for it. Editing `ctx.tenantId` alone would leave the envelope's other
+  // tenant-scoped derivations computed under the claim that was just rejected —
+  // `org_user_ids`, the fellow-org peer list Layer 1 scopes identity tables
+  // with, would still enumerate the members of the organization the user left.
+  //
+  // Session-only by construction: an admitted API key sets `userId`, which
+  // makes the session branch above unreachable, so a non-empty `tenantId` here
+  // with no `keyPrincipal` can only have come from the session claim.
+  if (
+    !keyPrincipal
+    && tenantId
+    && input.tenancyPosture
+    && postureEnforcesWall(input.tenancyPosture)
+    && !grants.accessible_org_ids.includes(tenantId)
+  ) {
+    // [#15256 / 2A, mirrored] The one decision point where the drop is decided.
+    warnSessionOrganizationClaimDropped({
+      reason: 'organization_membership_ended',
+      sessionId,
+      userId,
+      organizationId: tenantId,
+    });
+    tenantId = undefined;
+    delete ctx.tenantId;
+    grants = await resolveUserAuthzGrants(ql, userId, {
+      tenantId,
+      nowMs: input.nowMs,
+      seedPermissions: ctx.permissions,
+      seedEmail: ctx.email,
+    });
   }
 
   ctx.positions = grants.positions;

--- a/packages/rest/src/single-kernel-isolated-session-org-claim-matrix.test.ts
+++ b/packages/rest/src/single-kernel-isolated-session-org-claim-matrix.test.ts
@@ -1,0 +1,576 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * [#15409 — maintainer ruling 2026-09-05, option B] The SESSION row of the
+ * #15256 matrix, at REST level, on the single-kernel wiring under a live
+ * `isolated` posture.
+ *
+ * ## What was measured, before this guard existed
+ *
+ * On a real `objectstack serve` of cloud's `apps/objectos-ee` — 44 plugins, the
+ * REAL cloud-private `@objectstack/organizations`, `Tenancy: isolated`,
+ * `SqlDriver(better-sqlite3)` on a FILE — a browser session whose
+ * `activeOrganizationId` pointed at an organization its owner had LEFT:
+ *
+ * | after the membership ended | GET | POST | the row, read back from the sqlite file |
+ * |:--|:--|:--|:--|
+ * | direct `sys_member` DELETE | 200, total 3 | 201 | `organization_id: org_alpha`, `created_by: u_exmember` |
+ * | better-auth's own `/organization/remove-member`, driven by the org OWNER | 200, total 4 | 201 | `organization_id: org_alpha`, `created_by: u_victim` |
+ *
+ * The second row is the one that makes this everyday: the product's own
+ * offboarding path returned 200 and really deleted the `sys_member` row, and
+ * the removed member's session came out of it still stamped with that
+ * organization, still `revoked_at: null`, still served — for up to the session
+ * lifetime, 7 days by default.
+ *
+ * ⭐ The resolver HAD the fact: `get-session` returned positions
+ * `["user","org_member"]` while the membership was intact and `["user"]` on the
+ * very next request, off the same `sys_member` read that builds
+ * `accessible_org_ids`, while still serving that organization's rows. The
+ * framework's only tenant-claim-vs-membership comparison was `keyPrincipal`-
+ * gated, so a session never reached it.
+ *
+ * ## Option B, and what that makes this file assert
+ *
+ * The ruled repair DROPS the unbacked claim; it does ⛔ NOT refuse the
+ * principal. So the ex-member's request here is **not** a 401 — it is an
+ * authenticated request carrying NO active organization, which Layer 0 already
+ * fails closed on. That is the whole difference between B and A, and §3 pins it
+ * from the outside: the same person, same session, switched to an organization
+ * they really are in, still works.
+ *
+ * ## Why the fixture is shaped the way it is
+ *
+ * Carried over from the cloud reading, unchanged in intent:
+ *
+ *  1. **Data must be shown to REACH.** A rig that serves nobody has measured
+ *     nothing, so a current member runs every route in §1 and must get rows.
+ *  2. **The write is read back FROM THE STORE**, never from the response body.
+ *     `store()` is the fixture's table; the assertions count rows in it.
+ *  3. **RBAC is opened SYMMETRICALLY** — one permission set held identically by
+ *     both principals — so RBAC cannot be what separates any two arms. Only the
+ *     organization claim can be.
+ *  4. **A second organization is seeded** that the member must never see, so a
+ *     wall that silently stopped applying reddens here rather than passes.
+ *
+ * ## Layer 0 is modelled, not mocked away
+ *
+ * `protocol.findData` / `createData` implement `tenant-layer.ts`'s `isolated`
+ * branch as it is written there — `!organizationId ⇒ RLS_DENY_FILTER`,
+ * otherwise `organization_id = organizationId` — plus ADR-0123 D2's other half
+ * on the write side: under an authenticated context with no active
+ * organization, tenant-scoped READS resolve to nothing and tenant-scoped WRITES
+ * are REFUSED rather than landing a row with a NULL organization that no
+ * reader, including its author, could ever see. Both halves already shipped;
+ * this card adds neither.
+ *
+ * ⛔ `resolveExecCtx` is NOT stubbed: the whole subject is what that method
+ * derives, so the real `computeExecCtx` → `resolveAuthzContext` chain runs.
+ *
+ * ⚠️ This suite resolves `@objectstack/core` through the workspace link, i.e.
+ * its `dist/` — it is in `check-test-source-alias.mjs`'s
+ * `KNOWN_UNALIASED_TEST_IMPORTS` for `@objectstack/rest`. Rebuild
+ * `@objectstack/core` before reading a verdict from it, and rebuild BOTH legs
+ * of any ablation: an unbuilt ablation leaves this file GREEN against the old
+ * behaviour, which is the direction that fails silently.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { hashApiKey, ANONYMOUS_DENY_STATUS, ANONYMOUS_DENY_CODE } from '@objectstack/core';
+import { RestServer } from './rest-server.js';
+
+const DATA_COLLECTION = '/api/v1/data/:object';
+const OBJECT = 'sys_business_unit';
+
+/** Cookie values — the fixture's session lookup key. */
+const COOKIE_MEMBER = 'os_session=sid_member';
+const COOKIE_EXMEMBER = 'os_session=sid_exmember';
+const COOKIE_BOGUS = 'os_session=sid_not_a_real_session';
+
+/**
+ * The `sys_session.token` values. Separate columns from the row `id`, which is
+ * exactly why the drop's log line may name the id and never these: that field's
+ * own comment in `sys-session.object.ts` records a replay-proven impersonation.
+ */
+const TOKEN_EXMEMBER = 'sess_token_exmember_never_log_me';
+
+// ---------------------------------------------------------------------------
+// The store — the fixture's table, read directly by the write assertions
+// ---------------------------------------------------------------------------
+
+interface BusinessUnitRow {
+    id: string;
+    organization_id: string | undefined;
+    created_by: string | undefined;
+    name: string;
+}
+
+const SEED: BusinessUnitRow[] = [
+    { id: 'bu_a1', organization_id: 'org_alpha', created_by: undefined, name: 'alpha unit 1' },
+    { id: 'bu_a2', organization_id: 'org_alpha', created_by: undefined, name: 'alpha unit 2' },
+    // The other organization — seeded so "the wall is live" is a control rather
+    // than an assumption, and so §3 has somewhere legitimate for the ex-member
+    // to still work.
+    { id: 'bu_b1', organization_id: 'org_beta', created_by: undefined, name: 'beta unit 1' },
+    { id: 'bu_b2', organization_id: 'org_beta', created_by: undefined, name: 'beta unit 2' },
+];
+
+/**
+ * The fixture's ONE hand-written where-matcher: equality plus `$in` — the two
+ * shapes the shared resolver actually issues — refusing every other shape
+ * loudly, so a combinator it does not implement can never read as a field that
+ * happened not to match.
+ */
+function matchesWhere(row: any, where: any): boolean {
+    for (const [field, cond] of Object.entries(where ?? {})) {
+        if (field.startsWith('$')) {
+            throw new Error(`fixture where-matcher: unsupported combinator '${field}'`);
+        }
+        if (cond !== null && typeof cond === 'object') {
+            const ops = Object.keys(cond as object);
+            if (ops.length !== 1 || ops[0] !== '$in' || !Array.isArray((cond as any).$in)) {
+                throw new Error(`fixture where-matcher: unsupported operator shape on '${field}'`);
+            }
+            if (!(cond as any).$in.includes(row[field])) return false;
+            continue;
+        }
+        if (row[field] !== cond) return false;
+    }
+    return true;
+}
+
+/** A session row, as `sys_session` declares it: `id` and `token` are separate. */
+interface SessionRow {
+    id: string;
+    token: string;
+    userId: string;
+    activeOrganizationId: string | null;
+}
+
+/**
+ * The permission store, in the SHIPPED aggregation shapes.
+ *
+ * `u_exmember`'s session is stamped `org_alpha` while its only current
+ * `sys_member` row is for `org_beta` — the session outlived the membership that
+ * backed it, which is the whole scenario. `u_member` is a current `org_alpha`
+ * member, and is ALSO the row that makes `org_alpha` a real organization with
+ * real peers rather than an empty name.
+ */
+function makeQl() {
+    const tables: Record<string, any[]> = {
+        // No API keys on the session arms — an API key sets `userId` and makes
+        // the session path unreachable, so a stray one would make every arm
+        // below unreadable. §4 wires its own.
+        sys_api_key: [],
+        sys_member: [
+            { user_id: 'u_member', organization_id: 'org_alpha', role: 'member' },
+            { user_id: 'u_exmember', organization_id: 'org_beta', role: 'member' },
+        ],
+        sys_user: [
+            { id: 'u_member', email: 'u_member@example.com' },
+            { id: 'u_exmember', email: 'u_exmember@example.com' },
+        ],
+        // RBAC opened SYMMETRICALLY through one permission set — the cloud
+        // reading's discipline. With one shared grant, only the organization
+        // claim can separate the arms.
+        sys_user_permission_set: [
+            { user_id: 'u_member', permission_set_id: 'ps_shared' },
+            { user_id: 'u_exmember', permission_set_id: 'ps_shared' },
+        ],
+        sys_permission_set: [
+            { id: 'ps_shared', name: 'shared_access', system_permissions: ['manage_metadata', 'studio.access'] },
+        ],
+    };
+    return {
+        tables,
+        find: async (object: string, q: any = {}) => {
+            const rows = (tables[object] ?? []).filter((row: any) => matchesWhere(row, q?.where));
+            return typeof q?.limit === 'number' ? rows.slice(0, q.limit) : rows;
+        },
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Layer 0, as `plugin-security/src/tenant-layer.ts` computes it under `isolated`
+// ---------------------------------------------------------------------------
+
+/**
+ * `computeTenantLayer0Filter`'s `isolated` branch, transcribed: a missing active
+ * organization is the DENY sentinel, never "no filter". Getting this backwards
+ * is the whole defect class — a resolver that hands down no tenant and a wall
+ * that reads that as "unscoped" is a wall that is off.
+ */
+function layer0IsDenied(tenantId: string | undefined): boolean {
+    return !tenantId;
+}
+
+/** ADR-0123 D2's write half, as `security-plugin.ts` throws it. */
+function tenantWriteRefusal(): Error {
+    const err: any = new Error(
+        "[Security] Access denied: 'sys_business_unit' is scoped to an organization, and this session "
+        + 'has no active organization — so this create has no organization to place the record in. '
+        + 'Join or select an active organization and retry.',
+    );
+    err.name = 'PermissionDeniedError';
+    err.code = 'PERMISSION_DENIED';
+    return err;
+}
+
+// ---------------------------------------------------------------------------
+// The REST harness — real routes, real `computeExecCtx`, no stubbed exec ctx
+// ---------------------------------------------------------------------------
+
+function makeRes() {
+    const res: any = { statusCode: 200, body: undefined };
+    res.status = vi.fn((c: number) => { res.statusCode = c; return res; });
+    res.json = vi.fn((b: any) => { res.body = b; return res; });
+    res.header = vi.fn(() => res);
+    res.setHeader = vi.fn(); res.write = vi.fn(); res.end = vi.fn(); res.send = vi.fn();
+    return res;
+}
+
+interface Harness {
+    rest: RestServer;
+    /** Every row the fixture table holds, in insertion order. */
+    store: () => BusinessUnitRow[];
+    warnings: () => string[];
+    /**
+     * better-auth's `setActiveOrganization`, modelled: it rewrites
+     * `active_organization_id` on the SAME session row — same id, same token,
+     * same cookie. This is what "switch organization" is, and §3 uses it to
+     * show the principal was never signed out.
+     */
+    switchActiveOrganization: (cookie: string, org: string | null) => void;
+}
+
+/**
+ * The single-kernel wiring, byte-faithful to `rest-api-plugin.ts`: no
+ * kernelManager, an auth provider and an objectql provider over the lone local
+ * kernel, plus the tenancy provider.
+ */
+function setup(opts: { withExMemberApiKey?: string } = {}): Harness {
+    const rows: BusinessUnitRow[] = SEED.map((r) => ({ ...r }));
+    let seq = 0;
+    const ql = makeQl();
+
+    const sessions: Record<string, SessionRow> = {
+        sid_member: { id: 'ses_member', token: 'sess_token_member', userId: 'u_member', activeOrganizationId: 'org_alpha' },
+        // ⭐ THE SUBJECT: the claim outlived the membership.
+        sid_exmember: { id: 'ses_exmember', token: TOKEN_EXMEMBER, userId: 'u_exmember', activeOrganizationId: 'org_alpha' },
+    };
+
+    if (opts.withExMemberApiKey) ql.tables.sys_api_key.push(opts.withExMemberApiKey as any);
+
+    const protocol: any = {
+        getDiscovery: vi.fn().mockResolvedValue({
+            version: 'v0', routes: { data: '', metadata: '', ui: '', auth: '/auth' },
+        }),
+        getMetaTypes: vi.fn().mockResolvedValue([]),
+        getMetaItems: vi.fn().mockResolvedValue([]),
+        getMetaItem: vi.fn().mockResolvedValue({}),
+        findData: vi.fn(async (r: any) => {
+            const tenantId = r?.context?.tenantId;
+            // RLS_DENY_FILTER — zero rows, never "everything".
+            if (layer0IsDenied(tenantId)) return { value: [], total: 0 };
+            const visible = rows.filter((row) => row.organization_id === tenantId);
+            return { value: visible, total: visible.length };
+        }),
+        createData: vi.fn(async (r: any) => {
+            const tenantId = r?.context?.tenantId;
+            // [ADR-0123 D2] No active organization → the write is REFUSED, not
+            // landed with a NULL organization.
+            if (layer0IsDenied(tenantId)) throw tenantWriteRefusal();
+            const row: BusinessUnitRow = {
+                id: `w${++seq}`,
+                organization_id: tenantId,
+                created_by: r?.context?.userId,
+                name: String(r?.data?.name ?? ''),
+            };
+            rows.push(row);
+            return row;
+        }),
+    };
+
+    const server: any = {
+        get: vi.fn(), post: vi.fn(), put: vi.fn(), delete: vi.fn(), patch: vi.fn(), use: vi.fn(),
+        listen: vi.fn().mockResolvedValue(undefined), close: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const authServiceProvider = async () => ({
+        api: {
+            getSession: async ({ headers }: any) => {
+                const cookie: string | undefined = headers?.get?.('cookie') ?? undefined;
+                const sid = cookie?.split('os_session=')[1]?.split(';')[0];
+                const row = sid ? sessions[sid] : undefined;
+                if (!row) return undefined;
+                return {
+                    user: { id: row.userId, email: `${row.userId}@example.com` },
+                    session: { ...row },
+                };
+            },
+        },
+    });
+    const objectQLProvider = async () => ql;
+    const tenancyServiceProvider = async () => ({ posture: 'isolated' });
+
+    const rest = new RestServer(
+        server,
+        protocol,
+        {} as any,
+        undefined,               // kernelManager — THE single-kernel wiring
+        undefined,               // envRegistry
+        undefined,               // defaultEnvironmentIdProvider
+        authServiceProvider,
+        objectQLProvider,
+        undefined, undefined, undefined, undefined, undefined, undefined,  // email…i18n
+        undefined, undefined, undefined, undefined, undefined, undefined,  // analytics…metadata
+        tenancyServiceProvider,
+    );
+    rest.registerRoutes();
+
+    return {
+        rest,
+        store: () => rows.map((r) => ({ ...r })),
+        warnings: () => warnSpy.mock.calls.map((c: unknown[]) => c.map(String).join(' ')),
+        switchActiveOrganization: (cookie, org) => {
+            const sid = cookie.split('os_session=')[1]?.split(';')[0] as string;
+            sessions[sid].activeOrganizationId = org;
+        },
+    };
+}
+
+function routeOf(rest: any, method: string, path: string) {
+    const route = rest.getRoutes().find((r: any) => r.method === method && r.path === path);
+    if (!route) throw new Error(`${method} ${path} route not registered`);
+    return route;
+}
+
+function cookieHeaders(cookie?: string, apiKey?: string): Record<string, string> {
+    const h: Record<string, string> = {};
+    if (cookie) h.cookie = cookie;
+    if (apiKey) h['x-api-key'] = apiKey;
+    return h;
+}
+
+async function callGet(rest: any, cookie?: string, apiKey?: string) {
+    const res = makeRes();
+    await routeOf(rest, 'GET', DATA_COLLECTION).handler(
+        {
+            method: 'GET', path: `/api/v1/data/${OBJECT}`, params: { object: OBJECT }, query: {},
+            headers: cookieHeaders(cookie, apiKey),
+        },
+        res,
+    );
+    return res;
+}
+
+async function callPost(rest: any, cookie: string | undefined, name: string, apiKey?: string) {
+    const res = makeRes();
+    await routeOf(rest, 'POST', DATA_COLLECTION).handler(
+        {
+            method: 'POST', path: `/api/v1/data/${OBJECT}`, params: { object: OBJECT }, query: {},
+            headers: cookieHeaders(cookie, apiKey), body: { name },
+        },
+        res,
+    );
+    return res;
+}
+
+const dropLines = (h: Harness) => h.warnings().filter((l) => l.includes('Session organization claim dropped'));
+
+let warnSpy: ReturnType<typeof vi.spyOn>;
+let errorSpy: ReturnType<typeof vi.spyOn>;
+beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+afterEach(() => { warnSpy.mockRestore(); errorSpy.mockRestore(); });
+
+// ---------------------------------------------------------------------------
+// §1 — Instrument controls. Both directions, before any subject arm is read.
+// ---------------------------------------------------------------------------
+
+describe('[#15409] §1 — the rig can serve, and the door can refuse', () => {
+    it('CONTROL · data REACHES: a CURRENT member reads its own organization and only that one', async () => {
+        const h = setup();
+        const res = await callGet(h.rest, COOKIE_MEMBER);
+        expect(res.statusCode).toBe(200);
+        expect(res.body.total).toBe(2);
+        expect(res.body.value.map((r: BusinessUnitRow) => r.id)).toEqual(['bu_a1', 'bu_a2']);
+        // The wall IS live: org_beta's two rows exist in the store and are not served.
+        expect(h.store().filter((r) => r.organization_id === 'org_beta')).toHaveLength(2);
+    });
+
+    it('CONTROL · writes REACH: a CURRENT member\'s POST lands, read back FROM THE STORE', async () => {
+        const h = setup();
+        const res = await callPost(h.rest, COOKIE_MEMBER, 'w-member');
+        expect(res.statusCode).toBe(201);
+        const landed = h.store().filter((r) => r.name === 'w-member');
+        expect(landed).toHaveLength(1);
+        expect(landed[0]).toMatchObject({ organization_id: 'org_alpha', created_by: 'u_member' });
+    });
+
+    it('CONTROL · the door refuses: no cookie is 401 on both verbs, and nothing lands', async () => {
+        const h = setup();
+        const get = await callGet(h.rest, undefined);
+        expect(get.statusCode).toBe(ANONYMOUS_DENY_STATUS);
+        expect(get.body?.error?.code ?? get.body?.code).toBe(ANONYMOUS_DENY_CODE);
+        const post = await callPost(h.rest, undefined, 'w-anon');
+        expect(post.statusCode).toBe(ANONYMOUS_DENY_STATUS);
+        expect(h.store()).toHaveLength(SEED.length);
+    });
+
+    it('CONTROL · a bogus cookie is 401 too — and is not a drop, because nothing was claimed', async () => {
+        const h = setup();
+        const res = await callGet(h.rest, COOKIE_BOGUS);
+        expect(res.statusCode).toBe(ANONYMOUS_DENY_STATUS);
+        expect(dropLines(h)).toHaveLength(0);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// §2 — THE SUBJECT ROW. The card's own case, driven end to end.
+// ---------------------------------------------------------------------------
+
+describe('[#15409] §2 — a session whose membership ended while it stayed alive', () => {
+    it('REPAIRED: GET reads NOTHING from the organization it left — was 200 carrying that organization\'s rows', async () => {
+        const h = setup();
+        const res = await callGet(h.rest, COOKIE_EXMEMBER);
+        expect(res.body.total).toBe(0);
+        expect(res.body.value).toEqual([]);
+        // The rows are still there — they were not served, not deleted.
+        expect(h.store().filter((r) => r.organization_id === 'org_alpha')).toHaveLength(2);
+    });
+
+    it('REPAIRED: POST does NOT land in that organization — read back from the store', async () => {
+        const h = setup();
+        const res = await callPost(h.rest, COOKIE_EXMEMBER, 'w-exmember');
+        // 403 `PERMISSION_DENIED` — ADR-0123 D2's EXISTING write refusal for a
+        // context with no active organization, in its existing words. ⛔ No new
+        // status code and no new error code were added by this card.
+        expect(res.statusCode).toBe(403);
+        expect(res.body?.error?.code ?? res.body?.code).toBe('PERMISSION_DENIED');
+        // The measured defect was a write that LANDED, stamped with the left
+        // organization and attributed to the removed user. The STORE is the
+        // authority on whether it did — never the response body.
+        expect(h.store().filter((r) => r.name === 'w-exmember')).toHaveLength(0);
+        expect(h.store().filter((r) => r.created_by === 'u_exmember')).toHaveLength(0);
+        expect(h.store()).toHaveLength(SEED.length);
+    });
+
+    it('[2A, mirrored] the drop is said OUT LOUD once — session / principal / organization / reason, ⛔ never the token', async () => {
+        const h = setup();
+        await callGet(h.rest, COOKIE_EXMEMBER);
+        const lines = dropLines(h);
+        expect(lines).toHaveLength(1);
+        expect(lines[0]).toContain('organization_membership_ended');
+        expect(lines[0]).toContain('session=ses_exmember');
+        expect(lines[0]).toContain('principal=u_exmember');
+        expect(lines[0]).toContain('organization=org_alpha');
+        // ⛔ THE CREDENTIAL. A leaked `sys_session.token` is `Authorization:
+        // Bearer` for that user — its own field comment calls the disclosure
+        // impersonation rather than exposure.
+        expect(lines[0]).not.toContain(TOKEN_EXMEMBER);
+    });
+
+    it('the WIRE is unchanged: no new status code, no reason, no organization travels to the caller', async () => {
+        const h = setup();
+        const get = await callGet(h.rest, COOKIE_EXMEMBER);
+        const post = await callPost(h.rest, COOKIE_EXMEMBER, 'w-exmember-wire');
+        for (const body of [get.body, post.body]) {
+            expect(JSON.stringify(body ?? {})).not.toMatch(/organization_membership_ended|claim dropped|ses_exmember/i);
+        }
+        // The 200-shaped empty read and the ADR-0123 D2 write refusal are both
+        // states this deployment could already produce for a session that simply
+        // has not selected an organization. Nothing here is new vocabulary.
+        expect(get.statusCode).toBe(200);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// §3 — ⭐ B, NOT A. The assertion that reddens if B is "simplified" into A.
+// ---------------------------------------------------------------------------
+
+describe('[#15409] §3 — the principal is dropped-from-an-org, NOT refused', () => {
+    it('the ex-member is STILL AUTHENTICATED — the read is a 200 with nothing in it, not a 401', async () => {
+        const h = setup();
+        const res = await callGet(h.rest, COOKIE_EXMEMBER);
+        // ⛔ If this ever becomes ANONYMOUS_DENY_STATUS, option B has silently
+        // become option A: a person signed out of everything because one stored
+        // claim went stale.
+        expect(res.statusCode).not.toBe(ANONYMOUS_DENY_STATUS);
+        expect(res.statusCode).toBe(200);
+        expect(res.body?.error?.code ?? res.body?.code).not.toBe(ANONYMOUS_DENY_CODE);
+    });
+
+    it('and can still WORK in an organization they really are in — same session, switched', async () => {
+        const h = setup();
+        // The dropped request first, so the switch is measured on a session that
+        // has already met the guard.
+        await callGet(h.rest, COOKIE_EXMEMBER);
+        // better-auth's `setActiveOrganization`: the SAME session row, same id,
+        // same token, same cookie — only the claim moves.
+        h.switchActiveOrganization(COOKIE_EXMEMBER, 'org_beta');
+
+        const get = await callGet(h.rest, COOKIE_EXMEMBER);
+        expect(get.statusCode).toBe(200);
+        expect(get.body.total).toBe(2);
+        expect(get.body.value.map((r: BusinessUnitRow) => r.id)).toEqual(['bu_b1', 'bu_b2']);
+
+        const post = await callPost(h.rest, COOKIE_EXMEMBER, 'w-exmember-beta');
+        expect(post.statusCode).toBe(201);
+        const landed = h.store().filter((r) => r.name === 'w-exmember-beta');
+        expect(landed).toHaveLength(1);
+        expect(landed[0]).toMatchObject({ organization_id: 'org_beta', created_by: 'u_exmember' });
+    });
+
+    it('and the backed claim says NOTHING — one line per drop, not one per request', async () => {
+        const h = setup();
+        h.switchActiveOrganization(COOKIE_EXMEMBER, 'org_beta');
+        await callGet(h.rest, COOKIE_EXMEMBER);
+        await callGet(h.rest, COOKIE_MEMBER);
+        expect(dropLines(h)).toHaveLength(0);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// §4 — The API-key arm is UNTOUCHED (#15256 decision 1A stands).
+// ---------------------------------------------------------------------------
+
+describe('[#15409] §4 — an API key is still refused outright, not trimmed', () => {
+    /**
+     * A key IS its organization binding, so refusing the whole credential is
+     * right there. This card changed the SESSION arm only; if someone ever
+     * generalises the drop over both, this row goes red — an ex-member's
+     * automation would go back to answering 200 with an empty set, the silent
+     * empty #15256 exists to remove.
+     */
+    it('an ex-member\'s org-stamped key is 401, and the session drop line does not fire for it', async () => {
+        // The fixture stores the at-rest hash exactly as `sys_api_key` does.
+        const raw = 'osk_15409_exmember';
+        const h = setup({
+            withExMemberApiKey: {
+                id: 'key_exmember', key: hashApiKey(raw), user_id: 'u_exmember',
+                active_organization_id: 'org_alpha', revoked: false,
+            } as any,
+        });
+        const res = await callGet(h.rest, undefined, raw);
+        expect(res.statusCode).toBe(ANONYMOUS_DENY_STATUS);
+        expect(res.body?.error?.code ?? res.body?.code).toBe(ANONYMOUS_DENY_CODE);
+        expect(h.warnings().filter((l) => l.includes('API key refused'))).toHaveLength(1);
+        expect(dropLines(h)).toHaveLength(0);
+    });
+
+    it('its POST lands nothing either — the store still holds only the seed', async () => {
+        const raw = 'osk_15409_exmember';
+        const h = setup({
+            withExMemberApiKey: {
+                id: 'key_exmember', key: hashApiKey(raw), user_id: 'u_exmember',
+                active_organization_id: 'org_alpha', revoked: false,
+            } as any,
+        });
+        const res = await callPost(h.rest, undefined, 'w-exmember-key', raw);
+        expect(res.statusCode).toBe(ANONYMOUS_DENY_STATUS);
+        expect(h.store()).toHaveLength(SEED.length);
+    });
+});


### PR DESCRIPTION
Fixes #15409

Under a wall-enforcing tenancy posture, a **session** whose `activeOrganizationId` names an organization the user has left now resolves with **no** active organization instead of that one. Option B of the maintainer's 2026-09-05 ruling: the claim is dropped, the principal is **not** refused.

## I verified the defect myself first, on this branch's merge base

Both halves of the card's diagnosis, re-measured on `origin/main` before writing a line of the repair:

1. **The claim is taken unread.** `packages/core/src/security/resolve-authz-context.ts` line 361 (pre-change):

   ```
   tenantId = tenantId ?? sessionData?.session?.activeOrganizationId;
   ```

   and line 371 puts it straight on the context. Nothing between them consults membership.

2. **The only comparison is API-key-gated, and it is the only one.** Re-ran the exhaustiveness grep rather than trusting the card:

   ```
   $ grep -rn 'accessible_org_ids' packages --include='*.ts' | grep -v /dist/ | grep -v '\.test\.' | grep 'includes\|indexOf\|has('
   packages/core/src/security/resolve-authz-context.ts:410:    if (postureEnforcesWall(posture) && !grants.accessible_org_ids.includes(keyPrincipal.tenantId)) {
   ```

   One line, against **69** files that merely mention the key in this checkout. It opens on `keyPrincipal`, so a session never reaches it.

The premise holds in full.

## The change

`resolveAuthzContext` gains the session arm of the question its API-key block already asks. When there is no `keyPrincipal`, the transport supplied a wall-enforcing posture, and the session's claim is not in `grants.accessible_org_ids`:

- one `warn` at the decision point,
- `ctx.tenantId` is dropped, and
- the grants envelope is **re-resolved with no tenant**.

Re-resolved rather than field-edited, deliberately. "Resolves with no active organization" is an existing, well-defined state, and the honest way to reach it is to ask the same resolver for it. Editing `ctx.tenantId` alone would leave the envelope's other tenant-scoped derivations computed under the claim that was just rejected — `org_user_ids`, the fellow-org peer list Layer 1 scopes identity tables with, would still enumerate the members of the organization the user left. That residue is pinned by name in the unit suite. The second resolution is reached only by a request that presented an unbacked claim; a healthy request pays nothing.

**No second refusal mechanism was added**, as ruled. Both halves of the fail-closed behaviour already shipped and this change simply arrives at them:

| with no active organization | who already owns it |
|:---|:---|
| reads resolve to nothing | `plugin-security/src/tenant-layer.ts`, `isolated` branch: `!organizationId` returns `RLS_DENY_FILTER` |
| a tenant-scoped write is refused, 403 `PERMISSION_DENIED` | ADR-0123 D2, in `security-plugin.ts`, in its existing words |

**Not A**, and the difference is pinned from the outside: an API key **is** its organization binding, so it keeps refusing the principal outright (#15256 decision 1A, untouched). A session is a person who may hold memberships elsewhere — they stay signed in and can switch to an organization they are actually in.

**Not C**: no session revocation here. That is an event trigger and would cover exactly the removal paths someone remembered to wire; this test runs on every request, at the point the decision is made.

**Observability**, mirroring #15256's 2A — one `warn`, server-side only:

```
[security] Session organization claim dropped (organization_membership_ended): session=ses_victim principal=u_victim organization=org_alpha. The session stays authenticated with NO active organization — the wire is unchanged.
```

It names the `sys_session` **row id**, never `sys_session.token` — that column's own field comment records a replay-proven impersonation, so it is the one value the line must never carry. Pinned in both suites.

**The wire is unchanged**: no new status code, no new error code, no reason on the wire. Pinned by a test that asserts the GET and POST bodies mention no reason, no session id and no dropped organization.

## Scope

Untouched, as ruled: `activeOrganizationId`'s write path, better-auth configuration, session lifetime, revocation, and the API-key arm.

## The rig I used, and the one I did not

**Neither** `bootStack({ multiTenant: 'posture-only' })` / `SimulatedOrgScopingPlugin` **nor** the cloud-private `packages/organizations`. The pins are driven through the REST-level single-kernel harness that #15256's own repair is pinned with (`single-kernel-isolated-api-key-matrix.test.ts`), which supplies the posture directly through the tenancy service provider — and the posture is all this guard reads. `resolveExecCtx` is not stubbed, so the real `computeExecCtx` to `resolveAuthzContext` chain runs; Layer 0 is modelled as `tenant-layer.ts` writes it, including the deny half, rather than mocked away. The enterprise plugin's own refusals are not spoken for here and are not claimed.

## Pins

`packages/rest/src/single-kernel-isolated-session-org-claim-matrix.test.ts` — 13 cases, the measured scenario end to end:

- §1 controls, both directions: a current member reads its own organization and only that one, and writes a row read back **from the store**; no cookie is 401 on both verbs with nothing landing; a bogus cookie is 401 and is not a drop.
- §2 the card's own case: the ex-member reads **nothing** from the organization they left (the two rows are still in the store, just not served) and the POST is 403 with **nothing landing** — asserted against the store, never the response body. Plus the single `warn` and the unchanged wire.
- §3 **B, not A**: the ex-member's read is a 200, explicitly `not` the anonymous deny — and after `setActiveOrganization` moves the same session row to `org_beta` (same id, same token, same cookie) they read and write there normally. This is the assertion that reddens if B is ever simplified into A.
- §4 the API-key arm untouched: an ex-member's org-stamped key is still 401 outright, its POST lands nothing, and the session drop line does not fire for it.

`packages/core/src/security/resolve-authz-context.test.ts` — 11 unit cases: the backed-claim control, the drop itself (the key is *removed*, not set to undefined), the surviving principal, the `org_user_ids` residue, `group` behaves the same, `single` does **not**, an unwired transport does **not**, a session with no claim is not a drop, a lapsed ADR-0091 membership does not back a claim, the log line, and the API-key arm.

## Ablation — both legs proven on disk, both rebuilt

This REST suite consumes `@objectstack/core` through the workspace link (its `dist/`), so both legs rebuild core; an unbuilt ablation stays green and certifies nothing.

**Mutate** — the guard restored to base `6a3cc134c`:

```
on-disk blob = 671316e60e312ae3d4c1aaeba96cfc4360fa68a8 / base blob = 671316e60e312ae3d4c1aaeba96cfc4360fa68a8
src marker occurrences after mutation = 0  (was 1)
ablation-dist-preflight: marker absent from all 12 built files
core vitest exit = 1   Tests  5 failed | 81 passed (86)
rest vitest exit = 1   Tests  3 failed | 10 passed (13)
AssertionError: expected 2 to be +0            <- the ex-member reads org_alpha's rows again
AssertionError: expected 201 to be 403         <- and writes into it again
AssertionError: expected [] to have a length of 1 but got +0   <- and nothing is said about it
```

**Restore**, proven the same way:

```
on-disk blob after restore = 9928f2cfc4f4a4ecaa56c699214d0ee0388deafe / HEAD blob = 9928f2cfc4f4a4ecaa56c699214d0ee0388deafe
src marker occurrences after restore = 1
git diff HEAD -- target: empty
ablation-dist-preflight: marker present in 2 built files
tree: working tree clean against HEAD
core vitest exit = 0   Tests  86 passed (86)
rest vitest exit = 0   Tests  13 passed (13)
```

The mutation script carried a `trap ... EXIT INT TERM` restore throughout. §3's B-not-A cases stay green under the ablation **by design**: they assert the principal is not refused, which the leaky code also does not do. Their job is to redden if B becomes A, not if the guard is removed.

## Verification

All at `4733750e3`, with `origin/main` merged in (`901773b21`).

- `pnpm --filter @objectstack/core --filter @objectstack/rest test` — core 49 files / 1201 tests, rest 182 files / 3112 tests, all passing.
- `pnpm --filter @objectstack/core --filter @objectstack/rest typecheck` — exit 0. Both new/edited test files are genuinely inside their `tsconfig.test.json` programs, confirmed with `tsc --listFiles` (one hit each) rather than assumed; `check:test-typecheck` reports core at 4 pinned ledger errors, unchanged, and rest at 0.
- `pnpm lint` — the repo-wide `eslint . --no-inline-config`, exit 0 in 24s. Not narrowed.
- `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` — let it derive its own change set (4 paths, merge base `901773b21`), no stale-tree warning.

Every derived family, run and green (exit 0 captured before any pipe):

`check:authz-resolver` (the one whose gate source *is* the edited file) · `check:changeset-gate-self-tests` · `check:cross-package-test-inputs` · `check:dispatcher-error-vocabulary` · `check:doc-authoring` · `check:kernel-hook-pairs` · `check:logger-receiver-detach` · `check:objectql-double-limit` · `check:objectui-changeset` · `check:org-identifier` · `check:page-declaration-shape` · `check:pm-half-states` · `check:published-files` · `check:slot-lookup` · `check:test-source-alias` · `check:type-source-resolution` · `check:where-matcher` · `check:query-options-erasure` · `check:type-check-coverage` · `check:engine-double-contract` · `check:driver-memory-census` · `check:nul-bytes` · `check:refd-timer-probe` · `check:watch-hint-literal`

Two more needed the workspace built, so a full `turbo run build` over `packages/*` ran first (71 tasks, 2m11s) and both then answered:

- `check:dual-build-cjs-loads` — exit 0. Its first run was `PREREQUISITE NOT MET` (exit 3), which is NOT MEASURED, not a pass; reported here only because it was re-run properly.
- `check:type-check-debt` — exit 0, 12 ledger entries re-measured, 140 raw errors, none above its recorded number.

Also self-scanned the four changed files for raw control bytes (`grep -naP` over the C0 set plus DEL) — no match.

### NOT MEASURED, with reasons

- **Seven families the deriver itself marks `NOT RUNNABLE LOCALLY`** because their argv comes from the workflow (`$RUNNER_TEMP`, `${{ matrix.shard }}`, `$PROVENANCE`): `check-cross-package-test-inputs --union-into/--changed`, three `check-shard-attestation` invocations, two `check-test-completeness` invocations, and `pm/check-half-states --provenance`. Their scripts document no default for the pinned flags, so there is no local invocation and none was invented. CI runs them.
- **The enterprise arm.** The wall's `org-scoping` service has only one registrar and it is cloud-private, so this repo cannot speak for `@objectstack/organizations`' own refusals. The guard reads only the posture, which is why the pins are still meaningful — but the enterprise composition is not claimed.
- **The kernel-bound / hosted arm (`OS_MULTI_TENANT`)** remains unmeasured, exactly as the card and cloud#1982 carried it forward. Unknown, not safe.

### Declared narrowing — verification ran UNLOCKED

`scripts/pm/os-verify-lock.sh` could not take the shared verify lock on this host: no usable `flock`. The shared verify lock is declared Linux-only (`flock` is util-linux, and a stock macOS does not ship it), so the commands were run directly, without the lock — a declared narrowing, not a silent one. No serialization guarantee held for these runs, nor for any sibling agent in this container while they ran.

## Changeset

`.changeset/session-unbacked-org-claim-dropped.md` — `@objectstack/core` **patch**, naming the observable change: a session whose active organization is no longer one the user belongs to now resolves with no active organization instead of that one's data.

---
_Generated by [Claude Code](https://claude.ai/code/session_6679d191-11f4-465b-b322-0e0409d76793)_
