### PR TITLE
docs(metadata-protocol): the `getMetaItems` gate enumerates six `rest-server.ts` call sites, not five, and names the transitive diagnostics door

### DIFF
--- a/packages/metadata-protocol/src/protocol.ts
+++ b/packages/metadata-protocol/src/protocol.ts
@@ -6797,8 +6797,8 @@ export class ObjectStackProtocolImplementation implements
         // caller that already gates therefore sees no change, provided it gated
         // on the same type this line gates on. Every such caller does:
         //
-        //  • `packages/rest`'s `GET /meta/:type` list door — the only door
-        //    that both gates and reaches this method — computes
+        //  • `packages/rest`'s `GET /meta/:type` list door — one of TWO doors
+        //    that both gate and reach this method — computes
         //    `organizationIdForMetaRead(canonicalMetaUrlType(req.params.type),
         //    ctx?.tenantId)` and then passes `type: req.params.type`, the RAW
         //    segment. The first statement of this method folds that segment
@@ -6806,14 +6806,44 @@ export class ObjectStackProtocolImplementation implements
         //    `canonicalMetaUrlType` — so `request.type` here is the identical
         //    STRING the door gated on, and the second application is the
         //    algebraic no-op above.
+        //  • `GET /meta/diagnostics?type=` — the SECOND such door, and the one
+        //    a caller-side grep cannot see. It gates the same way
+        //    (`organizationIdForMetaRead(canonicalMetaUrlType(diagnosticsType),
+        //    ctx?.tenantId)`) and then passes its own RAW segment on — but it
+        //    reaches this method TRANSITIVELY, through
+        //    {@link getMetaDiagnostics}, whose `?type=` arm sets `targetTypes =
+        //    [request.type]` and loops `getMetaItems({ type: t,
+        //    organizationId, … })` over it. So the door's segment still arrives
+        //    here as `request.type` and is still folded by the same first
+        //    statement: the identical STRING, the same algebraic no-op, one hop
+        //    further out. ⚠️ That hop is UNDECLARED — `getMetaDiagnostics` is
+        //    not a member of `MetadataProtocol`, neither required nor optional,
+        //    so the door reaches it through a `(p as any)` cast behind a 501
+        //    feature-detect. Real at runtime, invisible to the type system, and
+        //    therefore something a caller census must be TOLD rather than left
+        //    to derive.
         //  • the search sweep's page read below gates on `'page'` and passes
         //    `'page'`; `page` is non-overridable, so both readings are
         //    `undefined` whatever the session holds.
         //  • the four remaining `organizationIdForMetaRead` call sites in
         //    `rest-server.ts` (`/layers`, the by-name read, `/history`,
         //    `/diff`) reach `getMetaItemLayered` / `getMetaItem` /
-        //    `historyMetaItem` / `diffMetaItem` — never this method — so this
-        //    line cannot move them at all.
+        //    `historyMetaItem` / `diffMetaItem` — never this method, at any
+        //    depth — so this line cannot move them at all. Two doors named
+        //    above plus these four IS that file's whole set of SIX; the
+        //    enumeration that named one door and "four remaining" described
+        //    five, and the door it dropped was the one that reaches here.
+        //
+        // ⭐ Read this list from the CALLEE side, which is how it is now built.
+        // A grep for doors that invoke `getMetaItems` answers only its own
+        // question: it cannot see a door that arrives through something else,
+        // and that is exactly how the diagnostics door went unlisted. The
+        // closed form is the other direction — `this.getMetaItems(` has THREE
+        // callers in this file: {@link getMetaDiagnostics},
+        // {@link searchAll} and {@link findReferencesToMeta}. The third gates
+        // nothing, deliberately: its door spends the organization on the
+        // reference SOURCES while `req.params.type` is the TARGET, so it hands
+        // the tenant over RAW and is not a caller this paragraph is about.
         //
         // ⛔ Gate AFTER the fold, never before it. `declaresOrgOverride`
         // tolerates the MANIFEST plurals and not the URL-only ones


