### PR TITLE
fix(cli): refuse `os lint --generator` without `--eval` instead of silently ignoring it

### DIFF
--- a/.changeset/lint-generator-requires-eval.md
+++ b/.changeset/lint-generator-requires-eval.md
@@ -1,0 +1,13 @@
+---
+"@objectstack/cli": minor
+---
+
+**BREAKING** `os lint --generator` now refuses to run without `--eval`, instead of accepting the flag and ignoring it.
+
+The flag's own description has always ended "Requires --eval.", and nothing checked it. `--generator` is read only by eval mode, so outside `--eval` the flag reached no code at all: `os lint --generator ./gen.mjs` linted the current project, exited 0 with "All checks passed", never loaded the module, and named the flag nowhere on either the human face or `--json`. A path that did not exist was accepted just as readily. Someone who meant to score a live generator got a successful-looking run whose generator was never called, with nothing said.
+
+The refusal is this command's own, not the argument parser's, so it keeps the shape the command's other failures already have: the reason on `error`, exit 1, and on `--json` a single JSON document with stdout still reserved for the machine. No error code is invented for it.
+
+A scripted invocation that passed `--generator` outside eval mode now exits 1 with the reason, where it previously exited 0 having silently skipped the generator. Eval mode itself is untouched: `--eval --generator` still loads the module and scores live output, and `--eval` alone still scores the bundled corpus offline.
+
+<!-- adr-0087: not-required (no-migration-prescription) The change narrows what a CLI flag combination accepts at invocation time. No metadata surface, stored row or spec declaration is touched, so `objectstack migrate meta` has nothing to carry and the ledger has nothing to record. -->

