### PR TITLE
test(service-automation): pin the mid-park eviction window in persistSuspendedRun

### DIFF
--- a/packages/services/service-automation/src/engine.ts
+++ b/packages/services/service-automation/src/engine.ts
@@ -2034,6 +2034,22 @@ export class AutomationEngine implements IAutomationService {
      * nobody read, and every in-flight approval zombified by the next restart.
      */
     private async persistSuspendedRun(run: SuspendedRun): Promise<void> {
+        // [#16129] THE MAP WRITE IS FIRST, and `cacheOnlySuspensions` is written
+        // only after the save below settles => for the whole duration of that
+        // await this entry is in the map and is NOT yet qualified. A concurrent
+        // per-id `loadSuspendedRunStrict` therefore reads a store that
+        // truthfully has no row yet, finds no qualifier, and takes
+        // `evictConsumedSuspension` on a run being parked RIGHT NOW. Reachable
+        // without out-of-band knowledge of the id, because the map write is what
+        // publishes it to `listSuspendedRuns`.
+        //
+        // Bounded, measured, and pinned in
+        // `suspended-run-mid-park-eviction-window.test.ts`: the store-first
+        // strict load keeps the run resumable once the save lands, and the cost
+        // falls entirely on `listSuspendedRuns`, which merely OMITS the run --
+        // inside that listing's declared latitude. Do not widen the marking, add
+        // a lock, or move the save above this line without reading that pin's
+        // header: it also records the ONE compound case that escapes the bounds.
         this.suspendedRuns.set(run.runId, run);
         if (this.store) {
             try {
@@ -2219,6 +2235,15 @@ export class AutomationEngine implements IAutomationService {
      *    {@link persistSuspendedRun}'s documented degradation — a failed save
      *    costs cross-restart durability, not in-process resumability — into a
      *    run that vanishes from its own process.
+     *
+     * [#16129] Neither guard covers the MID-PARK WINDOW: `persistSuspendedRun`
+     * writes its map entry BEFORE it awaits the durable save, so an entry can be
+     * live here while the store legitimately has no row for it and the
+     * cache-only qualifier is not yet set. Evicting it is bounded -- the run
+     * stays resumable through the store-first strict load and only the
+     * cache-only listing under-reports -- and
+     * `suspended-run-mid-park-eviction-window.test.ts` pins both the window and
+     * the one compound case that escapes those bounds.
      *
      * A store read that THROWS must never reach here: an outage means the
      * run's existence is UNKNOWN, not "gone". Every caller below is on a path

--- a/packages/services/service-automation/src/suspended-run-mid-park-eviction-window.test.ts
+++ b/packages/services/service-automation/src/suspended-run-mid-park-eviction-window.test.ts
@@ -1,0 +1,336 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * [#16129] The MID-PARK WINDOW in {@link AutomationEngine.persistSuspendedRun}:
+ * a concurrent per-id read can evict a LIVE map entry while the durable save is
+ * still in flight.
+ *
+ * ## Why this file exists at all
+ *
+ * This is not a contract defect and must not be read as one. It is a real but
+ * BOUNDED limit that was, until this file, undocumented and unpinned — and an
+ * unpinned limit becomes folklore: the next reader cannot tell a deliberate
+ * boundary from an oversight. Pinning it makes the boundary EXECUTABLE. A
+ * comment saying the same thing is a claim that drifts away from the code; a
+ * test that drives the interleaving cannot.
+ *
+ * ## The window, as measured on this head (not as inherited from the card)
+ *
+ * `persistSuspendedRun` writes the map entry FIRST and marks the run cache-only
+ * LAST, and only on the failure path:
+ *
+ *   1. `this.suspendedRuns.set(run.runId, run)`
+ *   2. `await this.store.save(run)`            <- the window is this await
+ *   3. on success: `cacheOnlySuspensions.delete(runId)`
+ *      on failure: `cacheOnlySuspensions.add(runId)`
+ *
+ * Between 1 and the resolution of 2 the entry is in the map and is NOT yet in
+ * {@link AutomationEngine.cacheOnlySuspensions}. A concurrent
+ * `loadSuspendedRunStrict` for that same id therefore reads a store that
+ * truthfully answers "no row" (the save has not landed), finds no cache-only
+ * qualifier, and takes the eviction path #16031 added — deleting an entry for a
+ * run that is being parked right now.
+ *
+ * ## Reachability — measured, because the card recorded a reading and not a
+ * measurement
+ *
+ * REACHABLE, on an ordinary single-process composition, and with no
+ * out-of-band knowledge of the run id. The map write happens first, so
+ * `listSuspendedRuns()` PUBLISHES the id during the window: the very
+ * list-then-open consumer #16031 was written for can obtain the id and issue
+ * the per-id read without the run having been handed to anyone yet. The second
+ * test drives the same window on the RE-suspend path, where the id has been
+ * public since the first park, so the reachability does not rest on the listing
+ * either. Both need only a store whose `save` is asynchronous — that is every
+ * real store.
+ *
+ * ## The two bounds this pin exists to keep standing
+ *
+ *  - {@link AutomationEngine.loadSuspendedRunStrict} is STORE-FIRST while a
+ *    store is attached, so once the save lands the run is resumable from the
+ *    store. The evicted entry was a cache, not the authority.
+ *  - {@link AutomationEngine.listSuspendedRuns} merely OMITS the run.
+ *    Under-reporting is already inside that method's declared latitude (its own
+ *    docblock says it omits runs parked in a previous process lifetime);
+ *    over-reporting never was, which is the asymmetry #16031 rests on.
+ *
+ * ⛔ So this file does NOT widen the cache-only marking, add a lock, or move the
+ * save before the map write. It pins the outcome those two bounds promise, and
+ * a future change that alters the trade — in either direction — has to come
+ * through here and say so.
+ *
+ * ## One measured case that does NOT stay inside those bounds
+ *
+ * `FINDING` below. Bound 1 holds only because the save eventually LANDS. Let the
+ * save FAIL after an evicting read has already run, and the compound outcome is
+ * a run with no durable row and no map entry: unresumable, and the engine's own
+ * `error` record for the failed save promises the opposite ("it is kept in
+ * memory only"). It is narrower than the base window — it needs a store that
+ * rejects the write while still answering reads with "no row" rather than
+ * throwing (a healthy read replica behind a broken write path, a missing INSERT
+ * grant, a full disk) — but it is not hypothetical, and it escapes the bound.
+ *
+ * ⛔ It is deliberately NOT fixed here. Widening the cache-only marking is
+ * exactly the move this card forbids taking unilaterally, and the choice
+ * between that, a lock, and reordering the save is a decision above it. The
+ * case is pinned at its MEASURED behaviour so the cost is visible and so any
+ * future fix has a red test to turn green.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { defineActionDescriptor } from '@objectstack/spec/automation';
+import { RESUME_AUTHORITY_SERVICE } from '@objectstack/spec/contracts';
+import { AutomationEngine } from './engine.js';
+import { InMemorySuspendedRunStore } from './suspended-run-store.js';
+import type { SuspendedRun, SuspendedRunStore } from './engine.js';
+
+function silentLogger(): any {
+  return { info() {}, warn() {}, error() {}, debug() {}, child() { return silentLogger(); } };
+}
+
+/** start -> lv1 -> lv2 -> end. Two levels, so a re-suspend has somewhere to go. */
+const APPROVAL_FLOW = {
+  name: 'expense_approval',
+  label: 'Expense approval',
+  type: 'autolaunched',
+  nodes: [
+    { id: 'start', type: 'start', label: 'Start' },
+    { id: 'lv1', type: 'approval_level', label: 'Department head' },
+    { id: 'lv2', type: 'approval_level', label: 'General manager' },
+    { id: 'end', type: 'end', label: 'End' },
+  ],
+  edges: [
+    { id: 'e1', source: 'start', target: 'lv1' },
+    { id: 'e2', source: 'lv1', target: 'lv2' },
+    { id: 'e3', source: 'lv2', target: 'end' },
+  ],
+} as any;
+
+function engineOver(store: SuspendedRunStore | undefined): AutomationEngine {
+  const engine = new AutomationEngine(silentLogger(), store);
+  engine.registerNodeExecutor({
+    type: 'approval_level',
+    descriptor: defineActionDescriptor({
+      type: 'approval_level',
+      version: '1.0.0',
+      name: 'Approval level',
+      supportsPause: true,
+      resumeAuthority: 'service',
+    }),
+    async execute(node: any) {
+      return { success: true, suspend: true, correlation: `req_${node.id}` };
+    },
+  } as any);
+  engine.registerFlow('expense_approval', APPROVAL_FLOW);
+  return engine;
+}
+
+const approve = (engine: AutomationEngine, runId: string) =>
+  engine.resume(runId, { [RESUME_AUTHORITY_SERVICE]: true } as any);
+
+/** Node ids the listing reports for `runId`, in call order. */
+const listedNodes = (rows: Array<{ runId: string; nodeId: string }>, runId: string) =>
+  rows.filter(r => r.runId === runId).map(r => r.nodeId);
+
+/**
+ * A store whose `save` PARKS INSIDE THE WINDOW. `entered` resolves with the run
+ * being saved the first time `save` is called — that is the instant between the
+ * map write and the save landing — and nothing proceeds until `release()`.
+ *
+ * Every later `save` passes straight through the already-resolved gate, so a
+ * re-suspend after the window is an ordinary park.
+ */
+function gatedSaveStore(
+  inner: SuspendedRunStore,
+  opts: { failSave?: boolean; loadThrows?: boolean } = {},
+): { store: SuspendedRunStore; entered: Promise<SuspendedRun>; release: () => void } {
+  let announce!: (run: SuspendedRun) => void;
+  const entered = new Promise<SuspendedRun>(r => { announce = r; });
+  let open!: () => void;
+  const gate = new Promise<void>(r => { open = r; });
+  const store: SuspendedRunStore = {
+    async save(run: SuspendedRun) {
+      announce(run);
+      await gate;
+      if (opts.failSave) throw new Error('sqlite: attempt to write a readonly database');
+      return inner.save(run);
+    },
+    async load(id: string) {
+      if (opts.loadThrows) throw new Error('sqlite: database is locked');
+      return inner.load(id);
+    },
+    delete: (id: string) => inner.delete(id),
+    list: () => inner.list(),
+  };
+  return { store, entered, release: () => open() };
+}
+
+// -- the window, and the bounds it stays inside -------------------------------
+
+describe('#16129 — the mid-park window between the map write and the durable save', () => {
+  it('THE WINDOW: a per-id read taken mid-park evicts a LIVE entry, and the listing hands out the id to do it with', async () => {
+    const inner = new InMemorySuspendedRunStore();
+    const { store, entered, release } = gatedSaveStore(inner);
+    const engine = engineOver(store);
+
+    const parking = engine.execute('expense_approval'); // deliberately not awaited
+    const parked = await entered;                       // now INSIDE the window
+    const runId = parked.runId;
+
+    // Reachability without out-of-band knowledge of the id: the map write is
+    // first, so the cache-only listing publishes the run mid-park...
+    expect(listedNodes(engine.listSuspendedRuns(), runId)).toEqual(['lv1']);
+    // ...while the store truthfully has no row for it yet.
+    expect(await inner.load(runId)).toBeNull();
+
+    // The per-id read. The store answers "no row", the run is not cache-only,
+    // so #16031's eviction path deletes an entry for a run being parked NOW.
+    expect(await engine.hasSuspendedRun(runId)).toBe(false);
+    expect(listedNodes(engine.listSuspendedRuns(), runId)).toEqual([]);
+
+    release();
+    expect((await parking).runId).toBe(runId);
+
+    // BOUND 1 — store-first: the run is resumable. The evicted entry was a
+    // cache; the authority is the row that has now landed.
+    expect(await inner.load(runId)).not.toBeNull();
+    expect(await engine.hasSuspendedRun(runId)).toBe(true);
+    expect(await engine.getSuspendedScreen(runId)).not.toBeUndefined();
+
+    // BOUND 2 — the cost is confined to the cache-only listing, which OMITS the
+    // run. Under-reporting is inside its declared latitude.
+    expect(listedNodes(engine.listSuspendedRuns(), runId)).toEqual([]);
+    // The durable listing is unaffected: it reads the store.
+    expect(listedNodes(await engine.listSuspendedRunsDurable(), runId)).toEqual(['lv1']);
+
+    // Resumable END TO END, not merely answering `true` — and the next park
+    // re-seeds the map, so the omission lasts one park, not forever.
+    expect((await approve(engine, runId)).status).toBe('paused');
+    expect(listedNodes(engine.listSuspendedRuns(), runId)).toEqual(['lv2']);
+    expect((await approve(engine, runId)).success).toBe(true);
+  });
+
+  it('THE WINDOW (re-suspend): the same eviction on a run whose id has been public since the first park', async () => {
+    // The reachability here rests on nothing at all: an operator holding the id
+    // from the first park issues an ordinary read while the SECOND park's save
+    // is in flight. `claimAdvance` has already removed the durable row, so the
+    // store's "no row" is again truthful and again not the whole truth.
+    const inner = new InMemorySuspendedRunStore();
+    const first = new InMemorySuspendedRunStore();
+    const engine = engineOver({
+      save: (run: SuspendedRun) => first.save(run),
+      load: (id: string) => first.load(id),
+      delete: (id: string) => first.delete(id),
+      list: () => first.list(),
+    });
+    const runId = (await engine.execute('expense_approval')).runId!;
+    expect(listedNodes(engine.listSuspendedRuns(), runId)).toEqual(['lv1']);
+
+    // Swap in the gated store over the same rows, then resume: lv1 -> lv2 parks
+    // again, and THAT save is the one that waits.
+    for (const r of await first.list()) await inner.save(r);
+    const { store, entered, release } = gatedSaveStore(inner);
+    engine.setSuspendedRunStore(store);
+
+    const resuming = approve(engine, runId);
+    const reparked = await entered;
+    expect(reparked.nodeId).toBe('lv2');
+
+    expect(listedNodes(engine.listSuspendedRuns(), runId)).toEqual(['lv2']);
+    expect(await inner.load(runId)).toBeNull();
+    expect(await engine.hasSuspendedRun(runId)).toBe(false);
+    expect(listedNodes(engine.listSuspendedRuns(), runId)).toEqual([]);
+
+    release();
+    expect((await resuming).status).toBe('paused');
+
+    // Same two bounds.
+    expect(await engine.hasSuspendedRun(runId)).toBe(true);
+    expect(listedNodes(engine.listSuspendedRuns(), runId)).toEqual([]);
+    expect(listedNodes(await engine.listSuspendedRunsDurable(), runId)).toEqual(['lv2']);
+    expect((await approve(engine, runId)).success).toBe(true);
+  });
+});
+
+// -- the one case that escapes the bounds, pinned at its measured behaviour ---
+
+describe('#16129 — the window compounded with a FAILING save', () => {
+  it('FINDING: an evicting read inside the window of a save that then fails leaves the run unresumable', async () => {
+    // ⛔ Deliberately NOT fixed here — see this file's header. Pinned so the
+    // cost is visible and so a future fix has a red test to turn green.
+    const inner = new InMemorySuspendedRunStore();
+    const { store, entered, release } = gatedSaveStore(inner, { failSave: true });
+    const engine = engineOver(store);
+
+    const parking = engine.execute('expense_approval');
+    const runId = (await entered).runId;
+
+    // Same window, same evicting read.
+    expect(listedNodes(engine.listSuspendedRuns(), runId)).toEqual(['lv1']);
+    expect(await engine.hasSuspendedRun(runId)).toBe(false);
+    expect(listedNodes(engine.listSuspendedRuns(), runId)).toEqual([]);
+
+    // The save now fails. `persistSuspendedRun` marks the run cache-only — but
+    // the map entry it qualifies is already gone, so the qualifier qualifies
+    // nothing and the strict loader has nothing left to serve.
+    release();
+    expect((await parking).runId).toBe(runId);
+
+    // ESCAPES BOUND 1. The store never took the row and the cache no longer
+    // holds it, so the run is unresumable — while the engine's `error` record
+    // for the failed save says it "is kept in memory only".
+    expect(await inner.load(runId)).toBeNull();
+    expect(await engine.hasSuspendedRun(runId)).toBe(false);
+    expect(listedNodes(engine.listSuspendedRuns(), runId)).toEqual([]);
+    const resumed = await approve(engine, runId);
+    expect(resumed.success).toBe(false);
+    expect(resumed.code).toBe('RUN_NOT_FOUND');
+
+    // The control that isolates the window as the cause: WITHOUT the mid-park
+    // read, the identical failing save is the documented degradation — the run
+    // stays resumable in-process, which is exactly what the promise says.
+    const solo = engineOver({
+      async save() { throw new Error('sqlite: attempt to write a readonly database'); },
+      async load() { return null; },
+      async delete() {},
+      async list() { return []; },
+    });
+    const soloRun = (await solo.execute('expense_approval')).runId!;
+    expect(await solo.hasSuspendedRun(soloRun)).toBe(true);
+    expect(listedNodes(solo.listSuspendedRuns(), soloRun)).toEqual(['lv1']);
+  });
+});
+
+// -- controls: the shapes in which the window cannot bite ---------------------
+
+describe('#16129 — where the window does not exist', () => {
+  it('CONTROL: with no store attached there is no window and nothing is evicted', async () => {
+    // `persistSuspendedRun` awaits nothing, and `evictConsumedSuspension`
+    // refuses to act because the map IS the authority.
+    const engine = engineOver(undefined);
+    const runId = (await engine.execute('expense_approval')).runId!;
+
+    expect(await engine.hasSuspendedRun(runId)).toBe(true);
+    expect(listedNodes(engine.listSuspendedRuns(), runId)).toEqual(['lv1']);
+    expect((await approve(engine, runId)).status).toBe('paused');
+  });
+
+  it('CONTROL: a read that THROWS inside the window evicts nothing — unknown is not "gone"', async () => {
+    // The store-outage guard covers the window too: an unreadable store makes
+    // the run's existence UNKNOWN, and the strict read throws rather than
+    // reaching the eviction.
+    const inner = new InMemorySuspendedRunStore();
+    const { store, entered, release } = gatedSaveStore(inner, { loadThrows: true });
+    const engine = engineOver(store);
+
+    const parking = engine.execute('expense_approval');
+    const runId = (await entered).runId;
+
+    await expect(engine.hasSuspendedRun(runId)).rejects.toThrow(/database is locked/);
+    expect(listedNodes(engine.listSuspendedRuns(), runId)).toEqual(['lv1']);
+
+    release();
+    expect((await parking).runId).toBe(runId);
+    expect(listedNodes(engine.listSuspendedRuns(), runId)).toEqual(['lv1']);
+  });
+});


### PR DESCRIPTION
Fixes #16129

Pins the mid-park window in `AutomationEngine.persistSuspendedRun` as an executable boundary. Not a contract defect and not worked as one: no behaviour changed, and the two bounds the limit rests on are restated below so they survive the next reader.

## Where the window actually is, on current head

`packages/services/service-automation/src/engine.ts`, `persistSuspendedRun` — re-located rather than inherited. The card's `1157e7b72` line numbers happen to have survived almost intact, but the method now starts at `:2036` and the three beats are:

| line (head `0ef4f8094`, pre-change) | what happens |
|---|---|
| `:2037` | `this.suspendedRuns.set(run.runId, run)` — the map write |
| `:2040` | `await this.store.save(run)` — the window is this await |
| `:2045` / `:2051` | `cacheOnlySuspensions.delete(...)` on success, `.add(...)` on failure |

Between the map write and the save settling, the entry is in the map and is **not yet** qualified by `cacheOnlySuspensions`. A concurrent per-id `loadSuspendedRunStrict` reads a store that truthfully answers "no row", finds no qualifier, and takes the eviction path #16031 added — deleting an entry for a run being parked right now.

## What I measured

**The interleaving is REACHABLE**, on an ordinary single-process composition, and it needs no out-of-band knowledge of the run id. The map write happens first, so `listSuspendedRuns()` publishes the id *during* the window: the very list-then-open consumer #16031 was written for can obtain the id and issue the evicting read before the run has been handed to anyone. A second pin drives the same window on the **re-suspend** path, where the id has been public since the first park, so reachability does not rest on the listing either. Both need only a store whose `save` is asynchronous — that is every real store.

Measured behaviour after the window closes, which is what the pins assert:

- the run is resumable through the store-first strict loader, and resumes end to end (lv1 to lv2 to completion), not merely "answers true";
- `listSuspendedRuns()` omits it, and only it — `listSuspendedRunsDurable()` is unaffected because it reads the store;
- the omission lasts one park: the next `persistSuspendedRun` for that run re-seeds the map.

Controls measured alongside: with no store attached there is no window and nothing is evicted; a read that **throws** inside the window evicts nothing, because unknown is not "gone".

### One measured case that does NOT stay inside the bounds

Bound 1 holds only because the save eventually **lands**. Let the save **fail** after an evicting read has already run, and the compound outcome is a run with neither a durable row nor a map entry: `hasSuspendedRun` answers `false`, `resume` answers `RUN_NOT_FOUND`, and the engine's own `error` record for the failed save promises the opposite ("it is kept in memory only"). Isolated in the same test against its control — the identical failing save **without** the mid-park read leaves the run resumable in-process, exactly as the documented degradation says.

It is narrower than the base window: it needs a store that rejects the write while still answering reads with "no row" rather than throwing (a healthy read replica behind a broken write path, a missing INSERT grant, a full disk).

⛔ **Deliberately not fixed here.** Widening the cache-only marking is the move this card forbids taking unilaterally, and choosing between that, a lock, and reordering the save is a decision above it. The case is pinned at its **measured** behaviour so the cost is visible and so any future fix has a red test to turn green. Reported to the PM as the separate card it would be.

## Which form, and why

⭐ **A control pin**, with two short comments as its companions. A pin makes the boundary executable; a comment is a claim that drifts away from the code it describes. The pin also carries the reachability finding, which a comment could only assert. The comments — one at the map write, one on `evictConsumedSuspension`'s docblock, where a reader investigating an eviction actually lands — say what the window is and point at the pin rather than restating it.

The pin lives in its own file, `packages/services/service-automation/src/suspended-run-mid-park-eviction-window.test.ts`, matching this package's one-file-per-pinned-mechanism convention, and keeping clear of the file PR #16128 owns.

## The two bounds, restated so they survive

- `loadSuspendedRunStrict` is **store-first** while a store is attached, so once the save lands the run is resumable from the store. The evicted entry was a cache, never the authority.
- `listSuspendedRuns()` merely **omits** the run. Under-reporting is already inside that method's declared latitude — its own docblock says it omits runs parked in a previous process lifetime — while over-reporting never was, which is the asymmetry #16031 rests on.

⛔ Nothing here widens the cache-only marking, adds a lock, or moves the save before the map write.

## Collision fence

`packages/services/service-automation/src/suspended-run-store.ts` belongs to PR #16128 and is untouched — it is only imported by the pin. The `scripts/engine-double-contract.pinned.json` collision the dispatch warned about **did not materialise**: the pin's store fake is a `SuspendedRunStore`, not an ObjectQL engine double, and `pnpm check:engine-double-contract` is green with that ledger unmodified (`git status` clean apart from the two files below). Nothing here needs re-running the writer after PR #16128 lands.

## Changeset

`skip-changeset`, judged not defaulted: this PR is one new test file plus comments. It changes no runtime behaviour, no public type and no emitted output — comments do not survive `tsup`, and a `*.test.ts` is not published — so it releases nothing from any package. Label applied on open.

## Files

- `packages/services/service-automation/src/suspended-run-mid-park-eviction-window.test.ts` (new, 336 lines)
- `packages/services/service-automation/src/engine.ts` (comments only, +25 lines)

## What was run, at head `ca585bb6e`

Exit codes captured immediately after a single redirected command, never through a pipe.

| run | exit | result |
|---|---|---|
| `pnpm --filter '@objectstack/service-automation^...' build` | 0 | dependency closure built first |
| `pnpm --filter @objectstack/service-automation typecheck` | 0 | `tsc --noEmit` plus `check:test-typecheck` — "0 file(s) / 0 error(s)" |
| `pnpm --filter @objectstack/service-automation test` | 0 | Test Files 117 passed (117), Tests 1400 passed (1400) |
| gate family union, 46 families | all 0 | derived mechanically, see below |

`tsc -p tsconfig.test.json --noEmit --listFiles` and `tsc -p tsconfig.json --noEmit --listFiles` each name the new test file once, so "typecheck is clean" is a statement **about** it and not around it.

**Ablation.** The pin was committed before anything was mutated. `this.evictConsumedSuspension(runId)` was removed from `loadSuspendedRunStrict`; the mutation was proved on disk by a `git hash-object` delta (`21892e23` to `1c8e0a89`) plus anchored occurrence counts (the call site 2 to 1, the injected marker 0 to 1), under a `trap ... EXIT INT TERM` restoring an absolute path from `HEAD`. Ablated run: **exit 1, 3 failed / 2 passed** — the three that depend on the eviction firing turned red and the two controls that assert nothing is evicted stayed green, which is the predicted direction and not a template's default. Restore proved by blob equality back to `21892e23`, an empty `git diff HEAD`, and counts back to 2 / 0; the restored run is exit 0, 5 passed. No rebuild is involved on either leg: the pin reaches `engine.ts` by a relative same-package specifier, so vitest resolves the source, never a `dist/`.

**Gate family**, derived mechanically on the final head with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` (no hand-built list, no paths passed): its Reconciliation line reads **46 families** — 34 by path, 7 by change kind, 7 declared whole-tree, 2 reached both ways. All 46 were run from `--commands` and all exited 0.

Two of them first exited **3 = PREREQUISITE NOT MET**, which is not a pass, and were re-run after satisfying the prerequisite rather than reported as measured:

- `pnpm check:dual-build-cjs-loads` — needed built output. After `turbo run build` across the packages: exit 0, "103 published require entry point(s) across 66 package(s) load".
- `pnpm check:type-check-debt` — needed the built closure, then OOM'd inside tsc because the gate propagates the caller's `NODE_OPTIONS` and my `--max-old-space-size=4096` was the tighter ceiling; the gate says so itself. Re-run at 8192 (14.9 GB free on the box): exit 0, "12 ledger entr(ies) re-measured in 93.2s, 140 raw tsc error(s) total, none above its recorded number".

**Named because it could not be invoked here, so it is UNMEASURED rather than green:** the 6 families whose argv takes a value from the workflow (`$RUNNER_TEMP`, `${{ matrix.shard }}`) — the two `check-shard-attestation.mjs` invocations, `check-test-completeness.mjs` twice, and `check-cross-package-test-inputs.mjs --union-into`. The derivation refuses to invent a local invocation for them and so do I. I assert nothing about CI state.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpTx2tbq3pZRYAdoGt6E6Y)_