### PR TITLE
tooling(hooks): the guards' escape hatch names where it actually works

### DIFF
--- a/.claude/hooks/guard-governed-enqueue.selftest.sh
+++ b/.claude/hooks/guard-governed-enqueue.selftest.sh
@@ -161,6 +161,14 @@ expect_says 'does NOT re-run on a later approval' 'the no-re-run reason is state
   "$(mcp $AUTO 13794)" "OS_GOVERNED_ENQUEUE_FIXTURE=$F_UNAPPROVED"
 expect_says 'OS_ALLOW_GOVERNED_ENQUEUE=1' 'the deliberate exception is named' \
   "$(mcp $AUTO 13794)" "OS_GOVERNED_ENQUEUE_FIXTURE=$F_UNAPPROVED"
+# …and it names WHERE that variable has to be set. A VAR=1 prefix sets the variable in the
+# environment of THAT COMMAND; this hook is not that command, and it reads its own
+# environment, so a prefix never reaches it (#15971). The `lacks` row is the shape shared
+# with the other four matrices, where the dead prefix remedy was actually printed.
+expect_lacks 're-run with' 'no prefix remedy is offered for the exception' \
+  "$(mcp $AUTO 13794)" "OS_GOVERNED_ENQUEUE_FIXTURE=$F_UNAPPROVED"
+expect_says 'hook itself runs in' 'the exception names the environment this hook reads' \
+  "$(mcp $AUTO 13794)" "OS_GOVERNED_ENQUEUE_FIXTURE=$F_UNAPPROVED"
 expect_says "$HEAD_SHA" 'the current head sha is named so the reader knows which PR state this is' \
   "$(mcp $AUTO 13794)" "OS_GOVERNED_ENQUEUE_FIXTURE=$F_UNAPPROVED"
 expect_says 'does NOT have to sit on the' 'the remedy states the 2026-09-04 predicate, not the retired sha pin' \

--- a/.claude/hooks/guard-governed-enqueue.sh
+++ b/.claude/hooks/guard-governed-enqueue.sh
@@ -555,6 +555,9 @@ approvals, decided by the register (check-governed-merges.mjs), not here.
 
 Verdict source: check-governed-merges.mjs --test (governed) +
 authorizedApprovalVerdict/GOVERNED_APPROVERS from check-governed-queue-guard.mjs.
-Deliberate exception (you know this one is right): OS_ALLOW_GOVERNED_ENQUEUE=1.
+Deliberate exception (you know this one is right): set OS_ALLOW_GOVERNED_ENQUEUE=1 in the
+environment this hook itself runs in — a local settings "env" entry, or whatever this
+agent process was started with. A VAR=1 prefix on a command sets it for that command
+only, and this hook is not that command, so a prefix never reaches it.
 EOF
 exit 2

--- a/.claude/hooks/guard-main-checkout-bash.selftest.sh
+++ b/.claude/hooks/guard-main-checkout-bash.selftest.sh
@@ -84,6 +84,34 @@ expect() { # expect <block|allow> <command> [env…]
   fi
 }
 
+stderr_of() { # stderr_of <command> [env…] -> the refusal text an agent actually reads
+  local cmd="$1"; shift
+  local payload
+  payload="$(jq -nc --arg c "$cmd" --arg w "$CWD" \
+    '{cwd:$w,tool_name:"Bash",tool_input:{command:$c}}')"
+  printf '%s' "$payload" | env "$@" "$hook" 2>&1 >/dev/null
+}
+
+says() { # says <needle> <label> <command> [env…]
+  local needle="$1" label="$2" subject="$3"; shift 3
+  local out; out="$(stderr_of "$subject" "$@")"
+  case "$out" in
+    *"$needle"*) pass=$((pass + 1)); printf '  ok   says   %s\n' "$label" ;;
+    *) fail=$((fail + 1)); printf '  FAIL missing "%s"  %s\n' "$needle" "$label" ;;
+  esac
+}
+
+lacks() { # lacks <needle> <label> <command> [env…]
+  # The direction only an ABSENCE assertion can hold: a remedy that stopped being true stays
+  # in the text a reader acts on long after the thing it described stopped working.
+  local needle="$1" label="$2" subject="$3"; shift 3
+  local out; out="$(stderr_of "$subject" "$@")"
+  case "$out" in
+    *"$needle"*) fail=$((fail + 1)); printf '  FAIL still says "%s"  %s\n' "$needle" "$label" ;;
+    *) pass=$((pass + 1)); printf '  ok   lacks  %s\n' "$label" ;;
+  esac
+}
+
 echo "== writes into the shared PRIMARY checkout are blocked =="
 CWD="$MAIN"
 expect block "sed -i s/a/b/ $MAIN/pkg/x.ts"
