### PR TITLE
docs(service-cluster-redis): record the measured ioredis 5-vs-6 gap in the contract test header, and drop a live-Redis path that never existed

### DIFF
--- a/packages/services/service-cluster-redis/src/redis.contract.test.ts
+++ b/packages/services/service-cluster-redis/src/redis.contract.test.ts
@@ -6,39 +6,59 @@
  * There is no live-Redis path in this file: every suite below runs on the
  * mock. (An earlier version of this header promised `RUN_REAL_REDIS=1` +
  * `REDIS_URL` and "conditional `describe.skipIf` blocks at the bottom" —
- * no such blocks were ever here, and the two names appeared nowhere in
- * this package outside that sentence.)
+ * no such blocks were ever here. Scanning the whole package, not just
+ * `src/`: `RUN_REAL_REDIS` and `skipIf` occur nowhere outside that
+ * sentence, so the escape hatch never existed. `REDIS_URL` does occur, at
+ * `README.md:42` — but as the env var a caller feeds to
+ * `createRedisClient()`, which is unrelated to any test path.)
  *
  * ## The double is one major version behind the client it doubles
  *
  * This package depends on `ioredis@^6`, while `ioredis-mock@8.13.1`
- * declares `peerDependencies: { ioredis: "^5" }` — so `pnpm install`
- * prints an unmet-peer warning for it. That gap is real, and it is
+ * declares `peerDependencies: { ioredis: "^5" }` — so a resolving
+ * `pnpm install` prints an unmet-peer warning for it (a frozen re-link
+ * prints nothing). That gap is real, and it is
  * declared here rather than closed, because it was measured to be inert
  * on the surface these suites actually drive. Measured against ioredis
  * 5.11.1 (newest release satisfying the mock's `^5` peer) and 6.0.0 (the
  * version resolved in this workspace):
  *
  *   - Every Redis command issued by this package's `src/*.ts` — get, set,
- *     del, incr, incrby, pttl, watch, unwatch, multi, exec, publish,
- *     subscribe, unsubscribe, quit, eval — carries all of its v5
- *     overloads verbatim into v6's `RedisCommander.d.ts`. `set` is a
- *     strict superset there (v6 adds the IFEQ/IFNE/IFDEQ/IFDNE tokens);
- *     nothing used here was removed or re-shaped.
- *   - v6's one substantive change reachable from this package is RESP3
- *     reply mapping, and it is opt-in: the class is declared with a
- *     `ReplyMapping` parameter defaulting to "legacy", `ChainableCommander`
- *     defaults to "resp2", and `duplicate()` with no override inherits the
- *     caller's mapping. This package never passes `replyMapping`, so every
- *     reply shape it sees is still the v5 one.
+ *     del, incr, incrby, pttl, watch, unwatch, exec, publish, subscribe,
+ *     unsubscribe, quit, eval — carries all of its v5 overloads verbatim
+ *     into v6's `RedisCommander.d.ts`. `set` is a strict superset there
+ *     (v6 adds the IFEQ/IFNE/IFDEQ/IFDNE tokens); nothing used here was
+ *     removed or re-shaped.
+ *   - `multi()` is deliberately not in that list: it is declared on
+ *     `Transaction` (`transaction.d.ts`) and appears in
+ *     `RedisCommander.d.ts` in neither version. Measured separately, it
+ *     DID change — all four overloads went from returning
+ *     `ChainableCommander` to `ChainableCommander` parameterised by a
+ *     mapping. It is inert here because the parameter defaults to "resp2"
+ *     and a client built without `replyMapping` reaches it as such: the
+ *     class defaults to "legacy" and extends `Transaction` at "resp2".
+ *     So this package's `multi()` resolves to the non-RESP3 instantiation,
+ *     and `exec()`'s own declaration is byte-identical across the pair.
+ *   - v6's one substantive change reachable from the surface these suites
+ *     drive is RESP3 reply mapping, and it is opt-in: the class is
+ *     declared with a `ReplyMapping` parameter defaulting to "legacy",
+ *     `ChainableCommander` defaults to "resp2", and `duplicate()` with no
+ *     override inherits the caller's mapping. This package never passes
+ *     `replyMapping`, so every reply shape these suites see is the v5 one.
+ *     ⚠️ Scoped deliberately: v6 also changes connection defaults that are
+ *     NOT opt-in — `protocol: 3` (no such option in v5) and `keepAlive`
+ *     0 -> 30000. Those are reached in production through
+ *     `createRedisClient()`, which no suite here calls (see below), so
+ *     they are changed-but-unexercised rather than absent.
  *   - The three `RedisOptions` keys client.ts sets — lazyConnect,
  *     maxRetriesPerRequest, enableAutoPipelining — are declared
  *     identically in both versions.
  *
  * That named set is the whole basis for the claim; it is not a statement
  * about ioredis 5 vs 6 in general. If the `ioredis` or `ioredis-mock`
