### PR TITLE
test(service-cluster-redis): pin the WATCH/MULTI abort-retry loop and the versioned-delete MULTI/DEL branch

### DIFF
--- a/packages/services/service-cluster-redis/src/kv.transaction.test.ts
+++ b/packages/services/service-cluster-redis/src/kv.transaction.test.ts
@@ -1,0 +1,268 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Pins for the two `RedisKV` limbs the shipped contract suite in
+ * `redis.contract.test.ts` does not assert: the WATCH/MULTI abort-retry
+ * loop, and the versioned-delete MULTI/DEL branch.
+ *
+ * ## What was measured before writing these, and how
+ *
+ * Instrument 1 — a recording `Proxy` around the `makeClient()` of an
+ * otherwise byte-identical copy of the shipped suite, run unmodified
+ * (28/28 green under instrumentation), dumping every method the driver
+ * invoked on the injected client plus every `multi().exec()` return
+ * value. Its reading:
+ *
+ *   - `multi().del` is called ZERO times. The only call site is the
+ *     `opts.ifVersion !== undefined` branch of `RedisKV.delete`, and
+ *     `runKVContract` only ever calls `kv.delete('k')` with no options,
+ *     so the versioned branch is entirely unexecuted. Confirmed.
+ *   - `multi().exec()` is called 10 times and returns `null` for 2 of
+ *     them. So the `result === null` retry limb is NOT unexecuted — it
+ *     runs twice, in `set then get round-trips` and in `cas succeeds on
+ *     match, fails on mismatch`. Nothing asserts that it ran, and both
+ *     tests pass either way, so it was unpinned rather than unreached.
+ *
+ * Instrument 2 — a proxy-free replay of the exact client-level sequence
+ * `RedisKV.set` issues (WATCH, GET, MULTI/SET, EXEC) against a bare
+ * `ioredis-mock`, to rule the Proxy itself out as the cause. It
+ * reproduces the two nulls, so the behaviour is the double's.
+ *
+ * ## The divergence those two nulls come from
+ *
+ * On `ioredis-mock@8.13.1` a connection that has itself EXECed a write to
+ * a key carries a stale dirty flag for it: the NEXT WATCH+EXEC on that
+ * same key from that same connection aborts once even though no competing
+ * writer exists. Measured, with controls that fire:
+ *
+ *   - fresh key on a fresh connection, no competing writer: EXEC returns
+ *     an array, NOT null (so the probe distinguishes the two outcomes)
+ *   - second WATCH+EXEC on the same key from the same connection: null
+ *   - third: array again (the abort clears the flag)
+ *   - the flag is per-connection: another connection WATCHing a key this
+ *     one EXECed on is unaffected
+ *   - an explicit UNWATCH between the two clears it
+ *
+ * A real server would not abort there. That is why every pin below runs
+ * the driver's client on a key that client has never EXECed on, seeding
+ * and competing from SEPARATE connections over ioredis-mock's shared
+ * store: it makes a competing write the only possible cause of an abort.
+ *
+ * ## What these pins do and do not establish
+ *
+ * They establish that the driver's retry limb converges, and re-reads
+ * rather than merely re-EXECing, when its client reports an aborted
+ * transaction; and that the versioned-delete branch reaches MULTI/DEL and
+ * reports removal from the reply. They also establish that this double
+ * does implement WATCH abort on a genuine competing write, rather than
+ * treating `watch()` as a no-op.
+ *
+ * They do NOT establish that a real Redis server aborts under the same
+ * interleaving, nor that this double's WATCH fidelity matches a real
+ * server in general — the divergence above is proof that it does not.
+ * That remains the open question the card records, and closing it needs a
+ * live-Redis path, which this package has none of.
+ */
+
+// `ioredis-mock` publishes no type declarations; the shipped suite's
+// import carries the full note on what that costs.
+// @ts-expect-error — ioredis-mock has no published types
+import RedisMock from 'ioredis-mock';
+import { describe, expect, it } from 'vitest';
+
+import { RedisKV, VersionMismatchError } from './kv.js';
+
+// ioredis-mock shares state across instances, so a per-test key prefix is
+// what isolates the tests — same device the shipped suite uses.
+let suffix = 0;
+const uniquePrefix = () => `tx${++suffix}:`;
+
+/** The mock is untyped (see the import note), so its instances are `any`. */
+type MockClient = any;
+
+interface Recorder {
+    /** `'NULL'` or `'ARRAY'` per `multi().exec()`, in call order. */
+    execOutcomes: string[];
+    /** Commands queued onto a `multi()` chain, e.g. `'set'`, `'del'`. */
+    multiCommands: string[];
+    /** Keys passed to `watch()`, in call order. */
+    watchedKeys: string[];
+}
+
+/**
+ * Wraps an ioredis-mock connection so a test can observe what the driver
+ * did inside its WATCH/MULTI loop, and can run a competing writer at the
+ * one instant that matters: after the driver's GET has resolved and
+ * before it calls EXEC.
+ *
+ * The wrapper adds no Redis semantics of its own — every reply, and the
+ * WATCH bookkeeping that decides whether EXEC aborts, still comes from
+ * ioredis-mock.
+ */
+function instrument(
+    raw: MockClient,
+    onFirstGet?: (rec: Recorder) => Promise<void>,
+): { client: MockClient; rec: Recorder } {
+    const rec: Recorder = { execOutcomes: [], multiCommands: [], watchedKeys: [] };
+    let hookFired = false;
+
+    const wrapMulti = (chain: MockClient): MockClient =>
+        new Proxy(chain, {
+            get(target, prop, receiver) {
+                const value = Reflect.get(target, prop, receiver);
+                if (typeof prop !== 'string' || typeof value !== 'function') return value;
+                return (...args: unknown[]) => {
+                    if (prop !== 'exec') rec.multiCommands.push(prop);
+                    const out = value.apply(target, args);
+                    if (prop === 'exec') {
+                        return Promise.resolve(out).then((reply: unknown) => {
+                            rec.execOutcomes.push(reply === null ? 'NULL' : 'ARRAY');
+                            return reply;
+                        });
+                    }
+                    // Keep the chain observable when a command returns `this`.
+                    return out === target ? receiver : out;
+                };
+            },
+        });
+
+    const client: MockClient = new Proxy(raw, {
+        get(target, prop, receiver) {
+            const value = Reflect.get(target, prop, receiver);
+            if (typeof prop !== 'string' || typeof value !== 'function') return value;
+            return (...args: unknown[]) => {
+                if (prop === 'watch') rec.watchedKeys.push(String(args[0]));
+                if (prop === 'multi') return wrapMulti(value.apply(target, args));
+                if (prop === 'get' && onFirstGet) {
+                    return (async () => {
+                        const reply = await value.apply(target, args);
+                        if (!hookFired) {
+                            hookFired = true;
+                            await onFirstGet(rec);
+                        }
+                        return reply;
+                    })();
+                }
+                return value.apply(target, args);
+            };
+        },
+    });
+
+    return { client, rec };
+}
+
+describe('RedisKV — WATCH/MULTI transaction limbs — redis(mock)', () => {
+    it('set(): a competing writer between WATCH and EXEC drives the abort-retry limb', async () => {
+        const keyPrefix = uniquePrefix();
+        // The rival is a separate connection driving the same production
+        // class, so the competing write is a real KV write rather than a
+        // hand-rolled storage envelope.
+        const rival = new RedisKV({ client: new RedisMock(), keyPrefix });
+        const { client, rec } = instrument(new RedisMock(), async () => {
+            await rival.set('k', 'intruder');
+        });
+        const kv = new RedisKV({ client, keyPrefix });
+
+        const entry = await kv.set('k', 'mine');
+
+        // Exactly one abort then one commit: the `result === null` limb ran
+        // once. Without the competing writer this key is fresh on this
+        // connection, so a null here has no other available cause.
+        expect(rec.execOutcomes).toEqual(['NULL', 'ARRAY']);
+        // v2, not v1. Only a retry that went back through WATCH and GET can
+        // have seen the rival's v1 and bumped past it; a retry that merely
+        // re-issued EXEC would still be writing v1.
+        expect(entry.version).toBe(2n);
+        expect(entry.value).toBe('mine');
+
+        const got = await kv.get<string>('k');
+        expect(got?.value).toBe('mine');
+        expect(got?.version).toBe(2n);
+
+        await kv.close();
+    });
+
+    it('delete(key, {ifVersion}): a competing writer drives the abort-retry limb into MULTI/DEL', async () => {
+        const keyPrefix = uniquePrefix();
+        // Seed from a separate connection so the driver's client has never
+        // EXECed on this key (see the header note on the per-connection
+        // stale flag) — the abort below can then only be the rival's doing.
+        const seeder = new RedisKV({ client: new RedisMock(), keyPrefix });
+        expect((await seeder.set('k', 'v0')).version).toBe(1n);
+
+        // The rival rewrites the row's current bytes verbatim. WATCH tracks
+        // writes, not value changes, so this aborts the driver's transaction
+        // while leaving the version at 1 — which is what lets the retry find
+        // a still-matching `ifVersion` and proceed into MULTI/DEL. The
+        // physical key is taken from what the driver itself WATCHed, so this
+        // test does not encode the key-layout private to RedisKV.
+        const rivalClient = new RedisMock();
+        const { client, rec } = instrument(new RedisMock(), async (r) => {
+            const physical = r.watchedKeys[r.watchedKeys.length - 1];
+            await rivalClient.set(physical, await rivalClient.get(physical));
+        });
+        const kv = new RedisKV({ client, keyPrefix });
+
+        expect(await kv.delete('k', { ifVersion: 1n })).toBe(true);
+        expect(rec.execOutcomes).toEqual(['NULL', 'ARRAY']);
+        expect(rec.multiCommands).toEqual(['del', 'del']);
+        expect(await kv.get('k')).toBeUndefined();
+
+        await kv.close();
+    });
+
+    it('delete(key, {ifVersion}) removes through the MULTI/DEL branch and reports it from the reply', async () => {
+        const keyPrefix = uniquePrefix();
+        const seeder = new RedisKV({ client: new RedisMock(), keyPrefix });
+        expect((await seeder.set('k', 'v0')).version).toBe(1n);
+
+        const { client, rec } = instrument(new RedisMock());
+        const kv = new RedisKV({ client, keyPrefix });
+
+        expect(await kv.delete('k', { ifVersion: 1n })).toBe(true);
+        // The unversioned fast path calls `client.del` and opens no
+        // transaction; this asserts the versioned branch was the one taken.
+        expect(rec.multiCommands).toEqual(['del']);
+        expect(rec.execOutcomes).toEqual(['ARRAY']);
+        expect(await kv.get('k')).toBeUndefined();
+
+        await kv.close();
+    });
+
+    it('delete(key, {ifVersion}) on an absent key returns false without opening a MULTI', async () => {
+        const keyPrefix = uniquePrefix();
+        const { client, rec } = instrument(new RedisMock());
+        const kv = new RedisKV({ client, keyPrefix });
+
+        expect(await kv.delete('absent', { ifVersion: 1n })).toBe(false);
+        expect(rec.multiCommands).toEqual([]);
+        expect(rec.execOutcomes).toEqual([]);
+
+        await kv.close();
+    });
+
+    it('delete(key, {ifVersion}) rejects a stale version, opens no MULTI, and leaves the row', async () => {
+        const keyPrefix = uniquePrefix();
+        const seeder = new RedisKV({ client: new RedisMock(), keyPrefix });
+        await seeder.set('k', 'v0');
+
+        const { client, rec } = instrument(new RedisMock());
+        const kv = new RedisKV({ client, keyPrefix });
+
+        // Assert the error's structured fields, not just that something was
+        // thrown: a bare `toThrow()` stays green when the driver throws a
+        // plain Error for an unrelated reason.
+        const err: unknown = await kv
+            .delete('k', { ifVersion: 99n })
+            .then(() => null, (e: unknown) => e);
+        expect(err).toBeInstanceOf(VersionMismatchError);
+        expect((err as VersionMismatchError).key).toBe('k');
+        expect((err as VersionMismatchError).expected).toBe(99n);
+        expect((err as VersionMismatchError).actual).toBe(1n);
+
+        expect(rec.multiCommands).toEqual([]);
+        expect((await kv.get<string>('k'))?.value).toBe('v0');
+
+        await kv.close();
+    });
+});