@@ -289,6 +317,25 @@ echo "== escape hatch =="
 CWD="$MAIN"
 expect allow 'sed -i s/a/b/ pkg/x.ts' OS_ALLOW_MAIN_EDITS=1
 expect allow 'echo x > README.md' OS_ALLOW_MAIN_EDITS=1
+
+echo "== the hatch names WHERE it works: this hook's own environment, never a prefix =="
+# The refusal used to end by telling the reader to re-run the same thing with the variable
+# as a VAR=1 command prefix — an instruction that cannot work where it is printed. A VAR=1
+# prefix sets the variable in the environment of THAT COMMAND; this hook is not that
+# command, and it reads the variable from its own environment, so the prefix changes
+# nothing and the refusal repeats (#15971). An instruction that does not work is an
+# invitation to route around the guard, so both directions are pinned: the dead remedy is
+# gone, and the sentence names the environment the hook actually reads. The `allow` rows
+# next door — the variable really in the hook's environment — are this pair's other half.
+# The first row is the card's own reproduction, kept as a case: the prefix spelled exactly
+# as the old message told the reader to spell it must still BLOCK, because it never reaches
+# this hook. It is the twin of the `allow` rows above, where the same variable is really in
+# the hook's environment.
+CWD="$MAIN"
+expect block "OS_ALLOW_MAIN_EDITS=1 rm -f $MAIN/x"
+expect block 'OS_ALLOW_MAIN_EDITS=1 sed -i s/a/b/ pkg/x.ts'
+lacks 're-run with' 'the refusal no longer prints the prefix remedy' 'sed -i s/a/b/ pkg/x.ts'
+says 'hook itself runs in' 'the refusal names the environment this hook reads' 'sed -i s/a/b/ pkg/x.ts'
 
 echo "== unparseable / absent payload fails open =="
 for probe in '{"tool_name":"Bash","tool_input":{}}' 'not json at all' '{}'; do

--- a/.claude/hooks/guard-main-checkout-bash.sh
+++ b/.claude/hooks/guard-main-checkout-bash.sh
@@ -571,7 +571,10 @@ Always fine, no flag needed:
   writes into a linked worktree  sed -i … ../${name}-<task>/packages/…
   writes outside any repo        /tmp/…, the scratchpad, \$HOME dotfiles
 
-Deliberate non-task exception: re-run with OS_ALLOW_MAIN_EDITS=1.
+Deliberate non-task exception: set OS_ALLOW_MAIN_EDITS=1 in the
+environment this hook itself runs in — a local settings "env" entry, or whatever this
+agent process was started with. A VAR=1 prefix on a command sets it for that command
+only, and this hook is not that command, so a prefix never reaches it.
 EOF
       exit 2
     fi

--- a/.claude/hooks/guard-main-checkout.selftest.sh
+++ b/.claude/hooks/guard-main-checkout.selftest.sh
@@ -123,6 +123,31 @@ expect() { # expect <block|allow> <file_path> [env…] — the common case
   check "$want" "$f" "$(payload "$f")" "$@"
 }
 
