### PR TITLE
fix(cli): the metadata rubric records a linter crash instead of scoring it 100 / A

### DIFF
--- a/.changeset/score-metadata-lint-crash-visible.md
+++ b/.changeset/score-metadata-lint-crash-visible.md
@@ -1,0 +1,17 @@
+---
+"@objectstack/cli": minor
+---
+
+`scoreMetadata` no longer scores a stack whose linter crashed as a perfect one.
+
+The metadata rubric is two halves: a schema parse and the lint sweep. When `lintConfig` threw, the scorer caught the throw and continued with `issues = []` — so the penalty was 0 and a stack half of whose rubric never ran came back as **100 / grade `A` / `valid: true`, every count zero, `issues: []`** — byte-for-byte the verdict a genuinely clean stack gets. "The linter found nothing" and "the linter never ran" collapsed into the better-looking one.
+
+The crash is reachable on a schema-valid stack: a localized `label` (`{ en: 'Todos', 'zh-CN': '待办' }`) on an app, or on a view's `list`, parses clean and makes the label-case rule throw a `TypeError`. That rule's crash is a separate defect, filed on its own; what changes here is that the scorer stops publishing a clean verdict it did not earn.
+
+A crashed lint run is now recorded in every carrier a consumer might read, because reading any one of them has to be enough:
+
+- **`lintError`** — a new optional string on `MetadataScore`, carrying the thrown message. Set only when the linter could not run; absent when it ran and reported errors, which is a lint verdict rather than a missing one. It reaches the CLI's published payload through `os lint --eval --json`, on `results[].score`.
+- **A synthetic `error` issue** (`rule: 'rubric/lint-crashed'`, exported as `LINT_CRASHED_RULE`) — so `issues`, `counts.errors` and `valid` carry the failure too. This is what makes the eval harness fail the case: its `passed` reads `counts.errors`, and would never have seen a new field. It still fails at `--eval-min 0`, where the score alone stops discriminating.
+- **`score: 0` / grade `F`** — the only channel `os lint --score --json` publishes, and the same refusal `unscorableScore()` already gives an eval case there was nothing to judge.
+
+The schema half is untouched and still reported: `schemaErrors` and `counts.schemaErrors` say exactly what the parse found, which was the defensible half of the original intent.

--- a/packages/cli/src/lint/score.ts
+++ b/packages/cli/src/lint/score.ts
@@ -27,6 +27,14 @@ export const SCORE_WEIGHTS = {
   suggestion: 1,
 } as const;
 
