### PR TITLE
fix(cli): `os migrate meta` names the protocol, not a package version

### DIFF
--- a/.changeset/migrate-meta-chain-line-protocol-label.md
+++ b/.changeset/migrate-meta-chain-line-protocol-label.md
@@ -1,0 +1,17 @@
+---
+"@objectstack/cli": patch
+---
+
+`os migrate meta` no longer prints the protocol version under the word "runtime", where it read as the installed package version.
+
+The chain line used to end `(runtime 17.0.0)`. That number is `PROTOCOL_VERSION` — the protocol major padded to a semver — and it is not, and never tracks, the version of the installed `@objectstack/cli` or `@objectstack/spec`. On a 17.3.0 install the line appeared beside the real package versions of the same upgrade session (`npm view`, the changelog), so it read as "your runtime is 17.0.0": an apparent downgrade or a stale install, neither of which was true.
+
+The value was never wrong — the label and the semver form were. The line now states the fact in the protocol's own units:
+
+```
+Chain:  protocol 17 → 17 (this runtime implements protocol 17)
+```
+
+The parenthetical is relabelled rather than dropped, because it carries a fact nothing else on screen does: when `--to` stops below this build's major, it is the only place the operator is told where the runtime actually stands (`Chain:  protocol 16 → 16 (this runtime implements protocol 17)`).
+
+The `--json` payload is deliberately untouched: its `runtime` key still carries the same padded protocol semver. Renaming a machine-readable key is a contract change owing a reader census and a deprecation window of its own, and it is tracked separately — an e2e pin now asserts the key's current value so that move cannot happen silently.