- * range in package.json moves, this paragraph expires and the diff has to
- * be re-taken.
+ * range in package.json moves — OR if the version either one RESOLVES to
+ * moves under an unchanged caret range, which a lockfile bump alone will
+ * do — this paragraph expires and the diff has to be re-taken.
  *
  * ## What these suites therefore do NOT certify
  *

--- a/packages/services/service-cluster-redis/src/redis.contract.test.ts
+++ b/packages/services/service-cluster-redis/src/redis.contract.test.ts
@@ -3,12 +3,67 @@
 /**
  * Driver contract tests for the Redis cluster driver, run against
  * `ioredis-mock` so they execute without a real Redis instance in CI.
+ * There is no live-Redis path in this file: every suite below runs on the
+ * mock. (An earlier version of this header promised `RUN_REAL_REDIS=1` +
+ * `REDIS_URL` and "conditional `describe.skipIf` blocks at the bottom" —
+ * no such blocks were ever here, and the two names appeared nowhere in
+ * this package outside that sentence.)
  *
- * The same suites can be invoked against a live Redis by setting
- * `RUN_REAL_REDIS=1` and providing `REDIS_URL` — see the conditional
- * `describe.skipIf` blocks at the bottom.
+ * ## The double is one major version behind the client it doubles
+ *
+ * This package depends on `ioredis@^6`, while `ioredis-mock@8.13.1`
+ * declares `peerDependencies: { ioredis: "^5" }` — so `pnpm install`
+ * prints an unmet-peer warning for it. That gap is real, and it is
+ * declared here rather than closed, because it was measured to be inert
+ * on the surface these suites actually drive. Measured against ioredis
+ * 5.11.1 (newest release satisfying the mock's `^5` peer) and 6.0.0 (the
+ * version resolved in this workspace):
+ *
+ *   - Every Redis command issued by this package's `src/*.ts` — get, set,
+ *     del, incr, incrby, pttl, watch, unwatch, multi, exec, publish,
+ *     subscribe, unsubscribe, quit, eval — carries all of its v5
+ *     overloads verbatim into v6's `RedisCommander.d.ts`. `set` is a
+ *     strict superset there (v6 adds the IFEQ/IFNE/IFDEQ/IFDNE tokens);
+ *     nothing used here was removed or re-shaped.
+ *   - v6's one substantive change reachable from this package is RESP3
+ *     reply mapping, and it is opt-in: the class is declared with a
+ *     `ReplyMapping` parameter defaulting to "legacy", `ChainableCommander`
+ *     defaults to "resp2", and `duplicate()` with no override inherits the
+ *     caller's mapping. This package never passes `replyMapping`, so every
+ *     reply shape it sees is still the v5 one.
+ *   - The three `RedisOptions` keys client.ts sets — lazyConnect,
+ *     maxRetriesPerRequest, enableAutoPipelining — are declared
+ *     identically in both versions.
+ *
+ * That named set is the whole basis for the claim; it is not a statement
+ * about ioredis 5 vs 6 in general. If the `ioredis` or `ioredis-mock`
+ * range in package.json moves, this paragraph expires and the diff has to
+ * be re-taken.
+ *
+ * ## What these suites therefore do NOT certify
+ *
+ * They reach the mock only through the injected `client` and the
+ * `client.duplicate()` the pub/sub adapter makes. They never call
+ * `createRedisClient()`, so `new Redis(url, options)` — this package's
+ * only contact with ioredis's constructor and connection surface, and the
+ * area v6 changed most — is exercised by nothing in this file. That is
+ * why the version gap is inert here, and it is not a reason to trust the
+ * double: the mock is simply never asked to stand in for the surface on
+ * which the two majors differ.
  */
 
+// `ioredis-mock` publishes no type declarations of its own — no `types`
+// field in its manifest and no `.d.ts` in the tarball — so this import
+// raises TS7016 ("could not find a declaration file ... implicitly has an
+// 'any' type") and the directive below is what silences it. Note the
+// second cost, beyond the missing types: with the module untyped
+// `RedisMock` is `any`, so every `client:` argument constructed from it
+// satisfies ioredis's `Redis` type without ever being checked against it.
+// That is the other reason a v5-vs-v6 divergence could not surface here.
+// `@types/ioredis-mock` exists and would type this seam, but it only
+// *asserts* `new(): ioredis.Redis` rather than describing the mock, so
+// adopting it would trade an honest `any` for an unearned certainty —
+// that trade has not been made, deliberately.
 // @ts-expect-error — ioredis-mock has no published types
 import RedisMock from 'ioredis-mock';
 import { describe, expect, it, vi } from 'vitest';