--- a/packages/services/service-cluster-redis/src/redis.contract.test.ts
+++ b/packages/services/service-cluster-redis/src/redis.contract.test.ts
@@ -70,6 +70,15 @@
  * why the version gap is inert here, and it is not a reason to trust the
  * double: the mock is simply never asked to stand in for the surface on
  * which the two majors differ.
+ *
+ * Two `RedisKV` limbs this file drives but does not assert are pinned in
+ * the sibling `kv.transaction.test.ts`: the WATCH/MULTI abort-retry loop,
+ * and the versioned-delete MULTI/DEL branch. Measured here rather than
+ * assumed: `multi().del` is called zero times by these suites, while
+ * `multi().exec()` DOES return null twice — not because a competing
+ * writer exists, but because of a per-connection stale-watch divergence
+ * in the double. The sibling file carries that measurement and its
+ * controls.
  */
 
 // `ioredis-mock` publishes no type declarations of its own — no `types`


### PR DESCRIPTION
Fixes #15983

Pins the two `RedisKV` limbs the shipped contract suite drives to no assertion: the WATCH/MULTI abort-retry loop, and the versioned-delete MULTI/DEL branch.

All readings below are from head `c08761472`.

## The gap, reproduced before it was closed

**Instrument 1 — recording `Proxy` census.** An otherwise byte-identical copy of `redis.contract.test.ts` with `makeClient()` wrapped in a recording Proxy, the suite run unmodified (28/28 green under instrumentation), dumping every method invoked on the injected client plus every `multi().exec()` return value. The copy was a separate scratch file, so the shipped test was never edited for the measurement and needed no restore.

