### PR TITLE
fix(plugin-auth): the magic-link mail reads the recipient's own `sys_user.locale` (#15106)

### DIFF
--- a/.changeset/magic-link-reads-recipient-locale.md
+++ b/.changeset/magic-link-reads-recipient-locale.md
@@ -1,0 +1,36 @@
+---
+"@objectstack/plugin-auth": patch
+---
+
+fix(plugin-auth): the magic-link mail reads the recipient's own `sys_user.locale` (#15106)
+
+`sendMagicLink` was the last of the five auth mail sends still on the two-rung
+#14319 ladder — the request's `Accept-Language`, then the deployment default.
+#14762 put the recipient's stored `sys_user.locale` above both at the three
+sends that hold a user row, and #14641 reached the invitation; the magic link
+was fenced out because it is handed `{ email, url, token }` and no row, so the
+column has to be read on the address rather than on an id. The visible cost was
+one deployment answering the same person in two languages: a Chinese
+password-reset mail and an English magic link, decided by whichever browser
+happened to send the request.
+
+It now reads the column behind the existing placeholder-address refusal, in the
+same shape #14641 gave the invitation send — one projected `findOne` on
+`sys_user` under a system context, best-effort, and never a reason a send fails.
+This completes the #14788 option-D ladder (`sys_user.locale` when set → the
+request's `Accept-Language` → the deployment default) across the whole auth mail
+surface: all five `sendTemplate` sites now answer per recipient.
+
+The request rung is kept rather than replaced. A magic link is requested BY its
+recipient, so its `Accept-Language` is the recipient's own and remains a
+legitimate second rung for an account that has stated no language; ruling D
+inserts the column above the header, it does not remove the header.
+
+Two branches, because a magic link is also a sign-up: an address that carries a
+row is written in that account's language, and an address with no row keeps
+exactly the previous behaviour. The address is lowercased for the lookup —
+better-auth applies no case transform to the magic-link request body, while
+`findUserByEmail`, which `/magic-link/verify` resolves the very same link with,
+matches on `email.toLowerCase()`, so the column is read for the row the link
+will sign into. An address that resolves nothing lands on the rungs below, which
+is the documented floor.

--- a/packages/plugins/plugin-auth/src/auth-email-locale.test.ts
+++ b/packages/plugins/plugin-auth/src/auth-email-locale.test.ts
@@ -126,8 +126,8 @@ const USER = { id: 'u1', email: 'ada@example.com', name: 'Ada' };
  * callback — that placement is itself the #8019 "does not gate" guarantee — so
  * it is driven through that hook with a synthetic success context.
  */