+stderr_of() { # stderr_of <payload> [env…] -> the refusal text an agent actually reads
+  local payload="$1"; shift
+  ( cd "$CWD" && printf '%s' "$payload" | env CLAUDE_PROJECT_DIR="$PROJ" "$@" "$hook" 2>&1 >/dev/null )
+}
+
+says() { # says <needle> <label> <payload> [env…]
+  local needle="$1" label="$2" subject="$3"; shift 3
+  local out; out="$(stderr_of "$subject" "$@")"
+  case "$out" in
+    *"$needle"*) pass=$((pass + 1)); printf '  ok   says   %s\n' "$label" ;;
+    *) fail=$((fail + 1)); printf '  FAIL missing "%s"  %s\n' "$needle" "$label" ;;
+  esac
+}
+
+lacks() { # lacks <needle> <label> <payload> [env…]
+  # The direction only an ABSENCE assertion can hold: a remedy that stopped being true stays
+  # in the text a reader acts on long after the thing it described stopped working.
+  local needle="$1" label="$2" subject="$3"; shift 3
+  local out; out="$(stderr_of "$subject" "$@")"
+  case "$out" in
+    *"$needle"*) fail=$((fail + 1)); printf '  FAIL still says "%s"  %s\n' "$needle" "$label" ;;
+    *) pass=$((pass + 1)); printf '  ok   lacks  %s\n' "$label" ;;
+  esac
+}
+
 echo "== the core verdict: shared PRIMARY checkout is blocked =="
 expect block "$MAIN/pkg/x.ts"
 expect block "$MAIN/pkg/deep/y.ts"
@@ -193,6 +218,27 @@ check block 'OS_ALLOW_MAIN_EDITS=true'             "$(payload "$MAIN/pkg/x.ts")"
 check block 'OS_ALLOW_MAIN_EDITS=yes'              "$(payload "$MAIN/pkg/x.ts")" OS_ALLOW_MAIN_EDITS=yes
 check block 'OS_ALLOW_MAIN_EDITS=11'               "$(payload "$MAIN/pkg/x.ts")" OS_ALLOW_MAIN_EDITS=11
 check block 'OS_ALLOW_MAIN_EDITS=" 1" (padded)'    "$(payload "$MAIN/pkg/x.ts")" OS_ALLOW_MAIN_EDITS=" 1"
+
+echo "== the hatch names WHERE it works: this hook's own environment, never a prefix =="
+# The refusal used to end by telling the reader to re-run the same thing with the variable
+# as a VAR=1 command prefix — an instruction that cannot work where it is printed. A VAR=1
+# prefix sets the variable in the environment of THAT COMMAND; this hook is not that
+# command, and it reads the variable from its own environment, so the prefix changes
+# nothing and the refusal repeats (#15971). An instruction that does not work is an
+# invitation to route around the guard, so both directions are pinned: the dead remedy is
+# gone, and the sentence names the environment the hook actually reads. The `allow` rows
+# next door — the variable really in the hook's environment — are this pair's other half.
+# Both of this hook's message sites carry the sentence: the ordinary refusal and the
+# schema-drift refusal, which is why each is asserted separately here.
+CWD="$PLAIN"; PROJ="$PLAIN"
+lacks 're-run with' 'the block message no longer prints the prefix remedy' \
+  "$(payload "$MAIN/pkg/x.ts")"
+says 'hook itself runs in' 'the block message names the environment this hook reads' \
+  "$(payload "$MAIN/pkg/x.ts")"
+lacks 're-run with' 'the drift message no longer prints the prefix remedy' \
+  '{"tool_name":"Edit","tool_input":{}}'
+says 'hook itself runs in' 'the drift message names the environment this hook reads' \
+  '{"tool_name":"Edit","tool_input":{}}'
 
 echo "== a ROUTED tool whose payload lacks its own path key is drift — it blocks, never guesses =="
 # The dangerous branch is the one that turns an unreadable payload into a confident verdict.

--- a/.claude/hooks/guard-main-checkout.sh
+++ b/.claude/hooks/guard-main-checkout.sh
@@ -83,7 +83,10 @@ blocks instead.
 Fix the row for $tool in this hook's known_path_keys table, then re-run
 .claude/hooks/guard-main-checkout.selftest.sh.
 
-Deliberate non-task exception: re-run with OS_ALLOW_MAIN_EDITS=1.
+Deliberate non-task exception: set OS_ALLOW_MAIN_EDITS=1 in the
+environment this hook itself runs in — a local settings "env" entry, or whatever this
+agent process was started with. A VAR=1 prefix on a command sets it for that command
+only, and this hook is not that command, so a prefix never reaches it.
 EOF
   exit 2
 fi
@@ -137,6 +140,9 @@ branch on the shared checkout is NOT enough; you must be in a dedicated worktree
 
 This guard checks the edited file's OWN repo, so sibling repos are covered too.
 
