### PR TITLE
fix(cli): route `os diff`'s missing-paths usage error to stderr, in both faces

### DIFF
--- a/.changeset/diff-usage-error-to-stderr.md
+++ b/.changeset/diff-usage-error-to-stderr.md
@@ -1,0 +1,17 @@
+---
+"@objectstack/cli": patch
+---
+
+`os diff` with no path arguments no longer prints its usage error on stdout — in either face.
+
+The refusal sat **above** the command's first `if (!flags.json)`, so the face was still undecided when it ran and it fired in **both**. `printError` plus three `console.log` calls — all four writing to stdout — then `process.exit(1)`. Measured on the published entry `bin/run.js` with `NO_COLOR=1` and the streams captured separately, `os diff --json` and bare `os diff` answered byte-identically: exit 1, **141 bytes of prose on stdout, an empty stderr**, and `JSON.parse(stdout)` throwing on the one stream `--json` reserves for the machine.
+
+The diagnostic now goes to stderr, where the rest of this CLI's diagnostics already go. The 141 bytes moved intact — stdout 141 → 0, stderr 0 → 141. Nothing else moves:
+
+- **the exit code is still 1**, so a consumer branching on exit status sees no change at all;
+- **the wording is unchanged**, both usage hints included, so a human reading a terminal sees the same four lines;
+- **nothing is accepted or rejected differently** — no invocation that worked before fails now.
+
+⚠️ **No error payload is invented on this path.** What a `--json` consumer should *receive* on a refusal is an open envelope question, entangled with `os lint --eval --json`'s bare `{ error }` (no `code`, no `httpStatus`), and it is deliberately left open here — this change settles only that the machine's channel no longer carries prose. `--json` on this path emits nothing on stdout; a consumer must still read the exit status, exactly as it must today.
+
+This is the sibling of the `resolveConfigPath` repair, and a genuinely different site: that one is reached through `loadConfig()`, this one is `diff.ts`'s own usage error, raised before any config work happens. The existing pin drives `os diff` with two paths precisely so the run gets *past* this check, so it could not see this path. A new pin (`diff-usage-error-stream.e2e.test.ts`) drives the bare form in both faces, and carries a structural tripwire: across 62 command modules, 27 of which offer `--json`, `diff` was the only one with a stdout write above its guard, and the tripwire goes red if another arrives.