Reading:

| observation | count |
| --- | --- |
| `multi().del` calls | **0** |
| `multi().exec()` calls | 10 |
| ... of which returned `null` | **2** |
| commands ever queued on a `multi()` chain | `set` only |

- **Gap 1 confirmed.** `multi().del` is called zero times. Its only call site is the `opts.ifVersion !== undefined` branch of `RedisKV.delete`, and `runKVContract` only ever calls `kv.delete('k')` with no options, so the versioned branch is entirely unexecuted.
- **Gap 2 corrected.** The card reasoned that the `result === null` retry limb runs zero times. It runs **twice** — in `set then get round-trips and increments version` and in `cas succeeds on match, fails on mismatch`. It was unpinned, not unreached. That half of the card's premise was an inference from the code rather than a reading, and the measurement contradicts it.

**Instrument 2 — proxy-free replay.** To rule the Proxy itself out as the cause, the client-level sequence `RedisKV.set` issues (WATCH, GET, MULTI/SET, EXEC) was replayed directly against a bare `ioredis-mock`, no Proxy anywhere. It reproduces both nulls, so the behaviour is the double's.

## Can the pin fail? Yes — measured, with a control

The card warns that a pin for the abort path is worthless if the double cannot produce `exec() === null`. It can:

| scenario | `exec()` |
| --- | --- |
| competing write from another connection between WATCH and EXEC | `null` |
| competing write from the same connection | `null` |
| rival rewrites byte-identical content | `null` |
| **CONTROL** — fresh key, fresh connection, no competing writer | **array, not null** |