-Deliberate non-task exception: re-run with OS_ALLOW_MAIN_EDITS=1.
+Deliberate non-task exception: set OS_ALLOW_MAIN_EDITS=1 in the
+environment this hook itself runs in — a local settings "env" entry, or whatever this
+agent process was started with. A VAR=1 prefix on a command sets it for that command
+only, and this hook is not that command, so a prefix never reaches it.
 EOF
 exit 2

--- a/.claude/hooks/guard-shared-stash.selftest.sh
+++ b/.claude/hooks/guard-shared-stash.selftest.sh
@@ -44,6 +44,33 @@ expect() { # expect <block|allow> <command> [env…]
   fi
 }
 
+stderr_of() { # stderr_of <command> [env…] -> the refusal text an agent actually reads
+  local cmd="$1"; shift
+  local payload
+  payload="$(jq -nc --arg c "$cmd" '{tool_name:"Bash",tool_input:{command:$c}}')"
+  printf '%s' "$payload" | env "$@" "$hook" 2>&1 >/dev/null
+}
+
+says() { # says <needle> <label> <command> [env…]
+  local needle="$1" label="$2" subject="$3"; shift 3
+  local out; out="$(stderr_of "$subject" "$@")"
+  case "$out" in
+    *"$needle"*) pass=$((pass + 1)); printf '  ok   says   %s\n' "$label" ;;
+    *) fail=$((fail + 1)); printf '  FAIL missing "%s"  %s\n' "$needle" "$label" ;;
+  esac
+}
+
+lacks() { # lacks <needle> <label> <command> [env…]
+  # The direction only an ABSENCE assertion can hold: a remedy that stopped being true stays
+  # in the text a reader acts on long after the thing it described stopped working.
+  local needle="$1" label="$2" subject="$3"; shift 3
+  local out; out="$(stderr_of "$subject" "$@")"
+  case "$out" in
+    *"$needle"*) fail=$((fail + 1)); printf '  FAIL still says "%s"  %s\n' "$needle" "$label" ;;
+    *) pass=$((pass + 1)); printf '  ok   lacks  %s\n' "$label" ;;
+  esac
+}
+
 echo "== mutating forms must be blocked =="
 expect block 'git stash'
 expect block 'git stash push -- packages/spec/src/kernel/metadata-plugin.zod.ts'
@@ -133,6 +160,18 @@ expect block "echo 'a \\' ; git stash pop"
 
 echo "== escape hatch =="
 expect allow 'git stash pop' OS_ALLOW_STASH=1
+
+echo "== the hatch names WHERE it works: this hook's own environment, never a prefix =="
+# The refusal used to end by telling the reader to re-run the same thing with the variable
+# as a VAR=1 command prefix — an instruction that cannot work where it is printed. A VAR=1
+# prefix sets the variable in the environment of THAT COMMAND; this hook is not that
+# command, and it reads the variable from its own environment, so the prefix changes
+# nothing and the refusal repeats (#15971). An instruction that does not work is an
+# invitation to route around the guard, so both directions are pinned: the dead remedy is
+# gone, and the sentence names the environment the hook actually reads. The `allow` rows
+# next door — the variable really in the hook's environment — are this pair's other half.
+lacks 're-run with' 'the refusal no longer prints the prefix remedy' 'git stash pop'
+says 'hook itself runs in' 'the refusal names the environment this hook reads' 'git stash pop'
 
 echo "== payload with no command fails open =="
 if printf '%s' '{"tool_name":"Bash","tool_input":{}}' | "$hook" >/dev/null 2>&1; then

--- a/.claude/hooks/guard-shared-stash.sh
+++ b/.claude/hooks/guard-shared-stash.sh
@@ -221,7 +221,10 @@ Already allowed, no flag needed:
   git stash list | git stash show | git stash create
   git stash apply <sha> | git stash store <sha>    # literal hex id, never stash@{N}
 
-Deliberate exception (the stack really is yours alone): re-run with OS_ALLOW_STASH=1.
+Deliberate exception (the stack really is yours alone): set OS_ALLOW_STASH=1 in the
+environment this hook itself runs in — a local settings "env" entry, or whatever this
+agent process was started with. A VAR=1 prefix on a command sets it for that command
+only, and this hook is not that command, so a prefix never reaches it.
 EOF
   exit 2
 done