### PR DESCRIPTION
Fixes #15467

Comment-only change to one test file. No code, no dependency, no behaviour touched. Head **`a2bbec441`**.

⭐ **Round 2** — the clause-② review returned NOT PASS on three header sentences whose stated population was wider than what was measured. All three are corrected, plus the two advisories. The three corrections and their new measurements are in the last section; the body below is corrected in place so nothing here still states the over-broad version.

## What was measured, before anything was proposed

The card asked whether the contract test still tests the shipped behaviour. On **the surface these suites drive**, the intersection with "surface where ioredis 5 and 6 differ" is **empty** — that is the finding, and the scoping words are load-bearing.

**Population 1 — what this package issues that lives in `RedisCommander.d.ts`.** 14 commands: get, set, del, incr, incrby, pttl, watch, unwatch, exec, publish, subscribe, unsubscribe, quit, eval. `multi()` and `duplicate()` are **not** in this population — they are declared elsewhere and are measured separately below.

**Population 2 — the version pair.** ioredis **5.11.1** (newest release satisfying the mock's `^5` peer, fetched via `npm pack`) against ioredis **6.0.0** (the version resolved in this workspace). Compared declaration-by-declaration, multi-line aware, normalising only quote style, `(T)[]` versus `T[]`, and whitespace.

| surface | reading |
|---|---|
| the 14 `RedisCommander` commands | every v5 overload survives verbatim into v6 |
| `set` | strict superset — v6 adds 48 overloads for the IFEQ/IFNE/IFDEQ/IFDNE tokens; **nothing removed or re-shaped** |
| `Pipeline.d.ts` | byte-identical between the two |
| `multi()` | **declared on `Transaction`, in `RedisCommander.d.ts` in neither version** (measured 0 and 0; control member `exec` reads 1 and 1). All four overloads **did change** return type, to `ChainableCommander` parameterised by a reply mapping |
| the class | gains a `ReplyMapping` parameter defaulting to `legacy`, and extends `Transaction` at resp2 when it is legacy; `duplicate()` with no override inherits the caller's mapping |
| `RedisOptions` keys `client.ts` sets | lazyConnect, maxRetriesPerRequest, enableAutoPipelining declared identically |

⇒ `multi()`'s change is **inert here**: the mapping parameter defaults to resp2, the class defaults to legacy and extends `Transaction` at resp2, so a client built without `replyMapping` resolves `multi()` to the non-RESP3 instantiation — and `exec()`'s own declaration is byte-identical across the pair.

Two **controls** on the normaliser, both fired: a genuinely different pair (NX versus XX) stayed different after normalisation; a purely cosmetic pair collapsed. An earlier run reported `eval` as changed — bracket-adjacent whitespace from my own multi-line join; the normaliser was fixed rather than the result eyeballed.

Separately, the command-metadata tables (`@ioredis/commands` 1.11.0 for the mock, 2.0.0 for ioredis 6) differ on 3 of the 15 used entries — `del`, `subscribe`, `eval` — entirely in server-side and cluster-routing fields. None changes a single-node client's call or reply shape. Control: 12 commands exist only in 2.0.0, 0 only in 1.11.0, an absent name reads undefined in both.

⇒ **On the surface these suites drive, v6's one substantive change is RESP3 reply mapping, and it is opt-in.** This package never passes `replyMapping`. ⚠️ Scoped deliberately: v6 **also** changes connection defaults that are *not* opt-in — `protocol: 3` (no such option in v5) and `keepAlive` 0 to 30000. Those live on the connection surface, reached in production via `createRedisClient()` and by no suite here, so they are changed-but-unexercised. The card's promotion trigger to p2 asks about a surface this package **uses in these tests**, and it does not fire.

## Where the suite stops standing in for shipped behaviour

Measured, not assumed: the shipped test's `makeClient` was temporarily wrapped in a recording Proxy and the suite run unmodified. All 28 tests passed under instrumentation; the file was then restored to a state proved byte-identical to HEAD.

The suite reaches the mock only through the injected client and the pub/sub `duplicate()`. It **never calls `createRedisClient()`** — so `new Redis(url, options)`, this package's only contact with ioredis's constructor and connection surface, is exercised by nothing in this file. That is *why* the version gap is inert here, and it is not a reason to trust the double. It is also what makes the scoping above honest rather than convenient: the non-opt-in connection changes are real, and unexercised.

## The `@ts-expect-error`: proven still needed, not assumed

Vacuity first: this package's `tsconfig` uses `include: ["src"]` and the test lives in `src/`. Proved with `tsc --listFiles` — the contract test is in the file set (present-control 1, absent-control 0).

Then the removal experiment, under a trap with the anchor asserted unique, the mutation proved on disk by a blob-hash delta plus a marker count going 1 to 0, and the restore proved byte-identical:

```
TYPECHECK_EXIT_WITHOUT_DIRECTIVE=2
src/redis.contract.test.ts: error TS7016: Could not find a declaration file for
module 'ioredis-mock' ... implicitly has an 'any' type.
```

⇒ **The suppression has not rotted.** `ioredis-mock@8.13.1` ships no `types` field and no `.d.ts`. Its comment now also records the *cost*: with the module untyped the client is `any` and satisfies ioredis's `Redis` type without being checked against it.

## Routes, including the ones not taken

- **Accept and declare** — taken; the triage comment named this the honest terminal state for exactly this measurement outcome.
- **Adopt `@types/ioredis-mock`** — not taken. It declares `new(): ioredis.Redis`: it *asserts* the mock is a real client rather than describing it, trading an honest `any` for an unearned certainty. ⭐ The review added a fact that strengthens this: the package is in the store but on **no `@types` directory `tsc` walks** from here, so it is not the near-free change it looks like.
- **Pin `ioredis` back to `^5`** / **real Redis in CI** — both above the manual floor per the card's triage, and neither warranted by a measurement that found the gap inert.

## Bounded in-place fix

The header promised `RUN_REAL_REDIS=1` plus `REDIS_URL` and "conditional `describe.skipIf` blocks at the bottom". Scanning the **whole package** (not just `src/`): `RUN_REAL_REDIS` and `skipIf` occur nowhere outside that sentence, so the escape hatch never existed. `REDIS_URL` **does** occur, at `README.md:42`, as the env var a caller feeds to `createRedisClient()` — unrelated to any test path. The header now says exactly that. Same defect class as the card (the header misdescribing its own instrument), same file, same gate family.

## Verification at `a2bbec441`

Gate family derived with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` from the actual changed file, never hand-built: **45 families, no STALE TREE warning, list identical to round 1**. `origin/main` merged (no `merge=os-regen` path in the merge).

- `node scripts/check-adr-0087-registration.mjs --self-test` → **exit 0** (325 assertions) — control.
- `node scripts/check-adr-0087-registration.mjs --base origin/main --head a2bbec441` → **exit 0**, no declared-breaking changeset.
- **45 of 45 derived gates green**, each exit captured right after a single redirected command. Two answered **3** (PREREQUISITE NOT MET) on the fresh worktree — `check:dual-build-cjs-loads` and `check:type-check-debt`; their prerequisite was built and both re-run green. Neither 3 is reported as a pass.
- `pnpm --filter @objectstack/service-cluster-redis test` → **28 passed**, exit 0. `typecheck` → exit 0 (which re-proves the directive is still "used").
- Diff proved **comments-only**: every added and removed line is a comment line, with a control showing the filter admits code.
- `check:nul-bytes` green plus a control-byte scan of the edited file, with a planted-byte control that fired.

## Round-2 corrections

1. **"nowhere in this package"** was false — the scan had been over `src/`, and `REDIS_URL` occurs at `README.md:42`. Re-scanned package-wide and the sentence now names each of the three strings by what it actually found.
2. **`multi` was listed among the verbatim `RedisCommander` commands.** It is declared there in neither version (0 and 0, control `exec` 1 and 1) and its return type *did* change. Removed from the list and given its own measured bullet, including why it is inert here.
3. **"one substantive change reachable from this package"** scoped to **"the surface these suites drive"**, with the non-opt-in connection defaults named as changed-but-unexercised.
4. Advisory: the expiry clause now also fires on a **resolved-version** move under an unchanged caret range (a lockfile-only bump).
5. Advisory: the unmet-peer warning is scoped to a **resolving** install.

## Out of scope, filed separately

**#15983** — `multi().del` is never called, so `RedisKV.delete`'s versioned branch is unexercised, and nothing produces the `exec() === null` WATCH-abort retry. **#15986** tracks the pin that would defend this declaration mechanically.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XpTx2tbq3pZRYAdoGt6E6Y