### PR DESCRIPTION
Fixes #15621

The `[#14683]` gate docblock above `getMetaItems`' `organizationIdForMetaRead` call
called the `GET /meta/:type` list door **"the only door that both gates and reaches
this method"**, and then accounted for **"the four remaining"** `organizationIdForMetaRead`
call sites in `rest-server.ts`. One named plus four remaining is five. That file has
**six**, and the missing one — `GET /meta/diagnostics?type=` — both gates and reaches
this method.

Comment only: no behaviour change, no schema change, no exported symbol touched.

## Where the text actually is

The card measured the block at `:6928-6942` and triage at `:6926-6942`; #15592 has
landed since. Re-located by **text**, not by line number, on `origin/main` at
`9b459b791`: the enumeration is at **`packages/metadata-protocol/src/protocol.ts:6800-6816`**,
inside `getMetaItems` (declared `:6750`), immediately above
`const orgId = organizationIdForMetaRead(request.type, request.organizationId);`.

## The census, re-counted here, with its dimension stated

`git grep -c organizationIdForMetaRead -- packages/rest/src/rest-server.ts` answers
**15** on this tree — that is **lines**, not call sites. (Triage read 13; the total has
moved by two comment mentions since. The call-site count did not move.) Classified
line by line:

| kind | count | lines |
|---|---|---|
| import | 1 | `:58` |
| comment mention | 8 | `:3499`, `:4943`, `:5007`, `:5030`, `:5803`, `:7073`, `:7088`, `:7637` |
| **real call site** | **6** | `:3504`, `:5066`, `:5338`, `:6239`, `:7095`, `:7663` |

1 + 8 + 6 = 15. The six call sites and what each reaches:

| line | door | reaches |
|---|---|---|
| `:3504` | `/meta/:type/:name/layers` (via `serveMetaItemLayered`) | `getMetaItemLayered` `:3521` |
| `:5066` | **`/meta/diagnostics?type=`** | **`getMetaItems`, transitively** |
| `:5338` | `GET /meta/:type` list door | `getMetaItems` `:5354` |
| `:6239` | by-name read | `getMetaItemCached` `:6290` / `getMetaItem` `:6413` |
| `:7095` | `/history` | `historyMetaItem` `:7146` |
| `:7663` | `/diff` | `diffMetaItem` `:7668` |

**Positive control for the census:** the same classification pass over the same file
yields a non-zero count in every one of its three buckets, and the six call-site rows
were each confirmed by reading the destination call rather than by pattern alone.

## Why the miss happened, and how the list is now built

The diagnostics door does not call `getMetaItems`. It calls `getMetaDiagnostics`,
whose `?type=` arm sets `targetTypes = [request.type]` and loops
`getMetaItems({ type: t, organizationId, ... })` per swept type (`protocol.ts:6167-6174`).
A grep for doors invoking `getMetaItems` therefore cannot see it.

So the list is now derived from the **callee** side and stated as closed.
`this.getMetaItems(` has exactly three callers in this file — `getMetaDiagnostics`
(`:6170`), `searchAll` (`:11393`) and `findReferencesToMeta` (`:21450`) — and a
transitive-closure walk of the class's call graph confirms no other method reaches it
at any depth. In particular none of `getMetaItemLayered` / `getMetaItem` /
`getMetaItemCached` / `historyMetaItem` / `diffMetaItem` reaches it, which is what
licenses the surviving "never this method" clause.

**Positive control for the closure instrument:** run on the same graph, it reports
`throwMetadataServiceUnavailable` as reached at depth 2 and 3 (by `saveMetaItem`,
`getMetaItemCached`, `duplicatePackage`, `migrateStoredMetadata`), so the zero result
above is a measurement and not a broken traversal.