--- a/packages/cli/src/commands/migrate/meta.ts
+++ b/packages/cli/src/commands/migrate/meta.ts
@@ -327,6 +327,11 @@ export default class MigrateMeta extends Command {
         await emitJson({
               from: result.fromMajor,
               to: result.toMajor,
+              // Deliberately NOT relabelled alongside the human line below:
+              // this is a machine-readable key on a published payload, so
+              // moving it is a contract change owing a reader census and a
+              // deprecation window of its own (#15585, option C). The value is
+              // the protocol major padded to a semver, not a package version.
               runtime: PROTOCOL_VERSION,
               applied: result.applied,
               todos: result.todos,
@@ -350,7 +355,15 @@ export default class MigrateMeta extends Command {
       }
 
       printInfo(`Config: ${chalk.white(absolutePath)}`);
-      printInfo(`Chain:  protocol ${fromMajor} → ${toMajor} (runtime ${PROTOCOL_VERSION})`);
+      // State this build's protocol major in the protocol's own units.
+      // `PROTOCOL_VERSION` is that major padded to a semver ('17.0.0'), never
+      // the installed package version -- printed as a bare semver under the
+      // word "runtime" it read as one, so on a 17.3.0 install the operator saw
+      // an apparent downgrade next to the real package versions of the same
+      // upgrade session. The fact itself is worth keeping: with `--to` below
+      // this build's major it is the only line saying where the runtime
+      // actually stands. So it is relabelled and de-padded, not dropped.
+      printInfo(`Chain:  protocol ${fromMajor} → ${toMajor} (this runtime implements protocol ${PROTOCOL_MAJOR})`);
       console.log('');
 
       if (result.applied.length === 0 && result.todos.length === 0) {

--- a/packages/cli/test/migrate-meta.e2e.test.ts
+++ b/packages/cli/test/migrate-meta.e2e.test.ts
@@ -23,6 +23,7 @@ import { dirname, join, resolve } from 'node:path';
 import { createRequire } from 'node:module';
 import { fileURLToPath } from 'node:url';
 import { ObjectStackDefinitionSchema } from '@objectstack/spec';
+import { PROTOCOL_MAJOR, PROTOCOL_VERSION } from '@objectstack/spec/kernel';
 import { childEnv } from './helpers/serve-process.js';
 
 const execFileP = promisify(execFile);
@@ -442,4 +443,72 @@ export default defineStack({
     }
     expect(refused, '`os validate` must still reject a retired key').toBe(true);
   }, 180_000);
+});
+
+/**
+ * The chain line states this build's protocol in the protocol's own units.
+ *
+ * `PROTOCOL_VERSION` is the protocol major padded to a semver ('17.0.0') and is
+ * never the installed package version. Printed here as a bare semver under the
+ * word "runtime", it read as one: on a 17.3.0 install the operator saw
+ * "runtime 17.0.0" beside the real package versions of the same upgrade
+ * session, which reads as an apparent downgrade or a stale install. Nothing
+ * about the VALUE was wrong; the label and the semver FORM were.
+ *
+ * Both halves are asserted, because either one alone is satisfiable the wrong
+ * way. A line that merely stopped saying "runtime" could still print the padded
+ * semver in a version position; and a line that dropped the parenthetical
+ * altogether would lose the one fact it carries -- with `--to` stopping below
+ * this build's major it is the only place the operator is told where the
+ * runtime actually stands, which is why the third case drives exactly that.
+ *
+ * The `--json` `runtime` key is pinned UNCHANGED here on purpose. It is a
+ * machine-readable key on a published payload, so moving it is a contract
+ * change owing a reader census and a deprecation window of its own. This pin is
+ * what makes that move loud instead of silent.
+ */
+describe('os migrate meta — the chain line names the protocol, not a package version', () => {
+  const LABEL_CONFIG = `
+export default {
+  manifest: { id: 'chain_label_e2e', name: 'Chain Label E2E', version: '1.0.0', type: 'app' },
+  objects: [{ name: 'label_ticket', label: 'Ticket', fields: { title: { type: 'text', label: 'Title' } } }],
+};
+`;
+  let labelDir: string;
+
+  beforeAll(() => {
+    labelDir = mkdtempSync(join(tmpdir(), 'os-migrate-meta-label-'));
+    writeFileSync(join(labelDir, 'objectstack.config.ts'), LABEL_CONFIG);
+  });
+
+  afterAll(() => {
+    try { rmSync(labelDir, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  it("names this build's protocol major, in majors", async () => {
+    const stdout = await runMeta(['--from', String(PROTOCOL_MAJOR)], labelDir);
+    expect(stdout).toContain(
+      `Chain:  protocol ${PROTOCOL_MAJOR} → ${PROTOCOL_MAJOR} (this runtime implements protocol ${PROTOCOL_MAJOR})`,
+    );
+  }, 120_000);
+
+  it('prints no padded protocol semver in the human output, under any label', async () => {
+    const stdout = await runMeta(['--from', String(PROTOCOL_MAJOR)], labelDir);
+    expect(stdout).not.toContain(PROTOCOL_VERSION);
+    expect(stdout).not.toMatch(/runtime \d+\.\d+\.\d+/);
+  }, 120_000);
+
+  it('still says where the runtime stands when --to stops below this build\'s major', async () => {
+    const below = PROTOCOL_MAJOR - 1;
+    const stdout = await runMeta(['--from', String(below), '--to', String(below)], labelDir);
+    expect(stdout).toContain(
+      `Chain:  protocol ${below} → ${below} (this runtime implements protocol ${PROTOCOL_MAJOR})`,
+    );
+    expect(stdout).not.toContain(PROTOCOL_VERSION);
+  }, 120_000);
+
+  it('leaves the --json `runtime` key exactly as published', async () => {
+    const parsed = JSON.parse(await runMeta(['--from', String(PROTOCOL_MAJOR), '--json'], labelDir));
+    expect(parsed.runtime).toBe(PROTOCOL_VERSION);
+  }, 120_000);
 });


### PR DESCRIPTION
Part of #15585 — this lands **option A only**. The card's `--json` half (option C) is deliberately left open; the section "What is NOT in this PR" says exactly what remains and why, so the card must stay open after this merges.

## The defect, driven

`PROTOCOL_VERSION` is the protocol major padded to a semver (`'17.0.0'`, `packages/spec/src/kernel/protocol-version.ts:18`). It is not, and never tracks, the installed package version. It was printed under the word `runtime`, as a bare semver, beside the real package versions of the same upgrade session.

This repo is itself at `@objectstack/spec` **17.3.0** / `@objectstack/cli` **17.3.0**, which is the reporter's exact scenario. Driving the real CLI (`bin/run-dev.js`, `NO_COLOR=1`) over a minimal stack config:

**Before**

```
◆ Migrate · meta
────────────────────────────────────────
  → Loading configuration…
  → Replaying chain: protocol 17 → 17…
  ℹ Config: /…/objectstack.config.ts
  ℹ Chain:  protocol 17 → 17 (runtime 17.0.0)

  ✓ Nothing to migrate — the metadata is already canonical for this range.
```

**After**

```
◆ Migrate · meta
────────────────────────────────────────
  → Loading configuration…
  → Replaying chain: protocol 17 → 17…
  ℹ Config: /…/objectstack.config.ts
  ℹ Chain:  protocol 17 → 17 (this runtime implements protocol 17)

  ✓ Nothing to migrate — the metadata is already canonical for this range.
```

## Why relabelled and not dropped

The card offers dropping the parenthetical, since the line already says `protocol 17 → 17`. Driving the other case shows the parenthetical carries a fact nothing else on screen does — when `--to` stops below this build's major it is the only place the operator is told where the runtime actually stands:

```
before:  ℹ Chain:  protocol 16 → 16 (runtime 17.0.0)
after:   ℹ Chain:  protocol 16 → 16 (this runtime implements protocol 17)
```

So the value stays; the **label** and the **semver form** are what changed. Both halves mattered: a line that merely stopped saying "runtime" would still print a padded semver in a version position.

## The sweep — every other site that prints `PROTOCOL_VERSION`

A one-site fix that leaves siblings lying would be worse than reporting the set, so the whole set was enumerated before touching one (`grep` over the tree, excluding `node_modules` and `dist`). Every other site already labels the value correctly:

| Site | Spelling | Verdict |
|:--|:--|:--|
| `packages/cli/src/commands/migrate/meta.ts:353` | `(runtime ${PROTOCOL_VERSION})` | **the defect — fixed here** |
| `packages/cli/src/commands/migrate/meta.ts:330` | `runtime: PROTOCOL_VERSION` (`--json`) | same ambiguity, machine face — **deliberately not moved**, see below |
| `packages/cli/src/commands/migrate/meta.ts:201` | ``Target protocol major (defaults to this runtime's, ${PROTOCOL_MAJOR})`` | correct — an integer major in a "protocol major" sentence, not a semver in a version position |
| `packages/metadata-core/src/protocol-handshake.ts:225,285` | message `…but this runtime is protocol ${runtimeVersion}` | correct — the prose says `protocol`. The machine field is named `runtimeVersion`, which is reported as a finding rather than moved: it is a different shipped surface (the `OS_PROTOCOL_INCOMPATIBLE` diagnostic) and its own contract move |
| `packages/metadata-protocol/src/protocol.ts:15610` | `protocol: PROTOCOL_VERSION` | correct |
| `packages/spec/scripts/build-spec-changes.ts:108` | `protocolVersion: PROTOCOL_VERSION` | correct |
| `packages/spec/scripts/build-upgrade-guide.ts:40` | `Current protocol: **17.0.0**` | correct |

## What is NOT in this PR

**The `--json` `runtime` key is untouched, on purpose.** It is a machine-readable key on a published payload; renaming it is a contract change owing a reader census and a deprecation window, and the card's triage ruled A and C independent with an explicit instruction not to bundle them. The payload is byte-identical across this change — same key set, same values (`duration` excluded, being a timer):

```
keys before: from,to,runtime,applied,todos,specChanges,schemaValid,dataMigrations,duration
keys after:  from,to,runtime,applied,todos,specChanges,schemaValid,dataMigrations,duration
payload identical (duration excluded): true
```

A reader census for that key found **no consumer in this tree**: nothing reads `.runtime` off this payload, and the published `skills/objectstack-upgrade/SKILL.md` documents `--json` without naming the field. That is a measurement offered to whoever decides C, not a decision.

To keep the deferral honest rather than silent, a comment now sits on the emit site, and one of the new e2e cases pins the key's current value — so a future rename fails a test instead of shipping quietly.

Option **B** (printing the real package version too) stays out: it depends on `@objectstack/cli/package.json` being resolvable, which is another card's work. Out of scope: #15325.

## Tests

`packages/cli/test/migrate-meta.e2e.test.ts` — four new cases in a new describe, driving the real CLI process, not a string in a fixture:

1. the chain line names this build's protocol major, in majors;
2. the human output contains no padded protocol semver under any label (`PROTOCOL_VERSION` absent, and no `runtime N.N.N` anywhere);
3. the fact survives when `--to` stops below this build's major;
4. the `--json` `runtime` key is exactly as published.

Every case derives its expectations from `PROTOCOL_MAJOR` / `PROTOCOL_VERSION` rather than hard-coding `17`, so they follow the next major bump.

**Suite:** `pnpm --filter @objectstack/cli exec vitest run --maxWorkers=2 test/migrate-meta.e2e.test.ts` → `Test Files 1 passed (1) · Tests 18 passed (18)`.

**Ablation.** The CLI is driven from `src/` (`bin/run-dev.js` imports `../src/…`), so no rebuild sits in this loop — stated because an ablation over a `dist/`-resolved subject that skipped the rebuild would stay green and prove nothing. With the fix committed, the defective line was put back on disk and the mutation confirmed there before measuring (injected-line count 1, removed-line count 0, blob hash moved `058a5bb7…` → `43064a9a…`), not by trusting the editor's exit code:

```
× names this build's protocol major, in majors
× prints no padded protocol semver in the human output, under any label
× still says where the runtime stands when --to stops below this build's major
Tests  3 failed | 1 passed | 14 skipped (18)
```

The one that stayed green is case 4 — the `--json` pin, which the mutation did not touch. That is the discrimination working in both directions rather than a blanket red. Restore was proven by observed state, not by an exit code: `git diff HEAD` empty, worktree blob back to `058a5bb7…`, fix line present, defect line absent.

## Gates

Union derived mechanically at the delivered commit — `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack --commands` — and asserted against its own reconciliation line: **56 families claimed, 56 command lines harvested, 56 green.** Exit codes captured before any pipe (`cmd > log 2>&1; EXIT=$?`).

Four came back NOT MEASURED on the first pass for want of built output — `check:dual-build-cjs-loads` and `check:i18n` / `check:i18n-coverage` (exit 3, PREREQUISITE NOT MET) and `check:i18n-walk-parity` (its own verdict line reads PREREQUISITE NOT MET). All four were then built for and re-run green; none was reported as a pass while unmeasured.

The **Artifact rosters** block (37 families, outside that total by the tool's design) was run separately: 35 green, 2 not measured —

- `node scripts/check-partof-closing-keyword.mjs` and `node scripts/check-single-claim-paths.mjs` returned **exit 2, NOT WIRED** (no `PR_BODY` / `PR_NUMBER` outside CI). Their pnpm spellings are green above but grade only the checkers' own fixtures — measured, not assumed: both `package.json` entries resolve to `--self-test` alone. The body-judging form of the first was then run locally against **this exact body** with `PR_BODY` set, and passes.
- `pnpm --filter @objectstack/spec run check:react-declaration-parity` exits 1 with `MANIFEST is not set … This gate did NOT run`. It needs an objectui-derived `sdui.manifest.json` and a browser, is an on-demand gate rather than a CI job, and this diff does not move the `.objectui-sha` pin.

## Clause ② — declared per limb, from the delivered diff

**Public-surface limb: NO.** The diff adds no key to any published payload (the `--json` payload is byte-identical, shown above), touches nothing under `packages/spec/src/**`, adds and changes no export, and leaves the command's flags, args and exit codes exactly as they were; the only shipped bytes that move are one human-readable diagnostic line on stdout, which no consumer in the tree parses.

**Conformance limb: NO.** No input class is re-selected between two already-published verdicts: the same configs load, the schema verdict is computed by untouched code, the support-floor refusal and every exit code are unchanged, and the whole change is the rendering of one informational line after the verdict has already been reached.

## Out of scope, filed rather than acted on

- **#16056** — `content/docs/releases/v17.mdx:5363` asserts this command "also prints `runtime 17.0.0` on a 17.3.0 install", a sentence this repair invalidates. `content/docs/releases/` may not be edited by a code PR (AGENTS.md, Documentation Guardrails); a code PR's input to release notes is its changeset, and this PR's changeset carries the corrected line. Whether that sentence is stale guidance or a historical measurement is a judgement for the release process, which is why it is a card and not an edit.
- **`runtimeVersion` on the `OS_PROTOCOL_INCOMPATIBLE` diagnostic** (`packages/metadata-core/src/protocol-handshake.ts`) carries the same padded protocol semver under a version-ish machine name. Its prose says `protocol`, so the human channel is unambiguous; the machine field is a separate shipped surface and a separate contract move. Reported here, not touched.

## Changeset

`.changeset/migrate-meta-chain-line-protocol-label.md` — `@objectstack/cli: patch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D47qPfEWVPmhguWgBZCi5N

---
_Generated by [Claude Code](https://claude.ai/code/session_01D47qPfEWVPmhguWgBZCi5N)_