### PR TITLE
ci(docker): assert the SQL drivers are in the published runtime image

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -97,8 +97,29 @@ jobs:
         # `os --version` proves the CLI resolved, installed, and runs on the
         # pushed image; a boot test needs an artifact + DB and belongs to the
         # examples/e2e suites, not here.
+        #
+        # The `require()` line proves the SQL drivers are actually IN the built
+        # image. `check:docs-image-tag` cannot see that: it compares the
+        # Dockerfile install line against README.md's published table, and both
+        # would still agree if the drivers vanished from the image. The class
+        # has already cost a boot once -- docker/Dockerfile records that a tree
+        # without `pg` "died at boot on `Cannot find module 'pg'`", which is why
+        # the install line exists. `require()` needs no artifact and no
+        # database, so it stays on the right side of the same line drawn above.
+        #
+        # `-w` is load-bearing, not incidental. `npm install -g` puts the
+        # drivers in /usr/local/lib/node_modules, which is NOT on `require()`'s
+        # search path from this image's WORKDIR (/srv/app): node's global
+        # folders are $PREFIX/lib/node, and the node:22-slim base sets no
+        # NODE_PATH. Run from /srv/app the probe fails on a CORRECT image, so
+        # it would be a constant red rather than a check. Resolving from inside
+        # the global tree is also how the real boot path resolves them --
+        # driver-sql lives there too. Do not "simplify" this to a bare
+        # `docker run`; verified in both directions before it landed.
         env:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
           docker pull "$IMAGE:$VERSION"
           docker run --rm "$IMAGE:$VERSION" os --version
+          docker run --rm -w /usr/local/lib/node_modules "$IMAGE:$VERSION" \
+            node -e "require('pg'); require('mysql2')"


### PR DESCRIPTION
Fixes #14701

Adds one `docker run` to the existing amd64 smoke step in `.github/workflows/docker-publish.yml`, asserting that `pg` and `mysql2` are actually **in** the built image.

## Why this line and not the in-repo pin

`check:docs-image-tag` compares `docker/Dockerfile`'s install line against `docker/README.md`'s published driver table. Both files would still agree if the drivers vanished from the built image, so that gate cannot see this.

The regression is not hypothetical. `docker/Dockerfile:46-52` records it happening — verified verbatim at this branch's base `c463d03e0`: `@objectstack/driver-sql` declares `pg` / `mysql2` / `tedious` as **optional** peer dependencies, npm 7+ skips optional peers, and the resulting tree "died at boot on `Cannot find module 'pg'`". The probe guards the exact regression the install line exists to prevent.

## The proposed one-liner does not work — it is a constant red

The card suggested:

```
docker run --rm "$IMAGE:$VERSION" node -e "require('pg'); require('mysql2')"
```

Measured, that spelling fails **identically on an image that has the drivers and one that does not**, so it never discriminates and would have broken every release:

| spelling | image WITH drivers | image WITHOUT drivers |
|---|---|---|
| as proposed (cwd `/srv/app`) | `exit=1` | `exit=1` |
| `-w /usr/local/lib/node_modules` | `exit=0` | `exit=1` |

Cause: `npm install -g` writes to `/usr/local/lib/node_modules`, which is **not** on `require()`'s search path from the image's `WORKDIR` (`/srv/app`). Node's global folders are `$PREFIX/lib/node`, and the `node:22-slim` base sets no `NODE_PATH` (confirmed against the upstream `nodejs/docker-node` Dockerfile for `22/bookworm-slim`, which sets only `NODE_VERSION` and `YARN_VERSION`).

Resolving from inside the global tree is also how the **real** boot path resolves them: `driver-sql` lives in that tree, so it walks up into `/usr/local/lib/node_modules` and finds `pg`. The shipped probe reproduces that resolution rather than inventing a second one. The `-w` flag is load-bearing and the step comment says so, because the obvious "simplification" is the broken form.

## Reverse reading — taken, both directions

Required as binding by triage. The line **as committed** was extracted verbatim from the YAML and run under Actions' shell (`bash -e`):

- image **with** the drivers: `exit=0`
- image **without** the drivers: `exit=1`, `Error: Cannot find module 'pg'`
- also confirmed under a non-root user, matching the image's `USER node`: `exit=0` / `exit=1`

**Vehicle, stated honestly:** the two images are purpose-built locally, not the real published image. Container **blob** reads are refused by this environment's egress policy — `docker pull` of both `node:22-slim` and `ghcr.io/objectstack-ai/objectstack` resolves the manifest and then gets `Forbidden` on the blob CDN — so the real image cannot be pulled or built here. The vehicles replicate the layout that decides the outcome exactly: `node` at `/usr/local/bin`, globals at `/usr/local/lib/node_modules`, `WORKDIR /srv/app`, no `NODE_PATH`. The outcome is a property of node's resolution algorithm over that layout, which is reproduced faithfully. What is **not** covered here is the real base image and the real `npm install -g`; CI exercises those on the first run.

## Scope

- No boot test — `require()` needs no artifact and no database, so the step stays on the right side of the line the existing comment draws.
- `check:docs-image-tag` is untouched; it asserts something different and still passes.
- CI-workflow-only, publishes nothing: `skip-changeset`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PU9zBGbH2s2ZtxSyu963M3)_