+/**
+ * The `rule` id on the synthetic issue raised when the linter throws.
+ *
+ * Exported so a consumer can tell "the linter reported a problem" from "the
+ * linter never ran" by matching an id rather than prose.
+ */
+export const LINT_CRASHED_RULE = 'rubric/lint-crashed';
+
 export interface MetadataScore {
   /** 0–100 quality score (higher is better). */
   score: number;
@@ -44,6 +52,18 @@ export interface MetadataScore {
   schemaErrors: string[];
   /** Lint issues (naming, labels, structure, data-model conventions). */
   issues: LintIssue[];
+  /**
+   * Set only when the lint half of the rubric could NOT run: `lintConfig` threw
+   * and this carries the thrown message. Absent on every run where the linter
+   * completed -- including one where it reported errors, which is a lint
+   * verdict, not a missing one.
+   *
+   * Optional on purpose. It is the machine-readable half of the refusal below,
+   * not its enforcement: a consumer that never reads it still cannot mistake a
+   * crashed run for a clean one, because the same event is carried by `issues`,
+   * `counts.errors`, `valid` and `score`.
+   */
+  lintError?: string;
 }
 
 function gradeFor(score: number): MetadataScore['grade'] {
@@ -72,12 +92,47 @@ export function scoreMetadata(stack: unknown): MetadataScore {
     : parsed.error.issues.map((i) => `${i.path.join('.') || '(root)'}: ${i.message}`);
 
   // 2) Lint (naming/labels/structure + data-model conventions).
+  //
+  // A linter crash must not mask the schema verdict — the original intent, and
+  // still right. What was not right is the number that came out of it: with
+  // `issues = []` the penalty was 0, so a stack whose linter threw scored
+  // 100 / A / `valid: true` with every count at zero — byte-for-byte the
+  // verdict a genuinely clean stack gets, on a rubric half of which never ran.
+  // "The linter found nothing" and "the linter never ran" are different facts.
+  //
+  // Reachable, and not exotically: a localized `label` (`{ en: …, 'zh-CN': … }`)
+  // on an app, or on a view's `list`, is schema-valid and makes the label-case
+  // rule throw. That crash is its own defect, filed separately; this function's
+  // job is to never publish a clean verdict it did not earn.
+  //
+  // So the failure is recorded in every carrier a consumer might read, because
+  // reading any ONE of them must be enough:
+  //   · `lintError` — the fact itself, typed, for a machine consumer;
+  //   · a synthetic `error` issue — so `issues`, `counts.errors` and `valid`
+  //     carry it too, which is what makes the eval harness fail the case: its
+  //     `passed` reads `counts.errors` and would never see a new field;
+  //   · `score` 0 / grade `F` — the only channel `os lint --score --json`
+  //     publishes, and the same refusal `unscorableScore()` (metadata-eval.ts)
+  //     already gives a case there was nothing to judge, for the same reason:
+  //     a clean number nothing earned is the worst possible output.
+  // The schema verdict survives all of it — `schemaErrors` and
+  // `counts.schemaErrors` still report exactly what the parse found.
   let issues: LintIssue[] = [];
+  let lintError: string | undefined;
   try {
     issues = lintConfig(normalized) as LintIssue[];
-  } catch {
-    // A linter crash shouldn't mask the schema verdict — treat as no lint data.
-    issues = [];
+  } catch (err) {
+    lintError = err instanceof Error ? err.message : String(err);
+    issues = [
+      {
+        severity: 'error',
+        rule: LINT_CRASHED_RULE,
+        message:
+          `The lint rubric did not run: ${lintError}. This verdict covers the schema ` +
+          `parse only — no lint verdict was produced, so it must not be read as a clean one.`,
+        path: '(lint)',
+      },
+    ];
   }
 
   const errors = bySeverity(issues, 'error');
@@ -90,7 +145,10 @@ export function scoreMetadata(stack: unknown): MetadataScore {
     warnings.length * SCORE_WEIGHTS.warning +
     suggestions.length * SCORE_WEIGHTS.suggestion;
 
-  const score = Math.max(0, Math.min(100, 100 - penalty));
+  // A rubric that did not run has no score to report. 0 / `F` is not a penalty
+  // dressed up as a measurement — it is the refusal, and it is the shape the
+  // eval harness already uses for "there was nothing to judge".
+  const score = lintError !== undefined ? 0 : Math.max(0, Math.min(100, 100 - penalty));
 
   return {
     score: Math.round(score),
@@ -104,5 +162,6 @@ export function scoreMetadata(stack: unknown): MetadataScore {
     },
     schemaErrors,
     issues,
+    ...(lintError !== undefined ? { lintError } : {}),
   };
 }

--- a/packages/cli/test/score-lint-crash.test.ts
+++ b/packages/cli/test/score-lint-crash.test.ts
@@ -1,0 +1,180 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * `scoreMetadata` must never publish a clean verdict for a rubric that did not
+ * run.
+ *
+ * ## Why the linter is mocked here rather than driven
+ *
+ * The crash IS reachable on a schema-valid stack — a localized `label`
+ * (`{ en: …, 'zh-CN': … }`) on an app, or on a view's `list`, parses clean and
+ * makes the label-case rule throw a `TypeError`. That is a defect in the rule,
+ * filed on its own; pinning it here would make this suite depend on a bug
+ * staying unfixed, and the day someone repairs the rule these assertions would
+ * go green for the wrong reason — or be deleted to make them pass.
+ *
+ * What this file pins is the SCORER's contract, which holds for any throw from
+ * any rule: a crash is recorded, never swallowed into `issues: []`. So the
+ * linter is replaced by one that throws on demand, and the control below runs
+ * the same harness with a linter that returns cleanly — a mock that always
+ * failed would satisfy every assertion here for no reason at all.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+const lint = vi.hoisted(() => ({
+  /** When set, the stand-in `lintConfig` throws this instead of returning. */
+  throws: null as unknown,
+}));
+
+vi.mock('../src/commands/lint.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/commands/lint.js')>();
+  return {
+    ...actual,
+    lintConfig: () => {
+      if (lint.throws !== null) throw lint.throws;
+      return [];
+    },
+  };
+});
+
+const { scoreMetadata, LINT_CRASHED_RULE, SCORE_WEIGHTS } = await import('../src/lint/score.js');
+const { runMetadataEval } = await import('../src/lint/metadata-eval.js');
+
+/** Schema-valid and, to the stand-in linter, clean. */
+const STACK = {
+  objects: [
+    {
+      name: 'invoice',
+      label: 'Invoice',
+      sharingModel: 'private',
+      fields: { name: { type: 'text', label: 'Invoice Number', required: true } },
+    },
+  ],
+};
+
+/** Schema-INVALID (`namespace` fails its pattern), so the parse half has a verdict. */
+const SCHEMA_INVALID_STACK = {
+  manifest: { id: 'bad', namespace: 'X', version: '1.0.0', name: 'Bad', type: 'app' as const },
+};
+
+function withLinterThrowing<T>(thrown: unknown, fn: () => T): T {
+  lint.throws = thrown;
+  try {
+    return fn();
+  } finally {
+    lint.throws = null;
+  }
+}
+
+/**
+ * The async twin. ⚠️ Not a stylistic variant of the above: the sync helper
+ * restores `lint.throws` when `fn` RETURNS, which for an async `fn` is the
+ * moment it hands back a pending promise — before a single line of the work
+ * being measured has run. Awaiting inside the `try` is what keeps the stand-in
+ * throwing for the whole run.
+ */
+async function withLinterThrowingAsync<T>(thrown: unknown, fn: () => Promise<T>): Promise<T> {
+  lint.throws = thrown;
+  try {
+    return await fn();
+  } finally {
+    lint.throws = null;
+  }
+}
+
+describe('scoreMetadata — when the linter crashes', () => {
+  it('CONTROL: the same harness with a linter that returns cleanly still scores 100 / A', () => {
+    const r = scoreMetadata(STACK);
+    expect(r.lintError).toBeUndefined();
+    expect(r.score).toBe(100);
+    expect(r.grade).toBe('A');
+    expect(r.valid).toBe(true);
+    expect(r.counts.errors).toBe(0);
+    expect(r.issues).toEqual([]);
+  });
+
+  it('refuses the verdict instead of scoring 100 / A / valid', () => {
+    const r = withLinterThrowing(new TypeError('boom'), () => scoreMetadata(STACK));
+
+    // The headline: nothing about this may read like a clean stack.
+    expect(r.score).toBe(0);
+    expect(r.grade).toBe('F');
+    expect(r.valid).toBe(false);
+  });
+
+  it('records the crash in every carrier a consumer might read', () => {
+    const r = withLinterThrowing(new TypeError('boom'), () => scoreMetadata(STACK));
+
+    expect(r.lintError).toBe('boom');
+    expect(r.counts.errors).toBe(1);
+    expect(r.issues).toHaveLength(1);
+    expect(r.issues[0]).toMatchObject({ severity: 'error', rule: LINT_CRASHED_RULE });
+    // The message must say the rubric did not RUN — "no issues found" is the
+    // exact reading this whole change exists to prevent.
+    expect(r.issues[0].message).toContain('did not run');
+    expect(r.issues[0].message).toContain('boom');
+  });
+
+  it('keeps the schema verdict, which the crash must not mask', () => {
+    const r = withLinterThrowing(new TypeError('boom'), () => scoreMetadata(SCHEMA_INVALID_STACK));
+
+    expect(r.counts.schemaErrors).toBeGreaterThan(0);
+    expect(r.schemaErrors.some((m) => m.includes('namespace'))).toBe(true);
+    expect(r.lintError).toBe('boom');
+  });
+
+  it('stringifies a non-Error throw rather than reporting "undefined"', () => {
+    const r = withLinterThrowing('plain string failure', () => scoreMetadata(STACK));
+
+    expect(r.lintError).toBe('plain string failure');
+    expect(r.issues[0].message).toContain('plain string failure');
+  });
+
+  it('is not a lint error in disguise: a real lint error scores by the rubric and sets no lintError', () => {
+    // One `error`-severity issue costs exactly its weight — the crash path is a
+    // different claim from "the linter found one error", and the two must not
+    // land on the same output.
+    const r = scoreMetadata({
+      objects: [{ name: 'BadName', label: 'Bad', fields: { name: { type: 'text', label: 'Name' } } }],
+    });
+    expect(r.lintError).toBeUndefined();
+    expect(r.score).toBeGreaterThan(100 - SCORE_WEIGHTS.error * 2);
+  });
+});
+
+describe('the eval harness reads the refusal without a new field', () => {
+  const CORPUS = [{ id: 'crashing_case', prompt: 'anything', fixture: STACK }];
+
+  it('CONTROL: the same case passes when the linter returns cleanly', async () => {
+    const report = await runMetadataEval(CORPUS, { minScore: 75 });
+    expect(report.results[0].passed).toBe(true);
+    expect(report.ok).toBe(true);
+  });
+
+  it('fails the case whose linter crashed, and contributes 0 to the mean', async () => {
+    const report = await withLinterThrowingAsync(new TypeError('boom'), () =>
+      runMetadataEval(CORPUS, { minScore: 75 }),
+    );
+
+    expect(report.results[0].passed).toBe(false);
+    expect(report.results[0].score.lintError).toBe('boom');
+    expect(report.meanScore).toBe(0);
+    expect(report.ok).toBe(false);
+  });
+
+  it('still fails it when the score bar is lowered to 0 — the synthetic error is what holds', async () => {
+    // `passed` reads `score >= minScore && counts.errors === 0 &&
+    // counts.schemaErrors === 0`. At `--eval-min 0` the score half stops
+    // discriminating, so the crash has to be an `error` in `counts` or the case
+    // passes again. This is why the refusal is not carried by the number alone.
+    const report = await withLinterThrowingAsync(new TypeError('boom'), () =>
+      runMetadataEval(CORPUS, { minScore: 0 }),
+    );
+
+    expect(report.results[0].score.score).toBeGreaterThanOrEqual(0);
+    expect(report.results[0].score.counts.errors).toBe(1);
+    expect(report.results[0].passed).toBe(false);
+    expect(report.ok).toBe(false);
+  });
+});


### PR DESCRIPTION
Fixes #15658

## The card's open question, settled by measurement first

The card refused to pre-answer its own question and was right to: **is the throw reachable at all, on a value that already survived `normalizeStackInput` and `ObjectStackDefinitionSchema.safeParse`?** If not, the honest repair was to delete the `catch`, not widen the report.

**World (i). The throw is REACHABLE, and not exotically.** A driven input:

```ts
scoreMetadata({ apps: [{ name: 'todo_app', label: { en: 'Todos', 'zh-CN': '待办' } }] })
```

`safeParse` returns `success: true` — `apps[].label` is `I18nLabelSchema`, a union of `z.string()` and an inline locale map, and the map form is the platform's own way to write a localized label. `lintConfig` then throws `TypeError: Cannot read properties of undefined (reading 'toUpperCase')`, because `checkLabelCase` indexes the label as a string. On `origin/main` the scorer swallowed that into `issues: []` and returned:

```json
{"score":100,"grade":"A","valid":true,"counts":{"schemaErrors":0,"errors":0,"warnings":0,"suggestions":0}}
```

`views[].list.label` with the same locale map does it too.

**How the input was found, with its control.** A single-value mutation sweep over `examples/app-todo`'s normalized config — every path, eight hostile values, 15,728 mutations — kept 3,064 schema-valid, of which exactly two crash `lintConfig` (the two above). Positive control in the same run: 241 schema-INVALID mutations also crash it, so the detector fires and the two hits are not an artefact of an empty scan. A second sweep over the four bundled eval-corpus fixtures (2,745 mutations, 241 schema-valid survivors, control 314) found none — those fixtures declare no `apps` and no `views`.

So the repair is the one this repo has chosen twice before (#10653, #10123): make the failure visible in the output, keep the guard.

⚠️ **The crash itself is a separate defect and is deliberately NOT repaired here.** `checkLabelCase` assuming a string is a bug in `packages/cli/src/commands/lint.ts`; repairing it in this PR would delete the very input that proves this path reachable, and it is a different defect class. Filed with its measurement as #15880.

## Both published faces, measured — and one correction to the card

The card lists two faces. Driven end to end against a CLI built from this tree, they behave differently, and the difference is worth recording:

**`os lint --score` — already loud, before and after.** The command calls `lintConfig(normalized, { sduiManifest })` at its own step, *before* `scoreMetadata`, so the same throw kills the run first:

```
$ os lint --score            → ✗ Cannot read properties of undefined (reading 'toUpperCase')   EXIT=1
$ os lint --score --json     → {"error":"Cannot read properties of undefined (reading 'toUpperCase')","conversions":[]}   EXIT=1
```

The silent 100 the card predicts for this face is not reachable through this input: the only difference between the two calls is `sduiManifest`, and the command's call is the superset. That is a correction to the card's blast-radius bullet 1, not to its verdict.

**`os lint --eval` — the face where a failure became a PASS.** It reaches `scoreMetadata` directly, with no earlier lint call. Same generator, same tree, before and after (before = this branch with the `catch` body ablated back to `issues = []`, rebuilt, so the `dist/` the CLI runs really carried the old behaviour):

| | `ok` | `passed` | `failed` | `meanScore` | case verdict | exit |
|:--|:--|:--|:--|:--|:--|:--|
| before | `true` | 5 | 0 | 100 | 100 / `A` / `valid: true`, counts all 0 | **0** |
| after | `false` | 0 | 5 | 0 | 0 / `F` / `valid: false`, `errors: 1`, `lintError` set | **1** |

A generator whose every output crashed the linter earned a green eval and exit 0. That is the pass-flip the card graded correctly.

## What changed

`packages/cli/src/lint/score.ts` only. The `catch` no longer discards; it records, in every carrier a consumer might read, because reading any **one** of them has to be enough:

- **`lintError?: string`** — new optional field on `MetadataScore`, the thrown message. Set only when the linter could not run; absent when it ran and reported errors, which is a lint verdict rather than a missing one. Optional on purpose: `unscorableScore()` in `metadata-eval.ts` constructs a `MetadataScore` literal, and a required field would have forced an edit into a file another card is fenced to.
- **A synthetic `error` issue**, `rule: 'rubric/lint-crashed'` (exported as `LINT_CRASHED_RULE`) — so `issues`, `counts.errors` and `valid` carry it. This is what makes the eval harness fail the case **with no edit to `metadata-eval.ts`**: its `passed` reads `counts.errors`, and would never have seen a new field. It is also what still fails the case at `--eval-min 0`, where the score alone stops discriminating — pinned by its own test.
- **`score: 0` / grade `F`** — the only channel `os lint --score --json` publishes (`{ score, grade }`), and the same refusal `unscorableScore()` already gives an eval case there was nothing to judge, for the same stated reason: a clean number nothing earned is the worst possible output.

The schema half is untouched and still reported: `schemaErrors` and `counts.schemaErrors` say exactly what the parse found. That was the defensible half of the original comment's intent, and it survives.

## Why this shape (the four axes)

- **② 长远合理性 (weighted highest).** The repo has already ruled on this exact question one module over: `unscorableScore()` returns 0 / `F` / `valid: false` and its docblock says why — ⛔ deliberately not `scoreMetadata({})`, because "a clean number nothing earned" is the failure mode. Reusing that verdict for "the rubric did not run" keeps one answer in the codebase instead of two. Adding a lower number *without* a flag would have been the alternative the card warns about (one wrong number for another); adding a flag *without* the number would have left `os lint --score --json`, which publishes nothing but `score` and `grade`, exactly as misleading as before.
- **③ 防 AI 写代码犯错.** A verdict that cannot distinguish "checked and clean" from "never checked" is precisely the input that teaches an agent the wrong thing — and the eval harness is an agent-facing gate. Three carriers means no single-field read can recover the comfortable answer.
- **① 实际业务需求, measured.** Not hypothetical: `apps[].label` accepting a locale map is a shipped authoring feature, and the crash it causes is reachable from a schema-valid stack today.
- **④ 不扩散需求.** One file changed, one optional field, one rule id, no new option, no new command, no edit to the sibling card's file.

## Ablation

Prediction written before the run (`catch` body reverted to `issues = []`, marker injected, nothing else moved): 6 RED by name, 3 GREEN in the same file plus all of `score.test.ts` and `metadata-eval.test.ts`, and the two schema assertions inside `keeps the schema verdict` staying green because the parse half is untouched.

Mutation proven on disk before the run — removed text `rule: LINT_CRASHED_RULE` 1 → 0, injected marker `ABLATION-15658` 0 → 1, blob hash `eef1cc1b` → `4c74b941`. Restore under an `EXIT INT TERM` trap, proven after: disk hash `eef1cc1b` equals the HEAD blob, and `git diff HEAD` is empty. The test reaches the subject through **source** (`test/score-lint-crash.test.ts` imports `../src/lint/score.js`), and `packages/cli/dist` held 0 entries at mutation time; for the CLI-face table above, where `dist` IS the path, the ablated build was verified to carry the marker (1) and the restored build to have lost it (0).

Result — exactly the prediction:

```
Test Files  1 failed | 2 passed (3)
     Tests  6 failed | 25 passed (31)
```

with the six failures being the six named ones, and `keeps the schema verdict` failing only on `expected undefined to be 'boom'` at its third assertion.

## Verification — exit codes captured before any pipe

At `c4f2e7ae671`, working tree clean.

- `pnpm --filter '@objectstack/cli^...' build` — `VERDICT command-exit 0` (the dependency closure; `@objectstack/spec` and `@objectstack/lint` resolve through `exports` to `dist/`).
- `pnpm --filter @objectstack/cli exec vitest run --maxWorkers=2` over `score-lint-crash`, `score`, `metadata-eval`, `lint-eval-json-unscorable-stack.e2e`, `lint-view-label`, `lint-namespace-prefix` — **6 files / 63 tests passed**, `VERDICT command-exit 0`.
- `pnpm --filter @objectstack/cli typecheck` — `VERDICT command-exit 0`; `check:test-typecheck: OK`. Both changed files are really in that program: `tsc -p packages/cli/tsconfig.test.json --listFiles` names `score-lint-crash.test.ts` (1) and `src/lint/score.ts` (1), so this is a measurement and not a NOT MEASURED.
- `pnpm lint` — the **repo-wide** `eslint . --no-inline-config`, not a narrowed run: `VERDICT command-exit 0`, 77s.
- 18 gates from `scripts/pm/dispatch-gates.mjs` (derived from the delivered diff at this commit, `--repo objectstack-ai/objectstack` asserted), each captured as `cmd > log 2>&1; EXIT=$?`: `nul-bytes`, `verify-stand-in`, `single-claim-paths`, `cli-test-child-env`, `cross-package-test-inputs`, `test-source-alias`, `type-source-resolution`, `changeset-gate-self-tests`, `check-changeset-no-major`, `check-empty-changeset`, `check-adr-0087-registration`, `check-comment-mask-adoption`, `objectql-double-limit`, `where-matcher`, `error-code-casing`, `doc-authoring`, `objectui-changeset`, `check-keyed-text-bounds` — **all EXIT=0**, quoting their own verdict lines, e.g. `check-nul-bytes: OK (scanned 7655 text file(s) …)`, `✓ This diff introduces no 'major' bump.`, `check-test-source-alias OK — 72 packages with tests scanned`. The remaining families the derivation lists are `packages/**`-glob matches CI runs in full; that half is CI's, by the dispatch's own rule.

## Clause ② (契约复审) — declared from the delivered diff

**Mechanical / path limb — YES.** `lintError` is a new key on a published payload: `os lint --eval --json` emits the whole report, and `results[].score` is the `MetadataScore` object. The key is in the JSON above, measured, not inferred. The `packages/spec/src/**` path leg does not apply — no spec file is touched.

**Non-mechanizable conformance limb — YES, and driven.** The before/after table is exactly the shape the doctrine names: an input class that **passed** on a shipped face (`ok: true`, exit 0) now fails (`ok: false`, exit 1). Not a re-reading of a borderline case — a measured verdict flip.

Bump: `minor`, per the Check Changeset step's WHICH LEVEL section (`scripts/check-changeset-no-major.mjs:54`) — a new accepted key on a published surface takes at least `minor`, and the commit type may raise but never lower it. Not `major`: the gate refuses it, and `check-adr-0087-registration` confirms this diff declares no breaking changeset.

## Scope

`#15578` is a separate card and its repair has landed on `main` already; nothing here touches `metadata-eval.ts`. The label-case crash that makes this path reachable is filed as #15880 and is not repaired here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D47qPfEWVPmhguWgBZCi5N


---
_Generated by [Claude Code](https://claude.ai/code/session_01D47qPfEWVPmhguWgBZCi5N)_