### PR TITLE
docs(spec,drivers,service-analytics): `CAST(col AS BLOB) LIKE` returning nothing is a compile-option behaviour, not a SQLite fact

### DIFF
--- a/.changeset/cast-blob-compile-option-claim.md
+++ b/.changeset/cast-blob-compile-option-claim.md
@@ -1,0 +1,14 @@
+---
+"@objectstack/spec": patch
+"@objectstack/driver-turso": patch
+"@objectstack/driver-sql": patch
+"@objectstack/service-analytics": patch
+---
+
+Correct the documented reason for rejecting `CAST(col AS BLOB) LIKE ?` as a portable case-exact construct.
+
+Four headers stated, as a universal fact about SQLite, that the construct "was measured to return NOTHING". That is not a property of SQLite: whether `LIKE` is false for a BLOB operand is fixed when SQLite is compiled, by `SQLITE_LIKE_DOESNT_MATCH_BLOBS`, and the two SQLite builds this project ships disagree about it. Measured over the shared `FILTER_TEXT_ROWS` fixture, `{ name: { $contains: 'acme' } }` compiled to that construct returns `[]` on better-sqlite3 13.0.3 (SQLite 3.53.4, flag compiled in) and `['1','2']` on sql.js 1.14.1 (SQLite 3.49.1, flag absent) — the latter being exactly the ASCII case-folding defect the construct was being considered to avoid.
+
+No behaviour changes and no conclusion changes: all four sites still reject the construct and still choose `GLOB`. The rejection is now stated in a form that does not depend on any particular return value — a construct whose meaning is decided by an upstream compile flag cannot carry a read scope, because it means two different things on the two builds shipped here. Two supporting readings are recorded alongside it: `typeof CAST(name AS BLOB)` is `'blob'` on both builds, so the CAST is not the part that differs, and `GLOB` answers identically on both.
+
+Documentation only. `@objectstack/spec` and `@objectstack/driver-turso` ship the corrected text in their published type declarations (and `spec` also publishes the corrected source file directly, via its `src/**/*.zod.ts` entry); for `@objectstack/driver-sql` and `@objectstack/service-analytics` the change reaches published output only through sourcemaps.