--- a/.claude/hooks/guard-tree-enum.selftest.sh
+++ b/.claude/hooks/guard-tree-enum.selftest.sh
@@ -47,6 +47,33 @@ expect() { # expect <block|allow> <command> [env…]
   fi
 }
 
+stderr_of() { # stderr_of <command> [env…] -> the refusal text an agent actually reads
+  local cmd="$1"; shift
+  local payload
+  payload="$(jq -nc --arg c "$cmd" '{tool_name:"Bash",tool_input:{command:$c}}')"
+  printf '%s' "$payload" | env "$@" "$hook" 2>&1 >/dev/null
+}
+
+says() { # says <needle> <label> <command> [env…]
+  local needle="$1" label="$2" subject="$3"; shift 3
+  local out; out="$(stderr_of "$subject" "$@")"
+  case "$out" in
+    *"$needle"*) pass=$((pass + 1)); printf '  ok   says   %s\n' "$label" ;;
+    *) fail=$((fail + 1)); printf '  FAIL missing "%s"  %s\n' "$needle" "$label" ;;
+  esac
+}
+
+lacks() { # lacks <needle> <label> <command> [env…]
+  # The direction only an ABSENCE assertion can hold: a remedy that stopped being true stays
+  # in the text a reader acts on long after the thing it described stopped working.
+  local needle="$1" label="$2" subject="$3"; shift 3
+  local out; out="$(stderr_of "$subject" "$@")"
+  case "$out" in
+    *"$needle"*) fail=$((fail + 1)); printf '  FAIL still says "%s"  %s\n' "$needle" "$label" ;;
+    *) pass=$((pass + 1)); printf '  ok   lacks  %s\n' "$label" ;;
+  esac
+}
+
 echo "== THE MEASURED SIGNATURE: working-tree list + origin/main read in one command =="
 # objectui, 2026-08-29 — the loop that reported "no workflow subscribes ready_for_review"
 expect block 'for f in .github/workflows/*.yml; do git show "origin/main:$f" | grep -q ready_for_review && echo "$f"; done'
@@ -100,6 +127,20 @@ expect allow 'git worktree add ../objectstack-issue-13305 -b claude/issue-13305 
 
 echo "== the deliberate exception releases it =="
 expect allow 'for f in .github/workflows/*.yml; do git show "origin/main:$f"; done' OS_ALLOW_TREE_ENUM=1
+
+echo "== the hatch names WHERE it works: this hook's own environment, never a prefix =="
+# The refusal used to end by telling the reader to re-run the same thing with the variable
+# as a VAR=1 command prefix — an instruction that cannot work where it is printed. A VAR=1
+# prefix sets the variable in the environment of THAT COMMAND; this hook is not that
+# command, and it reads the variable from its own environment, so the prefix changes
+# nothing and the refusal repeats (#15971). An instruction that does not work is an
+# invitation to route around the guard, so both directions are pinned: the dead remedy is
+# gone, and the sentence names the environment the hook actually reads. The `allow` rows
+# next door — the variable really in the hook's environment — are this pair's other half.
+lacks 're-run with' 'the refusal no longer prints the prefix remedy' \
+  'for f in .github/workflows/*.yml; do git show "origin/main:$f"; done'
+says 'hook itself runs in' 'the refusal names the environment this hook reads' \
+  'for f in .github/workflows/*.yml; do git show "origin/main:$f"; done'
 
 echo "== fails OPEN on payloads it cannot parse =="
 printf '%s' '{"tool_name":"Bash","tool_input":{}}' | "$hook" >/dev/null 2>&1

--- a/.claude/hooks/guard-tree-enum.sh
+++ b/.claude/hooks/guard-tree-enum.sh
@@ -312,7 +312,10 @@ A command that enumerates with git ls-tree is never blocked here, however it the
 Either half alone is fine too — this fires only on the two together.
 
 Deliberate exception (the working tree really is the population you mean — e.g. asking
-what YOUR branch changed): re-run with OS_ALLOW_TREE_ENUM=1.
+what YOUR branch changed): set OS_ALLOW_TREE_ENUM=1 in the
+environment this hook itself runs in — a local settings "env" entry, or whatever this
+agent process was started with. A VAR=1 prefix on a command sets it for that command
+only, and this hook is not that command, so a prefix never reaches it.
 EOF
   exit 2
 fi


