### PR TITLE
fix(runtime): the dispatcher's scope strip matches `/environments/`, the prefix its own hint parser reads

### DIFF
--- a/.changeset/dispatcher-scope-strip-environments-prefix.md
+++ b/.changeset/dispatcher-scope-strip-environments-prefix.md
@@ -1,0 +1,19 @@
+---
+"@objectstack/runtime": patch
+---
+
+An environment-scoped URL now reaches a dispatcher domain instead of answering 404.
+
+`HttpDispatcher.dispatch()` reads the scoped-URL prefix in three places — the environment-id hint parser, the OAuth-on-MCP gate, and the scope strip that lets `DomainHandlerRegistry` match the remainder. Only the first had been moved to the ADR-0006 `/environments/` spelling; the other two still matched the retired `/projects/` one. The strip therefore never fired on a real scoped URL, and since the registry matches from the head of the path, every environment-scoped request arriving through the `@objectstack/hono` catch-all — the entry cloud hosts mount, and the only one that hands `dispatch()` a still-scoped path — matched no domain at all:
+
+```
+GET /api/v1/environments/<id>/data/task   ->  404 ROUTE_NOT_FOUND   (now: reaches /data)
+GET /api/v1/environments/<id>/health      ->  404 ROUTE_NOT_FOUND   (now: 200)
+GET /api/v1/data/task          (control)  ->  reaches /data, unchanged
+```
+
+The dispatcher-plugin's own scoped mounts were never affected: they pass a pre-stripped subpath (`${prefix}/environments/:environmentId/automation` dispatches the literal `/automation`), which is why the standalone server showed nothing.
+
+The OAuth 2.1 gate moved with it. An access token is honoured only on the MCP surface, and that test runs against the still-scoped path — so `/api/v1/environments/<id>/mcp` would have reached the MCP domain with its token refused had the strip been repaired alone.
+
+**If you still emit the old spelling**: replace `/api/v1/projects/:projectId/...` with `/api/v1/environments/:environmentId/...`, as `content/docs/api/environment-routing.mdx` has instructed since ADR-0006 D2. That prefix is no longer stripped, and it was never a working alias in the first place: nothing parses `/projects/<id>`, so stripping it discarded the only place the request named an environment and served it from the host default instead. ADR-0006 D2 retired `project` on the API surface with no aliases, so the repair is one spelling in all three readings rather than a two-prefix alternation.