--- a/packages/drivers/driver-sql/src/sql-driver.ts
+++ b/packages/drivers/driver-sql/src/sql-driver.ts
@@ -2883,7 +2883,10 @@ function mysqlAsciiLowerBinary(expr: string): string {
  *   the rejection on its own: a construct whose meaning depends on how the
  *   driver's SQLite was BUILT cannot carry a read scope (#3948) whatever value
  *   it happens to return in any one container — the `[]` above is a build's
- *   answer, not SQLite's. So the operator has to change. `GLOB` is case-exact
+ *   answer, not SQLite's. The CAST itself is not the part that differs:
+ *   `typeof CAST(name AS BLOB)` is `'blob'` on BOTH builds, so what diverges is
+ *   purely `LIKE`'s rule for a blob operand, which is the compile-time half. So
+ *   the operator has to change. `GLOB` is case-exact
  *   by definition, answers `['2']` on BOTH builds above, and carries its own
  *   escape mechanism ({@link escapeGlobComparand}). `lower()` in front of it is
  *   still the

--- a/packages/drivers/driver-sql/src/sql-driver.ts
+++ b/packages/drivers/driver-sql/src/sql-driver.ts
@@ -2864,10 +2864,29 @@ function mysqlAsciiLowerBinary(expr: string): string {
  * - **SQLite → `GLOB`.** `LIKE`'s ASCII fold cannot be turned off per-statement;
  *   `PRAGMA case_sensitive_like` is a CONNECTION-global switch, so one query
  *   would change every other query's meaning. Of the operand-level tricks,
- *   `CAST(col AS BLOB) LIKE ?` was measured to return NOTHING at all (SQLite's
- *   LIKE is false for a BLOB operand), so the operator has to change. `GLOB` is
- *   case-exact by definition and carries its own escape mechanism
- *   ({@link escapeGlobComparand}). `lower()` in front of it is still the
+ *   `CAST(col AS BLOB) LIKE ?` is disqualified by something worse than
+ *   failing: it means TWO DIFFERENT THINGS on the two SQLite builds this repo
+ *   ships. Whether `LIKE` is false for a BLOB operand is not a property of
+ *   SQLite the language — it is set when SQLite is COMPILED, by
+ *   `SQLITE_LIKE_DOESNT_MATCH_BLOBS`. Measured over the shared
+ *   `FILTER_TEXT_ROWS` fixture, `{name: {$contains: 'acme'}}` compiled to that
+ *   construct:
+ *
+ *   | build | `SQLITE_LIKE_DOESNT_MATCH_BLOBS` | rows |
+ *   |---|---|---|
+ *   | better-sqlite3 13.0.3 (SQLite 3.53.4) | compiled in | `[]` |
+ *   | sql.js 1.14.1 (SQLite 3.49.1) | absent | `['1','2']` — `ACME Corp` AND `acme corp` |
+ *
+ *   So one build silently answers nothing and the other silently answers
+ *   exactly the ASCII over-fold this whole function exists to end, and which
+ *   one a caller gets is decided by a flag upstream of us. That divergence is
+ *   the rejection on its own: a construct whose meaning depends on how the
+ *   driver's SQLite was BUILT cannot carry a read scope (#3948) whatever value
+ *   it happens to return in any one container — the `[]` above is a build's
+ *   answer, not SQLite's. So the operator has to change. `GLOB` is case-exact
+ *   by definition, answers `['2']` on BOTH builds above, and carries its own
+ *   escape mechanism ({@link escapeGlobComparand}). `lower()` in front of it is
+ *   still the
  *   `$icontains` fold, and still ASCII-only: measured, `lower('CAFÉ')` is
  *   `'cafÉ'`, so `lower(name) GLOB '*café*'` answers row 4 and `'*cafÉ*'`
  *   answers row 3 — the Q1 = A boundary, executed rather than argued.

--- a/packages/drivers/driver-turso/src/remote-transport.ts
+++ b/packages/drivers/driver-turso/src/remote-transport.ts
@@ -3036,7 +3036,20 @@ export class RemoteTransport {
    * over-matching rather than a near miss. The fold cannot be switched off per
    * statement (`PRAGMA case_sensitive_like` is connection-global, so one query
    * would silently redefine every other query on the same connection), and
-   * `CAST(col AS BLOB) LIKE ?` was measured to match NOTHING at all. `GLOB` is
+   * `CAST(col AS BLOB) LIKE ?` cannot replace it either: whether `LIKE` is false
+   * for a BLOB operand is fixed when SQLite is COMPILED, by
+   * `SQLITE_LIKE_DOESNT_MATCH_BLOBS`, so the construct means two DIFFERENT
+   * things on the two SQLite builds this repo ships. Measured over the shared
+   * `FILTER_TEXT_ROWS` fixture, `{name: {$contains: 'acme'}}` compiled to it:
+   * better-sqlite3 13.0.3 (SQLite 3.53.4, flag compiled in) answers `[]`, and
+   * sql.js 1.14.1 (SQLite 3.49.1, flag absent) answers `['1','2']` — the very
+   * over-match described above. `typeof CAST(name AS BLOB)` is `'blob'` on BOTH,
+   * so the CAST is not the part that differs; `LIKE`'s blob rule is. That
+   * divergence disqualifies it here without any claim about return values, and
+   * it bites hardest on THIS face: a remote transport cannot pin the build its
+   * libSQL server was compiled from, so the flag is not merely upstream, it is
+   * across the wire. `GLOB` carries no such dependency — measured, it answers
+   * `['2']` on both builds. It is
    * SQLite's case-exact pattern operator and is what both SQLite faces now
    * emit — `SqlDriver.applyLike`'s `textMatchPredicate` reaches the identical
    * decision for the local transport, and `turso-local-remote-*` parity suites

--- a/packages/services/service-analytics/src/text-match-sql.ts
+++ b/packages/services/service-analytics/src/text-match-sql.ts
@@ -31,8 +31,16 @@
  *     Postgres and MySQL.
  *   - `CAST(… AS BINARY)` is byte-wise on MySQL, is not a type on Postgres, and
  *     takes NUMERIC affinity on SQLite (it would compare a number).
- *   - `CAST(col AS BLOB) LIKE ?` was measured on the driver side to return
- *     NOTHING at all — SQLite's LIKE is false for a BLOB operand.
+ *   - `CAST(col AS BLOB) LIKE ?` means two DIFFERENT things on the two SQLite
+ *     builds this repo ships, which disqualifies it more firmly than any single
+ *     wrong answer would. Whether `LIKE` is false for a BLOB operand is fixed
+ *     when SQLite is COMPILED, by `SQLITE_LIKE_DOESNT_MATCH_BLOBS`, so it is
+ *     not a portable property at all: measured on this same fixture,
+ *     `{ name: { $contains: 'acme' } }` answered `[]` on better-sqlite3 13.0.3
+ *     (SQLite 3.53.4, flag compiled in) and `['1','2']` on sql.js 1.14.1
+ *     (SQLite 3.49.1, flag absent) — the latter being precisely the over-fold
+ *     above. A construct that a read scope's correctness rests on cannot be one
+ *     whose meaning an upstream build flag decides.
  *   - The portable primitives that ARE case-sensitive everywhere (`replace()`)
  *     express "occurs somewhere" but not "occurs at the start / at the end"
  *     without character-length arithmetic that is spelled differently on every

--- a/packages/spec/src/data/filter.zod.ts
+++ b/packages/spec/src/data/filter.zod.ts
@@ -1082,11 +1082,28 @@ export function matchesLikePattern(value: string, pattern: string, foldAscii = f
  * #6518 measured every way out of that and landed on `GLOB`, which is
  * case-exact by definition: `PRAGMA case_sensitive_like` is CONNECTION-global,
  * so one query would redefine every other query on the connection, and
- * `CAST(col AS BLOB) LIKE ?` was measured to match NOTHING. Three of the five
- * backends are SQLite underneath (driver-sql on better-sqlite3,
- * driver-sqlite-wasm, driver-turso on both transports), so without this
- * translation `$like` would mean one thing on Postgres and another on SQLite —
- * the divergence #6518 closed for `$contains`, re-opened one operator over.
+ * `CAST(col AS BLOB) LIKE ?` is not portable enough to be the answer — whether
+ * `LIKE` is false for a BLOB operand is fixed when SQLite is COMPILED, by
+ * `SQLITE_LIKE_DOESNT_MATCH_BLOBS`, so that construct means two DIFFERENT
+ * things on the two SQLite builds this repo ships. Measured over the shared
+ * `FILTER_TEXT_ROWS` fixture, `{name: {$contains: 'acme'}}` compiled to it:
+ *
+ * | build | `SQLITE_LIKE_DOESNT_MATCH_BLOBS` | rows |
+ * |---|---|---|
+ * | better-sqlite3 13.0.3 (SQLite 3.53.4) | compiled in | `[]` |
+ * | sql.js 1.14.1 (SQLite 3.49.1) | absent | `['1','2']` — `ACME Corp` AND `acme corp` |
+ *
+ * That divergence is disqualifying on its own, without any claim about what the
+ * construct returns: the flag is upstream of us, so the meaning is a property of
+ * how a backend's SQLite was BUILT. And this file is exactly where that bites —
+ * three of the five backends are SQLite underneath (driver-sql on
+ * better-sqlite3, driver-sqlite-wasm, driver-turso on both transports), and
+ * those are NOT the same build: the two rows above ARE two of the three. `GLOB`
+ * has no such dependency — measured, it answers `['2']` on BOTH builds — and
+ * `typeof CAST(name AS BLOB)` is `'blob'` on both, so the CAST is not the part
+ * that differs; `LIKE`'s blob rule is. Without this translation `$like` would
+ * mean one thing on Postgres and another on SQLite — the divergence #6518
+ * closed for `$contains`, re-opened one operator over.
  *
  * `GLOB` has a DIFFERENT pattern language, which is the whole reason this is a
  * translation and not an escape:


### PR DESCRIPTION
Fixes #15805
Fixes #16112

Docs precision only across **four** files. No behaviour changes, no exported surface moves, and **no conclusion is weakened** — all four sites still reject `CAST(col AS BLOB) LIKE ?` and all four still choose `GLOB`. What changes is the supporting premise, which was stated as a universal fact about SQLite and is not one.

#16112 was filed by this seat mid-round, after a grep showed the sentence had four carriers rather than the two #15805 names. It is **absorbed here rather than landed separately**, on the PM's ruling: applying #15805's own rule to the corrected population gives four, which is the same rule rather than a widened scope.

## The false sentence

Four headers rejected the construct on the strength of one claim — that it "was measured to return NOTHING". Whether `LIKE` is false for a BLOB operand is not a property of SQLite the language: it is fixed when SQLite is **compiled**, by `SQLITE_LIKE_DOESNT_MATCH_BLOBS`. The two SQLite builds this repo ships disagree about it.

## Measurement — re-measured by this seat, not carried from the card

Both builds are already dependencies. `{ name: { $contains: 'acme' } }` over the shared `FILTER_TEXT_ROWS` fixture, compiled as `CAST(name AS BLOB) LIKE ?`:

| build | `pragma_compile_options` | result |
|---|---|---|
| better-sqlite3 13.0.3 (SQLite 3.53.4) | `LIKE_DOESNT_MATCH_BLOBS` **present** | `[]` |
| sql.js 1.14.1 (SQLite 3.49.1) | **absent** | `['1','2']` — `ACME Corp` AND `acme corp` |

Two further readings, now carried in **all four** headers so the remedy's stability is measured rather than asserted:

- `typeof CAST(name AS BLOB)` is `'blob'` on **both** builds — the CAST is not the part that differs; `LIKE`'s blob rule is the compile-time half.
- `name GLOB '*acme*'` answers `['2']` on **both** builds — stable across exactly the axis that disqualifies the rejected construct.

## Why this makes the argument stronger

The original premise was a universal claim about return values, which a single counter-example overturns — and this repo ships the counter-example. The replacement needs no particular return value: a construct that means **two different things on the two SQLite builds this repo ships** — silently answering nothing on one and silently answering exactly the ASCII over-fold the change was made to end on the other — is disqualifying for a read scope (#3948) on its own, because the deciding flag is upstream of us.

## The four carriers, and their provenance

`git log -S` on a non-shallow clone dates the spread to one origin:

```
31728314c  2026-08-08  #6518 / #6706  planted it in sql-driver.ts AND
                                      remote-transport.ts, in the SAME commit
d063a969d  2026-08-11  #7536 / #7593  copied it into packages/spec
54bb2f125  2026-09-05  #15790         copied it into service-analytics
```

One origin, four carriers, four weeks.

| file | note |
|---|---|
| `packages/drivers/driver-sql/src/sql-driver.ts` | the `#6518` header at 2867-2868 — located and verified here, not carried from a note. Where the sentence originated. |
| `packages/drivers/driver-turso/src/remote-transport.ts` | planted by the same commit. Sharpened for this face: a remote transport cannot pin the build its libSQL server was compiled from, so the flag is not merely upstream, it is across the wire. |
| `packages/spec/src/data/filter.zod.ts` | the contract layer, and the worst carrier — a reader trusts it *because* of where it sits. Its own next sentence already lists three SQLite backends without noting they are not the same build; the two measured rows ARE two of the three. |
| `packages/services/service-analytics/src/text-match-sql.ts` | inherited the sentence most recently. |

Confined to those four comment blocks — no code, no signatures, no tests touched.

## Changeset — the two-site verdict was re-decided on the widened set, and reversed

This PR originally carried `skip-changeset`. That was correct while the change was confined to a module-private function and a file header. It does **not** survive adding `packages/spec` and `driver-turso`, so a changeset is included and **the label has been removed** (confirmed by API read-back; the labels now are `documentation`, `tests`, `tooling`, `protocol:data`).

- `likePatternToGlobPattern` in `filter.zod.ts` is **exported**, so its TSDoc reaches published declarations — measured in `packages/spec/dist/filter.zod-DGYUwZPS.d.ts` and `.d.mts`.
- `driver-turso` ships it in `dist/index.d.ts`, `dist/index.d.mts`, **and** the emitted `dist/index.js` / `dist/index.mjs`.
- `@objectstack/spec` also publishes the edited **source file itself**, via its `files` entry `src/**/*.zod.ts`.

⇒ Two packages ship changed declarations, which is a release. For `driver-sql` and `service-analytics` the change reaches published output only through sourcemaps; they are listed because all four are in one `fixed` version group.

Leaving the label on would have been worse than a wrong label: it exempts the `changeset-check` job wholesale, so the changeset gates would have reported **skipped** — unmeasured, not green.

**Does the spec docblock reach a generated reference page? No — established, not assumed.** `pnpm --filter @objectstack/spec run check:docs` exits 0 with the edit in place, reporting `227 generated files in sync with packages/spec`, and `check:generated` reports `All 15 generated artifacts are up to date`. Affirmatively: `gen:docs` was run **twice**, exit 0 both times, with `git status --porcelain` empty after each — zero files rewritten, so the fixpoint holds and nothing generated was hand-edited.

## Verification

Gate family re-derived from the **widened** change set — ⛔ the earlier 42 was not reused:

```
node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack
  -> exit 0; merge base 0ef4f8094; Reconciliation — 71 famil(ies)
```

The count moved 42 (two sites) to 65 (adding `packages/spec`) to **71** once the changeset existed. Unless noted, figures ran on `990b3d48d`, the pushed head:

| what | command | result |
|---|---|---|
| all 71 derived families | each from `dispatch-gates.mjs --commands` | exit **0** — 71 of 71, on `990b3d48d` |
| closure build (prerequisite) | `os-verify-lock.sh -c 'pnpm build'` | VERDICT command-exit **0**, 72/72 tasks |
| typecheck, 4 packages | `pnpm --filter ... typecheck` | exit **0** on `990b3d48d` (each echoed its `tsc --noEmit`) |
| tests, 4 packages | under the verify lock | VERDICT command-exit **0**, measured on `ecea92c17` |
| control bytes | `grep -naP` over all 5 changed files | no matches |

Test totals: `spec` 482 files / 12950 tests passed; `driver-sql` 155 passed + 9 skipped / 2389 passed + 140 skipped; `driver-turso` 44 files / 1168 tests passed; `service-analytics` 93 files / 2013 tests passed. The `driver-sql` skips are pre-existing declared MySQL/Postgres cells — **unmeasured**, not green, and unchanged here. Those suites ran on `ecea92c17`; the only change since is a merge of `main`, whose incoming files (`packages/cli`, `packages/drivers/driver-memory`) touch none of the four packages — verified with `git diff --name-only`.

Six roster-based families whose rosters sit under directories these paths are in — where the derivation warns its own silence is evidence in neither direction — were run explicitly rather than read as clear: `check-changeset-fixed`, spec `check:meta-url-spelling`, spec `check:spec-changes`, `check:authz-resolver`, `check:error-code-casing`, `check:filter-alias-parity`. All exit **0**.

Every exit code was captured immediately after a single redirected command, ⛔ never through a pipe. One earlier batch of spec-check readings was **discarded** rather than reported: a malformed substitution turned the command into a pipeline, so `$?` was reporting `tr`'s status; those checks were re-run cleanly and are the numbers above.

## Branch note

A container restart interrupted this round, and the branch had diverged because this seat rebased onto a newer `main` *after* pushing — leaving `d53445224` on the remote and its rebased twin locally. Reconciled by **merging** the pushed commit rather than force-pushing (force-push is barred here, and the PR already pointed at it). Verified before merging that nothing was lost: `text-match-sql.ts` was byte-identical between the two, and `sql-driver.ts` differed only by this round's additive `typeof` paragraph.

That merge left the PR comparing against a stale base, so GitHub briefly attributed 11 files from #16035 to this PR. Merging current `main` in corrected it; the comparison now lists exactly the five files above. Both pushes were fast-forwards (`d53445224..ecea92c17`, `ecea92c17..990b3d48d`).

⛔ This section reports only what was measured locally. It makes **no claim about this PR's CI state**, which this seat has not read.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpTx2tbq3pZRYAdoGt6E6Y)_