### PR DESCRIPTION
Fixes #15971

Every guard's refusal ended by telling the reader to re-run the blocked thing with the override spelled as a command prefix. A `VAR=1 cmd` prefix sets the variable in the environment of **that command**; the hook is not that command, and it reads the variable from its **own** environment — so the one place an operator naturally applies the printed remedy is the one place it cannot work.

The guard is right and is not weakened here: no predicate, no `OS_ALLOW_*` check and no block/allow verdict is touched. **Message text only.** The hatch stays, because it is the repo's sanctioned deliberate exception and CLAUDE.md names it; what changes is that the sentence now names the environment the hook actually reads.

## Reproduced first, against a throwaway fixture (never the shared checkout)

A fixture primary checkout under `$TMPDIR`, fed the same PreToolUse payload shape Claude Code delivers, with the prefix spelled exactly as the old message told the reader to spell it:

```
### A. the printed remedy, applied exactly as printed (prefix on the command)
exit=2
⛔ Blocked: this Bash command WRITES into the shared PRIMARY checkout, not a worktree.
   command: OS_ALLOW_MAIN_EDITS=1 rm -f $FIX/x
   target:  $FIX/x

### B. the SAME payload with the variable in the hook's OWN environment
exit=0

VERDICT: prefix_exit=2 env_exit=0  (2 = blocked, 0 = allowed)
```

The hook sees the prefix in the command string and blocks anyway — the prefix never became part of the hook's environment.

## The exact sentences, for the objectui twin to mirror

Six message sites, one wording. The three-line tail is **byte-identical** at all six; only the head line carries each hook's own qualifier and variable name. Diffing the twin against this block is therefore mechanical.

Shared tail, all six sites:

```
environment this hook itself runs in — a local settings "env" entry, or whatever this
agent process was started with. A VAR=1 prefix on a command sets it for that command
only, and this hook is not that command, so a prefix never reaches it.
```

Head line, per site:

```
guard-main-checkout.sh:86   (schema-drift refusal)
guard-main-checkout.sh:140  (the ordinary refusal)
guard-main-checkout-bash.sh:574
  Deliberate non-task exception: set OS_ALLOW_MAIN_EDITS=1 in the

guard-shared-stash.sh:224
  Deliberate exception (the stack really is yours alone): set OS_ALLOW_STASH=1 in the

guard-tree-enum.sh:314 (its two-line qualifier is unchanged; only the second line moves)
  what YOUR branch changed): set OS_ALLOW_TREE_ENUM=1 in the

guard-governed-enqueue.sh:558
  Deliberate exception (you know this one is right): set OS_ALLOW_GOVERNED_ENQUEUE=1 in the
```

Removed at all six: the `re-run with OS_ALLOW_...=1` prefix remedy (the governed-enqueue line implied the same reading without the words).