The control fires, so the `null` readings are a discrimination and not a constant. `watch()` is not a no-op on this double.

## The divergence those two incidental nulls come from

`ioredis-mock@8.13.1` leaves a **per-connection** stale watch flag: a connection that has itself EXECed a write to a key aborts its *next* WATCH+EXEC on that key with no competing writer present. Measured: second attempt `null`, third `array` (the abort clears it), an explicit UNWATCH clears it, and another connection is unaffected. A real server would commit there.

So every pin here runs the driver's client on a key that client has **never EXECed on**, seeding and competing from separate connections over the mock's shared store — which makes a competing write the only available cause of an abort. Filed separately as #16053 (a fidelity finding about the double, not about our code); that card is a recording and stays open.

## The pins and what each one's population is

Five pins in `packages/services/service-cluster-redis/src/kv.transaction.test.ts`.

1. **`set()` abort-retry.** Covers: the `result === null` limb converging, and re-reading rather than merely re-EXECing — asserted via the returned version, which can only be `2n` if the retry went back through WATCH+GET and saw the rival's `1n`. Does not cover: any real-server interleaving.
2. **`delete(key, {ifVersion})` abort-retry into MULTI/DEL.** Covers: the same limb in the versioned delete, retrying into a successful `multi().del`. The rival rewrites the row's current bytes verbatim so the version is unchanged and the retry's `ifVersion` still matches. The physical key is read back from what the driver itself WATCHed, so the test does not encode `RedisKV`'s private key layout.
3. **`delete(key, {ifVersion})` clean path.** Covers: the versioned branch reaching `multi().del` at all, and reading the removal out of the EXEC reply. Asserts the queued command list is exactly `['del']`, which is what distinguishes it from the unversioned `client.del` fast path.
4. **`delete(key, {ifVersion})` on an absent key.** Covers: the early return, and that no MULTI is opened.
5. **`delete(key, {ifVersion})` on a stale version.** Covers: the rejection, asserted on the error's structured fields (`key`, `expected`, `actual`) rather than a bare `toThrow()`, and that no MULTI is opened.

Across all five: they establish that the driver's retry limb converges when its client reports an abort, and that this double implements WATCH abort on a genuine competing write. They do **not** establish that a real Redis server aborts under the same interleaving, nor that the double's WATCH fidelity matches a real server in general — the divergence above proves it does not. Closing that needs a live-Redis path, which this package has none of.

## Mutation proof — every pin was driven RED