`findReferencesToMeta` is the third caller and gates nothing, deliberately — its door
spends the organization on the reference SOURCES while `req.params.type` is the TARGET
(`rest-server.ts:5803-5816`), so it hands the tenant over raw and is not one of the
"already gates" callers this paragraph is about. That is now written down too, so the
next reader does not re-derive it as an omission.

## The undeclared hop

`getMetaDiagnostics` is **not a member of `MetadataProtocol`** — neither required nor
optional. Verified on this tree by a brace-balanced scan of the interface
(`packages/spec/src/api/protocol.zod.ts:3381-3459`): `getMetaItems`, `getMetaItem`,
`getMetaItemLayered` and `historyMetaItem` are declared there; `getMetaDiagnostics` is
absent. The door reaches it through a `(p as any)` cast behind a 501 feature-detect
(`rest-server.ts:4922-4927`). Real at runtime, invisible to the type system — which is
exactly the kind of path a caller census has to be told rather than left to derive.

## Scope

#14683's conclusion is not reopened. It is measured and holds — PR #15619 pinned it
30/30. Only the enumeration backing it was short a caller.

The `packages/rest` half is tracked separately as #15620 and is not addressed here;
#15620 remains open.

## Verification

- `dispatch-gates.mjs --repo objectstack-ai/objectstack` derived **40** runnable
  families for this diff (32 by path + 1 by change kind + 7 declared whole-tree).
  **38 ran and exited 0.** Verdict lines quoted rather than bare exit codes, e.g.
  `check-nul-bytes: OK (scanned 7804 text file(s) ... no raw ASCII control bytes)`
  and `doc authoring guard: ... clean`.
- `pnpm check:dts-closure` — green: `76/76 declared declaration file(s) present across
  14 package(s)`.
- `pnpm check:dual-build-cjs-loads` — **NOT MEASURED**, not red. It exits 3 with
  `Run pnpm build first. This is NOT a pass: nothing was measured.` (49 packages have
  no `dist` in this worktree). It needs a repo-wide build; CI's Build Core covers it.
- Pins, at commit `ebdb9d6ae`: `pnpm --filter @objectstack/metadata-protocol exec
  vitest run --maxWorkers=2 src/get-meta-items-org-read-gate.test.ts
  src/protocol.diagnostics-store-outage.test.ts` — **2 files, 204 tests, 204 passed.**

### Published-surface measurement (Clause-②)

`Clause-②: no` — measured, not assumed. Full ablation against the published artefacts:
built at head, swapped this file back to `origin/main`'s copy, rebuilt, compared every
artefact `files: ["dist"]` ships.

- Mutation proven on disk before measuring (anchored counts: injected text 0 hits,
  original text 1 hit; blob `89436302` vs HEAD blob `87087b71`).
- `index.d.ts`, `index.d.cts`, `index.js`, `index.cjs` — **all four byte-IDENTICAL**
  across the ablation.
- Only `index.js.map` and `index.cjs.map` differ, because a sourcemap embeds
  `sourcesContent` verbatim. Control: pre-existing text from this same docblock that
  this PR never touched (`THE HARM IS RESURRECTION`, `Gate AFTER the fold`) is present
  in exactly those two files and absent from the other four — so this is the comment
  family's normal behaviour, not something this diff introduced.
- Restore proven byte-exact afterwards: blob back to `87087b71`, `git diff HEAD` empty,
  `git status --porcelain` empty (index included), and the restore leg rebuilt so
  `dist` matches head.

No declaration moves, no accept/reject behaviour moves, no exported symbol changes.

### Changeset

None, and `skip-changeset` applied: this publishes nothing from any package. Precedent
on this exact shape is `b339a38377` — `docs(metadata-protocol): record that hidden does
not govern getUiView's default sort`, one file, comment-only, no changeset. The
ablation above is the measurement behind the claim.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ARYe3yQTQCUFm5qPYNgKaJ)_