-async function driveAllFive(locale: string | undefined) {
-  const { capturedConfig, sent } = await boot(locale);
+async function driveAllFive(locale: string | undefined, extra: Record<string, unknown> = {}) {
+  const { capturedConfig, sent } = await boot(locale, extra);
 
   await capturedConfig.emailAndPassword.sendResetPassword({
     user: USER,
@@ -846,5 +846,297 @@ describe("#14641 — an invitation reads the INVITEE's own sys_user.locale", () 
       }),
     ).rejects.toThrow(/placeholder address/);
     expect(reads.filter((r) => r.object === 'sys_user')).toHaveLength(0);
+  });
+});
+
+// ── #15106 — the magic-link send reaches the same top rung ─────────────────
+
+/**
+ * The last of the five sends to read the recipient's own `sys_user.locale`.
+ *
+ * ⚠️ POPULATION of the class claim these blocks close, stated rather than
+ * implied: the auth mail surface is the five `sendTemplate` call sites in
+ * `auth-manager.ts` — `IEmailService` declares exactly two delivering members
+ * (`send`, `sendTemplate`), plugin-auth's only `.send(` calls are the SMS
+ * service's, and no other file under `plugin-auth/src` calls either. Those
+ * five are the same five `driveAllFive` above drives and `TEMPLATES` names.
+ * Before this change four of them read the column and `sendMagicLink` did not;
+ * `the whole surface reads it` is pinned below by driving all five against one
+ * recipient-keyed engine, not by asserting it about this send alone.
+ *
+ * Two branches, because a magic link is BOTH a sign-in for an existing account
+ * and a sign-up for a new address (measured in the installed better-auth
+ * 1.7.2: `/sign-in/magic-link` sends without looking the address up, and
+ * `/magic-link/verify` creates the user unless `disableSignUp`). Branch 2 is
+ * therefore a real state here, not a theoretical one.
+ *
+ * ⛔ The request rung is kept, not replaced. Ruling D (#14788, 2026-09-03,
+ * maintainer verbatim 「同意」) reads `sys_user.locale` when set → the
+ * request's `Accept-Language` → the deployment default; a magic link is
+ * requested by its own recipient, so its `ctx` header is the recipient's and
+ * stays the legitimate SECOND rung. The pins below assert both directions:
+ * the column outranks the header, and the header still answers with no column.
+ */
+function recipientKeyedEngine(rows: { byId?: Record<string, unknown>; byEmail?: Record<string, unknown> }) {
+  const reads: any[] = [];
+  const has = (o: Record<string, unknown> | undefined, k: unknown) =>
+    typeof k === 'string' && !!o && Object.prototype.hasOwnProperty.call(o, k);
+  return {
+    reads,
+    engine: {
+      async findOne(object: string, query: any) {
+        reads.push({ object, query });
+        if (object !== 'sys_user') return null;
+        const where = (query?.where ?? {}) as Record<string, unknown>;
+        if (has(rows.byId, where.id)) return { locale: rows.byId![where.id as string] };
+        if (has(rows.byEmail, where.email)) return { locale: rows.byEmail![where.email as string] };
+        return null;
+      },
+    },
+  };
+}
+
+async function driveMagicLink(opts: {
+  engine?: unknown;
+  deployment?: string;
+  recipient?: string;
+  /** The RECIPIENT's own browser language — magic link is requested by them. */
+  header?: string;
+}) {
+  const { capturedConfig, sent } = await boot(
+    opts.deployment,
+    opts.engine === undefined ? {} : ({ dataEngine: opts.engine } as never),
+  );
+  const magic = capturedConfig.plugins.find((p: any) => p.id === 'magic-link');
+  await magic._opts.sendMagicLink(
+    { email: opts.recipient ?? 'ada@example.com', url: 'http://x/magic', token: 't' },
+    opts.header === undefined
+      ? undefined
+      : { request: new Request('http://x/magic', { headers: { 'accept-language': opts.header } }) },
+  );
+  return sent;
+}
+
+describe("#15106 — the magic link reads the recipient's own sys_user.locale", () => {
+  const prevMcpEnv = process.env.OS_MCP_SERVER_ENABLED;
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.OS_MCP_SERVER_ENABLED = 'false';
+  });
+  afterEach(() => {
+    if (prevMcpEnv === undefined) delete process.env.OS_MCP_SERVER_ENABLED;
+    else process.env.OS_MCP_SERVER_ENABLED = prevMcpEnv;
+  });
+
+  it('the stored column outranks BOTH the request header and the deployment default', async () => {
+    // Three rungs, three distinct tags — each assertion names exactly one.
+    const { engine } = recipientKeyedEngine({ byEmail: { 'ada@example.com': 'ja-JP' } });
+    const sent = await driveMagicLink({ engine, header: 'zh-CN', deployment: 'es-ES' });
+    expect(sent).toHaveLength(1);
+    expect(sent[0].template).toBe('auth.magic_link');
+    expect(sent[0].locale).toBe('ja-JP');
+    expect(sent[0].locale).not.toBe('zh-CN');
+    expect(sent[0].locale).not.toBe('es-ES');
+  });
+
+  it('and the reverse — swapping the tags swaps nothing but the answer', async () => {
+    // Rules out a pin that passes because one particular tag always wins.
+    const { engine } = recipientKeyedEngine({ byEmail: { 'ada@example.com': 'zh-CN' } });
+    const sent = await driveMagicLink({ engine, header: 'ja-JP', deployment: 'es-ES' });
+    expect(sent[0].locale).toBe('zh-CN');
+    expect(sent[0].locale).not.toBe('ja-JP');
+  });
+
+  it('BRANCH 2 — an address with no row still takes the request rung, #14319 intact', async () => {
+    // ⚠️ Positive control for the zero, driven through ONE engine: the same
+    // table and the same predicate answer ja-JP for an address that carries a
+    // row and fall through for one that does not. Without it, "the read ran
+    // and found nothing" is indistinguishable from "the read never ran".
+    const { engine, reads } = recipientKeyedEngine({ byEmail: { 'known@example.com': 'ja-JP' } });
+
+    const known = await driveMagicLink({ engine, recipient: 'known@example.com', header: 'zh-CN', deployment: 'es-ES' });
+    expect(known[0].locale).toBe('ja-JP');
+
+    const newcomer = await driveMagicLink({ engine, recipient: 'newcomer@example.com', header: 'zh-CN', deployment: 'es-ES' });
+    expect(newcomer[0].locale).toBe('zh-CN');
+    expect(newcomer[0].locale).not.toBe('ja-JP');
+
+    // ...and the newcomer's read really was attempted, on their address.
+    const userReads = reads.filter((r) => r.object === 'sys_user');
+    expect(userReads.map((r) => r.query.where)).toEqual([
+      { email: 'known@example.com' },
+      { email: 'newcomer@example.com' },
+    ]);
+  });
+
+  it('with neither a row nor a request, the deployment rung answers — #8195 intact', async () => {
+    const { engine } = recipientKeyedEngine({});
+    const sent = await driveMagicLink({ engine, deployment: 'es-ES' });
+    expect(sent[0].locale).toBe('es-ES');
+  });
+
+  it('with nothing at all, NO locale is named and the documented en-US floor applies', async () => {
+    // The ladder's contract is written against an ABSENT key, not an explicit
+    // `undefined` — the same shape the other four sends are pinned on.
+    const { engine } = recipientKeyedEngine({});
+    const sent = await driveMagicLink({ engine });
+    expect(sent[0].locale).toBeUndefined();
+    expect(Object.prototype.hasOwnProperty.call(sent[0], 'locale')).toBe(false);
+  });
+
+  it("reads the column off the recipient's ADDRESS, projected, under a system context", async () => {
+    // Establishes WHICH rung produced the value and on WHAT predicate: this
+    // callback is handed no user row, so an id-keyed read would be a bug.
+    const { engine, reads } = recipientKeyedEngine({ byEmail: { 'ada@example.com': 'ja-JP' } });
+    const sent = await driveMagicLink({ engine, header: 'zh-CN' });
+    expect(sent[0].locale).toBe('ja-JP');
+    const userReads = reads.filter((r) => r.object === 'sys_user');
+    expect(userReads).toHaveLength(1);
+    expect(userReads[0].query.where).toEqual({ email: 'ada@example.com' });
+    expect(userReads[0].query.fields).toEqual(['locale']);
+    expect(userReads[0].query.context?.isSystem).toBe(true);
+  });
+
+  it('matches the address better-auth itself will resolve the link with — lowercased', async () => {
+    // ⚠️ Measured against the installed better-auth 1.7.2, not assumed:
+    // `signInMagicLinkBodySchema` applies no case transform, so a typed
+    // `Ada@Example.com` arrives here verbatim, while
+    // `internalAdapter.findUserByEmail` — what `/magic-link/verify` resolves
+    // this very link with — matches on `email.toLowerCase()`. The column must
+    // be read for the row the link will sign into.
+    const { engine, reads } = recipientKeyedEngine({ byEmail: { 'ada@example.com': 'ja-JP' } });
+    const sent = await driveMagicLink({ engine, recipient: 'Ada@Example.com', deployment: 'es-ES' });
+    const userReads = reads.filter((r) => r.object === 'sys_user');
+    expect(userReads, 'no sys_user read happened at all').toHaveLength(1);
+    expect(userReads[0].query.where).toEqual({ email: 'ada@example.com' });
+    expect(sent[0].locale).toBe('ja-JP');
+    // ...and the address the mail is actually sent to is untouched.
+    expect(sent[0].to).toBe('Ada@Example.com');
+  });
+
+  it('refuses the stringified-nothing literals a lossy producer leaves at rest', async () => {
+    for (const junk of ['undefined', 'null', '', '   ', 42, {}]) {
+      const { engine } = recipientKeyedEngine({ byEmail: { 'ada@example.com': junk } });
+      const sent = await driveMagicLink({ engine, deployment: 'es-ES' });
+      expect(sent[0].locale, `stored ${JSON.stringify(junk)} named a locale`).toBe('es-ES');
+    }
+  });
+
+  it('a failing recipient read never blocks the magic link', async () => {
+    // A magic link IS the credential — a locale lookup must never be why one
+    // fails to arrive.
+    const sent = await driveMagicLink({
+      engine: { async findOne() { throw new Error('sys_user unavailable'); } },
+      header: 'zh-CN',
+      deployment: 'es-ES',
+    });
+    expect(sent).toHaveLength(1);
+    expect(sent[0].template).toBe('auth.magic_link');
+    expect(sent[0].locale).toBe('zh-CN');
+  });
+
+  it('with no data engine at all, the two-rung #14319 behaviour is exactly intact', async () => {
+    const sent = await driveMagicLink({ header: 'zh-CN', deployment: 'es-ES' });
+    expect(sent[0].locale).toBe('zh-CN');
+  });
+
+  it('does not disturb the rest of the magic-link payload', async () => {
+    const { engine } = recipientKeyedEngine({ byEmail: { 'ada@example.com': 'ja-JP' } });
+    const sent = await driveMagicLink({ engine, deployment: 'es-ES' });
+    expect(sent[0].to).toBe('ada@example.com');
+    expect(sent[0].data.magicLinkUrl).toBe('http://x/magic');
+    expect(sent[0].data.token).toBe('t');
+    expect(sent[0].data.expiresInMinutes).toBe(10);
+  });
+
+  it('a placeholder address is still refused BEFORE any recipient read', async () => {
+    // #2766 V1.5 ordering, re-pinned now that a read sits on this path too.
+    const { engine, reads } = recipientKeyedEngine({});
+    const { capturedConfig } = await boot('es-ES', { dataEngine: engine } as never);
+    const magic = capturedConfig.plugins.find((p: any) => p.id === 'magic-link');
+    await expect(
+      magic._opts.sendMagicLink({
+        email: 'u-abcdefghijklmnopqrst@placeholder.invalid',
+        url: 'http://x/magic',
+        token: 't',
+      }),
+    ).rejects.toThrow(/placeholder address/);
+    expect(reads.filter((r) => r.object === 'sys_user')).toHaveLength(0);
+  });
+
+  it('no recipient read happens at all when no transport is wired', async () => {
+    // The no-email-service branch returns before the lookup: an unwired
+    // deployment must not pay for a query whose answer it cannot use.
+    const { engine, reads } = recipientKeyedEngine({ byEmail: { 'ada@example.com': 'ja-JP' } });
+    const { betterAuth } = await import('better-auth');
+    let capturedConfig: any;
+    (betterAuth as any).mockImplementation((config: any) => {
+      capturedConfig = config;
+      return { handler: vi.fn(), api: {} };
+    });
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const manager = new AuthManager({
+      secret: 'test-secret-at-least-32-chars-long',
+      baseUrl: 'http://localhost:3000',
+      emailAndPassword: { enabled: true },
+      plugins: { magicLink: true },
+      dataEngine: engine,
+    } as never);
+    await manager.getAuthInstance();
+    const magic = capturedConfig.plugins.find((p: any) => p.id === 'magic-link');
+    await magic._opts.sendMagicLink({ email: 'ada@example.com', url: 'http://x/magic', token: 't' });
+    warnSpy.mockRestore();
+    expect(reads.filter((r) => r.object === 'sys_user')).toHaveLength(0);
+  });
+});
+
+describe('#15106 — the CLASS claim: all five auth sends read the recipient column', () => {
+  const prevMcpEnv = process.env.OS_MCP_SERVER_ENABLED;
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.OS_MCP_SERVER_ENABLED = 'false';
+  });
+  afterEach(() => {
+    if (prevMcpEnv === undefined) delete process.env.OS_MCP_SERVER_ENABLED;
+    else process.env.OS_MCP_SERVER_ENABLED = prevMcpEnv;
+  });
+
+  it('every one of the five sends is written in the stored language of its own recipient', async () => {
+    // ⚠️ POPULATION: the five `sendTemplate` sites in `auth-manager.ts` — the
+    // same five `driveAllFive` drives and `TEMPLATES` names, and the whole of
+    // plugin-auth's mail surface (see this section's header). This is the pin
+    // that closes the class; the per-send pins above only cover one member.
+    //
+    // The tags are chosen so no send can borrow another's answer: the three
+    // id-keyed sends read `ja-JP`, the invitation reads `zh-CN` off the
+    // invitee's address, and the magic link reads `en-GB` off ITS recipient's
+    // address — a different tag from the SAME person's id-keyed row, which is
+    // what proves the magic link reads by address rather than by id.
+    const { engine } = recipientKeyedEngine({
+      byId: { u1: 'ja-JP' },
+      byEmail: { 'invitee@example.com': 'zh-CN', 'ada@example.com': 'en-GB' },
+    });
+    const sent = await driveAllFive('es-ES', { dataEngine: engine } as never);
+
+    expect(sent.map((s: any) => s.template)).toEqual([...TEMPLATES]);
+    expect(sent.map((s: any) => s.locale)).toEqual([
+      'ja-JP', // auth.password_reset        — id u1
+      'ja-JP', // auth.verify_email          — id u1
+      'zh-CN', // auth.invitation            — invitee@example.com
+      'en-GB', // auth.magic_link            — ada@example.com (by ADDRESS)
+      'ja-JP', // auth.email_change_notice   — id u1
+    ]);
+    // The direction that makes it real: not one of the five fell through to
+    // the deployment default.
+    expect(sent.some((s: any) => s.locale === 'es-ES')).toBe(false);
+  });
+
+  it('...and with an empty table every one of the five falls back, none stuck', async () => {
+    // The negative half of the same population: the class claim is about the
+    // rung being WIRED at all five sites, so the fallback must also be five.
+    const { engine } = recipientKeyedEngine({});
+    const sent = await driveAllFive('es-ES', { dataEngine: engine } as never);
+    expect(sent.map((s: any) => s.template)).toEqual([...TEMPLATES]);
+    expect(sent.map((s: any) => s.locale)).toEqual(['es-ES', 'es-ES', 'es-ES', 'es-ES', 'es-ES']);
   });
 });