--- a/packages/cli/src/commands/lint.ts
+++ b/packages/cli/src/commands/lint.ts
@@ -514,6 +514,60 @@ export default class Lint extends Command {
     const configPath = args.config;
     const timer = createTimer();
 
+    // ── `--generator` means nothing without `--eval` — refuse, don't ignore ──
+    //
+    // [#15550] The flag's own description ends "Requires --eval." and nothing
+    // checked it. Driven on this entry before this change, from a lint-clean
+    // project, with a generator that writes a marker file at TOP-LEVEL
+    // evaluation so "was it loaded?" is answered by the filesystem rather than
+    // by reading the control flow:
+    //
+    //     os lint --generator ./gen-marker.mjs            exit 0 · All checks passed · marker ABSENT
+    //     os lint --generator ./does-not-exist.mjs        exit 0 · All checks passed
+    //     os lint --json --generator ./does-not-exist.mjs exit 0 · {"passed":true,…}
+    //
+    // ⇒ accepted by the parser, never loaded, and not named once on either
+    // face — a path that does not exist passes too. `flags.generator` is read
+    // at exactly three sites, all inside `runEval`, which `run()` reaches only
+    // when `flags.eval` is set, so outside eval mode the flag reaches no code
+    // at all.
+    //
+    // That is Prime Directive #10's declared-≠-enforced shape landing on the
+    // person least able to diagnose it: a successful-looking run whose
+    // generator was never called, saying nothing. The direction is #12 — refuse
+    // the off-contract invocation loudly at the boundary. The alternative
+    // repair, deleting "Requires --eval." from the description, was rejected
+    // for the reason that sentence exists: nothing outside eval mode reads this
+    // flag, so dropping the claim documents a no-op flag instead of removing
+    // one, and blesses the silent acceptance rather than ending it.
+    //
+    // ⛔ NOT oclif's `dependsOn: ['eval']`, and that is measured rather than
+    // assumed. It does refuse — but it refuses in the PARSER, before the
+    // command runs, so the refusal is oclif's and not this command's: exit 2, a
+    // stack trace on stderr, and under `--json` an EMPTY STDOUT (measured, both
+    // faces). A machine consumer of `os lint --json` would get no JSON document
+    // at all — the off-envelope class #15549/#16044 had just repaired one exit
+    // over on this very command. Refusing here keeps the envelope this command
+    // already answers with: the human message on `error`, exit 1, both faces.
+    //
+    // ⛔ Nor the raw-argv guard `os migrate meta` uses for its stored-only
+    // flags. That one exists because oclif reads a `default: false` boolean and
+    // an `env`-backed string as "provided"; `--generator` has neither a default
+    // nor an `env`, so `!== undefined` already means the operator typed it.
+    //
+    // ⛔ Nothing is minted: no `code` is attached. This refusal has no producer
+    // error to pass one through, and ADR-0112's ledger is the authority on who
+    // may mint one — the same restraint the generator-load exit below keeps.
+    if (flags.generator !== undefined && !flags.eval) {
+      const message =
+        '--generator only applies to `os lint --eval` (the metadata-generation eval). '
+        + 'Without --eval this command lints the current project and never loads the generator. '
+        + 'Re-run as `os lint --eval --generator <module>`.';
+      if (flags.json) await emitJson({ error: message }, 0, { compact: true });
+      else printError(message);
+      process.exit(1);
+    }
+
     // ── Eval mode — score generated metadata against the convention rubric ──
     // Short-circuits the project lint: this evaluates a generation corpus, not
     // the current config.

--- a/packages/cli/src/commands/lint.ts
+++ b/packages/cli/src/commands/lint.ts
@@ -541,14 +541,29 @@ export default class Lint extends Command {
     // flag, so dropping the claim documents a no-op flag instead of removing
     // one, and blesses the silent acceptance rather than ending it.
     //
-    // ⛔ NOT oclif's `dependsOn: ['eval']`, and that is measured rather than
-    // assumed. It does refuse — but it refuses in the PARSER, before the
-    // command runs, so the refusal is oclif's and not this command's: exit 2, a
-    // stack trace on stderr, and under `--json` an EMPTY STDOUT (measured, both
-    // faces). A machine consumer of `os lint --json` would get no JSON document
-    // at all — the off-envelope class #15549/#16044 had just repaired one exit
-    // over on this very command. Refusing here keeps the envelope this command
-    // already answers with: the human message on `error`, exit 1, both faces.
+    // ⛔ NOT oclif's `dependsOn: ['eval']` — and the reason is BLAST RADIUS,
+    // not an inability to answer inside this command's envelope.
+    //
+    // Bare `dependsOn` refuses in the PARSER, before the command runs, so its
+    // refusal is oclif's: exit 2, and under `--json` an EMPTY STDOUT. (The
+    // stack trace that accompanies it on `bin/run-dev.js` is a DEV-ENTRY
+    // artefact of `settings.debug`; the shipped `bin/run.js` prints oclif's
+    // pretty message with no stack. Don't generalise the dev entry's output.)
+    //
+    // ⚠️ That much CAN be brought inside the envelope: a `catch()` override on
+    // the parse was measured answering exit 1 with `{error}` on the `--json`
+    // face and an empty stderr. So "the framework spelling cannot be
+    // enveloped" is FALSE, and ⛔ nobody should re-derive this choice from it.
+    //
+    // The real objection is scope. That override re-shapes EVERY parse error on
+    // this command, not the one precondition this card is about: every unknown
+    // flag and every bad value would move from exit 2 / stderr to exit 1 /
+    // stdout, and would carry oclif's own prose plus its `--help` hint inside
+    // the JSON `error` string — a wide, uncommissioned change to the very
+    // `--json` envelope #15549/#16044 had just repaired one exit over. A guard
+    // here moves ONE invocation class and leaves every other parse error
+    // exactly as it was, while keeping the envelope this command already
+    // answers with: the human message on `error`, exit 1, both faces.
     //
     // ⛔ Nor the raw-argv guard `os migrate meta` uses for its stored-only
     // flags. That one exists because oclif reads a `default: false` boolean and

--- a/packages/cli/test/lint-generator-requires-eval.e2e.test.ts
+++ b/packages/cli/test/lint-generator-requires-eval.e2e.test.ts
@@ -1,0 +1,218 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * `os lint --generator` claimed a precondition nothing checked.
+ *
+ * ## The measured before-shape
+ *
+ * The flag's description ends "Requires --eval." and `run()` enforced nothing.
+ * Driven on this entry before the fix, from a lint-clean project, with a
+ * generator that writes a marker file at TOP-LEVEL evaluation so "was it
+ * loaded?" is answered by the filesystem instead of by reading control flow:
+ *
+ *     os lint --generator ./gen-marker.mjs             exit 0 · All checks passed · marker ABSENT
+ *     os lint --generator ./does-not-exist.mjs         exit 0 · All checks passed
+ *     os lint --json --generator ./does-not-exist.mjs  exit 0 · {"passed":true,…}
+ *
+ * ⇒ accepted by the parser, never loaded, and not named once on either face —
+ * a path that does not exist passed too. The operator got a successful-looking
+ * run whose generator was never called, with nothing said. Silent, not loud.
+ *
+ * ## What is pinned, and why the negatives are not decoration
+ *
+ * The fix REFUSES rather than amending the description, so the accept set
+ * narrows and the pins have to hold both directions:
+ *
+ *   - positive — the refusal happens, on both faces, with the same envelope
+ *     this command already answers with (#16044): the human message on
+ *     `error`, exit 1, `--json` stdout still one JSON document.
+ *   - ⛔ negative — `--eval --generator` still LOADS the generator (marker
+ *     present, live mode). A "fix" that refused too broadly, or that refused
+ *     after loading the module, fails these directly. So does one that moved
+ *     plain `os lint` or offline `--eval`.
+ *
+ * ⛔ `nothing is minted` pins the ADR-0112 restraint from this side: the
+ * refusal has no producer error to pass a `code` through, so the payload's key
+ * set is exactly `error`. A later edit that invents a code for it goes red here
+ * rather than handing consumers a vocabulary no ledger declares.
+ *
+ * ⛔ The refusal is deliberately NOT oclif's `dependsOn: ['eval']`. Measured on
+ * this entry: `dependsOn` refuses in the parser with exit 2, a stack trace on
+ * stderr, and EMPTY STDOUT under `--json`. `the --json face stays a machine
+ * face` and the exit-code assertions fail that implementation.
+ *
+ * ## Why no `dist/` sits on the measured path
+ *
+ * These run the CLI through `bin/run-dev.js`, the SOURCE entry — same CLI, run
+ * from `src/` through tsx — so `commands/lint.ts` is loaded from source by the
+ * child and this change is measured without a rebuild.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { execFile } from 'node:child_process';
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { childEnv } from './helpers/serve-process.js';
+
+const HERE = resolve(fileURLToPath(import.meta.url), '..');
+const CLI = resolve(HERE, '../bin/run-dev.js');
+const TSX = resolve(HERE, '../../../node_modules/.bin/tsx');
+
+interface Run {
+  code: number;
+  stdout: string;
+  stderr: string;
+}
+
+let dir: string;
+
+/** A project this command lints CLEAN, so any non-zero exit is the refusal. */
+const CONFIG = `export default {
+  name: 'refusal_probe',
+  objects: [
+    {
+      name: 'probe_item',
+      label: 'Probe Item',
+      sharingModel: 'private',
+      fields: { name: { type: 'text', label: 'Name' } },
+    },
+  ],
+};
+`;
+
+/**
+ * The marker path the generator writes at import. Absent ⇒ the module was
+ * never evaluated, which is the fact "was the generator loaded?" needs.
+ */
+const MARKER = 'GENERATOR_WAS_LOADED.marker';
+
+const GENERATOR = `import { writeFileSync } from 'node:fs';
+writeFileSync(new URL('./${MARKER}', import.meta.url), 'loaded\\n');
+export default function generate() {
+  return { name: 'from_generator', objects: [] };
+}
+`;
+
+function markerPresent(): boolean {
+  return existsSync(join(dir, MARKER));
+}
+
+function clearMarker(): void {
+  rmSync(join(dir, MARKER), { force: true });
+}
+
+function runLint(args: string[]): Promise<Run> {
+  return new Promise((resolvePromise) => {
+    execFile(
+      TSX,
+      [CLI, 'lint', ...args],
+      { cwd: dir, maxBuffer: 16 * 1024 * 1024, env: childEnv({ NO_COLOR: '1' }) },
+      (err, stdout, stderr) => {
+        resolvePromise({
+          code: err
+            ? typeof (err as { code?: unknown }).code === 'number'
+              ? (err as unknown as { code: number }).code
+              : 1
+            : 0,
+          stdout: String(stdout),
+          stderr: String(stderr),
+        });
+      },
+    );
+  });
+}
+
+/** stdout as ONE JSON document, or a failure that quotes what was there instead. */
+function payloadOf(run: Run, label: string): Record<string, unknown> {
+  try {
+    return JSON.parse(run.stdout) as Record<string, unknown>;
+  } catch {
+    throw new Error(
+      `${label}: stdout was not one JSON document (exit ${run.code}, ${run.stdout.length} stdout bytes)\n` +
+        `stdout: ${JSON.stringify(run.stdout)}\nstderr: ${JSON.stringify(run.stderr)}`,
+    );
+  }
+}
+
+beforeAll(() => {
+  dir = mkdtempSync(join(tmpdir(), 'os-lint-generator-requires-eval-'));
+  writeFileSync(join(dir, 'objectstack.config.mjs'), CONFIG, 'utf8');
+  writeFileSync(join(dir, 'gen-marker.mjs'), GENERATOR, 'utf8');
+});
+
+afterAll(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe('os lint --generator without --eval is refused', () => {
+  it('refuses on the human face, naming the flag it requires', async () => {
+    clearMarker();
+    const run = await runLint(['--generator', './gen-marker.mjs']);
+
+    expect(run.code).toBe(1);
+    expect(run.stdout).toContain('--generator');
+    expect(run.stdout).toContain('--eval');
+    // ⛔ The sharpest pin: the refusal happens INSTEAD of the run, not after
+    // loading the module. Before the fix this marker was absent for the
+    // opposite reason — nothing read the flag at all — so it is asserted
+    // together with the exit code, which was 0 then.
+    expect(markerPresent()).toBe(false);
+  }, 120_000);
+
+  it('the --json face stays a machine face — one JSON document, nothing on stderr', async () => {
+    clearMarker();
+    const run = await runLint(['--json', '--generator', './gen-marker.mjs']);
+    const payload = payloadOf(run, 'json refusal');
+
+    expect(run.code).toBe(1);
+    expect(String(payload.error)).toContain('--eval');
+    expect(run.stderr).toBe('');
+    expect(markerPresent()).toBe(false);
+  }, 120_000);
+
+  it('nothing is minted — the payload key set is exactly `error`', async () => {
+    // ADR-0112: this refusal has no producer error to pass a code through, and
+    // the ledger is the authority on who may mint one.
+    const run = await runLint(['--json', '--generator', './gen-marker.mjs']);
+    const payload = payloadOf(run, 'key set');
+
+    expect(Object.keys(payload)).toEqual(['error']);
+  }, 120_000);
+
+  it('is judged on the flag being TYPED, not on the path resolving', async () => {
+    // Before the fix this exited 0 with "All checks passed" — a generator path
+    // that does not exist was accepted as readily as one that does.
+    const run = await runLint(['--generator', './does-not-exist.mjs']);
+
+    expect(run.code).toBe(1);
+    expect(run.stdout).toContain('--eval');
+    // The refusal is this command's, not esbuild's: the module is never reached.
+    expect(run.stdout).not.toContain('Failed to load generator');
+  }, 120_000);
+});
+
+describe('os lint — what the refusal must NOT move', () => {
+  it('`--eval --generator` still loads the generator and runs live', async () => {
+    clearMarker();
+    const run = await runLint(['--eval', '--generator', './gen-marker.mjs']);
+
+    expect(markerPresent()).toBe(true);
+    expect(run.stdout).toContain('Mode: live');
+  }, 120_000);
+
+  it('offline `--eval` with no generator is untouched', async () => {
+    const run = await runLint(['--eval']);
+
+    expect(run.code).toBe(0);
+    expect(run.stdout).toContain('Mode: offline');
+  }, 120_000);
+
+  it('a plain project lint is untouched', async () => {
+    const run = await runLint([]);
+
+    expect(run.code).toBe(0);
+    expect(run.stdout).toContain('All checks passed');
+  }, 120_000);
+});

--- a/packages/cli/test/lint-generator-requires-eval.e2e.test.ts
+++ b/packages/cli/test/lint-generator-requires-eval.e2e.test.ts
@@ -36,10 +36,14 @@
  * set is exactly `error`. A later edit that invents a code for it goes red here
  * rather than handing consumers a vocabulary no ledger declares.
  *
- * ⛔ The refusal is deliberately NOT oclif's `dependsOn: ['eval']`. Measured on
- * this entry: `dependsOn` refuses in the parser with exit 2, a stack trace on
- * stderr, and EMPTY STDOUT under `--json`. `the --json face stays a machine
- * face` and the exit-code assertions fail that implementation.
+ * ⛔ The refusal is deliberately NOT oclif's `dependsOn: ['eval']` — and these
+ * pins are NOT the argument for that. Bare `dependsOn` does fail them (exit 2,
+ * empty stdout under `--json`, measured), but a `catch()` override brings it
+ * inside the envelope and PASSES them. So a green here is not a verdict on the
+ * choice, and ⛔ must not be read as one. The reason the guard lives in the
+ * command is BLAST RADIUS — that override re-shapes every parse error on this
+ * command rather than this one precondition — and it is recorded where the
+ * decision is, at the guard in `src/commands/lint.ts`.
  *
  * ## Why no `dist/` sits on the measured path
  *


### PR DESCRIPTION
Fixes #15550

The card was filed **STATIC ONLY** and said so itself: the reading was control flow, nobody had run the command. **The first deliverable here is the drive, and it CONFIRMS the card.**

> **Revised at `1c032a2be8d` after contract review.** The reviewer drove `dependsOn` instead of taking this body's word for it and found the recorded reason partly false. **The choice is unchanged and the diff's behaviour is unchanged; the REASON is corrected** — in this body, at the guard, and in the test header, which had carried the same false claim. The section "Why the guard, and not `dependsOn`" below is the corrected argument.

## Driven, not reasoned about — the command's own bytes

Probed on `bin/run-dev.js` (the source entry) from a project this command lints clean, with a generator that writes a marker file at **top-level evaluation**, so "was it loaded?" is answered by the filesystem instead of by re-reading the control flow.

| invocation | before | after |
|---|---|---|
| `lint --generator ./gen-marker.mjs` | exit 0 · `All checks passed` · marker **ABSENT** | exit 1 · refusal naming `--eval` · marker ABSENT |
| `lint --generator ./does-not-exist.mjs` | exit 0 · `All checks passed` | exit 1 · same refusal (judged on the flag being typed, not on the path resolving) |
| `lint --json --generator ./does-not-exist.mjs` | exit 0 · `{"passed":true,"total":0,…}` | exit 1 · `{"error":"--generator only applies to …"}` |
| `lint --eval --generator ./gen-marker.mjs` | `Mode: live` · marker **PRESENT** | unchanged |
| `lint --eval` | `Mode: offline` · exit 0 | unchanged |
| `lint` | exit 0 · `All checks passed` | unchanged |

⇒ **The STATIC ONLY claim survives the drive.** Outside `--eval` the flag was accepted by the parser, never read, and named nowhere on either face — a path that does not exist passed exactly as readily as one that does. The positive control is in the table's last three rows: with `--eval` the flag really is wired, so the silence was the flag being unreachable, not the probe being wrong.

## Which side moves — and why it is not the description

The card and its triage both refused to pick, and asked whoever took it to answer **both** halves rather than delete a sentence.

- **Is the flag meaningful outside eval mode?** No. `flags.generator` is read at exactly three sites, all inside `runEval`, which `run()` reaches only when `flags.eval` is set — and the drive confirms nothing else refuses it or reads it.
- **So amending the description would document a no-op**, not remove one. Dropping "Requires --eval." makes the CLI *declare* that a flag can be accepted and ignored, which is the inverse of Prime Directive #10's corollary and of #12's "reject it at authoring, loudly". The measured harm is a **successful-looking** run whose generator was never called; the repair direction that ends it is refusal.
- **What enforcement costs:** the accept set narrows, and that is real. But the population it breaks is exactly the population being silently misled — measured, no run's *result* outside eval mode depends on this flag, so nothing that works today stops working; only a silently-wrong invocation becomes loud.

## Why the guard, and not `dependsOn` — the corrected reason

⚠️ **This section previously claimed that oclif's `dependsOn: ['eval']` could not answer inside this command's `--json` envelope. That claim is FALSE and has been removed from the code, the test header and this body.** Contract review measured a `catch()` override on the parse answering **exit 1** with `{error}` on the `--json` face and an empty stderr, and a fresh pin over it went 7/7 green. Anyone re-deriving this choice from "the framework spelling cannot be enveloped" would be re-deriving it from something untrue.

**The real objection is blast radius, and it is the stronger argument.** Bringing `dependsOn` inside the envelope means overriding the parse for the whole command, which re-shapes **every** parse error `os lint` can raise — not the one precondition this card is about:

- every unknown flag and every bad value moves from **exit 2 / stderr** to **exit 1 / stdout**;
- each one then carries oclif's own prose **plus its `--help` hint** inside the JSON `error` string.

That is a wide, uncommissioned change to the very `--json` envelope #15549/#16044 had just repaired one exit over. The in-command guard moves **one invocation class** and leaves every other parse error exactly as it was, while keeping the envelope this command already answers with: the human message on `error`, exit 1, both faces.

⚠️ **A second correction, on precision:** bare `dependsOn` does refuse with exit 2 and an empty `--json` stdout, but the **stack trace** beside it is a DEV-ENTRY artefact of `settings.debug` on `bin/run-dev.js`. The shipped `bin/run.js` prints oclif's pretty message with no stack. The earlier body generalised the dev entry's output; it no longer does.

⛔ **Nothing is minted.** The refusal has no producer error to pass an ADR-0112 code through, so the payload's key set is exactly `error`, and a test pins that so a later edit cannot invent a vocabulary no ledger declares.

⛔ **Not the raw-argv guard `os migrate meta` uses** for its stored-only flags either: that exists because oclif reads a `default: false` boolean and an env-backed string as "provided". `--generator` has neither a default nor an env, so `!== undefined` already means the operator typed it.

## Tests

`packages/cli/test/lint-generator-requires-eval.e2e.test.ts` — 7 cases driving the real command, no `dist/` on the measured path (`bin/run-dev.js` loads `../src/commands/lint.ts` through tsx).

Both directions are pinned deliberately. Four cases pin the refusal (both faces, the exact key set, and the typed-not-resolved reading); three pin **what the refusal must not move** — `--eval --generator` still loads the module and reports `Mode: live`, `--eval` alone still reports `Mode: offline`, and a plain project lint still exits 0. A repair that refused too broadly fails those three directly.

⚠️ The header now states what these pins do **not** decide: bare `dependsOn` fails them, but a `catch()` override passes them, so a green here is not a verdict on the `dependsOn` question. That argument lives at the guard, where the decision is.

**Ablation** — the guard reverted, the test file kept, at `3c2125464e1`. Mutation confirmed on disk (the guard's own line count went 1 to 0; `git hash-object` moved off the then-HEAD blob `c6213446e8c` and landed exactly on the pre-change blob `b8e0dbef945`); restore confirmed byte-identical (`git diff HEAD` empty, hash back to `c6213446e8c`, guard line count back to 1).

```
Tests  4 failed | 3 passed (7)
  × refuses on the human face, naming the flag it requires
  × the --json face stays a machine face — one JSON document, nothing on stderr
  × nothing is minted — the payload key set is exactly `error`
  × is judged on the flag being TYPED, not on the path resolving
```

Exactly the four refusal pins go red and the three "must not move" controls stay green — the discriminating direction, not merely "it goes red". The correction commit is comment-only (the `expect(` count is 18 before and after, and the test-file diff is comment lines only), so the ablation is not re-run on the new head; the pins themselves were, and pass 14/14 alongside the sibling suite.

## Clause ② — declared per limb, from the delivered diff

- **Mechanical floor — NO.** The delivered diff adds no key to any published payload and touches nothing under `packages/spec/src/**`; the three paths are `packages/cli/src/commands/lint.ts`, one new test, and one changeset.
- **Conformance limb — YES, and not a close call.** The diff re-selects an input class between two already-published verdicts on a shipped face: `os lint --generator MODULE` without `--eval` moved from *accepted, exit 0, ordinary lint report* to *refused, exit 1, error payload*, on both the human and the `--json` face. That is a published accept/reject change, which is why the changeset carries a `**BREAKING**` banner.

⛔ The `needs:contract-review` label is **not** applied here — that is the seat's to place on the card and the PR together.

## Changeset

`.changeset/lint-generator-requires-eval.md` — `"@objectstack/cli": minor`, with a `**BREAKING**` banner and an ADR-0087 disposition of `not-required (no-migration-prescription)`. Unchanged by the correction commit.

The level follows the `os create` project-name precedent (#15893), the closest shape in the tree: a CLI command that starts refusing input it previously accepted, graded `minor` with the banner carrying the breaking-ness because the workspace versions in lockstep. `check-changeset-no-major` refuses `major` in the launch window, and no gate answers whether a level fits a surface (#16055), so this is stated rather than inferred.

## Verification

Gate union re-derived on the corrected head `1c032a2be8d` with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack --commands`, asserted against its own `Reconciliation — 56 famil(ies)` line: **56 commands emitted, 56 families reconciled**, and byte-identical to the union derived before the correction (the three paths are unchanged). All exit codes captured before any pipe.

- **56/56 green on `1c032a2be8d`.** Two (`check:dual-build-cjs-loads`, `check:i18n-coverage`) again answered **exit 3 PREREQUISITE NOT MET** first, on packages with no `dist/` in a freshly recreated worktree — not a pass and not a finding — and both returned real verdict lines once the build state was complete: `provenance — entries/packages/cjsFiles/probes: this run 103/66/619/1 · floors 90/58/520/1` and `check-i18n-coverage: OK (13 config(s), 621 baselined untranslated string(s), none new)`.
- **Check Changeset job, gate by gate on `1c032a2be8d`: 8/8 exit 0** — `check-empty-changeset` (`--self-test` and `--base`), `check-adr-0087-registration` (both), `check-changeset-no-major` (both), `check-changeset-fixed`, and `check:changeset-gate-self-tests`.
- **Artifact rosters block, run separately** (37 families, outside that total by design): **34 green, 3 NOT MEASURED**, identical to the previous head. `check-partof-closing-keyword.mjs` and `check-single-claim-paths.mjs` exit 2 NOT WIRED (they need PR context that exists only in CI), and `check:react-declaration-parity` states "MANIFEST is not set … This gate did NOT run", which needs a browser-built objectui manifest this container cannot produce. None is a pass, and none is caused by this diff. ⚠️ The pnpm-spelled `check:partof-closing-keyword` and `check:single-claim-paths` in that block are green, but resolve to `--self-test` only (#16030) — that green grades the checker's fixtures, not this diff.
- **Lint: the repo-wide run, not a narrowing.** `pnpm lint` (`eslint . --no-inline-config`) exits **0** over the whole repo on the corrected head.
- `pnpm --filter @objectstack/cli typecheck` green on the corrected head, with the new test file inside the type-checked set (1 hit under `tsconfig.test.json --listFiles`, contributing 0 of that program's errors).
- `vitest run` over the new e2e plus its sibling `lint-eval-generator-load-envelope.e2e` — **14/14 pass** on the corrected head.

## Scope

This card only. Two things are handed back rather than folded in:

1. **`os lint --eval --generator ""` still runs the offline eval silently** — driven on both entries, exit 0, `Mode: offline`, generator never loaded, nothing said. `runEval` guards the load with a truthiness test (`if (flags.generator)`), so an empty string falls through it. It is the same family as the defect fixed here — a flag value accepted while quietly doing nothing useful — but a **different input class**, on the eval path rather than the non-eval one, so it belongs on its own card and is handed to the dispatching seat with its measurement rather than folded in. This PR's guard *does* catch `--generator ""` in the non-eval case, because it tests `!== undefined` rather than truthiness.
2. **The card's harm sentence is inaccurate.** It says someone who typed `--generator` without `--eval` "gets a successful-looking offline eval scored against fixtures". Driven, no eval runs at all — they get an ordinary project lint reporting `All checks passed`. The defect and the direction are unchanged; only the symptom description needed correcting, and it is corrected here rather than by editing the card.

This diff touches neither `packages/rest/src/rest-server.ts` nor any file #16071 holds, so it collides with no hard serial. `packages/cli/src/commands/lint.ts` was released by #16044's merge.

Still a draft, not flipped ready, auto-merge not armed, labels untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D47qPfEWVPmhguWgBZCi5N