### PR TITLE
fix(service-automation): evict a suspension consumed by another replica, so the run listings stop reporting phantoms

### DIFF
--- a/.changeset/suspended-run-cache-consumed-elsewhere.md
+++ b/.changeset/suspended-run-cache-consumed-elsewhere.md
@@ -1,0 +1,64 @@
+---
+"@objectstack/service-automation": patch
+---
+
+fix(service-automation): evict a suspension consumed by another replica, so the run listings stop reporting phantoms (#15832)
+
+`AutomationEngine` had exactly one eviction site for its `suspendedRuns`
+map, inside `forgetSuspendedRun` — and that runs in whichever process
+**consumes** the suspension. In a multi-replica deployment that is routinely
+not the process that parked it: replica A parks a run, replica B resumes it,
+and nothing ever removes A's entry. There is no invalidation channel from B
+to A.
+
+The card that found this located the leak on `resumeInternal`'s
+`claim.kind === 'lost'` branch, which returns before that choke point. That
+branch does leak, but it is not the common shape: the **no-race** variant
+leaks identically — A parks, only B ever resumes, A never attempts a claim
+and there is no `'lost'` anywhere in the sequence — so an eviction hung on
+`'lost'` alone would have left the ordinary deployment untouched.
+
+The retained snapshot was **not only memory**. Two readers handed it back:
+`listSuspendedRuns()` (synchronous, cache-only, and the one listing on the
+`AutomationService` spec contract) and `listSuspendedRunsDurable()` (which
+deliberately appends map entries the durable list lacks). Once the other
+replica **completed** the run, both reported a phantom — a finished run
+listed as suspended, whose `getSuspendedScreen()` answers `null`, so a
+consumer that listed and then opened got an entry it could not act on.
+
+An entry is now dropped whenever this process holds a store-authoritative,
+per-id "no row" answer for it: the strict loader's store miss (which reaches
+`resume`, `hasSuspendedRun`, `cancelRun` and `getSuspendedScreen`), a lost
+advance claim, and a bounded per-id reconcile for the map-only entries of
+`listSuspendedRunsDurable()`.
+
+**Nothing here moves the cache-only listing's contract.** The fix only ever
+*removes* entries. The spec says `listSuspendedRuns()` lists "the currently
+suspended (paused) runs awaiting a resume"; the engine's own docblock adds
+only that it may OMIT runs (those parked in a previous process lifetime),
+because it reads the cache alone. Under-reporting is therefore already
+inside the declared latitude, and over-reporting was never inside the
+promise. Neither listing becomes store-backed, and `listSuspendedRuns()`
+stays synchronous.
+
+Three shapes are deliberately **never** evicted, each pinned by a control:
+no store attached (the map IS the authority); a run whose durable save
+failed (`cacheOnlySuspensions` — the store was never handed the row, so its
+silence says nothing about it); and a store read that THROWS (an outage
+means the run's existence is unknown, not gone). A failed `list()`
+enumeration likewise triggers no per-id reconcile — during an outage that
+would ask about every live run in the process.
+
+**Residual, stated rather than implied.** Eviction is demand-driven: a
+phantom is cleared when this process next obtains the per-id answer for that
+run — any `resume` / `hasSuspendedRun` / `getSuspendedScreen`, or a
+`listSuspendedRunsDurable()` reconcile. A process that never looks at the
+run again keeps the entry until it does. With no invalidation channel
+between replicas, closing that last gap needs either a background sweep or a
+store-backed listing, and both are decisions above this change; the boundary
+is pinned by a `RESIDUAL` test rather than left to be discovered.
+
+Note 2 of the same card — the `'unsupported'` branch deciding on the shape of
+a value the conditional delete has **already** been issued to obtain — is
+**not** addressed here: its honest fix is a declared return contract for the
+engine's multi-row delete, which lands in another package.

--- a/packages/services/service-automation/src/engine.ts
+++ b/packages/services/service-automation/src/engine.ts
@@ -2165,6 +2165,72 @@ export class AutomationEngine implements IAutomationService {
     }
 
     /**
+     * [#15832] Drop a map entry for a run this process has a store-authoritative
+     * per-id "no row" answer for — a run parked HERE and consumed by another
+     * replica.
+     *
+     * ## Why this exists at all, and why not on the `'lost'` branch
+     *
+     * {@link forgetSuspendedRun} is the one eviction site, and it runs in
+     * whichever process CONSUMES the suspension. Put two replicas over one
+     * store and the parking process is routinely not that one: A parks a run
+     * and B resumes it, so A's entry is never removed by anything. The card
+     * that found this located the leak on `resumeInternal`'s `'lost'` branch,
+     * which returns before that choke point — but the NO-RACE shape leaks
+     * identically (A parks, only B ever resumes, A never attempts a claim and
+     * there is no `'lost'` at all), so an eviction hung on `'lost'` alone would
+     * leave the ordinary multi-replica deployment untouched.
+     *
+     * The retained snapshot is not only memory. Two readers hand it back:
+     * {@link listSuspendedRuns} — synchronous, cache-only, and the one listing
+     * on the `AutomationService` spec contract — and
+     * {@link listSuspendedRunsDurable}, which deliberately appends map entries
+     * the durable list lacks. After the other replica COMPLETES the run both
+     * report a phantom: a finished run listed as suspended, whose
+     * {@link getSuspendedScreen} answers `null`, so a consumer that lists and
+     * then opens gets an entry it cannot act on.
+     *
+     * ## What this does NOT do
+     *
+     * ⛔ It does not touch the cache-only listing's contract. The spec says
+     * `listSuspendedRuns()` lists "the currently suspended (paused) runs
+     * awaiting a resume"; this engine's own docblock adds only that it may
+     * OMIT runs (those parked in a previous process lifetime) because it reads
+     * the cache alone. Removing an entry therefore moves nothing: under-
+     * reporting is already inside that declared latitude, and over-reporting
+     * was never inside the promise. Nothing here makes either listing
+     * store-backed.
+     *
+     * ⛔ It does not notify the paused node's executor
+     * ({@link NodeExecutor.onSuspensionReleased}). That notification belongs to
+     * {@link forgetSuspendedRun} because it is the choke point every
+     * CONSUMPTION passes through, and an eviction is not a consumption — this
+     * process consumed nothing, the replica that did fired its own. Firing one
+     * here would tear down a pause twice, once per replica.
+     *
+     * ## The two guards, and why each is load-bearing
+     *
+     *  - **no store** — the map IS the authority (`loadSuspendedRunStrict`
+     *    returns from it directly), so there is no second reader to be wrong
+     *    about and nothing may be dropped.
+     *  - **{@link cacheOnlySuspensions}** — a run whose durable save failed was
+     *    never handed to the store, so the store's "no row" is SILENCE about it
+     *    rather than an answer (#13617). Evicting on that would convert
+     *    {@link persistSuspendedRun}'s documented degradation — a failed save
+     *    costs cross-restart durability, not in-process resumability — into a
+     *    run that vanishes from its own process.
+     *
+     * A store read that THROWS must never reach here: an outage means the
+     * run's existence is UNKNOWN, not "gone". Every caller below is on a path
+     * where the store answered.
+     */
+    private evictConsumedSuspension(runId: string): void {
+        if (!this.store) return;
+        if (this.cacheOnlySuspensions.has(runId)) return;
+        this.suspendedRuns.delete(runId);
+    }
+
+    /**
      * [#14333] Claim the right to advance this run past the node it is parked
      * at — the CROSS-REPLICA half of the resume idempotency guard.
      *
@@ -4996,6 +5062,13 @@ export class AutomationEngine implements IAutomationService {
         // deliberately keeps such a run resumable in-process (it reports the
         // lost durability at `error`).
         if (this.cacheOnlySuspensions.has(runId)) return this.suspendedRuns.get(runId) ?? null;
+        // [#15832] The store ANSWERED, and the answer is "no row". Any entry
+        // this process still holds for that run is a run it parked and another
+        // replica consumed — the phantom the two listings hand back. This is
+        // the definitive per-id evidence the paragraph above already rests on,
+        // so the same reading that refuses to serve it here stops publishing it
+        // there. A store read that threw never reaches this line.
+        this.evictConsumedSuspension(runId);
         return null;
     }
 
@@ -5374,6 +5447,14 @@ export class AutomationEngine implements IAutomationService {
                 // already maps it to 409. A distinct code would be vocabulary
                 // nothing reads — add one the day a caller needs the
                 // difference.
+                // [#15832] The store's compare-and-set ANSWERED: no row is parked
+                // where this replica read it. Whatever snapshot this process
+                // still holds for the run is stale by construction — it names a
+                // node the run has left — so it stops being published by the two
+                // listings. ⛔ NOT `forgetSuspendedRun`: nothing was consumed
+                // here, and firing that choke point would tear the pause down a
+                // second time in this process on top of the winner's own.
+                this.evictConsumedSuspension(runId);
                 return {
                     success: false,
                     code: 'RESUME_IN_PROGRESS',
@@ -6536,11 +6617,16 @@ export class AutomationEngine implements IAutomationService {
      */
     async listSuspendedRunsDurable(): Promise<Array<{ runId: string; flowName: string; nodeId: string; correlation?: string }>> {
         const byId = new Map<string, { runId: string; flowName: string; nodeId: string; correlation?: string }>();
+        // [#15832] Did the ENUMERATION answer? The reconcile below is allowed
+        // only when it did — see the merge comment for why a failed listing is
+        // silence rather than evidence.
+        let enumerated = false;
         if (this.store) {
             try {
                 for (const r of await this.store.list()) {
                     byId.set(r.runId, { runId: r.runId, flowName: r.flowName, nodeId: r.nodeId, correlation: r.correlation });
                 }
+                enumerated = true;
             } catch (err) {
                 // #6299 — driver text to the structured slot, message one line,
                 // same as the two seams above. The SLOT differs: the `Logger`
@@ -6605,8 +6691,35 @@ export class AutomationEngine implements IAutomationService {
         // only {@link cacheOnlySuspensions} answer out of the map. Applying that
         // qualifier here would let a truncated or failed enumeration silently
         // drop live runs from an operability listing.
-        for (const r of this.suspendedRuns.values()) {
+        //
+        // [#15832] What that reasoning leaves open is a run this process parked
+        // and ANOTHER replica has since consumed: absent from the durable list
+        // because it is finished, appended here, and published as suspended by
+        // a listing that also backs the cache-only one. The paragraph above is
+        // right that list-absence is not evidence — so this asks for the
+        // evidence instead. `store.load` is the same definitive per-id read
+        // {@link loadSuspendedRunStrict} rests on, and it is bought only for the
+        // entries that look suspicious: a healthy process, whose map entries all
+        // appear in the durable list, buys none. A read that THROWS leaves the
+        // entry standing (unknown is not gone), and a store that could not be
+        // enumerated at all is not probed row by row — an outage would answer
+        // for every live run in the process.
+        for (const r of [...this.suspendedRuns.values()]) {
             if (byId.has(r.runId)) continue;
+            if (enumerated && !this.cacheOnlySuspensions.has(r.runId)) {
+                let stored: SuspendedRun | null;
+                try {
+                    stored = await this.store!.load(r.runId);
+                } catch {
+                    // Unknown, not gone — keep the entry and publish it, exactly
+                    // as this method did before the reconcile existed.
+                    stored = r;
+                }
+                if (stored === null) {
+                    this.evictConsumedSuspension(r.runId);
+                    continue;
+                }
+            }
             byId.set(r.runId, { runId: r.runId, flowName: r.flowName, nodeId: r.nodeId, correlation: r.correlation });
         }
         return [...byId.values()];

--- a/packages/services/service-automation/src/suspended-run-cache-eviction.test.ts
+++ b/packages/services/service-automation/src/suspended-run-cache-eviction.test.ts
@@ -1,0 +1,287 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * A run parked by one process and consumed by another leaves the parking
+ * process's `suspendedRuns` map holding it forever (#15832 note 1).
+ *
+ * ## The defect, located where the correction measured it and not where the
+ * card first pointed
+ *
+ * The card put the leak on `resumeInternal`'s `claim.kind === 'lost'` branch,
+ * which returns before the one `suspendedRuns.delete` in `forgetSuspendedRun`.
+ * That branch does leak — but it is not where the common shape lives. The
+ * NO-RACE variant leaks identically: replica A parks a run, replica B is the
+ * only one that ever resumes it, A never attempts a claim and there is no
+ * `'lost'` at all. So the leak is a property of ANY run parked by one process
+ * and consumed by another — the ordinary multi-replica deployment — and an
+ * eviction hung on `'lost'` would leave that shape untouched.
+ *
+ * ## Why it is not only a memory leak
+ *
+ * The card's severity note said "the stale entry is not read back", which is
+ * false: two readers hand it back.
+ *
+ *  - {@link AutomationEngine.listSuspendedRuns} — synchronous, cache-only, and
+ *    the one listing on the `AutomationService` SPEC contract, where it is
+ *    documented as "the currently suspended (paused) runs awaiting a resume".
+ *  - {@link AutomationEngine.listSuspendedRunsDurable} — which deliberately
+ *    APPENDS map entries the durable list lacks.
+ *
+ * After B **completes** the run the durable row is gone, and both listings
+ * still report it: a phantom whose `getSuspendedScreen()` answers `null`, so a
+ * consumer that lists and then opens gets an entry it cannot act on.
+ *
+ * ## The promise this file's fix relies on — stated, because it is the whole
+ * question
+ *
+ * The fix only ever REMOVES map entries, and only ones the process has a
+ * store-authoritative, per-id "no row" answer for. It relies on exactly one
+ * promise, in the direction that promise already runs:
+ *
+ *  - the SPEC contract says `listSuspendedRuns()` lists "the currently
+ *    suspended (paused) runs awaiting a resume" — a completed run is not one;
+ *  - the engine's own docblock adds only that it may OMIT runs (those parked in
+ *    a previous process lifetime), because it reads the cache alone.
+ *
+ * So under-reporting is already inside the method's declared latitude and
+ * over-reporting was never inside its promise. ⛔ Nothing here makes the
+ * synchronous listing store-backed, and nothing widens what it returns.
+ *
+ * ## The residual, pinned rather than described
+ *
+ * A phantom is evicted when this process obtains the per-id answer — any
+ * `hasSuspendedRun` / `resume` / `getSuspendedScreen` on that run, or a
+ * `listSuspendedRunsDurable()` reconcile. A process that never looks at the run
+ * again keeps the entry: with no invalidation channel from B to A, the only
+ * remedies for THAT are a background sweep or a store-backed listing, and both
+ * are decisions above this card. `RESIDUAL` below pins the boundary so it
+ * cannot be mistaken for a fix.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { defineActionDescriptor } from '@objectstack/spec/automation';
+import { RESUME_AUTHORITY_SERVICE } from '@objectstack/spec/contracts';
+import { AutomationEngine } from './engine.js';
+import { InMemorySuspendedRunStore } from './suspended-run-store.js';
+import type { SuspendedRun, SuspendedRunStore } from './engine.js';
+
+function silentLogger(): any {
+  return { info() {}, warn() {}, error() {}, debug() {}, child() { return silentLogger(); } };
+}
+
+/** start -> lv1 -> lv2 -> end. Two approval levels is all the shape needs. */
+const APPROVAL_FLOW = {
+  name: 'expense_approval',
+  label: 'Expense approval',
+  type: 'autolaunched',
+  nodes: [
+    { id: 'start', type: 'start', label: 'Start' },
+    { id: 'lv1', type: 'approval_level', label: 'Department head' },
+    { id: 'lv2', type: 'approval_level', label: 'General manager' },
+    { id: 'end', type: 'end', label: 'End' },
+  ],
+  edges: [
+    { id: 'e1', source: 'start', target: 'lv1' },
+    { id: 'e2', source: 'lv1', target: 'lv2' },
+    { id: 'e3', source: 'lv2', target: 'end' },
+  ],
+} as any;
+
+/** One replica: a fresh engine over the SHARED store. */
+function replica(store: SuspendedRunStore | undefined, opened: string[] = []): AutomationEngine {
+  const engine = new AutomationEngine(silentLogger(), store);
+  engine.registerNodeExecutor({
+    type: 'approval_level',
+    descriptor: defineActionDescriptor({
+      type: 'approval_level',
+      version: '1.0.0',
+      name: 'Approval level',
+      supportsPause: true,
+      resumeAuthority: 'service',
+    }),
+    async execute(node: any) {
+      opened.push(node.id);
+      return { success: true, suspend: true, correlation: `req_${node.id}` };
+    },
+  } as any);
+  engine.registerFlow('expense_approval', APPROVAL_FLOW);
+  return engine;
+}
+
+const approve = (engine: AutomationEngine, runId: string) =>
+  engine.resume(runId, { [RESUME_AUTHORITY_SERVICE]: true } as any);
+
+/** Node ids the listing reports for `runId`, in call order. */
+const listedNodes = (rows: Array<{ runId: string; nodeId: string }>, runId: string) =>
+  rows.filter(r => r.runId === runId).map(r => r.nodeId);
+
+// ── the leak, both variants ─────────────────────────────────────────────────
+
+describe('#15832 note 1 — a run parked here and consumed elsewhere leaves no phantom', () => {
+  it('THE BUG (no race): A parks, B alone runs it to completion, A must list nothing', async () => {
+    // The ordinary multi-replica shape: A never attempts a claim, so there is
+    // no `'lost'` anywhere in this sequence.
+    const store = new InMemorySuspendedRunStore();
+    const opened: string[] = [];
+    const a = replica(store, opened);
+    const b = replica(store, opened);
+
+    const runId = (await a.execute('expense_approval')).runId!;
+    expect(opened).toEqual(['lv1']);
+    expect((await approve(b, runId)).status).toBe('paused');   // lv1 -> lv2, on B
+    expect((await approve(b, runId)).success).toBe(true);      // lv2 -> end, run COMPLETES
+    expect(await store.load(runId)).toBeNull();                 // durable row is gone
+
+    // Reader 1: the durable listing must not append a completed run.
+    expect(listedNodes(await a.listSuspendedRunsDurable(), runId)).toEqual([]);
+    // Reader 2: the spec-contract listing, once the reconcile above has run.
+    expect(listedNodes(a.listSuspendedRuns(), runId)).toEqual([]);
+  });
+
+  it('THE BUG (race): the loser of the advance claim drops its stale entry', async () => {
+    // A reads the run parked at lv2, then blocks INSIDE claimSuspension while B
+    // consumes it — so A's compare-and-set runs against a row that is gone and
+    // answers `'lost'`. That is the branch the card named.
+    const store = new InMemorySuspendedRunStore();
+    const opened: string[] = [];
+    const a = replica(store, opened);
+    const b = replica(store, opened);
+
+    const runId = (await a.execute('expense_approval')).runId!;
+    expect((await approve(b, runId)).status).toBe('paused');   // parked at lv2
+
+    let releaseClaim: () => void = () => {};
+    const gate = new Promise<void>(r => { releaseClaim = r; });
+    a.setSuspendedRunStore({
+      save: (run: SuspendedRun) => store.save(run),
+      load: (id: string) => store.load(id),
+      delete: (id: string) => store.delete(id),
+      list: () => store.list(),
+      async claimSuspension(id: string, at: any) {
+        await gate;
+        return store.claimSuspension(id, at);
+      },
+    });
+
+    const losing = approve(a, runId);
+    expect((await approve(b, runId)).success).toBe(true);       // B finishes the run
+    releaseClaim();
+    const lost = await losing;
+    expect(lost.success).toBe(false);
+    expect(lost.code).toBe('RESUME_IN_PROGRESS');
+
+    expect(listedNodes(a.listSuspendedRuns(), runId)).toEqual([]);
+  });
+
+  it('list-then-open: the per-id read a consumer makes next evicts the phantom', async () => {
+    // The harm the correction named — list, then open — is also the channel
+    // that heals it: `hasSuspendedRun` is store-authoritative per id.
+    const store = new InMemorySuspendedRunStore();
+    const a = replica(store);
+    const b = replica(store);
+
+    const runId = (await a.execute('expense_approval')).runId!;
+    expect((await approve(b, runId)).status).toBe('paused');
+    expect((await approve(b, runId)).success).toBe(true);
+
+    expect(await a.hasSuspendedRun(runId)).toBe(false);
+    expect(listedNodes(a.listSuspendedRuns(), runId)).toEqual([]);
+    expect(await a.getSuspendedScreen(runId)).toBeNull();
+  });
+
+  it('RESIDUAL: with no store-authoritative read of its own, A still holds the entry', async () => {
+    // The declared boundary, pinned so it is not mistaken for a fix: eviction
+    // is demand-driven. Closing THIS requires a background sweep or a
+    // store-backed listing — both above this card.
+    const store = new InMemorySuspendedRunStore();
+    const a = replica(store);
+    const b = replica(store);
+
+    const runId = (await a.execute('expense_approval')).runId!;
+    expect((await approve(b, runId)).status).toBe('paused');
+    expect((await approve(b, runId)).success).toBe(true);
+
+    // No `listSuspendedRunsDurable()`, no `hasSuspendedRun`, no resume on A.
+    expect(listedNodes(a.listSuspendedRuns(), runId)).toEqual(['lv1']);
+  });
+});
+
+// ── controls: the three shapes eviction must NEVER touch ────────────────────
+
+describe('#15832 note 1 — eviction fires only on a store-authoritative per-id miss', () => {
+  it('CONTROL: with no store attached the map IS the authority and nothing is evicted', async () => {
+    const solo = replica(undefined);
+    const runId = (await solo.execute('expense_approval')).runId!;
+
+    expect(await solo.hasSuspendedRun(runId)).toBe(true);
+    expect(listedNodes(await solo.listSuspendedRunsDurable(), runId)).toEqual(['lv1']);
+    expect(listedNodes(solo.listSuspendedRuns(), runId)).toEqual(['lv1']);
+  });
+
+  it('CONTROL: a run the store never accepted (cache-only) is never evicted', async () => {
+    // `persistSuspendedRun`'s documented degradation: a failed durable save
+    // costs cross-restart durability, not in-process resumability. The store's
+    // "no row" is SILENCE about this run, not an answer.
+    const saves: string[] = [];
+    const writeFailingStore: SuspendedRunStore = {
+      async save(run: SuspendedRun) { saves.push(run.nodeId); throw new Error('sqlite: disk I/O error'); },
+      async load() { return null; },
+      async delete() {},
+      async list() { return []; },
+    };
+    const engine = replica(writeFailingStore);
+    const runId = (await engine.execute('expense_approval')).runId!;
+    expect(saves).toEqual(['lv1']);
+
+    expect(await engine.hasSuspendedRun(runId)).toBe(true);
+    expect(listedNodes(await engine.listSuspendedRunsDurable(), runId)).toEqual(['lv1']);
+    expect(listedNodes(engine.listSuspendedRuns(), runId)).toEqual(['lv1']);
+  });
+
+  it('CONTROL: an unreadable store is "unknown", not a licence to evict', async () => {
+    const store = new InMemorySuspendedRunStore();
+    const engine = replica(store);
+    const runId = (await engine.execute('expense_approval')).runId!;
+
+    engine.setSuspendedRunStore({
+      save: (run: SuspendedRun) => store.save(run),
+      async load() { throw new Error('sqlite: database is locked'); },
+      delete: (id: string) => store.delete(id),
+      list: () => store.list(),
+    });
+
+    // The strict read THROWS rather than answering "no row" — the entry stands.
+    await expect(engine.hasSuspendedRun(runId)).rejects.toThrow(/database is locked/);
+    expect(listedNodes(engine.listSuspendedRuns(), runId)).toEqual(['lv1']);
+  });
+
+  it('CONTROL: an unlistable store degrades the listing and evicts nothing', async () => {
+    // `listSuspendedRunsDurable`'s documented degraded path: `byId` is empty
+    // because the ENUMERATION failed, not because the rows are gone. A
+    // reconcile here would evict every live run in the process.
+    const store = new InMemorySuspendedRunStore();
+    const engine = replica(store);
+    const runId = (await engine.execute('expense_approval')).runId!;
+
+    engine.setSuspendedRunStore({
+      save: (run: SuspendedRun) => store.save(run),
+      load: (id: string) => store.load(id),
+      delete: (id: string) => store.delete(id),
+      async list() { throw new Error('sqlite: database is locked'); },
+    });
+
+    expect(listedNodes(await engine.listSuspendedRunsDurable(), runId)).toEqual(['lv1']);
+    expect(listedNodes(engine.listSuspendedRuns(), runId)).toEqual(['lv1']);
+  });
+
+  it('CONTROL: a live run parked in THIS process survives every reconcile', async () => {
+    const store = new InMemorySuspendedRunStore();
+    const engine = replica(store);
+    const runId = (await engine.execute('expense_approval')).runId!;
+
+    expect(listedNodes(await engine.listSuspendedRunsDurable(), runId)).toEqual(['lv1']);
+    expect(await engine.hasSuspendedRun(runId)).toBe(true);
+    expect(listedNodes(engine.listSuspendedRuns(), runId)).toEqual(['lv1']);
+    expect((await approve(engine, runId)).status).toBe('paused');
+  });
+});


### PR DESCRIPTION
Part of #15832 — note 1 only. Note 2 is judged cross-lane and is deliberately left open here; see the lane judgement below.

## Phase 1 first: the measurement that gated everything

Triage ruled that the escalation to p1 turns on whether **any published composition's** `engine.delete(object, { multi: true, … })` resolves to something other than a `number` — and that it cannot be settled by reading source, because `ObjectQL.delete` declares `Promise` of `any`. Driven as real kernels over real drivers against a real `sys_automation_run` table:

| composition | winner | 0-row loser | `claimSuspension` |
|---|---|---|---|
| `InMemoryDriver` | `number` / `1` | `number` / `0` | `claimed` / `lost` |
| `SqlDriver` better-sqlite3 | `number` / `1` | `number` / `0` | `claimed` / `lost` |
| `SqliteWasmDriver` | `number` / `1` | `number` / `0` | `claimed` / `lost` |
| `TursoDriver` local | `number` / `1` | `number` / `0` | `claimed` / `lost` |
| `TursoDriver` remote transport, real SQL via `libsql-sqlite-stub.testkit` | `number` / `1` | `number` / `0` | `claimed` / `lost` |
| `SqlDriver` + `SecurityPlugin` (the one middleware that rewrites `opCtx.result`) | `number` / `1` | `number` / `0` | `claimed` / `lost` |

**No measured composition resolves to a non-number**, so the escalation condition did not fire. The control fires, though: with `InMemoryDriver.deleteMany` wrapped to perform the delete and then resolve `undefined`, the harness reads `typeof undefined`, `claimSuspension` answers `'unsupported'` for a genuine winner **and** for a replica that actually lost, and the store logs *"resolved undefined, not an affected-row count"*. NOT MEASURED: `driver-mongodb` (the mongod binary download is refused by the egress proxy — `curl: (56) CONNECT tunnel failed, response 403`), `driver-sql` on postgres/mysql dialects, and Turso against a real hosted endpoint.

## What this PR changes

`AutomationEngine` had exactly one eviction site for its `suspendedRuns` map, inside `forgetSuspendedRun` — and that runs in whichever process **consumes** the suspension. In a multi-replica deployment that is routinely not the process that parked it, and there is no invalidation channel between them.

The card located the leak on `resumeInternal`'s `claim.kind === 'lost'` branch. That branch does leak, but the **no-race** variant leaks identically — A parks, only B ever resumes, A never attempts a claim and there is no `'lost'` anywhere in the sequence — so an eviction hung on `'lost'` alone would have left the ordinary deployment untouched. This is built to that reading, not to the card body.

The retained snapshot is not only memory. `listSuspendedRuns()` (synchronous, cache-only, and the one listing on the `AutomationService` spec contract) and `listSuspendedRunsDurable()` (which deliberately appends map entries the durable list lacks) both hand it back, so once the other replica **completes** the run both publish a phantom whose `getSuspendedScreen()` answers `null`.

An entry is now dropped whenever this process holds a store-authoritative, per-id "no row" answer for it: the strict loader's store miss, a lost advance claim, and a bounded per-id reconcile for the map-only entries of the durable listing.

### The promise relied on — stated, because it is the whole question

The fix only ever **removes** entries. The spec says `listSuspendedRuns()` lists "the currently suspended (paused) runs awaiting a resume"; the engine's own docblock adds only that it may OMIT runs (those parked in a previous process lifetime), because it reads the cache alone. Under-reporting is therefore already inside the declared latitude, and over-reporting was never inside the promise. **Neither listing becomes store-backed and the synchronous one stays synchronous**, so the cache-only contract is not moved or reinterpreted in either direction.

### Residual, pinned rather than described

Eviction is demand-driven: a phantom clears when this process next obtains the per-id answer for that run. A process that never looks at the run again keeps the entry. Closing that needs a background sweep or a store-backed listing, both decisions above this card — so a `RESIDUAL` test pins the boundary instead of leaving it to be discovered.

## Note 2 — the lane judgement, and why it is (b)

Triage offered **(a)** an in-store one-shot capability probe (stays in `domain:services`) or **(b)** declaring "multi delete returns the affected-row count" as a contract (cross-lane). **This is (b).** Reasoning, with what Phase 1 added:

1. The driver layer **already** contracts the count: `IDataDriver.deleteMany` declares `Promise` of `number` in `packages/spec/src/contracts/data-driver.ts:269`, and its Zod mirror `packages/spec/src/data/driver.zod.ts` pins `.output(z.promise(z.number()))` with "Count of deleted records". The gap is exactly one layer up: `ObjectQL.delete` declares `Promise` of `any` and nothing states that the `multi` route passes the driver's count through. So (b) propagates an existing contract rather than inventing one — and it lands in `packages/objectql`, another lane.
2. Phase 1 measured that every shipped composition already returns a number, so (b) declares what is already true: a declaration change, not a behaviour change, and no driver has to move.
3. (a) is strictly worse here. The version triage described — cache the answer after the first real claim — leaves the first claim unprotected, which is the harm itself. The version that closes that (a synthetic 0-row probe delete) buys a real DELETE round-trip per process and emits a bulk `deleted` data event with `matched: 0` on `sys_automation_run` — a fabricated write event to answer a typing question. Both keep the store guessing about a shape the layer beneath it already promises, which is the contract-first refusal: the producer's declaration is weaker than its behaviour, so the producer is where it is repaired.

⛔ No file under `packages/objectql` or `packages/spec` is touched by this PR.

### Note 5 confirmed by run, not quoted

Same recorded shape as filed. Observed delete sequence on a composition whose multi-delete resolves to a non-count:

```
[ { where: { id, node_id, correlation }, multi: true },
  { where: { id } } ]
```

with the store warning *"the data engine's multi-row delete resolved undefined, not an affected-row count"* and the engine warning *"no cross-replica advance guarantee … resume idempotency is IN-PROCESS ONLY"*.

## Verification

Every command run bare, exit code captured before any pipe.

- `pnpm --filter @objectstack/service-automation test` — **exit 0**, `Test Files 116 passed (116) · Tests 1395 passed (1395)`.
- `pnpm --filter @objectstack/service-automation typecheck` — **exit 0**; `check:test-typecheck: OK — the test layer compiles under tsconfig.test.json`. Confirmed the new test file is genuinely in both programs rather than excluded: `tsc --listFiles` counts it once under `tsconfig.json` and once under `tsconfig.test.json`.
- Derived gate family: `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` — 55 families (43 by path + 7 by kind + 7 whole-tree). **All 55 exit 0.** Two needed the built workspace and were re-run after `turbo run build` rather than left unmeasured: `check:dual-build-cjs-loads` first answered `PREREQUISITE NOT MET … exit 3` (not a pass), then `exit 0` — *"103 published require entry point(s) across 66 package(s) load"*; `check:type-check-debt` — `exit 0`, *"12 ledger entr(ies) re-measured … none above its recorded number"*.
- `pnpm lint` (whole repo, `eslint . --no-inline-config`) — **exit 0**. Run in full, so no narrowing is claimed.
- The union above was run on the final commit, `db6133ab`.

### Mutation proof — one leg per fix site

Each: the implementation committed first, the mutation proven on disk by an anchored occurrence count plus a `git hash-object` change, restore via `git checkout HEAD --` under `trap … EXIT INT TERM` with an absolute path, and the restore proven by blob equality **and** an empty `git diff HEAD`. Resolution is a same-package relative import, so no `dist` sits between the edit and the run — which the red readings themselves demonstrate, since no rebuild happened between mutation and result.

| site removed | pin that goes RED | split |
|---|---|---|
| `evictConsumedSuspension` in `loadSuspendedRunStrict` | *list-then-open: the per-id read a consumer makes next evicts the phantom* | 1 red / 8 green |
| `evictConsumedSuspension` in the lost-claim branch | *THE BUG (race): the loser of the advance claim drops its stale entry* | 1 red / 8 green |
| the durable-listing reconcile guard | *THE BUG (no race): A parks, B alone runs it to completion, A must list nothing* | 1 red / 8 green |

Every leg failed with `AssertionError: expected [ 'lv1' ] to deeply equal []`, and every restore reported `match=YES diff-HEAD-empty=YES`.

### Pin populations — what each actually covers

Nine tests over two engines and one shared store. Three cover the defect (no-race, race, list-then-open); one is the `RESIDUAL` boundary, which asserts the entry **survives** with no reconcile, so it is a statement of the limit and not of the fix. Five are controls that must stay green in both directions: no store attached (the map is the authority), a run whose durable save failed (`cacheOnlySuspensions` — the store's silence is not an answer), a store read that throws (unknown is not gone), a store whose `list()` throws (a failed enumeration triggers no per-id reconcile), and a live run parked in this process surviving every reconcile. A passing control proves only the shape it drives; none of them speaks for the engine's other suspension paths, which the 1395-test package suite covers instead.

⚠️ `packages/services/service-automation/src/engine.ts` is edited here (115 lines, all additive but one). PR #15966 was reported as holding it at 0 files changed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpTx2tbq3pZRYAdoGt6E6Y)_