### PR TITLE
docs(driver-sql): the lookup arm no longer claims a platform id is 26 characters

### DIFF
--- a/packages/drivers/driver-sql/src/sql-driver-string-maxlength-varchar.test.ts
+++ b/packages/drivers/driver-sql/src/sql-driver-string-maxlength-varchar.test.ts
@@ -139,8 +139,11 @@ describe('string-family columns take their declared maxLength (#11431)', () => {
     driver = new SqlDriver(dialectCell('sqlite').config());
     await driver.initObjects([parentObject(), stringObject()]);
     const shapes = await columnShapes(driver as any, T);
-    // A lookup holds the referenced row's ID, not the declared value: a
-    // platform id is 26 characters, so `varchar(20)` could hold none of them.
+    // A lookup holds the referenced row's ID, not the declared value — and
+    // [#15522] that id's width is not this field's to declare. The driver
+    // mints 16 characters when the caller supplies none, and stores a
+    // SUPPLIED id verbatim at whatever width the caller chose, so no
+    // `maxLength` can be known to fit one.
     expect(shapes.a_lookup).toBe('varchar(255)');
     expect(shapes.a_user).toBe('varchar(255)');
     // Runtime-issued; `maxLength` has no write-time counterpart on this type.

--- a/packages/drivers/driver-sql/src/sql-driver.ts
+++ b/packages/drivers/driver-sql/src/sql-driver.ts
@@ -16008,12 +16008,30 @@ export class SqlDriver implements IDataDriver {
         // not anything this field declared. Measured on MySQL 8.0.46: the FK
         // itself is content with mismatched widths (`varchar(20)` child →
         // `varchar(255)` parent `id` creates cleanly, and Postgres 16 accepts
-        // it too), so the type system gives no warning — but the first write
-        // is refused, because a platform id is 26 characters and
-        // `INSERT … VALUES ('01JQ8XKZ9M4N7P2R5T6V8W0Y3B')` into `varchar(20)`
-        // is `ERROR 1406 Data too long`. Honouring `maxLength` here would make
-        // the column structurally incapable of holding ANY id — a strictly
-        // worse defect than the one #11431 fixes.
+        // it too), so the type system gives no warning — the refusal arrives on
+        // the first write too wide for the child, as `ERROR 1406 Data too long`.
+        //
+        // [#15522] ⛔ An id's width is NOT a fixed number, and it is NOT this
+        // field's to declare. Both halves are this driver's own behaviour: when
+        // the caller supplies no id it mints `nanoid(DEFAULT_ID_LENGTH)` — 16
+        // characters, from the constant above and the three mint sites it feeds
+        // — and when the caller DOES supply one it is stored verbatim at
+        // whatever width the caller chose (measured on this arm's own driver:
+        // 10-, 17- and 18-character ids all landed unaltered). Nothing on this
+        // path bounds an id's width at all, so `maxLength: 20` already cannot
+        // hold a 24-character supplied id, and any `maxLength` under 16 cannot
+        // hold even a minted one. Honouring it here would make the column
+        // structurally incapable of holding ids it will be asked to hold — a
+        // strictly worse defect than the one #11431 fixes.
+        //
+        // ⛔ Do not restore the number this sentence used to carry. It called a
+        // platform id 26 characters long and spelled out a ULID
+        // (`01JQ8XKZ9M4N7P2R5T6V8W0Y3B`). `DEFAULT_ID_LENGTH` has been 16 for the
+        // whole life of this file and no ULID is minted anywhere in this repo, so
+        // at the real numbers the worked example did not hold either — 16
+        // characters FIT in `varchar(20)`. Four `packages/cli` sites still cite
+        // this arm BY NAME for that number; they are filed as #16114, not fixed
+        // here.
         //
         // [#11567] ⛔ This arm emits NO `FOREIGN KEY`, and that is the ruled
         // contract rather than an omission. It used to carry


### PR DESCRIPTION
Fixes #15522

## Deliverable 1 first — the reading, before either number moved

The card and the claim both forbade touching either number until the id's provenance was established, and offered two readings. **Measured on `origin/main` `64011dd3f`: neither holds, and the third answer is what shipped.**

| probe | result | control |
|---|---|---|
| `git grep -rni ulid` repo-wide, lockfile excluded | **0** | `nanoid` on the same instrument → **50** (fires) |
| `git log -p --follow` over `sql-driver.ts`, all `const DEFAULT_ID_LENGTH` lines | exactly one `+` line (`= 16`), **no `-` line ever** | — |
| `DEFAULT_ID_LENGTH` across every driver | `driver-sql` 16 · `driver-mongodb` 16 · `driver-turso` 16 | `driver-memory` mints `name-timestamp-counter` — a different shape entirely |
| `nanoid(` in `sql-driver.ts` | exactly 3, all in the `else if (id === undefined)` fallback branch | re-derived, complete not sampled |
| id-minting above the driver | none — `engine.ts` hands the row to `driver.create` unaltered; its only generator is `generateEventUuid` for `DataEvent.id` | — |

**And the firing empirical control** — the real `SqlDriver` driven against SQLite, one write supplying an id and one not:

```
PROBE-CREATE [{"name":"a","id":"CALLER_SUPPLIED_ID","len":18},
              {"name":"b","id":"vst5t2rcKZb8TGDl","len":16},
              {"name":"c","id":"ALIAS_SUPPLIED_ID","len":17}]
PROBE-BULK   [{"name":"u","id":"-hyYncA6knoVTp8J","len":16},
              {"name":"x","id":"7vnoM1WTP6VtCuuz","len":16},
              {"name":"y","id":"yN6YwQhse7V9MDek","len":16},
              {"name":"z","id":"SUPPLIED_B","len":10}]
```

- **Reading 1 is false.** Nothing mints a 26-character ULID above the driver; no ULID exists anywhere in this repo.
- **Reading 2 is false.** The id shape never moved — `DEFAULT_ID_LENGTH` has been 16 for the whole life of the file, and the sentence was written 2026-08-24 (`c49afd088`), after the constant was already 16. Neither site is residue.
- **What actually held:** the number was **wrong when written**, and at the real numbers the worked example did not even hold — a 16-character id **fits** in `varchar(20)`, so the `ERROR 1406 Data too long` the comment promised would not have fired.

⇒ **The STOP CONDITION is not reached.** The fix touches prose only; `DEFAULT_ID_LENGTH` stays 16 and all three mint sites are untouched. No data-shape change, no manual floor.

## The argument is kept, and stated in the stronger form the measurement licenses

The sentence exists to argue that `maxLength` must not bind a reference column. That argument never depended on 26 — and it is stronger without it: **an id's width is not a fixed number at all.** The driver mints 16 when the caller supplies none, and stores a **supplied** id verbatim at whatever width the caller chose, so no `maxLength` can be known to fit one.

## Scope, and the one bounded in-place fix

- `packages/drivers/driver-sql/src/sql-driver.ts` — the card's site, in the `case 'lookup': case 'user':` arm.
- `packages/drivers/driver-sql/src/sql-driver-string-maxlength-varchar.test.ts` — **the bounded in-place fix, named here with its evidence.** The same sentence, same package, same gate family, same defect class; it is a **comment**, not an asserted value (the assertion is `expect(shapes.a_lookup).toBe('varchar(255)')` and is untouched). Leaving it would have shipped a driver whose own pin test's comment contradicted it.
- **Boundary scan** (`git grep "platform id is 26 characters"`, repo-wide): after this PR the phrase survives at **four `packages/cli` source sites** and **two CHANGELOG entries**. The CLI four are a **different package and a different verification surface**, so they are ⛔ filed as #16114 rather than fixed here; the CHANGELOGs are historical records and are ⛔ not editable.

⭐ Those four each cite this driver arm **by name** as their authority. That is exactly the harm the card was filed on — *"a citation waiting to be relied on again"* — already realized, in a second package, four times over. The corrected comment now points at #16114 so the chain is traceable.

## The card's own measurement, corrected

The card, triage and the claim all recorded **two** prose sites saying 26. Only one is about ids. The other, `sql-driver.ts` `* that exactly 26 characters fold, without knowing the server's locale.`, is about the **26 letters of the ASCII alphabet** in the LIKE case-folding map (`ASCII_UPPER_LETTERS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'`) — a coincidental hit from a bare `grep "26 characters"`, carried forward by three seats. ⛔ **It is deliberately untouched.**

## Clause ② — `no`, measured on both limbs

- **Limb 1 (prose):** `no`. The diff is **37 changed lines, 0 of them non-comment** — mechanically checked, every added and removed line matches `^[+-]\s*//`. Zero executable tokens.
- **Limb 2 (would the fix change what the driver mints):** **does not arise** — measured false above. `DEFAULT_ID_LENGTH` and all three `nanoid(DEFAULT_ID_LENGTH)` sites are byte-untouched.
- **Published-surface ablation**, with both legs proven: mutate (swap both files back to `64011dd3f`) → mutation confirmed on disk by anchored counts (`#15522` 1→0, claim phrase 0→1) **and** blob hash `ce45e8de` != HEAD blob `4f3fcd6e` → rebuild → restore → `git diff HEAD` empty **and** blob `4f3fcd6e` == HEAD blob → rebuild. `files[]` publishes `dist`; **both** declaration files `dist/index.d.ts` and `dist/index.d.mts` are **byte-identical across the ablation** (`28f610ed`), with the head rebuild reproducing the same hash as the control. The only published bytes that move are the `sourcesContent` blobs inside `dist/index.js.map` / `index.mjs.map` — a verbatim copy of the source comment, not a surface.

⇒ Comment-only, publishes no API ⇒ **`skip-changeset`**, applied additively and read back.

## Verification — all at `d337f421d`

- `pnpm --filter '@objectstack/driver-sql^...' build` — VERDICT command-exit 0
- `tsc --noEmit` (driver-sql) — exit 0, and `--listFiles` confirms **both** edited files are in the program (1 hit each), so this is a measurement about them and not a vacuous pass
- `vitest run src/sql-driver-string-maxlength-varchar.test.ts src/sql-driver-11567-lookup-no-foreign-key.test.ts` — **11 passed, 2 skipped** (the skips are the live MySQL/Postgres cells, no live server here)
- Gates, exit codes captured **before any pipe**, all **0**: `check:nul-bytes` · `check-comment-mask-adoption` (+ self-test) · `check-comment-mask-corpus` · `check-keyed-text-bounds` (+ self-test) · `check:driver-conformance` · `check:tenant-chokepoint` · `check:test-source-alias` · `check:cross-package-test-inputs` · `check:doc-authoring` · `check:published-files` · `check:dts-closure` · `check:objectql-double-limit` · `check:where-matcher` · `check:single-claim-paths` · `check-closing-keyword-parity` · `check-empty-changeset` · `check-changeset-no-major` · `check-changeset-fixed` · `check-adr-0087-registration`
- `check-partof-closing-keyword.mjs` first returned **NOT WIRED** (no `PR_BODY`/`PR_NUMBER`) — a prerequisite failure and ⛔ not a verdict, so it is not reported as one. Re-run with `PR_BODY` set to this exact body: **exit 0**, `✓ check:partof-closing-keyword: this PR carries no Part-of/closing-keyword contradiction.`
- **Declared narrowing:** the derived family is 40 matched families / 122 runnable rows. The set above is the subset this comment-only diff can implicate plus the mandatory ones; the farm is CI's, which runs it exactly once regardless. Family re-derived **after** the final commit with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` — provenance line confirms `objectstack-ai/objectstack` at `d337f421d`, change set 2 paths vs merge base `64011dd3f`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ARYe3yQTQCUFm5qPYNgKaJ)_