--- a/packages/plugins/plugin-auth/src/auth-manager.ts
+++ b/packages/plugins/plugin-auth/src/auth-manager.ts
@@ -3306,11 +3306,46 @@ export class AuthManager {
             );
             return;
           }
+          // #15106 — the recipient's OWN stored language, the last auth mail
+          // to reach the top rung of the #14788 option-D ladder. Same rung and
+          // same helper as the other four sends; only the predicate differs,
+          // because this callback is handed an address rather than a user row
+          // — the #14641 invitation shape, and for the same reason it has two
+          // branches:
+          //
+          //  1. the address HAS a `sys_user` row — the ordinary case, since a
+          //     magic link is how an existing account signs in without a
+          //     password → their own `locale`;
+          //  2. NO row — magic link doubles as sign-up (measured in the
+          //     installed 1.7.x: `/sign-in/magic-link` sends WITHOUT checking
+          //     for an account, and `/magic-link/verify` creates one unless
+          //     `disableSignUp`), so an unknown address is legitimate here and
+          //     its language is genuinely unknown → the rungs below stand.
+          //
+          // ⚠️ Lowercased, unlike the invitation predicate, and the difference
+          // is measured rather than stylistic: better-auth lowercases the
+          // invitee address on the invite route, but `signInMagicLinkBodySchema`
+          // applies no such transform, so what arrives here is whatever the
+          // caller typed. `internalAdapter.findUserByEmail` — the lookup
+          // `/magic-link/verify` resolves this very link with — matches on
+          // `email.toLowerCase()`. Reading the column on the same spelling
+          // keeps the row the mail is ABOUT identical to the row the link will
+          // sign into; an address that resolves nothing lands on the rungs
+          // below, which is the documented floor rather than a failure.
+          //
+          // ⛔ The request rung is NOT removed: ruling D inserts the column
+          // ABOVE `Accept-Language`, it does not replace it. A magic link is
+          // requested by its own recipient, so `ctx` here carries the
+          // recipient's own header and stays a legitimate second rung for an
+          // account that has stated no language.
+          const storedLocale = await this.storedRecipientLocale({
+            email: recipientEmail.toLowerCase(),
+          });
           try {
             await emailService.sendTemplate({
               template: 'auth.magic_link',
               to: recipientEmail,
-              ...this.emailLocaleArg(ctx),
+              ...this.emailLocaleArg(ctx, storedLocale),
               data: {
                 magicLinkUrl: url,
                 token,
@@ -5121,9 +5156,10 @@ export class AuthManager {
    * #14641 added. Three predicates, one per caller shape: `sys_user.id` (the
    * sends that hold a user row), the unique `phone_number` (the SMS sends,
    * which are handed a number and nothing else), and the unique `email` (the
-   * invitation send, which is handed an address for an account that may not
-   * exist yet). All three are `unique: true` in the better-auth `user` table
-   * this object is backed by (`@better-auth/core` `db/get-tables.mjs`).
+   * two sends handed an address for an account that may not exist yet — the
+   * invitation since #14641 and the magic link since #15106). All three are
+   * `unique: true` in the better-auth `user` table this object is backed by
+   * (`@better-auth/core` `db/get-tables.mjs`).
    */
   private async storedRecipientLocale(where: Record<string, unknown>): Promise<string | undefined> {
     const engine = this.getDataEngine();


### PR DESCRIPTION
Fixes #15106

`sendMagicLink` was the last auth mail send still on the two-rung #14319 ladder. It now reads the recipient's own `sys_user.locale`, completing the #14788 option-D ladder across the whole auth mail surface.

## Ruling D, read at its source

Read from #14788 comment 5522880441 (os-project-manager, 2026-09-03, maintainer verbatim 「同意」), not from the card's paraphrase. The card's paraphrase turns out to be faithful; two things the ruling says that the card does not are load-bearing here:

1. The ladder is stated for `GET /auth/me/localization` — **`sys_user.locale` when set → the request's `Accept-Language` → the deployment default** — and the ruling derives its order from **#14787's ruling B: the column is a user-stated preference**, not an administered value. The application of that same ladder to *mail sends* comes from #14762, which the ruling explicitly unblocks in its Execution paragraph ("#14762 (`pm:blocked`) re-reads its `Blocked-by:` once this lands"). So this PR extends a ladder that a landed PR already applied at four sends — not a shape invented here.
2. Ruling D **inserts** the column above `Accept-Language`; it does not remove the header rung.

Point 2 answers the open question the card raised and the triage told the lane to answer rather than skip:

> a magic link is requested **BY the recipient**, so the request rung is legitimate here in a way it is not for an admin-initiated reset.

That is true, and it argues for *keeping* the request rung — which this PR does. It does not argue for putting the header **above** the column, because #14787's ruling B makes the column a preference the user stated for themselves, which is stronger evidence of intent than the header the browser happened to send. The header remains the second rung and still answers for any account that has stated no language (pinned). No narrowing of the ruling, so nothing goes to the decision inbox.

## The enumeration — the card's "the one", verified

The card and its triage disagree on the count ("the fifth auth send" in the body, "this is the fourth" in the triage comment). Measured at `origin/main` (`2e3576503`), both readings resolve: **five mail sends, of which magic link was the fourth to read the column and the last one that did not.**

**Population** (mechanism-anchored, not keyword-guessed): `IEmailService` declares exactly two delivering members, `send` and `sendTemplate` (`packages/spec/src/contracts/email-service.ts`). Every mail plugin-auth sends goes through `sendTemplate`, and there are exactly five such call sites, all in `auth-manager.ts`.

| # | send | recipient predicate | read the column before this PR? |
|---|---|---|---|
| 1 | `sendResetPassword` | `{ id: user.id }` | yes (#14762) |
| 2 | `sendVerificationEmail` | `{ id: user.id }` | yes (#14762) |
| 3 | `sendInvitationEmail` | `{ email }` | yes (#14641, landed as `f074616e6`) |
| 4 | `sendMagicLink` | none | **no** |
| 5 | `sendChangeEmailNotice` | `{ id: from.id }` | yes (#14762) |

Sends 1, 2, 4 and 5 always address an existing account; 3 may not. So among auth mails to an existing user, the magic link was indeed the only one ignoring the column — **the card's headline holds in both directions.** Two SMS sends (`sendOTP`, `sendPasswordResetOTP`, via `deliverPhoneOtp`) read the column on `{ phone_number }` already and are not mail.

**Controls, both of which fire** (a search-based claim with no firing control is not a reading):

- *Control 1 — the pattern is not silently over-narrow*: `grep -rln "sendTemplate("` across `packages/` hits **16 files outside plugin-auth** (`plugin-email`, `service-messaging`, `spec`, `platform-objects`). The pattern works; the scoping to one file is a fact about plugin-auth, not a broken grep.
- *Control 2 — no second mechanism*: `grep -rn "\.send("` across `packages/plugins/plugin-auth/src` (non-test) returns **three hits, all the SMS service** (`sms.send(...)` at two call sites plus one docstring). There is no `email.send(` bypassing `sendTemplate`.
- *Closing the callback surface*: `grep -rnE "^\s*send[A-Za-z]*:"` over the same tree enumerates every wired better-auth callback — four email, three SMS — with no unaccounted mail callback. `send-verification-email.ts` re-dispatches through `sendVerificationEmail` rather than sending itself.

## The fix

One `findOne` on `sys_user`, behind the existing placeholder-address refusal and behind the no-transport early return, threaded into `emailLocaleArg`'s stored parameter — the shape the card suggested and the shape #14641 gave the invitation send. `AuthManager.storedRecipientLocale` already takes an arbitrary `where`, so this is a call site, not a mechanism.

Two branches, because a magic link is also a sign-up. Measured against the installed better-auth 1.7.2 rather than assumed: `/sign-in/magic-link` sends **without looking the address up**, and `/magic-link/verify` creates the user unless `disableSignUp`. An address with no row therefore falls through to the rungs below, exactly as invitation branch 2 does.

**The address is lowercased for the lookup, and the invitation site's raw pass-through is not copied.** Also measured in 1.7.2: `signInMagicLinkBodySchema` applies no case transform, so what reaches the callback is whatever the caller typed; `internalAdapter.findUserByEmail` — the lookup `/magic-link/verify` resolves this very link with — matches on `email.toLowerCase()`. Reading the column on that spelling keeps the row the mail is *about* identical to the row the link will sign *into*. The address the mail is sent to is untouched.

A `storedRecipientLocale` failure still never blocks a send: a magic link is itself the credential.

## Pins, with their populations stated

`packages/plugins/plugin-auth/src/auth-email-locale.test.ts`, +17 cases (51 → 68 in the file; the package suite is 2157 tests over 102 files, all green).

- **13 cases covering `sendMagicLink` alone** — population: this one send. Three-rung precedence with three distinct tags; the reverse with the tags swapped (so no pin can pass because one tag always wins); branch 2 with a positive control for the zero driven through **one** engine, which is what separates "the read ran and found nothing" from "the read never ran"; the predicate itself (address, projected, system context); the lowercase match; the junk-at-rest literals; a failing read; no data engine; no transport; the absent-key contract; the placeholder refusal still ordered before any read.
- **2 cases covering the class** — population stated in the test itself: the five `sendTemplate` sites, which is the whole of plugin-auth's mail surface for the reasons above, and the same five `driveAllFive`/`TEMPLATES` already name. Each recipient gets a distinct tag so no send can borrow another's answer; the magic link's tag differs from the **same person's** id-keyed row, which is what proves it reads by address and not by id.

A passing per-send pin would only have proved something about that send. The class pin is the one that carries "the whole surface answers per recipient".

## Mutation proof

Fix committed **first**, then reverted on disk, pins run RED, restored under `trap … EXIT INT TERM` with an absolute path and `git checkout HEAD -- ABSOLUTE_PATH`.

Mutation confirmed on disk at the anchor, by counting the deleted and injected text (never a bare `--stat`): `email: recipientEmail.toLowerCase()` 1 → 0, `emailLocaleArg(ctx, storedLocale)` 1 → 0, `emailLocaleArg(ctx),` → 1; blob `574c9270…` → `a145d8d9…`.

RED: `Tests 6 failed | 62 passed (68)`. The class pin's assertion, verbatim — position 4 is the magic link falling back to the deployment default:

```
AssertionError: expected [ 'ja-JP', 'ja-JP', 'zh-CN', …(2) ] to deeply equal [ 'ja-JP', 'ja-JP', 'zh-CN', …(2) ]
    "zh-CN",
-   "en-GB",
+   "es-ES",
```

and the per-send ladder pin: `AssertionError: expected 'zh-CN' to be 'ja-JP' // Object.is equality` — the header winning where the column should.

Restore proved by **both** halves: `git hash-object` equals the `HEAD` blob `574c92703bef747011327133814a7ed60a8d064e` (a non-empty hash — an empty one would be a failure, not a nothing-to-compare), and `git diff HEAD` is empty with a clean `git status --porcelain`.

## Verification, all at the shipped commit

Gate family derived by `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` from the script's own change set. Its **Reconciliation line reads 55 families** (43 by path + 7 by change kind + 7 declared whole-tree, 2 reached both ways); harvested with `--commands` so neither spelling nor section could be dropped. **All 55 ran green at `291a73190`**, re-run after the final commit so the ratchet readings are about the tree that ships.

Two of them first answered **exit 3 — PREREQUISITE NOT MET, which is not a red gate and not a pass**: `check:dual-build-cjs-loads` ("this gate reads built output, and some package has no dist/") and `check:type-check-debt` ("--re-measure cannot run: 5 workspace dependenc(ies) … have no built type entry point on disk"). Both were converted to real measurements by building the closure the gates name, and both are counted green above only from that second run:

- `check-dual-build-cjs-loads` — `provenance — entries/packages/cjsFiles/probes: this run 103/66/619/1 · floors 90/58/520/1`
- `check-type-check-coverage --re-measure: OK — 12 ledger entr(ies) re-measured in 105.2s, 140 raw tsc error(s) total, none above its recorded number.`

`pnpm --filter @objectstack/plugin-auth typecheck` exit 0, with `tsc` echoed in the output rather than inferred from a zero — the run also carries `check:test-typecheck: OK — … 10 file(s) / 94 error(s) / 23 pinned signature(s) held`, so the new test file is inside a checked program rather than merely transpiled. Its first invocation had also answered exit 2 on a **missing module** (`examples/basic-usage.ts … Cannot find module '@objectstack/plugin-auth'`), which is NOT MEASURED; the reading above is from after the package's own build.

**NOT MEASURED, stated plainly:** the six workflow-valued families `dispatch-gates` prints outside its total (`$RUNNER_TEMP` / `${{ matrix.shard }}` in argv — the tool refuses to invent a local invocation, and so do I); repo-wide `pnpm lint`, which CI owns; and any runtime behaviour of a real deployment — this change is pinned at the callback boundary with a fake engine and a fake transport, not dogfooded in a browser.

## Not in this PR

No adjacency to #15981 or #15972 — nothing here reads or writes a name-derived authority, and no write path is touched. `packages/plugins/plugin-auth/src/auth-manager.ts` is shared with the #15948 change that landed as `8e0b29758` (already in this branch's base), but at a different member: that one moved the session payload's `positions[]`; this one touches a mail callback. #14641 (invitations) stays out of scope — and has since landed on its own.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpTx2tbq3pZRYAdoGt6E6Y)_