--- a/packages/runtime/src/http-dispatcher.scoped-url-strip.test.ts
+++ b/packages/runtime/src/http-dispatcher.scoped-url-strip.test.ts
@@ -1,0 +1,172 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect } from 'vitest';
+import { HttpDispatcher, type HttpDispatcherResult } from './http-dispatcher.js';
+
+/**
+ * The scoped-URL prefix is ONE convention, read three times in one request —
+ * and the three readings had drifted apart.
+ *
+ * `dispatch()` handles an environment-scoped URL by reading the same prefix in
+ * three places:
+ *
+ *   1. `extractEnvironmentIdFromPath` (via `prepareResolverHints`) parses the
+ *      environment id out of it and hands it to the host's `KernelResolver`;
+ *   2. the `acceptOAuthAccessToken` test decides whether an OAuth 2.1 access
+ *      token is honoured, and runs against the STILL-SCOPED path;
+ *   3. the scope strip removes the prefix so `DomainHandlerRegistry` — which
+ *      matches from the head of the path — can claim the remainder.
+ *
+ * Reading 1 said `/environments/`; readings 2 and 3 still said the
+ * pre-ADR-0006 `/projects/`. What that cost, measured through the real
+ * `@objectstack/hono` catch-all before the repair:
+ *
+ * ```
+ * GET /api/v1/environments/env_alpha/health     -> 404 ROUTE_NOT_FOUND
+ * GET /api/v1/environments/env_alpha/data/task  -> 404 ROUTE_NOT_FOUND
+ * GET /api/v1/health                 (control)  -> 200
+ * GET /api/v1/data/task              (control)  -> 503 SERVICE_UNAVAILABLE (i.e. it REACHED /data)
+ * GET /api/v1/projects/env_alpha/health         -> 200   <- stripped, but nothing ever parsed the id
+ * ```
+ *
+ * The legacy spelling was not a working alias in exchange: nothing parses
+ * `/projects/<id>`, so stripping it discarded the only place the environment
+ * was named and served the request from the host default. ADR-0006 D2 retired
+ * `project` on the API surface with NO aliases, and
+ * `content/docs/api/environment-routing.mdx` tells callers to replace
+ * `/api/v1/projects/:projectId/...` with `/api/v1/environments/:environmentId/...`
+ * — so the repair is one spelling everywhere, not a two-prefix alternation.
+ *
+ * ## Why this suite drives `dispatch()` with a hand-derived subpath
+ *
+ * `packages/runtime` cannot depend on `@objectstack/hono` (that adapter depends
+ * on THIS package). What the adapter contributes is one line —
+ * `const subPath = c.req.path.substring(prefix.length)` in the
+ * `app.all(`${prefix}/*`)` catch-all of `packages/adapters/hono/src/index.ts` —
+ * so {@link subPathAsTheCatchAllDerivesIt} reproduces exactly that, and nothing
+ * else. It matters that it is the catch-all: it is the ONLY entry that hands
+ * `dispatch()` a still-scoped path. Every scoped mount in `dispatcher-plugin.ts`
+ * passes a pre-stripped subpath (`registerAutomationRoutes` mounts
+ * `${prefix}/environments/:environmentId/automation` but dispatches the literal
+ * `'/automation'`), which is why the standalone server never saw this.
+ */
+
+const PREFIX = '/api/v1';
+const ENV_ID = 'env_alpha';
+
+/** The `@objectstack/hono` catch-all's one contribution, reproduced exactly. */
+function subPathAsTheCatchAllDerivesIt(url: string): string {
+    return url.substring(PREFIX.length);
+}
+
+/**
+ * A kernel that provides NO services at all.
+ *
+ * Deliberate: it makes "which domain claimed the path" the only variable. A
+ * claimed `/data` answers 503 SERVICE_UNAVAILABLE (the domain ran and found no
+ * data service); an unclaimed path answers 404 ROUTE_NOT_FOUND. Those two are
+ * the whole signal, and a kernel with services wired would blur them.
+ */
+function bareKernel(): any {
+    return {
+        getState: () => 'running',
+        getService: () => undefined,
+        getServiceAsync: async () => undefined,
+    };
+}
+
+function dispatcher(): HttpDispatcher {
+    return new HttpDispatcher(bareKernel(), undefined, { enforceProjectMembership: false });
+}
+
+/**
+ * Narrow the optional `response`. Lifted from `http-dispatcher.ready.test.ts`
+ * for the reason stated there: this package's test layer IS type-checked, and
+ * `expect(res.response).toBeDefined()` narrows nothing. "Answered no response
+ * at all" and "answered the wrong status" must stay distinguishable.
+ */
+function responseOf(res: HttpDispatcherResult, what: string): NonNullable<HttpDispatcherResult['response']> {
+    const { response } = res;
+    if (!response) throw new Error(`${what} answered no response at all`);
+    return response;
+}
+
+/** `GET <url>` through the catch-all derivation; returns status + error code + the context it mutated. */
+async function get(url: string): Promise<{ status: number; code: unknown; ctx: any }> {
+    const ctx: any = { request: new Request(`http://pin.local${url}`) };
+    const res = await dispatcher().dispatch('GET', subPathAsTheCatchAllDerivesIt(url), undefined, {}, ctx, PREFIX);
+    const response = responseOf(res, `GET ${url}`);
+    return { status: response.status, code: (response.body as any)?.error?.code, ctx };
+}
+
+describe('scoped-URL prefix — the environment-scoped URL reaches a dispatcher domain', () => {
+    it('CONTROL: the unscoped forms reach their domains (a suite that measured nothing would fail here first)', async () => {
+        expect((await get(`${PREFIX}/health`)).status).toBe(200);
+
+        // `/data` has no exact/short-circuit answer, so it proves the DOMAIN ran
+        // rather than merely that some route matched: the domain body is what
+        // raises 503 on a missing data service.
+        await expect(get(`${PREFIX}/data/task`)).rejects.toMatchObject({ statusCode: 503 });
+    });
+
+    it('NEGATIVE CONTROL: an unclaimed path answers 404 ROUTE_NOT_FOUND — the shape "matched no domain" takes', async () => {
+        const res = await get(`${PREFIX}/no-such-domain`);
+        expect(res.status).toBe(404);
+        expect(res.code).toBe('ROUTE_NOT_FOUND');
+    });
+
+    it('the environment-scoped URL is stripped and reaches the same domain as the unscoped one', async () => {
+        expect((await get(`${PREFIX}/environments/${ENV_ID}/health`)).status).toBe(200);
+        await expect(get(`${PREFIX}/environments/${ENV_ID}/data/task`)).rejects.toMatchObject({ statusCode: 503 });
+    });
+
+    it('parses the environment id off the SAME prefix it strips — the two readings must not drift again', async () => {
+        const { ctx } = await get(`${PREFIX}/environments/${ENV_ID}/health`);
+        expect(ctx.urlEnvironmentId).toBe(ENV_ID);
+    });
+
+    it('the retired `/projects/` spelling resolves nothing — ADR-0006 D2 grants no alias', async () => {
+        const res = await get(`${PREFIX}/projects/${ENV_ID}/health`);
+        expect(res.status).toBe(404);
+        expect(res.code).toBe('ROUTE_NOT_FOUND');
+
+        // The point of removing it, stated as an assertion: this spelling was
+        // never a working alias. Nothing parses it, so the pre-repair strip
+        // deleted the only mention of the environment and served the request
+        // from the host default. A 404 is the honest answer to a URL naming an
+        // environment the dispatcher cannot resolve.
+        expect(res.ctx.urlEnvironmentId).toBeUndefined();
+    });
+});
+
+describe('scoped-URL prefix — the OAuth-on-MCP gate reads the same prefix', () => {
+    /**
+     * Capture the `acceptOAuthAccessToken` decision `resolveRequestScope`
+     * computes. It is handed to a private method, so the instance-level
+     * override is the observation seam; throwing afterwards is deliberate —
+     * `resolveRequestScope` catches it and leaves `executionContext` undefined,
+     * which is precisely the anonymous-request path and keeps this pin free of
+     * any identity stack.
+     */
+    async function acceptsOAuthFor(url: string): Promise<boolean | undefined> {
+        const d = dispatcher();
+        let seen: boolean | undefined;
+        (d as any).timedResolveExecutionContext = async (opts: { acceptOAuthAccessToken?: boolean }) => {
+            seen = opts.acceptOAuthAccessToken;
+            throw new Error('captured — anonymous from here');
+        };
+        const ctx: any = { request: new Request(`http://pin.local${url}`) };
+        await d.resolveRequestScope(ctx, subPathAsTheCatchAllDerivesIt(url));
+        return seen;
+    }
+
+    it('honours OAuth access tokens on the plain AND the environment-scoped MCP route', async () => {
+        expect(await acceptsOAuthFor(`${PREFIX}/mcp`)).toBe(true);
+        expect(await acceptsOAuthFor(`${PREFIX}/environments/${ENV_ID}/mcp`)).toBe(true);
+    });
+
+    it('CONTROL: refuses them off the MCP surface, and on the retired `/projects/` spelling', async () => {
+        expect(await acceptsOAuthFor(`${PREFIX}/data/task`)).toBe(false);
+        expect(await acceptsOAuthFor(`${PREFIX}/projects/${ENV_ID}/mcp`)).toBe(false);
+    });
+});