The objectui twin (objectstack-ai/objectui#7775) is dispatched separately and waits behind objectui PR #7749 on the same two files; it mirrors the block above.

## Self-tests — both directions pinned

Each of the five matrices gains an **absence** assertion (the dead prefix remedy is gone from the emitted text) and its positive twin (the sentence names the environment the hook reads). The `allow` rows that already export the variable into the hook's environment are the other half of the pair and were left as they are. The Bash matrix additionally pins the card's own reproduction: the prefix spelled as the old message told the reader to spell it must still **block**.

Green on this head:

```
guard-governed-enqueue.selftest.sh    52 passed, 0 failed
guard-main-checkout-bash.selftest.sh 130 passed, 0 failed
guard-main-checkout.selftest.sh      120 passed, 0 failed
guard-shared-stash.selftest.sh        53 passed, 0 failed
guard-tree-enum.selftest.sh           38 passed, 0 failed
```

Red against the OLD message text — the new assertions run against scratch copies of the hooks read out of the merge base with `git show`, never against the tree:

```
guard-main-checkout      116 passed, 4 failed   (both message sites x 2 assertions)
guard-main-checkout-bash 128 passed, 2 failed
guard-shared-stash        51 passed, 2 failed
guard-tree-enum           36 passed, 2 failed
guard-governed-enqueue    50 passed, 2 failed
```

Two readings of that last line, stated rather than buried. Its `lacks` assertion passes against the old text too, because that message never printed the words — which is exactly why its positive twin earns its place; only the twin goes red there. Its second failure ("the hook agrees with the register about an exception-row candidate") is an artifact of the scratch root, not a regression: both the hook and the register resolve their repo root from the hook's own location, and the scratch root is not a real checkout. Isolated by putting the **new** hook in that same scratch root, where the same case still fails, while the matrix is 52/52 in the tree.

## Verification, all at `a4f2124a4f`

- `node scripts/pm/dispatch-gates.mjs --commands --repo objectstack-ai/objectstack` derived 13 commands from the 10 changed paths; all 13 ran. Reconciliation: `✓ dispatch-gates --ran: 13 derived famil(ies) accounted for — 13 run, 0 NOT-MEASURED.`
- 12 of the 13 were green first time. `check:doc-formula-expressions` returned **exit 3 — prerequisite not met, nothing measured** (unbuilt `@objectstack/formula` and `@objectstack/lint`); after building those two it is exit 0. Recorded as the gate itself insists: exit 3 is not a finding.
- All five `.claude/hooks/*.selftest.sh`, green (numbers above). CI discovers these by glob, so the added assertions run there with no workflow edit.
- `node scripts/pm/check-governed-merges.mjs --test` on the 10-path file list: **exit 3, GOVERNED** — `.claude/**` x10. Hence draft, `skip-changeset`, human merge; no ready flip, no enqueue, no auto-merge.
- Whole-repo `pnpm lint` (`eslint . --no-inline-config`, no narrowing) through `scripts/pm/os-verify-lock.sh` in slot `issue-15971`: `VERDICT command-exit 0`.
- Every exit code captured by redirecting to a file before any pipe.

`CLAUDE.md`, `AGENTS.md` and `settings*.json` are untouched — they already name the overrides without the prefix form, which is why the defect lived only in the emitted messages.

## 维护者速读(草稿)

**这张卡在修什么。** 五个护栏(worktree 守卫的两处消息、Bash 守卫、stash 守卫、tree-enum 守卫、governed-enqueue 守卫)在拦下一次操作时,最后一句都告诉读者「带上 OS_ALLOW_xxx=1 重跑一遍」。这句话在它被打印的那个位置恰好行不通:`VAR=1 命令` 这种前缀只把变量塞进那条命令自己的环境,而钩子不是那条命令,它读的是它自己的环境。填卡的席位实测被拦了两次,本 PR 动手前又在一次性夹具上复现了一次。

**为什么值得一张卡,而不是耸耸肩。** 护栏本身是对的,这个改动一个字都没动它的判定逻辑。风险全在教学面:一个照着提示做、发现照样被拒的 agent,离「这护栏坏了」只有一步,再一步就是 `--no-verify`、改 settings、或者干脆把钩子关掉——那些的破坏力远大于它原本想写的那一次改动。一条不成立的指令,等于在邀请别人绕过护栏。

**改法。** 保留豁免口(它是仓库明文承认的 deliberate exception,CLAUDE.md 点名了它),只把话说准:变量要设在钩子自己所在的那个环境里,命令前缀永远到不了钩子。六处消息共用同一段措辞,三行尾巴逐字节相同,objectui 的孪生卡因此可以机械镜像,两个仓不会各自漂移。

**风险面。** 纯文案改动:谓词、`OS_ALLOW_*` 判断、每一条 block/allow 判定都没碰,`CLAUDE.md`/`AGENTS.md`/`settings*.json` 也没碰。五个自测矩阵 393 例在本 head 全绿;更要紧的是每个矩阵新增的断言拿旧文案跑都确实转红,所以这几条断言不是摆设。`.claude/**` 命中治理面,按规矩走草稿 + 人工合并。

**席位意见。** (留空,待席位在 ACCEPT 时填写。)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019RfFHiRCSs3JXLK4cwcfox

---
_Generated by [Claude Code](https://claude.ai/code/session_019RfFHiRCSs3JXLK4cwcfox)_