--- a/packages/cli/src/commands/diff.ts
+++ b/packages/cli/src/commands/diff.ts
@@ -8,6 +8,7 @@ import {
   printSuccess,
   printWarning,
   printError,
+  printErrorToStderr,
   printInfo,
   printStep,
   createTimer,
@@ -177,11 +178,32 @@ export default class Diff extends Command {
     const beforePath: string | undefined = args.before || flags.before;
     const afterPath: string | undefined = args.after || flags.after;
 
+    // This refusal goes to STDERR, and it is the one write in this file that
+    // has to (#15697).
+    //
+    // It sits ABOVE the first `if (!flags.json)` below, so it is reached with
+    // the face still undecided and fires in BOTH — the text face and the
+    // machine face alike. Measured on the published entry `bin/run.js` with
+    // `NO_COLOR=1` and the streams captured separately, it used to answer
+    // `os diff --json` with **exit 1, 141 bytes of prose on stdout and an empty
+    // stderr**: `JSON.parse(stdout)` threw, on the one stream `--json` reserves
+    // for the machine (`utils/json-stdout.ts`). Both faces measured identically,
+    // because there is no branch here to tell them apart.
+    //
+    // ⚠️ Every other diagnostic in this file stays on stdout deliberately: they
+    // sit INSIDE a `!flags.json` branch, i.e. the command has already decided it
+    // is rendering its text face, which is exactly the case `printError` is for
+    // (see the note on {@link printErrorToStderr}).
+    //
+    // ⛔ Moving the bytes is the whole change. The exit code stays 1, the
+    // wording stays identical, and no payload is invented: what `--json` should
+    // emit on a refusal is an open envelope question (#15549) touching this
+    // command family at once, and settling it is above this fix's authority.
     if (!beforePath || !afterPath) {
-      printError('Two config file paths are required.');
-      console.log('');
-      console.log(chalk.dim('  Usage: objectstack diff <before> <after>'));
-      console.log(chalk.dim('     or: objectstack diff --before path1 --after path2'));
+      printErrorToStderr('Two config file paths are required.');
+      console.error('');
+      console.error(chalk.dim('  Usage: objectstack diff <before> <after>'));
+      console.error(chalk.dim('     or: objectstack diff --before path1 --after path2'));
       process.exit(1);
     }
 

--- a/packages/cli/test/diff-usage-error-stream.e2e.test.ts
+++ b/packages/cli/test/diff-usage-error-stream.e2e.test.ts
@@ -1,0 +1,261 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * `os diff` with NO path arguments ⇒ nothing unparseable on stdout, in EITHER
+ * face (#15697).
+ *
+ * ## Why this is a second file rather than a case in the sibling pin
+ *
+ * `config-miss-stdout-purity.e2e.test.ts` (#15547) drives the same command, but
+ * a different branch of it: its `FAMILY` entry is
+ * `diff: { explicit: [MISSING, MISSING], auto: null }` — two paths, supplied so
+ * the run gets *past* the usage check and down into `resolveConfigPath()`. It
+ * says so in place: "`os diff` requires two config paths, so there is no bare
+ * form that reaches the helper without one."
+ *
+ * That is precisely the branch this file drives — the bare form. The refusal
+ * here is `diff.ts`'s own usage error, reached BEFORE any config work happens,
+ * so the sibling pin structurally cannot see it and stayed green through it.
+ *
+ * ## What was measured
+ *
+ * The four writes sat ABOVE the command's first `if (!flags.json)`, so the face
+ * was still undecided when they ran and they fired in BOTH. On the published
+ * entry `bin/run.js`, `NO_COLOR=1`, streams captured separately:
+ *
+ *     os diff --json   → exit 1 · stdout 141 bytes of prose · stderr 0 bytes
+ *     os diff          → exit 1 · stdout 141 bytes of prose · stderr 0 bytes
+ *
+ * Byte-identical, because there was no branch to tell the faces apart. And
+ * `JSON.parse(stdout)` threw on the one stream `--json` reserves for the
+ * machine.
+ *
+ * ## What is asserted — and what is deliberately NOT
+ *
+ * ⛔ No error-payload shape is pinned here. Whether `--json` should emit an
+ * envelope on a refusal is an open question entangled with #15549
+ * (`os lint --eval --json`'s bare `{ error }`, no `code`, no `httpStatus`), and
+ * settling it is above this pin's authority.
+ *
+ * So the assertion is the half that needs no ruling, and it is a PROPERTY, not
+ * a string: **stdout carries nothing a machine cannot read.** Empty passes, one
+ * JSON document passes, prose fails. A pin on "141 bytes" would rot on the next
+ * wording change; this one survives it, and survives whoever settles the
+ * envelope question without their having to touch this file.
+ *
+ * The other assertions are the ones a "just silence it" regression would break:
+ * the diagnostic must still reach the operator on **stderr**, and the exit
+ * status must still be 1.
+ *
+ * ## Anti-vacuity
+ *
+ * Every assertion below is green if the command dies early for an unrelated
+ * reason — an empty stdout is "machine-readable" and a missing string is "not
+ * on stdout". So the suite refuses to report until a CONTROL has shown that
+ * this argv actually reaches this command: `os diff --help` must exit 0 and
+ * render the command's own description. If the binary were broken, the control
+ * goes red and the rest is known to be worthless rather than quietly green.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { execFile } from 'node:child_process';
+import { mkdtempSync, rmSync, existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, relative, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { childEnv } from './helpers/serve-process.js';
+
+const HERE = resolve(fileURLToPath(import.meta.url), '..');
+const CLI = resolve(HERE, '../bin/run-dev.js');
+const TSX = resolve(HERE, '../../../node_modules/.bin/tsx');
+const COMMANDS_DIR = resolve(HERE, '../src/commands');
+
+/** The refusal and its two hint lines — what must be on stderr, never stdout. */
+const REFUSAL = 'Two config file paths are required.';
+const HINTS = ['Usage: objectstack diff', 'or: objectstack diff --before'] as const;
+
+interface Run {
+  code: number;
+  stdout: string;
+  stderr: string;
+}
+
+function runCli(argv: string[], cwd: string): Promise<Run> {
+  return new Promise((resolvePromise) => {
+    execFile(
+      TSX,
+      [CLI, ...argv],
+      { cwd, maxBuffer: 32 * 1024 * 1024, env: childEnv({ NO_COLOR: '1' }) },
+      (err, stdout, stderr) => {
+        resolvePromise({
+          code: err
+            ? (typeof (err as { code?: unknown }).code === 'number'
+                ? (err as unknown as { code: number }).code
+                : 1)
+            : 0,
+          stdout: String(stdout),
+          stderr: String(stderr),
+        });
+      },
+    );
+  });
+}
+
+/**
+ * Whether stdout is something a program can read: nothing at all, or exactly
+ * one JSON document. Prose is the failure — see the header for why the choice
+ * between the two passing shapes is deliberately left open.
+ */
+function stdoutIsMachineReadable(stdout: string): boolean {
+  if (stdout.trim() === '') return true;
+  try {
+    JSON.parse(stdout);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * The two faces, both driven with NO path arguments — the argv that reaches the
+ * usage error. `--json` is the machine face; bare is the text face. The defect
+ * fired in both, so both are pinned.
+ */
+const FACES: Record<string, string[]> = {
+  'machine face (--json)': ['diff', '--json'],
+  'text face (bare)': ['diff'],
+};
+
+let dir: string;
+let control: Run;
+let runs: Record<string, Run>;
+
+beforeAll(async () => {
+  // Deliberately EMPTY. The usage error is raised before any config work, so
+  // the cwd cannot influence it — an empty dir keeps that true rather than
+  // assumed, by making sure no stray `objectstack.config.*` is in reach.
+  dir = mkdtempSync(join(tmpdir(), 'os-diff-usage-e2e-'));
+
+  // Sequential: concurrent `tsx` starts are the kind of load that makes a
+  // shared box report timeouts instead of verdicts.
+  control = await runCli(['diff', '--help'], dir);
+  runs = {};
+  for (const [name, argv] of Object.entries(FACES)) {
+    runs[name] = await runCli(argv, dir);
+  }
+}, 900_000);
+
+afterAll(() => {
+  try { rmSync(dir, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+describe('control — the reading below is worthless without this', () => {
+  it('resolves the dev entry it drives', () => {
+    // A run against a path that does not exist fails exactly like a true
+    // negative: empty streams, non-zero exit. Rule it out before reading
+    // anything off the runs.
+    expect(existsSync(CLI)).toBe(true);
+    expect(existsSync(TSX)).toBe(true);
+  });
+
+  it('actually reaches `os diff` with this argv', () => {
+    // If this is red, every assertion below is green for the wrong reason.
+    expect(control.code).toBe(0);
+    expect(control.stdout).toContain('Compare two ObjectStack configurations');
+  });
+});
+
+describe.each(Object.keys(FACES))('os diff, no path arguments — %s', (face) => {
+  const runOf = (): Run => runs[face];
+
+  it('leaves nothing on stdout that a machine cannot read', () => {
+    // Under the defect this was 141 bytes of `  ✗ Two config file paths are
+    // required.` plus a blank line and two usage hints — on the one stream
+    // `--json` reserves for the machine, with stderr completely empty.
+    expect(stdoutIsMachineReadable(runOf().stdout)).toBe(true);
+  });
+
+  it('keeps the human refusal off stdout entirely', () => {
+    // Asserted separately from the parse so a regression names its cause
+    // rather than only `Unexpected token`.
+    const { stdout } = runOf();
+    expect(stdout).not.toContain(REFUSAL);
+    for (const hint of HINTS) expect(stdout).not.toContain(hint);
+  });
+
+  it('still shows the operator the refusal and both hints — on stderr', () => {
+    // Diagnostics are MOVED, never destroyed: a regression toward silencing
+    // this path goes red here. This is also the pair that makes the assertion
+    // above non-vacuous — an early death would leave stderr without these.
+    const { stderr } = runOf();
+    expect(stderr).toContain(REFUSAL);
+    for (const hint of HINTS) expect(stderr).toContain(hint);
+  });
+
+  it('still exits 1', () => {
+    expect(runOf().code).toBe(1);
+  });
+});
+
+/**
+ * The structural tripwire: `diff` was the ONLY command shaped this way, and a
+ * new one must not arrive unnoticed.
+ *
+ * ⚠️ Its bound, stated rather than implied: this is a source-text scan, so it
+ * sees only the print helpers it names, called syntactically inside `run()`
+ * above the first `flags.json` read. It does NOT follow calls into helpers —
+ * that is how #15547 was reached, through `loadConfig()` — and a command that
+ * reads `flags.json` into a local on its first line hides everything below from
+ * this check. It is a tripwire for the shape that was measured, not a proof
+ * that no other shape exists.
+ */
+describe('no new command has grown a stdout write above its --json guard', () => {
+  function commandFiles(d: string): string[] {
+    const out: string[] = [];
+    for (const entry of readdirSync(d)) {
+      const abs = join(d, entry);
+      if (statSync(abs).isDirectory()) {
+        out.push(...commandFiles(abs));
+        continue;
+      }
+      if (!entry.endsWith('.ts') || entry.endsWith('.test.ts')) continue;
+      out.push(abs);
+    }
+    return out;
+  }
+
+  const WRITES_TO_STDOUT =
+    /\b(?:console\.log|printHeader|printStep|printInfo|printSuccess|printWarning|printError)\(/;
+
+  function offenders(): string[] {
+    const found: string[] = [];
+    for (const abs of commandFiles(COMMANDS_DIR)) {
+      const lines = readFileSync(abs, 'utf-8').split('\n');
+      if (!lines.some((l) => /\bjson:\s*Flags\.boolean\(/.test(l))) continue;
+      const runIdx = lines.findIndex((l) => /async run\s*\(/.test(l));
+      if (runIdx < 0) continue;
+      const guardIdx = lines.findIndex(
+        (l, i) => i >= runIdx && /flags\.json|flags\[['"]json['"]\]/.test(l),
+      );
+      if (guardIdx < 0) continue;
+      if (lines.slice(runIdx, guardIdx).some((l) => WRITES_TO_STDOUT.test(l))) {
+        found.push(relative(COMMANDS_DIR, abs).split(sep).join('/'));
+      }
+    }
+    return found.sort();
+  }
+
+  it('scans a non-empty family — refuse to reason from zero', () => {
+    // The scan is only evidence if it looked at something. A refactor that
+    // moved or renamed the commands directory would otherwise report "no
+    // offenders" from an empty sweep.
+    const withJson = commandFiles(COMMANDS_DIR).filter((abs) =>
+      /\bjson:\s*Flags\.boolean\(/.test(readFileSync(abs, 'utf-8')),
+    );
+    expect(withJson.length).toBeGreaterThan(10);
+  });
+
+  it('finds none', () => {
+    expect(offenders()).toEqual([]);
+  });
+});


### PR DESCRIPTION
Fixes #15697

`os diff`'s missing-paths usage error printed through `printError` plus three `console.log` calls — **all four writing to stdout** — and then called `process.exit(1)`. The bytes now go to **stderr**. Nothing else moves.

The site sits **above** the command's first `if (!flags.json)`, so the face was still undecided when it ran and it fired in **both**.

## The measurement, re-derived on today's tree

Through the **published** entry `packages/cli/bin/run.js`, `NO_COLOR=1`, stdout and stderr captured separately, exit code read before any pipe. Re-derived rather than quoted, because PR #15692 has landed since the card was filed.

| face | before | after |
|---|---|---|
| `os diff --json` (machine) | exit 1 · stdout **141 B** · stderr **0 B** · `JSON.parse` **throws** | exit 1 · stdout **0 B** · stderr **141 B** · `JSON.parse` **empty, machine-readable** |
| `os diff` (text) | exit 1 · stdout **141 B** · stderr **0 B** | exit 1 · stdout **0 B** · stderr **141 B** |

The card's numbers hold exactly. The two faces measured **byte-identically** before and after — there is no branch at this site to tell them apart, which is the whole reason this card is distinct from #15547. The 141 bytes moved intact; only the stream changed.

⚠️ **The harness caught itself first.** The first run of this measurement reported exit 1 / 749 stderr bytes for *all three* cases including the `--help` control — a relative CLI path resolved against a temp-dir `cwd`, so nothing ran. It looked exactly like a true reading. The control is what separated them; the numbers above are from the corrected run, in which `os diff --help` exits **0** with 566 bytes of help.

## Scope — one site, and it is the only one of its shape

Measured, glob declared: over `packages/cli/src/commands/**/*.ts` minus `*.test.ts`, **62** command modules, **27** of which declare `json: Flags.boolean(`. Exactly **one** has a stdout write above its first `flags.json` read: `diff.ts`. So this repair closes the class, not just an instance.

Bound stated: that is a source-text scan. It does not follow calls into helpers — which is how #15547 was reached, through `loadConfig()` — and a command reading `flags.json` into a local on its first line would hide writes below it. It is a tripwire for the measured shape, not a proof that no other shape exists.

⛔ Not widened into the 196 `printError` call sites. The card records that shape and explicitly does not propose it as a card; a "diagnostics belong on stderr" pass over that helper is a far larger change than this one.

## Why this is a different site from #15547

The sibling pin drives `os diff` with **two** paths, supplied precisely so the run gets *past* this usage check and down into `resolveConfigPath()`. Its own comment says so: "`os diff` requires two config paths, so there is no bare form that reaches the helper without one." This PR drives the bare form. The refusal here is `diff.ts`'s own usage error, raised before any config work happens, so the sibling pin structurally could not see it and stayed green through it.

## What is deliberately NOT settled

⛔ **No error payload is invented, no `code` minted, no `httpStatus` added.** What `--json` should emit on a refusal is an open envelope question and **#15549 remains open**; settling it in passing here would answer that card implicitly. `--json` on this path still emits nothing on stdout; a consumer must read the exit status, exactly as it must today.

The two measured reasons the "make it throw" route is ruled out are on record from PR #15692 and were not re-litigated: `os verify` has no `try`, so a throw becomes an oclif crash dump; and `errorCodeFields()` mints no `code` for a plain `Error`, so a throw would emit the bare `{ error }` shape that #15549 is about.

## Clause ② (契约复审) — declared per limb, from the delivered diff: **NO**

- **Mechanical / path limb — NO.** No key is added to any published payload (this path emits none, before or after). No `packages/spec/src/**` path is touched. Moving prose between streams adds no key. `printErrorToStderr` is package-internal and already published by PR #15692; this PR only calls it.
- **Non-mechanizable conformance limb — NO.** No input class is re-selected between two published verdicts: no invocation that worked before fails now, none that failed now succeeds. Same exit code, same wording, same four lines.

Judged honestly rather than by default, because which stream a published CLI writes to is arguably contractual. The decisive evidence is a landed verdict on the **identical** question: PR #15692 declared clause ② NO for the same repair on the sibling site and merged. This site differs only in *which* site, not in kind.

⚠️ One residual for a reviewer to weigh, carried over from that PR: a wrapper that showed a user only the child's **stdout** now shows nothing on this path. Exit 1 is unchanged, and stderr was empty before, so nothing could have been parsing it.

## The pin

`packages/cli/test/diff-usage-error-stream.e2e.test.ts` drives both faces of the bare form.

⛔ It does **not** assert a payload shape, and it does **not** pin the byte count — "141 bytes" would rot on the next wording change. It pins the **property**: stdout carries nothing a machine cannot read (empty passes, one JSON document passes, prose fails). That holds under the shape shipped today and under any future envelope, so whoever settles #15549 changes the payload without touching this file.

The other assertions are the ones a "just silence it" regression would break: the refusal and both hints must still reach the operator on stderr, and the exit status must still be 1.

**Anti-vacuity.** Every assertion above is green if the command dies early for an unrelated reason — an empty stdout is "machine-readable" and a missing string is "not on stdout". So the suite carries a control block that must pass first: the dev entry and `tsx` must resolve on disk, and `os diff --help` must exit 0 and render the command's own description. The structural tripwire likewise refuses to reason from zero, asserting it scanned a non-empty family.

## Ablation — direction predicted in writing first, and it matched exactly

**No rebuild is part of this ablation, and that is proven rather than assumed.** ⭐ This falsifies the dispatch's Zone 2 assumption that the test reads `dist/`: it drives `bin/run-dev.js` through `tsx`, which is the **source** entry. Proven positively — `packages/cli/dist/commands/diff.js` was rebuilt *with the fix* and verified to hold it (3 `console.error`) both before and during the mutation, yet the suite went red. A red against a fixed `dist/` can only come from `src/`.

Predicted before the mutation, per assertion: for each of the two faces, "leaves nothing on stdout that a machine cannot read", "keeps the human refusal off stdout entirely" and "still shows the operator the refusal and both hints — on stderr" go **red** (stderr goes empty under the defect), while "still exits 1" stays **green** — the exit code is untouched by the defect, which is precisely why the card was graded p2. The two control cases and the tripwire's non-empty-family case stay **green**; "finds none" goes **red**. **⇒ 7 red, 5 green.**

Measured: **`Tests 7 failed | 5 passed (12)`**, and the seven failing names are exactly the seven predicted. No assertion outside the predicted set failed even once. Sample cause, confirming it is the defect and not an early death: `AssertionError: expected '' to contain 'Two config file paths are required.'`.

Mutation proven on disk before any result was read — `printErrorToStderr` occurrences 1 to **0**, `console.log(chalk.dim` occurrences to **3**, and the mutated blob hash differing from the HEAD blob. Restore under an `EXIT INT TERM` trap using an **absolute** path, proven by blob-hash equality with the HEAD blob (`16518ee6cf1b991395448143d50c870e7605b475`, both sides) plus an empty `git diff HEAD` — an empty hash treated as failure, not as "nothing to compare".

## Verification — all at `f27192da2bd`, the final commit

Every exit code captured after redirection to a file, never through a pipe; each verdict read from the gate's own printed line.

- `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` re-derived the family from the tree (not from a hand-passed path list) and reported **122** gate families over 3 changed paths. CI runs the farm exactly once regardless, so the local set is declared and narrowed to the implicated ones, all **green**:
  - `check:nul-bytes` — OK, 7655 text files scanned, no raw control bytes.
  - `check:cli-test-child-env` — OK, 52 spawner sources among 130 under `packages/cli/test/**`; the new file's `childEnv()` spawns are declared.
  - `check:cross-package-test-inputs` — OK, 27 packages read outside themselves, all declared.
  - `check:test-source-alias` — OK, 72 packages scanned.
  - `check:comment-mask-adoption`, `check:empty-changeset`, `check:changeset-no-major`, `check:adr-0087-registration`, `check:changeset-gate-self-tests` — all OK.
- `pnpm --filter @objectstack/cli typecheck` green, **including** `check:test-typecheck`, which compiles the test layer under `tsconfig.test.json` — so the new pin is genuinely in a program, not merely unmentioned by one.
- Tests, narrowed and declared: the new pin, the #15547 sibling pin, and the tier-partition test — **112 passed across 3 files**. The sibling pin still passes, so the two-path branch of `os diff` is unaffected. The full CLI suite is CI's.
- The new file is derived into the **integration** tier by the existing predicate (`vitest list --project integration` lists it), so there is no hand-maintained list to keep in step.
- **Lint, narrowed with its narrowing proven** rather than skipped. `eslint --no-inline-config --format json` over the 2 changed `.ts` files: **2 files linted** (count read from eslint's own JSON, not assumed), **0 errors, 0 warnings, 0 ignored**. The narrowing is sound because this repo runs one `eslint.config.mjs` which, in its own words, "never enables type-aware linting (no `parserOptions.project`, no typed `@typescript-eslint` rules) for ANY file" — with no cross-file inference, this diff cannot move the verdict on any untouched file. The whole-repo run is CI's.
- **File-claim re-check before committing**: `git ls-remote` then a tree-only fetch of all `claude/*` branches; **428 refs scanned**, exactly one touches `packages/cli/src/commands/diff.ts` — this branch. Validated by a known-true positive control (this branch's own claim is detected by the same scan).

## Dedup, re-run as the card asked

The card was filed on a 376-issue snapshot with both channels down, and asked for one more pass when a channel recovered. Repo-scoped REST still answers `403 GitHub access is not enabled for this session` and `gh` is absent, so this went through two targeted MCP searches, with the channel switch declared.

**No duplicate has appeared.** Both of the card's named positive controls are live in the search corpus — **#15547** and **#15549**, both `open` — and #15697 itself (created `2026-09-05T03:20:51Z`) returned in both passes, which is the stronger recency control: the index reaches past the snapshot the card was filed on.

---
_Generated by [Claude Code](https://claude.ai/code/session_01D47qPfEWVPmhguWgBZCi5N)_