--- a/packages/runtime/src/http-dispatcher.ts
+++ b/packages/runtime/src/http-dispatcher.ts
@@ -560,9 +560,18 @@ export class HttpDispatcher {
                 // OAuth 2.1 access tokens are honoured ONLY on the MCP
                 // surface (#2698): their coarse tool-family scopes are
                 // enforced at MCP tool dispatch, which other routes don't do.
-                // Matches the plain and `/projects/:id`-scoped route forms
-                // (the scoped prefix is stripped only by the caller, later).
-                acceptOAuthAccessToken: /^(?:\/projects\/[^/]+)?\/mcp(?:[/?]|$)/.test(cleanPath),
+                // Matches the plain and `/environments/:environmentId`-scoped
+                // route forms (the scoped prefix is stripped only by the caller,
+                // later, which is why this tests the still-scoped path).
+                //
+                // Third reading of the one scoped-URL convention, and it carried
+                // the same pre-ADR-0006 `/projects/` residue as the strip in
+                // `dispatch()`. On its own that was unobservable — a scoped
+                // `/mcp` URL never reached the MCP domain at all — so repairing
+                // the strip is exactly what makes this line reachable, and the two
+                // have to move together: left behind, scoped MCP callers would
+                // reach the domain with their OAuth 2.1 access tokens refused.
+                acceptOAuthAccessToken: /^(?:\/environments\/[^/]+)?\/mcp(?:[/?]|$)/.test(cleanPath),
             });
         } catch {
             // anonymous request — leave executionContext undefined
@@ -1130,11 +1139,6 @@ export class HttpDispatcher {
         return handleKeysRequest(this.domainDeps, method, body, context);
     }
 
-    /**
-     * Parse a project UUID out of a scoped URL path such as
-     * `/api/v1/environments/abc-123/data/task` or `/projects/abc-123/meta`.
-     * Returns `undefined` when the path does not match the scoped pattern.
-     */
     /**
      * Parse an environment UUID out of a scoped URL path such as
      * `/api/v1/environments/abc-123/data/task` or `/environments/abc-123/meta`.
@@ -2195,7 +2199,35 @@ export class HttpDispatcher {
         // Strip the `/environments/:environmentId` prefix so the protocol dispatchers
         // below (meta, data, ui, automation, …) see the same shape whether
         // the caller used host-based routing, `X-Environment-Id`, or a scoped URL.
-        const scopedMatch = cleanPath.match(/^\/projects\/[^/]+(\/.*)?$/);
+        //
+        // The prefix spelled here MUST stay equal to the one
+        // `extractEnvironmentIdFromPath` parses — they are one convention read
+        // twice per request, and they had drifted apart. This line matched the
+        // pre-ADR-0006 `/projects/` spelling while the hint parser already read
+        // `/environments/`, and the consequence was a live routing defect rather
+        // than stale prose:
+        //
+        //   • An environment-scoped URL reached this line UNSTRIPPED, so
+        //     `DomainHandlerRegistry` (prefix/segment matching from the head of
+        //     the path) matched no domain at all — measured through the real
+        //     `@objectstack/hono` catch-all: `GET /api/v1/environments/<id>/data/task`
+        //     → 404 ROUTE_NOT_FOUND, against the unscoped `GET /api/v1/data/task`
+        //     → the `/data` domain. That catch-all is the ONLY entry that hands
+        //     `dispatch()` a still-scoped path; every scoped mount in
+        //     `dispatcher-plugin.ts` passes a pre-stripped subpath, which is why
+        //     the defect was invisible to the standalone server.
+        //   • The legacy spelling was not "still supported" in exchange. Nothing
+        //     parses `/projects/<id>`, so stripping it discarded the only place
+        //     the environment was named: `/projects/<id>/data/task` was served
+        //     with `urlEnvironmentId` undefined — from the host default, not the
+        //     environment its own URL named.
+        //
+        // One spelling, deliberately, and not a two-prefix alternation: ADR-0006
+        // D2 retired `project` on the API surface with no aliases, and the
+        // published migration checklist (`content/docs/api/environment-routing.mdx`)
+        // tells callers to replace `/api/v1/projects/:projectId/...` with
+        // `/api/v1/environments/:environmentId/...`.
+        const scopedMatch = cleanPath.match(/^\/environments\/[^/]+(\/.*)?$/);
         if (scopedMatch) {
             cleanPath = scopedMatch[1] ?? '';
         }

--- a/packages/runtime/src/security/permission-denied-envelope.ts
+++ b/packages/runtime/src/security/permission-denied-envelope.ts
@@ -61,7 +61,7 @@
  * Mirrors `@objectstack/rest`'s `req.params?.object` on the `/data/:object`
  * family — the only dispatcher routes whose path carries an object name.
  * Expects the dispatcher's already-cleaned path (trailing slash removed,
- * `/projects/:environmentId` prefix stripped).
+ * `/environments/:environmentId` prefix stripped).
  */
 export function routeObjectFromPath(cleanPath: string): string | undefined {
     const m = /^\/data\/([^/?#]+)/.exec(cleanPath);


### PR DESCRIPTION
Fixes #15488

The card asked which of three readings is true: stale prose, a live routing defect, or a strip that should accept both spellings. It was driven, not read.

## The answer: reading 1 — a live routing defect

Measured through the **real** `@objectstack/hono` catch-all (`createHonoApp`, unmocked, real `HttpDispatcher`, `app.request()`), on `cc5b3dd0c27`, before any edit. Ten requests sent; the probe printed its own send count so an empty run could not read as a clean one.

| request | before | after |
|---|---|---|
| `GET /api/v1/health` — CONTROL | 200 | 200 |
| `GET /api/v1/data/task` — CONTROL | 503 `SERVICE_UNAVAILABLE` (the `/data` domain ran) | unchanged |
| `GET /api/v1/no-such-domain` — NEGATIVE CONTROL | 404 `ROUTE_NOT_FOUND` | unchanged |
| `GET /api/v1/environments/env_alpha/health` | **404 `ROUTE_NOT_FOUND`** | **200** |
| `GET /api/v1/environments/env_alpha/ready` | **404 `ROUTE_NOT_FOUND`** | **200** |
| `GET /api/v1/environments/env_alpha/data/task` | **404 `ROUTE_NOT_FOUND`** | **503 — it reaches `/data`** |
| `GET /api/v1/projects/env_alpha/health` | 200 | **404 `ROUTE_NOT_FOUND`** |

The negative control matters: an unclaimed path and a scoped path answered the *same* 404 shape before the repair, which is what "matches no dispatcher domain" looks like from outside.

A second probe read the mutated context back, and it is the sharper half — the two spellings fail in **opposite** directions:

```
/api/v1/projects/env_alpha/data/task       urlEnvironmentId = undefined   -> stripped, served UNSCOPED
/api/v1/environments/env_alpha/data/task   urlEnvironmentId = "env_alpha" -> parsed, then matched NO domain
```

So `dispatch()`'s own two readings of one convention disagreed with each other, in this repository, with no cloud-side wiring needed to decide it. `extractEnvironmentIdFromPath` parsed `/environments/`; the strip removed `/projects/`. The card's reading 2 ("dead legacy, fix the comment") is refuted, and so is the triage comment's reading 3 ("both spellings are meant to work") — see below.

**Why the catch-all specifically.** It is the only entry that hands `dispatch()` a still-scoped path: `const subPath = c.req.path.substring(prefix.length)`. Every scoped mount in `dispatcher-plugin.ts` passes a pre-stripped subpath — `registerAutomationRoutes` mounts `${prefix}/environments/:environmentId/automation` and dispatches the literal `/automation` — which is why the standalone server never showed this.

**The legacy prefix was not a working alias in exchange.** Nothing parses `/projects/:id`, so stripping it discarded the only place the request named an environment: it was served from the host default, not the environment its own URL named. A 404 is the honest answer, and that is what it answers now.

## Why one spelling, not an alternation

The triage comment's reading 3 would widen the regex to accept either prefix. That is exactly what the standing ruling forbids, and the four axes agree, led by long-term rationality:

- **Long-term rationality (the heaviest axis).** ADR-0006 v4, second addendum — D2 executed 2026-08-28 — renames the API surfaces to `environment` / `environments` **with no aliases**, and the ADR states the posture in as many words: *"no gradualism, no dual-spelling interval, no single release carrying both."* An alternation here is precisely the alias it exists to prevent.
- **Actual need.** No in-repo emitter of a `/projects/:id` API URL survives: the client SDK builds scoped bases as `.../environments/:id`, `rest-server.ts` mounts `/environments/:environmentId` at every one of its `isScoped` sites, and `dispatcher-plugin.ts` mounts the same. The one remaining hit is a UI-location fixture in an unrelated websocket test.
- **Guarding against the next agent's mistake.** A comment that lies about a regex is the shape that teaches the wrong invariant, and a regex accepting two spellings under a comment naming one is the same defect with more surface.
- **Not diffusing scope pre-launch.** `content/docs/api/environment-routing.mdx` already tells callers *"Replace `/api/v1/projects/:projectId/...` with `/api/v1/environments/:environmentId/...`"* and *"there is no alias, so the old spelling does not resolve."* Honouring the published checklist costs nothing; contradicting it costs a compatibility surface.

## The repair — four sites, all located by content

Three in `packages/runtime/src/http-dispatcher.ts`, one in a sibling:

1. **The strip** — `/^\/projects\/[^/]+(\/.*)?$/` becomes `/^\/environments\/[^/]+(\/.*)?$/`. The card's subject.
2. **The OAuth-on-MCP gate** — `acceptOAuthAccessToken` tested the still-scoped path against the same retired prefix. **This had to move with the strip, and could not have been left for a follow-up**: unrepaired, a scoped `/mcp` URL never reached the MCP domain at all, so the flag was unobservable; repairing the strip is exactly what makes the line reachable, and left behind it would have started admitting scoped MCP callers to the domain with their OAuth 2.1 access tokens refused. A new defect manufactured by the fix.
3. **An orphaned pre-rename docblock** stacked above `extractEnvironmentIdFromPath`, describing a *"project UUID"* and the retired URL form. Deleted; the live docblock immediately beneath it already says the right thing.
4. **`packages/runtime/src/security/permission-denied-envelope.ts`** — `routeObjectFromPath`'s docblock states what it expects of the dispatcher's cleaned path, and said *"`/projects/:environmentId` prefix stripped"*. Prose only; the function's own `/^\/data\/([^/?#]+)/` is untouched.

Sites 2 to 4 are declared in-scope deliberately rather than swept in quietly: same defect class, mechanical, the correct spelling pinned by the ADR and by site 1, no new gate family (re-derived and diffed — identical list). The claim comment on the card names the file surface.

**What this branch did NOT touch.** `packages/rest/src/rest-server.ts` carries two more docblocks naming the retired form, and that file is held by two open pull requests — #15673 and #15395. The sweep stopped there and filed the finding as #15858 instead of reaching into a file two branches are rewriting.

## The pin, and the ablation that proves it can fail

New: `packages/runtime/src/http-dispatcher.scoped-url-strip.test.ts` — 7 assertions, including the two controls and the negative control from the table above, and an observation seam that captures the `acceptOAuthAccessToken` decision.

Both ablation limbs had their direction **and their green assertions** predicted in writing first, then measured. Each mutation was proven on disk by removed-text and injected-marker counts before the run, and restored under a trap via `git checkout HEAD -- <absolute path>`, proven by blob-hash equality against the HEAD blob and an empty `git diff HEAD`.

| limb (revert one site only) | predicted | measured |
|---|---|---|
| A — the strip | 2 fail, 5 pass | 2 fail, 5 pass — the two scoped-routing assertions, exactly as named |
| B — the OAuth matcher | 2 fail, 5 pass | 2 fail, 5 pass — both OAuth assertions, exactly as named |

⭐ **The assertion that deliberately stays GREEN under limb A is the finding restated as a test**: "parses the environment id off the SAME prefix it strips" keeps answering `env_alpha` while the strip is broken, because `extractEnvironmentIdFromPath` is a *separate* reading. That independence is exactly how the two drifted apart unnoticed for a release, and an ablation that reddened it would be measuring the wrong thing.

**No rebuild was needed, and that is proven rather than assumed.** The pin imports `./http-dispatcher.js` — a relative import inside the package, resolved to source. To make the claim falsifiable, each limb printed `dist/index.js` still holding the repaired spelling at mutation time: a RED pin therefore proves source resolution, and a GREEN one would have proved the suite was reading dist.

## Verification — all on the final head `4538d6289d5`

- **Gate union: 53 of 53 families green**, derived with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack --commands` on that head with no STALE TREE banner, re-derived after the change set was final and diffed against the executed list (identical). Two of them (`check:dual-build-cjs-loads`, `check:type-check-debt`) first answered `PREREQUISITE NOT MET` / exit 3 — read as NOT MEASURED, not as a pass — and were re-run green after `turbo run build` over the workspace closure. Exit codes captured after redirection, never through a pipe.
- **Tests**: 39 files / 714 assertions green across the `http-dispatcher.*`, `dispatcher-plugin`, `error-envelope.conformance`, `auth-unknown-subpath.hono.integration` and `security/*` suites in `@objectstack/runtime`, plus `@objectstack/hono` (2 files / 74).
- **Typecheck**: `@objectstack/runtime` green, and the new test file was confirmed **inside** the type-checked program via `tsc -p tsconfig.test.json --listFiles` (1 hit, 0 errors attributable to either changed file) rather than inferred from a green script.
- **Lint**: the full repo sweep, `pnpm lint` = `eslint . --no-inline-config`, green in 90s — no narrowing claimed or needed.
- Control-character self-scan over the changed files: clean.

## For triage

The triage comment set a promotion rule: *"if reading 1 or 3 is established, re-grade to p2 immediately — no new card, no re-argument."* Reading 1 is established by driven measurement, so that rule has fired.

The same comment's boundary test applies too: this changes what the door accepts — requests that reached no dispatcher domain now reach one, and the retired spelling now refuses — so it reads as clause ② YES and a manual floor. ⛔ Left as a draft for that judgement rather than pre-labelled.

One observation handed back rather than acted on: the card called this *"the third independent reason the dispatcher cannot serve the scoped `/packages` path"*, alongside two measured by #14503's census. This branch removes this one — a scoped `/packages` URL now reaches the `/packages` domain through the catch-all — which may change how #14503's other two findings read. That is #14503's question, not this card's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D47qPfEWVPmhguWgBZCi5N

---
_Generated by [Claude Code](https://claude.ai/code/session_01D47qPfEWVPmhguWgBZCi5N)_