### PR TITLE
test(cli): pin the SHAPES of the ratified hook-body surface, not only its names

### DIFF
--- a/packages/cli/test/published-subpath-hook-body.pin.test.ts
+++ b/packages/cli/test/published-subpath-hook-body.pin.test.ts
@@ -441,7 +441,8 @@ let scratch: string;
 let packedFiles: string[];
 let installedRoot: string;
 let probe: ProbeResult;
-let conformance: { status: number; output: string };
+let typecheckDir: string;
+let conformance: { status: number; diagnostics: string; programFiles: string[] };
 
 beforeAll(() => {
   const rootEntry = MANIFEST.exports['.'];
@@ -503,7 +504,7 @@ beforeAll(() => {
   // fixture as ESM (this package IS ESM-only, and a CJS-classified fixture
   // would red with TS1479 — a fact about the fixture's own manifest, not about
   // the ratified surface). Nothing of the probe's environment changes.
-  const typecheckDir = join(consumer, 'typecheck');
+  typecheckDir = join(consumer, 'typecheck');
   mkdirSync(typecheckDir);
   writeFileSync(
     join(typecheckDir, 'package.json'),
@@ -515,13 +516,27 @@ beforeAll(() => {
   // the version question is not what this file pins), but it is spawned with
   // the consumer directory as cwd, so what it RESOLVES it resolves from there.
   const tscEntry = createRequire(import.meta.url).resolve('typescript/lib/tsc.js');
-  const tsc = spawnSync(process.execPath, [tscEntry, '--pretty', 'false', '-p', 'tsconfig.json'], {
+  // `--listFiles` is not decoration: a clean tsc run and a tsc run that
+  // compiled NOTHING both print nothing and both exit 0, so "no diagnostics"
+  // is only evidence once the program is known to contain the fixture AND the
+  // packed `.d.ts` it is supposed to be judging. The file list is what
+  // separates those two, and it is asserted below rather than assumed here.
+  const tsc = spawnSync(process.execPath, [tscEntry, '--pretty', 'false', '--listFiles', '-p', 'tsconfig.json'], {
     cwd: typecheckDir,
     encoding: 'utf8',
     env: childEnv(),
   });
   if (tsc.error) throw new Error(`tsc could not start: ${tsc.error.message}`);
-  conformance = { status: tsc.status ?? -1, output: `${tsc.stdout ?? ''}${tsc.stderr ?? ''}`.trim() };
+  // tsc interleaves the file list with the diagnostics on stdout. A listed
+  // file is a path that EXISTS; a diagnostic is `path(l,c): error TSxxxx: …`,
+  // which never does — so the split is by disk, not by a regex over prose.
+  const lines = `${tsc.stdout ?? ''}${tsc.stderr ?? ''}`.split('\n').map((l) => l.trim()).filter((l) => l !== '');
+  const listed = new Set(lines.filter((l) => existsSync(l)));
+  conformance = {
+    status: tsc.status ?? -1,
+    diagnostics: lines.filter((l) => !listed.has(l)).join('\n'),
+    programFiles: [...listed].map((p) => realpathSync(p)),
+  };
 }, 120_000);
 
 afterAll(() => {
@@ -594,9 +609,32 @@ describe('the ratified surface is exactly four names', () => {
 });
 
 describe('the ratified surface still has the SHAPES a consumer compiles against (#15630)', () => {
+  // ⛔ This assertion comes FIRST on purpose. Zero diagnostics is the verdict
+  // the next test reads, and zero diagnostics is also what a program that
+  // compiled nothing prints — so the population has to be established before
+  // the silence over it means anything.
+  it('put the fixture AND the packed .d.ts in the program — not the workspace source, not nothing', () => {
+    const real = (p: string): string => realpathSync(p);
+    expect(conformance.programFiles, 'the fixture itself was never compiled').toContain(
+      real(join(typecheckDir, 'conformance.ts')),
+    );
+    expect(
+      conformance.programFiles,
+      'the ratified entry was not reached — a `types` condition that stops resolving lands here',
+    ).toContain(real(join(installedRoot, 'dist', 'hook-body.d.ts')));
+    expect(
+      conformance.programFiles,
+      'the shapes were read from somewhere other than the PACKED tarball',
+    ).toContain(real(join(installedRoot, 'dist', 'utils', 'extract-hook-body.d.ts')));
+    // Nothing of this workspace may be in that program: a source-tree file
+    // would make every shape below a verdict about the checkout instead of
+    // about what ships.
+    expect(conformance.programFiles.filter((p) => p.startsWith(`${realpathSync(PACKAGE_ROOT)}/`))).toEqual([]);
+  });
+
   it('compiles a real consumer against the PACKED .d.ts, reached through the exports map', () => {
     expect(
-      conformance.output,
+      conformance.diagnostics,
       'tsc reported diagnostics compiling the conformance fixture against the packed .d.ts. Either the ratified ' +
         'shape moved — in which case this is a BREAKING change to a published surface and the fixture is updated ' +
         'deliberately, with a changeset — or a CONTROL stopped firing (TS2578), which says the same thing from the ' +

--- a/packages/cli/test/published-subpath-hook-body.pin.test.ts
+++ b/packages/cli/test/published-subpath-hook-body.pin.test.ts
@@ -45,13 +45,50 @@
  * still declares `ts-morph` under `dependencies` before symlinking, because the
  * copy this file hands over is a copy a real consumer would never receive.
  *
+ * ## Names are not shapes — why a consumer-side `tsc` runs here too (#15630)
+ *
+ * `declaredExports()` below reads the packed `.d.ts` for exported NAMES and
+ * star re-exports. That is the barrel question, and it is not the contract
+ * question: three changes that break every consumer of this newly-public
+ * surface leave all four names in place, so a name-only pin passes green
+ * through each of them — a signature change to any ratified export, a renamed
+ * field on `ExtractedBody`, and a member dropped from the `HookBodyRefusalKind`
+ * union. The last is the sharpest: those members became a public type the
+ * moment these subpaths were ratified, so removing one is a breaking change to
+ * a published union that the pin existing to hold this surface would not
+ * notice.
+ *
+ * So a fixture is compiled by a real `tsc` from the consumer directory,
+ * against the PACKED `.d.ts` reached through the `exports` map — never the
+ * source tree. The distinction is the same one this file already draws for
+ * resolution, and it is not a formality: the source tree can be correct while
+ * the shipped `.d.ts` is not, and a `types` condition that stops resolving is
+ * invisible to every workspace-internal check. The fixture has two halves,
+ * because a type-level pin that cannot fail is worth nothing:
+ *
+ *   - **assertions** — invariant type identity (`Equals`) against the ratified
+ *     shape, so a widening reds exactly as loudly as a narrowing;
+ *   - **controls** — `@ts-expect-error` directives over deliberately wrong
+ *     expectations, one per failure mode above. Each MUST error; a directive
+ *     that stops firing is itself reported (TS2578). That is what keeps the
+ *     assertions from going vacuous should the packed types ever resolve to
+ *     `any`, and it carries this card's ablation into CI permanently rather
+ *     than leaving it in a PR body.
+ *
+ * ⛔ The fixture is a STRING written into the consumer directory, not a `.ts`
+ * file under `test/`. A file there is compiled by this package's own
+ * `tsconfig.test.json`, where the same import resolves through the workspace —
+ * i.e. to a build artifact, which `check:type-source-resolution` refuses — so
+ * checking it in would answer a different question under the same name.
+ *
  * ## What this file deliberately does NOT do
  *
  * It does not assert the extractor's behaviour beyond one clean body and two
  * classified refusals — `test/extract-hook-body.test.ts` owns that, over the
  * source. What this file owns is the DOOR: that the ratified subpath resolves
  * under both `require` and `import` conditions, that it exposes exactly the
- * four ratified names and nothing the internal module may grow next, that the
+ * four ratified names and nothing the internal module may grow next, that
+ * those four still carry the SHAPES a consumer compiles against, that the
  * deep `dist/` path STAYS sealed, and that the extractor which answers from the
  * packed copy is the platform's own (its refusal is a `HookBodyExtractionError`
  * carrying `kind`, not a bare `Error`). ⚠️ That refusal is a build-time class,
@@ -71,6 +108,7 @@ import {
   symlinkSync,
   writeFileSync,
 } from 'node:fs';
+import { createRequire } from 'node:module';
 import { tmpdir } from 'node:os';
 import { basename, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -172,6 +210,149 @@ try {
 process.stdout.write(JSON.stringify(out));
 `;
 
+/**
+ * The consumer's `tsconfig.json`. Three options carry the whole question:
+ *
+ *   - `moduleResolution: nodenext` is what makes this a test of the PUBLISHED
+ *     door — it reads the `exports` map's `types` condition, so a condition
+ *     that stops resolving is `TS2307` here, exactly as it would be for a real
+ *     dependent. `bundler` would answer a laxer question under the same name.
+ *   - `strict` — a shape assertion under a non-strict program is a weaker
+ *     assertion, and `strictNullChecks` in particular is load-bearing for the
+ *     optional-parameter half of the constructor pin.
+ *   - `skipLibCheck` — the consumer directory installs this ONE tarball, so the
+ *     `.d.ts` files of the workspace dependencies it references are absent by
+ *     construction. Checking them would report their absence, which is a fact
+ *     about the fixture's cupboard and not about the ratified surface. It does
+ *     not weaken anything asserted below: `conformance.ts` is not a declaration
+ *     file, so every diagnostic in IT is still reported.
+ *
+ * `types: []` keeps `@types/node` out of the program — the fixture reaches for
+ * no Node global, and a missing ambient package would otherwise red for a
+ * reason that has nothing to do with this surface.
+ */
+const CONSUMER_TSCONFIG = JSON.stringify(
+  {
+    compilerOptions: {
+      strict: true,
+      noEmit: true,
+      skipLibCheck: true,
+      target: 'es2022',
+      lib: ['ES2022'],
+      module: 'nodenext',
+      moduleResolution: 'nodenext',
+      types: [],
+    },
+    include: ['conformance.ts'],
+  },
+  null,
+  2,
+);
+
+/**
+ * The consumer the `.d.ts` is compiled for (#15630). Written into the consumer
+ * directory rather than checked in under `test/` — this file's header says why.
+ *
+ * `Equals` is the invariant identity check, not an assignability check: two
+ * types satisfy it only when tsc considers them THE SAME, so a member added to
+ * a union reds as loudly as one removed. An assignability pin would let every
+ * widening through, and a widening on a published union is the half that breaks
+ * an exhaustive `switch` in a dependent.
+ *
+ * ⛔ Every `@ts-expect-error` below is a CONTROL and must stay unsatisfiable-on
+ * -purpose. If a real change makes one of them legal, the directive goes unused
+ * and tsc reports TS2578 — which is the pin telling you the contract moved, not
+ * a lint to silence.
+ */
+const CONFORMANCE_FIXTURE = `
+import type { ExtractedBody, HookBodyRefusalKind } from '@objectstack/cli/hook-body';
+import { HookBodyExtractionError, extractHookBody } from '@objectstack/cli/hook-body';
+
+type Equals<A, B> = (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? true : false;
+type Expect<T extends true> = T;
+
+// --- HookBodyRefusalKind: the exact union, member for member ---------------
+type RefusalKindIsExactlyTheThreeRatifiedMembers = Expect<Equals<HookBodyRefusalKind, 'unparseable' | 'forbidden-token' | 'free-identifiers'>>;
+
+// --- ExtractedBody: the exact field set, then the exact whole shape --------
+// The keyof assertion is redundant against the whole-shape one and kept
+// anyway: a renamed field reds on BOTH, and the keyof diagnostic names the
+// field, which is the sentence a reader needs first.
+type ExtractedBodyHasExactlyTheseThreeFields = Expect<Equals<keyof ExtractedBody, 'source' | 'capabilities' | 'isExpression'>>;
+type ExtractedBodyMembersKeepTheirRatifiedTypes = Expect<
+  Equals<
+    ExtractedBody,
+    { source: string; capabilities: Array<'api.read' | 'api.write' | 'crypto.uuid' | 'log'>; isExpression: boolean }
+  >
+>;
+
+// --- extractHookBody: the exact signature ---------------------------------
+type ExtractHookBodyKeepsItsRatifiedSignature = Expect<Equals<typeof extractHookBody, (fn: (...a: unknown[]) => unknown, originLabel: string) => ExtractedBody>>;
+
+// --- HookBodyExtractionError: what it adds to Error, and how it is built ---
+type RefusalErrorAddsExactlyTheseFourMembers = Expect<Equals<Exclude<keyof HookBodyExtractionError, keyof Error>, 'kind' | 'originLabel' | 'freeIdentifiers' | 'nodeOnlyIdentifiers'>>;
+type RefusalErrorMembersKeepTheirRatifiedTypes = Expect<
+  Equals<
+    Pick<HookBodyExtractionError, 'kind' | 'originLabel' | 'freeIdentifiers' | 'nodeOnlyIdentifiers'>,
+    {
+      readonly kind: HookBodyRefusalKind;
+      readonly originLabel: string;
+      readonly freeIdentifiers: readonly string[];
+      readonly nodeOnlyIdentifiers: readonly string[];
+    }
+  >
+>;
+type RefusalErrorIsStillAnError = Expect<HookBodyExtractionError extends Error ? true : false>;
+type RefusalErrorConstructorKeepsItsRatifiedParameters = Expect<Equals<ConstructorParameters<typeof HookBodyExtractionError>, [HookBodyRefusalKind, string, string, (readonly string[])?, (readonly string[])?]>>;
+
+// --- The consumer limb: code a real dependent writes, compiled for real ----
+// The assertions above answer "did the shape move". This answers the question
+// the shape exists for — can a dependent still WRITE the ordinary thing.
+export function describeExtraction(fn: (...a: unknown[]) => unknown, label: string): string {
+  try {
+    const body: ExtractedBody = extractHookBody(fn, label);
+    return body.isExpression ? 'expr:' + body.source : 'block:' + body.capabilities.join(',');
+  } catch (err) {
+    if (err instanceof HookBodyExtractionError) {
+      const kind: HookBodyRefusalKind = err.kind;
+      return kind + '@' + err.originLabel + ':' + err.freeIdentifiers.join(',') + '/' + err.nodeOnlyIdentifiers.join(',');
+    }
+    throw err;
+  }
+}
+
+// --- Controls: one per failure mode the name-only pin passed green through --
+// Each directive below MUST fire. An unused one is TS2578, so these are what
+// keep the assertions above from going vacuous — if the packed types ever
+// resolved to \`any\`, or \`Equals\` stopped discriminating, every control here
+// turns red at once.
+
+// @ts-expect-error CONTROL — a member dropped from the union must not satisfy the identity check
+type MemberDroppedFromUnionMustRed = Expect<Equals<HookBodyRefusalKind, 'forbidden-token' | 'free-identifiers'>>;
+// @ts-expect-error CONTROL — a renamed field must not satisfy the identity check
+type FieldRenamedOnExtractedBodyMustRed = Expect<Equals<keyof ExtractedBody, 'source' | 'capabilities' | 'isExpr'>>;
+// @ts-expect-error CONTROL — a dropped parameter must not satisfy the identity check
+type SignatureChangeMustRed = Expect<Equals<typeof extractHookBody, (fn: (...a: unknown[]) => unknown) => ExtractedBody>>;
+
+// The same three, met the way a dependent meets them rather than through a
+// type-level identity check — a value assignment, a call and a field read.
+// @ts-expect-error CONTROL — 'unparsable' is not a member of the ratified union
+const notAMemberOfTheUnion: HookBodyRefusalKind = 'unparsable';
+// @ts-expect-error CONTROL — originLabel is a REQUIRED second parameter
+const callWithoutOriginLabel = extractHookBody(() => undefined);
+// @ts-expect-error CONTROL — ExtractedBody declares isExpression, never isExpr
+type ReadOfARenamedField = ExtractedBody['isExpr'];
+// @ts-expect-error CONTROL — the refusal's identifier lists are readonly to a consumer
+const writeToAReadonlyMember = (e: HookBodyExtractionError): void => { e.freeIdentifiers = []; };
+`;
+
+/** The fixture, line-numbered, so a tsc diagnostic's line points at something. */
+function numbered(source: string): string {
+  const lines = source.split('\n');
+  const width = String(lines.length).length;
+  return lines.map((line, i) => `${String(i + 1).padStart(width, ' ')} | ${line}`).join('\n');
+}
+
 interface Resolution {
   ok: boolean;
   path?: string;
@@ -260,6 +441,7 @@ let scratch: string;
 let packedFiles: string[];
 let installedRoot: string;
 let probe: ProbeResult;
+let conformance: { status: number; output: string };
 
 beforeAll(() => {
   const rootEntry = MANIFEST.exports['.'];
@@ -315,6 +497,31 @@ beforeAll(() => {
   });
   if (run.status !== 0) throw new Error(`probe exited ${run.status}\n--- stderr ---\n${run.stderr}\n--- stdout ---\n${run.stdout}`);
   probe = JSON.parse(run.stdout) as ProbeResult;
+
+  // #15630 — the SHAPE half. A sibling directory, not `consumer` itself: its
+  // own `package.json` declares `type: module` so `nodenext` classifies the
+  // fixture as ESM (this package IS ESM-only, and a CJS-classified fixture
+  // would red with TS1479 — a fact about the fixture's own manifest, not about
+  // the ratified surface). Nothing of the probe's environment changes.
+  const typecheckDir = join(consumer, 'typecheck');
+  mkdirSync(typecheckDir);
+  writeFileSync(
+    join(typecheckDir, 'package.json'),
+    JSON.stringify({ name: 'objectstack-cli-hook-body-consumer', private: true, type: 'module' }, null, 2),
+  );
+  writeFileSync(join(typecheckDir, 'tsconfig.json'), CONSUMER_TSCONFIG);
+  writeFileSync(join(typecheckDir, 'conformance.ts'), CONFORMANCE_FIXTURE);
+  // The compiler is resolved from THIS package (a consumer brings its own tsc;
+  // the version question is not what this file pins), but it is spawned with
+  // the consumer directory as cwd, so what it RESOLVES it resolves from there.
+  const tscEntry = createRequire(import.meta.url).resolve('typescript/lib/tsc.js');
+  const tsc = spawnSync(process.execPath, [tscEntry, '--pretty', 'false', '-p', 'tsconfig.json'], {
+    cwd: typecheckDir,
+    encoding: 'utf8',
+    env: childEnv(),
+  });
+  if (tsc.error) throw new Error(`tsc could not start: ${tsc.error.message}`);
+  conformance = { status: tsc.status ?? -1, output: `${tsc.stdout ?? ''}${tsc.stderr ?? ''}`.trim() };
 }, 120_000);
 
 afterAll(() => {
@@ -383,6 +590,19 @@ describe('the ratified surface is exactly four names', () => {
     const { names, starReExports } = declaredExports(join(installedRoot, 'dist', 'hook-body.d.ts'));
     expect(starReExports, 'a star re-export ratifies whatever the internal module grows next').toBe(0);
     expect(names).toEqual(RATIFIED_SURFACE);
+  });
+});
+
+describe('the ratified surface still has the SHAPES a consumer compiles against (#15630)', () => {
+  it('compiles a real consumer against the PACKED .d.ts, reached through the exports map', () => {
+    expect(
+      conformance.output,
+      'tsc reported diagnostics compiling the conformance fixture against the packed .d.ts. Either the ratified ' +
+        'shape moved — in which case this is a BREAKING change to a published surface and the fixture is updated ' +
+        'deliberately, with a changeset — or a CONTROL stopped firing (TS2578), which says the same thing from the ' +
+        `other side. The fixture, numbered:\n${numbered(CONFORMANCE_FIXTURE)}`,
+    ).toBe('');
+    expect(conformance.status, 'tsc exited non-zero').toBe(0);
   });
 });
 


### PR DESCRIPTION
Fixes #15630

## What passed green that should not have

`packages/cli/test/published-subpath-hook-body.pin.test.ts` read the packed `.d.ts` for exported NAMES and star re-exports only (`declaredExports()`). It never looked at the shape behind any name, so three changes that break every consumer of the newly-public `@objectstack/cli/hook-body` surface left all four names in place and the pin stayed green through each:

- a signature change to any of the four ratified exports;
- a renamed field on `ExtractedBody`;
- a member dropped from the `HookBodyRefusalKind` union.

The last is the sharpest, as the card says: those members became a public type the moment the subpath was ratified, so removing one is a breaking change to a published union that the pin existing to hold this surface would not notice.

## Route A, not route B — and why

Triage left the fork open and named the criterion: **A catches "can a consumer still compile", B catches "did the shipped bytes change".** This PR implements A — a conformance fixture compiled by a real `tsc` from the consumer directory, against the PACKED `.d.ts` reached through the `exports` map.

1. A answers the contract question; the card is about a contract, not about churn.
2. B's known failure mode is that people accept the new snapshot when it reds. A cannot be discharged that way: to make it green you have to state the new shape as a type, which is the reviewable act.
3. A is nearly free here. The file already packs the package, unpacks it into a throwaway `node_modules` outside the workspace and runs a child process against it. The shape limb is one more child in the same consumer directory, so it inherits the packed-not-source discipline the file was built around rather than re-deriving it.
4. A also covers a mode the card does not list: a `types` condition that stops resolving is `TS2307` in the fixture, exactly as it would be for a real dependent. B would not see it at all — the bytes it snapshots would be unchanged.

All three of the card's failure modes are blocked, each with a positive assertion **and** a negated control. Nothing from finding 1 of the review is re-done here; that landed with #15611.

## What the fixture is

- **Assertions** — invariant type identity against the ratified shape, so a widening reds exactly as loudly as a narrowing. An assignability check would let every widening through, and a widening on a published union is the half that breaks an exhaustive `switch` in a dependent. Covered: the exact union members; the exact key set and whole shape of `ExtractedBody`; the exact signature of `extractHookBody`; what `HookBodyExtractionError` adds to `Error`, the types and `readonly` of those members, and its constructor parameters.
- **A consumer limb** — a function a real dependent would write, compiled for real. The assertions answer "did the shape move"; this answers the question the shape exists for.
- **Controls** — `@ts-expect-error` directives over deliberately wrong expectations, one per failure mode. Each MUST error; a directive that stops firing is reported as TS2578. This is what keeps the assertions from going vacuous if the packed types ever resolve to `any` or the identity check stops discriminating, and it carries the ablation below into CI permanently instead of leaving it in a PR body.
- **An anti-vacuity assertion, ordered first** — a clean `tsc` run and a `tsc` run that compiled nothing both print nothing and both exit 0. The run asks for `--listFiles` and the population is asserted before the silence over it is read: the fixture, the ratified entry and the internal module it re-exports are all in the program, and no file from this workspace is.

The fixture is a string written into the consumer directory, not a `.ts` file under `test/`. A file there is compiled by this package's own `tsconfig.test.json`, where the same import resolves through the workspace to a build artifact — which `check:type-source-resolution` refuses — so checking it in would answer a different question under the same name.

## The ablation — predicted before it was run, and what happened

One mutation batch on `packages/cli/src/hook-body.ts`, carrying all three failure modes at once and moving **no name**: the union re-exported one member short, `ExtractedBody` re-exported with `isExpression` renamed to `isExpr`, and `extractHookBody` re-exported with its second parameter dropped. It was chosen so the package still type-checks and still builds, and so the runtime namespace is byte-for-byte the same two keys.

| limb | predicted | observed |
|---|---|---|
| pin as it stands on `main`, under the mutation | GREEN, 13/13 | **GREEN, 13 passed (13)** |
| pin in this PR, same mutation, same build | RED on the conformance limb only | **1 failed, 14 passed (15)** — the failure is the conformance test; the anti-vacuity test stayed green |
| restore leg | back to green | **15 passed (15)** |

The baseline row is the measurement the card is worth: every name assertion, the star-re-export count, the runtime key list, both resolution conditions and all three extractor behaviours pass while the published contract is broken in three places at once.

Diagnostics predicted and observed, class for class: TS2344 x6 (identity assertions), TS2578 x5 (controls that stopped firing), TS2554 x1, TS2339 x1, TS2322 x1 — 14, each mapped to its fixture line. One extra `TS2344` in a naive grep of the log was vitest's truncated preamble, not a diagnostic.

Discipline on both legs: the pristine entry was captured as a git blob with `git hash-object -w` before any mutation and restored with `git cat-file blob` against absolute paths; the mutation was proved on disk by a removed-text count and an injected-marker count, and proved in the built artifact by `scripts/ablation-dist-preflight.mjs`; the restore leg was proved by blob-hash identity, by a clean whole-tree `git status --porcelain`, by the same preflight in `--absent` mode, and only then by colour.

One correction worth recording: the first attempt reported the new pin as RED when vitest had actually matched **no test file** (a repo-relative path handed to a runner whose cwd is the package). That is a measurement that never happened, not a red pin. The script now refuses to read any run whose log says "No test files found".

## Clause 2, declared per limb from the delivered diff

The delivered diff is one file, `packages/cli/test/published-subpath-hook-body.pin.test.ts`, 259 insertions and 1 deletion.

- **Mechanical floor — NO.** No new key on any published payload: the file is a test, and this package publishes `dist`, `README.md` and `CHANGELOG.md` only, so nothing in the diff reaches a consumer. Nothing under `packages/spec/src/**` is touched.
- **Conformance limb — NO.** Nothing is re-selected between two already-published verdicts on a shipped face. No runtime code changes; no acceptance or refusal boundary moves; the diff only adds assertions over a `.d.ts` that is already published and is byte-identical before and after. The call is not close, which is why it is graded NO rather than YES.

`skip-changeset` accordingly: the PR publishes nothing from any package.

## Verification

- Gate union derived with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack --commands` against the real change set, and asserted against that tool's own `Reconciliation — 44 famil(ies)` line: **44 commands, 43 exit 0.** The one non-zero is `pnpm check:dual-build-cjs-loads` at **exit 3 = PREREQUISITE NOT MET** — it reads built output and eleven packages outside this card's build closure have no `dist/`. Its own text says "This is NOT a pass: nothing was measured", and it is reported here as NOT MEASURED, never as a pass. It names no path in this diff.
- The **Artifact rosters** block was run separately, as it sits outside that total by the tool's design: **37 commands, 34 exit 0.** `check-partof-closing-keyword.mjs` and `check-single-claim-paths.mjs` exit **2 = NOT WIRED** (they need `PR_BODY` / `PR_NUMBER`, supplied only by their workflows) and `@objectstack/spec check:react-declaration-parity` exits 1 stating "This gate did NOT run" — it needs an objectui manifest and a browser. All three are NOT MEASURED, none is a verdict about this diff.
- `pnpm --filter @objectstack/cli typecheck` — green, and its test layer ledger is unchanged at 3 files / 28 errors / 6 pinned signatures. The edited file is confirmed present in that program by `--listFiles` and contributes zero of those errors.
- `pnpm lint` over the whole repository — exit 0. Not narrowed; the full scan was run.
- The shape pin and `test/vitest-tiers-partition.test.ts` together: 37 passed. The partition pin matters because the edit adds a child-process spawn, which is a tier signal; the file is still classified `unit`.
- Every exit code above was captured before any pipe.

All test runs and builds went through `scripts/pm/os-verify-lock.sh`; the figures are shared-box seconds, not idle-box seconds.

## Handed back, not acted on

Measured while checking the card's own NOT MEASURED question about sibling surfaces, and deliberately left alone here:

1. **`@objectstack/spec` carries the same class of gap at scale.** Its `api-surface/*.json` ledger pins **5309 exports across 17 entry points by name and kind**, while `api-surface-signatures.json` pins **27 of them by signature hash — 0.5 percent**. A signature change, a renamed interface field or a dropped union member moves neither the name nor the kind, so the other 5282 behave exactly like the surface this PR repairs.
2. **`@objectstack/console` does not share it.** It exports `./package.json` and nothing else, declares no `types`, and has no type surface behind any name — the spelling is the same but there is nothing there to widen.
3. **`@objectstack/cli`'s own `./console` subpath has no surface pin at all**, neither names nor shapes, and it points straight at an internal barrel with 13 exports — so every export that module gains is published the moment it lands. The existing pin asserts that `./console` is a declared subpath, and stops there.

So the card's open question has an answer: **this is one fix, not a family** — but item 1 is a real, separate finding about a different package and a different gate, and item 3 is a real gap inside this package that this card does not cover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D47qPfEWVPmhguWgBZCi5N)_