Each production branch was broken in turn, the pin observed RED, and `src/kv.ts` restored under `trap ... EXIT INT TERM` via `git checkout HEAD -- ABSOLUTE_PATH`. Every anchor was asserted unique **in the form written** before mutating (a deliberately ambiguous control anchor, the bare `if (result === null) continue;`, counts 2 and would have been refused). Each mutation was proved to have landed on disk by counting the injected marker *and* the removed original — never by the editor's exit code. Restore proved by blob equality **and** an empty `git diff HEAD`.

| # | branch broken | pin RED | assertion text |
| --- | --- | --- | --- |
| 1 | `set()`'s `if (result === null) continue` | pin 1 | `expected [ 'NULL' ] to deeply equal [ 'NULL', 'ARRAY' ]` |
| 2 | `delete()`'s `if (result === null) continue` | pin 2 | `expected false to be true` |
| 3 | `multi.del(physical)` removed | pins 2, 3 | `expected false to be true` |
| 4 | absent-key leg returns `true` | pin 4 | `expected true to be false` |
| 5 | throws a plain `Error` instead of `VersionMismatchError` | pin 5 | `expected Error: stale to be an instance of VersionMismatchError` |

Mutation 1's text is worth reading twice: `[ 'NULL' ]` shows the abort still happened, so the pin's competing writer really does trip the double's WATCH — the retry is the only thing the mutation removed. Mutation 5 is why the rejection asserts the envelope: a bare `toThrow()` would have stayed green.

The implementation was committed **before** any mutation ran, so the restore leg had a real reference to restore to. Final `git status --porcelain` after all five: empty.

## Verification

| command | exit | verdict line |
| --- | --- | --- |
| `pnpm --filter @objectstack/service-cluster-redis test` | 0 | `Test Files 2 passed (2)` / `Tests 33 passed (33)` (28 shipped + 5 new) |
| `pnpm --filter @objectstack/service-cluster-redis typecheck` | 0 | echoed `tsc --noEmit` |
| gate union, 45 families | 0 | 45/45 |

`typecheck` is a real reading, not a vacuous one: `tsc --listFiles` puts both edited files in the program (1 occurrence each), against a control spelling that returns 0. The package's `tsconfig.json` is `include: ["src"]`, so it does not exclude `*.test.ts`.

The gate family was derived with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` — 45 families per its Reconciliation line, and `--commands` printed exactly 45. Two initially returned **exit 3, PREREQUISITE NOT MET** (`check:dual-build-cjs-loads`, `check:type-check-debt`) — not a pass and not a failure, nothing measured. The workspace closure was built (`turbo run build`, 71/71 successful) and both re-run to real verdicts:

- `check:dual-build-cjs-loads` exit 0 — `provenance — entries/packages/cjsFiles/probes: this run 103/66/619/1 · floors 90/58/520/1`
- `check:type-check-debt` exit 0 — `check-type-check-coverage --re-measure: OK — 12 ledger entr(ies) re-measured in 119.6s, 140 raw tsc error(s) total, none above its recorded number.`

Every gate exit code was captured before any pipe (`cmd > log 2>&1; code=$?`), never read through `| head`.

## NOT MEASURED

- **Real Redis.** No live-Redis path exists in this package; nothing here is evidence about a real server's WATCH/EXEC behaviour.
- **`createRedisClient()`.** Still called by no test in this package. Unchanged by this PR.
- **6 CI families** whose argv takes a value from the workflow (`$RUNNER_TEMP`, `${{ matrix.shard }}`) have no local invocation; `dispatch-gates` places them outside the 45 by design.
- **37 artifact-roster families** score `silent` for every card in the tree; their silence is a fact about a list, not a clearance.
- **`ioredis-mock` versions other than the resolved 8.13.1**, and commands other than WATCH/MULTI/EXEC/SET/DEL.
- **Full-repo `pnpm lint`** was not run; it is CI's. The gate union above is what this card owes locally.

## Not in scope

#15986 carries the ioredis 5-vs-6 version-pin question and is untouched here; it stays open. This PR does not make that pin easier or harder — it adds no dependency on either version's behaviour, and its own version-sensitive claim (the `ioredis-mock` WATCH readings) is dated and scoped to the resolved 8.13.1 in the file header, so it expires the same way the existing declaration does.

## Changeset

None. Tests-only: one new test file plus a comment block in an existing test file. `package.json` publishes `files: ["dist", ...]` and tsup bundles from `src/index.ts`, so no test file reaches the tarball and no published surface or behaviour moves. `skip-changeset` applies and is applied.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpTx2tbq3pZRYAdoGt6E6Y)_