### PR TITLE
feat(spec)!: `FlowSchema` refuses a flow whose top-level `nodes[]` declares the same id twice (#15713)

### DIFF
--- a/.changeset/flow-node-id-uniqueness.md
+++ b/.changeset/flow-node-id-uniqueness.md
@@ -1,0 +1,75 @@
+---
+"@objectstack/spec": minor
+---
+
+feat(spec)!: `FlowSchema` refuses a flow whose top-level `nodes[]` declares the same id twice (#15713)
+
+<!-- adr-0087: not-required (no-migration-prescription) No authorable key is renamed, retired or re-typed: `nodes[].id` keeps its name, its type and its describe, and every flow whose top-level node ids are unique parses byte-identically. The only newly refused shape is two top-level nodes sharing one id — a collision, not a spelling — and its remedy is to rename one of the two (and re-point the edges that meant it), which is authoring intent no `objectstack migrate meta` rewrite can choose for the author. The census over this repo at `1f2a02ba` (997 literal `nodes[]` arrays, 2,186 nodes, 2,011 literal ids under `packages/**` and `examples/**` including tests; 79 arrays / 256 nodes excluding tests; AST scan with a planted-duplicate control that reads 1) found zero instances, so there is no in-repo file to name. -->
+
+**BREAKING** accept-set narrowing on `FlowSchema` — a flow whose top-level
+`nodes[]` carries two nodes with the same `id` is now **refused at parse time**
+— by `FlowSchema.parse` / `safeParse`, `defineFlow`, and every door that
+validates a flow through the schema (`objectstack validate`, the runtime
+publish gate, a stack's `flows[]`) — where it used to parse on green. Shipped
+as `minor` under the repo's launch-window convention for breaking changes. The
+exact parallel of #14964 (edge ids, maintainer ruling 2026-09-05, option A —
+an `error`, not a `warning`; no opt-out, no transition window), applied to the
+other hand-authored id space in the same schema.
+
+Every edge's `source` / `target` names a node by id, and the engine's traversal
+picks out-edges by `source` — with two nodes sharing an id, every edge from
+that id is ambiguous and whichever node wins is decided by array order,
+silently. A designer, a BPMN export and a flow diff key on node ids the same
+way they key on edge ids. Only region bodies (`loop` / `try_catch` / `parallel`
+sub-graphs) were checked, by `analyzeRegion` at `registerFlow()`; the flow's
+own top-level `nodes[]` parsed with the collision intact — measured on
+`origin/main` `1f2a02ba` with two lit controls on the same schema instance (a
+node missing its `label` → refused at `nodes.1.label`; an unknown key on a node
+→ `unrecognized_keys`).
+
+**What changes** (`packages/spec/src/automation/flow.zod.ts`): the existing
+`superRefine` on `FlowSchema` gains a pass over the top-level `nodes[]`, the
+same shape as the `edges[]` pass. Each later occurrence of an already-declared
+id raises one `custom` issue, anchored at `nodes[N].id` of the *later* node and
+naming both positions, so the formatted error points at the node to rename:
+
+```text
+✗ nodes.2.id: Duplicate node id `n` — `nodes[2]` reuses the id already declared by `nodes[1]`; every node id in a flow must be unique. Rename one of them: …
+```
+
+**What does NOT change:** `nodes[].id` keeps its name, type and describe; the
+open node-type vocabulary (ADR-0018), the region rules (`analyzeRegion`) and
+every other refusal are untouched; a flow with unique top-level node ids
+parses exactly as before. The rule judges the flow's **own top-level**
+`nodes[]` only — a region body's nodes remain `analyzeRegion`'s to judge, and
+whether a region node may reuse a top-level node id (one id space or two) is a
+separate decision this change neither takes nor pre-empts.
+
+The shape that is refused, and what the author does about it — a four-node
+excerpt, the later node renamed and its edge re-pointed:
+
+```ts
+// before — parsed on green, two nodes keyed 'n'
+nodes: [
+  { id: 'start', type: 'start', label: 'Start' },
+  { id: 'n', type: 'assignment', label: 'Assign A' },
+  { id: 'n', type: 'assignment', label: 'Assign B' },
+  { id: 'end', type: 'end', label: 'End' },
+]
+
+// after — refused at parse (nodes.2.id: Duplicate node id `n` …); rename the later one
+// and point the edges that meant it at the new id:
+nodes: [
+  { id: 'start', type: 'start', label: 'Start' },
+  { id: 'n', type: 'assignment', label: 'Assign A' },
+  { id: 'n2', type: 'assignment', label: 'Assign B' },
+  { id: 'end', type: 'end', label: 'End' },
+]
+```
+
+**Remedy.** Rename the later node to an id no other top-level node in that
+flow carries, then re-point at the new id the edges whose `source` / `target`
+meant that node; nothing else in the flow needs to move. The census over this
+repository found no flow to migrate, so this is a release note, not a
+migration: no shipped example, fixture or seed in `packages/**` or
+`examples/**` declares a duplicate top-level node id.

--- a/.changeset/flow-node-id-uniqueness.md
+++ b/.changeset/flow-node-id-uniqueness.md
@@ -43,7 +43,7 @@ every other refusal are untouched; a flow with unique top-level node ids
 parses exactly as before. The rule judges the flow's **own top-level**
 `nodes[]` only — a region body's nodes remain `analyzeRegion`'s to judge, and
 whether a region node may reuse a top-level node id (one id space or two) is a
-separate decision this change neither takes nor pre-empts.
+separate decision (#16134) this change neither takes nor pre-empts.
 
 The shape that is refused, and what the author does about it — a four-node
 excerpt, the later node renamed and its edge re-pointed:

--- a/packages/spec/src/automation/flow.test.ts
+++ b/packages/spec/src/automation/flow.test.ts
@@ -2124,9 +2124,10 @@ describe('FlowSchema — top-level node ids are unique (#15713)', () => {
   // Scope boundary, pinned so the rule cannot silently widen: it judges the
   // flow's OWN top-level `nodes[]`. A region body (`loop.config.body.nodes`) is
   // `analyzeRegion`'s to judge, at `registerFlow()`, and whether a region node
-  // may reuse a top-level id — one id space or two — is an open decision that
-  // this rule neither takes nor pre-empts. This pin records today's accept set
-  // at that boundary; the decision, when taken, moves it deliberately.
+  // may reuse a top-level id — one id space or two — is an open decision
+  // (#16134) that this rule neither takes nor pre-empts. This pin records
+  // today's accept set at that boundary; the decision, when taken, moves it
+  // deliberately.
   it('judges the top-level nodes[] only — a region node reusing a top-level id is outside this rule', () => {
     const result = FlowSchema.safeParse(flowWith([
       { id: 'start', type: 'start', label: 'Start' },

--- a/packages/spec/src/automation/flow.test.ts
+++ b/packages/spec/src/automation/flow.test.ts
@@ -1981,3 +1981,168 @@ describe('FlowSchema — edge ids are unique (#14964)', () => {
     expect(issues![0].message).toContain('Duplicate edge id `dup`');
   });
 });
+
+describe('FlowSchema — top-level node ids are unique (#15713)', () => {
+  // The card's probe, reproduced: a four-node flow with `nodes[1].id ===
+  // nodes[2].id === 'n'`, parsed on green (`origin/main` 1f2a02ba re-measured
+  // before this rule landed). The two controls beside it — a node missing its
+  // required `label`, and an unknown key on a node, on the SAME schema instance
+  // — are what proved the acceptance was a missing rule rather than a disabled
+  // validator, so both are pinned here too. An invalid node `type` is NOT a
+  // control on this schema: the node-type vocabulary is open by contract
+  // (ADR-0018), so that lever never fires — recorded so nobody reuses it.
+  const edges: Flow['edges'] = [
+    { id: 'e1', source: 'start', target: 'n' },
+    { id: 'e2', source: 'n', target: 'end' },
+  ];
+  const flowWith = (nodes: Flow['nodes']): Flow => ({
+    name: 'node_id_flow',
+    label: 'Node id flow',
+    type: 'autolaunched',
+    nodes,
+    edges,
+  });
+  const duplicate = flowWith([
+    { id: 'start', type: 'start', label: 'Start' },
+    { id: 'n', type: 'assignment', label: 'Assign A' },
+    { id: 'n', type: 'assignment', label: 'Assign B' },
+    { id: 'end', type: 'end', label: 'End' },
+  ]);
+
+  it('refuses a flow whose top-level nodes[] declares one id twice — the issue names the id and BOTH positions, anchored on the later node', () => {
+    const result = FlowSchema.safeParse(duplicate);
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.issues).toHaveLength(1);
+    const [issue] = result.error.issues;
+    expect(issue.code).toBe('custom');
+    expect(issue.path).toEqual(['nodes', 2, 'id']);
+    expect(issue.message).toContain('Duplicate node id `n`');
+    expect(issue.message).toContain('`nodes[2]` reuses the id already declared by `nodes[1]`');
+  });
+
+  it('renders through formatZodError as a line that points at the node to rename', () => {
+    const result = FlowSchema.safeParse(duplicate);
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    const rendered = formatZodError(result.error);
+    expect(rendered).toContain('Validation failed (1 issue):');
+    expect(rendered).toContain(
+      '✗ nodes.2.id: Duplicate node id `n` — `nodes[2]` reuses the id already declared by `nodes[1]`',
+    );
+  });
+
+  it('raises one issue per later occurrence, each naming the FIRST declaration of that id', () => {
+    const result = FlowSchema.safeParse(flowWith([
+      { id: 'a', type: 'start', label: 'Start' },
+      { id: 'b', type: 'assignment', label: 'B' },
+      { id: 'a', type: 'assignment', label: 'A again' },
+      { id: 'b', type: 'assignment', label: 'B again' },
+      { id: 'a', type: 'end', label: 'A once more' },
+    ]));
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.issues.map((i) => i.path)).toEqual([
+      ['nodes', 2, 'id'],
+      ['nodes', 3, 'id'],
+      ['nodes', 4, 'id'],
+    ]);
+    expect(result.error.issues[0].message).toContain('`nodes[2]` reuses the id already declared by `nodes[0]`');
+    expect(result.error.issues[1].message).toContain('`nodes[3]` reuses the id already declared by `nodes[1]`');
+    expect(result.error.issues[2].message).toContain('`nodes[4]` reuses the id already declared by `nodes[0]`');
+  });
+
+  it('a duplicate node id and a duplicate edge id in one flow raise one issue each, nodes first, same shape', () => {
+    const result = FlowSchema.safeParse({
+      ...duplicate,
+      edges: [
+        { id: 'dup', source: 'start', target: 'n' },
+        { id: 'dup', source: 'n', target: 'end' },
+      ],
+    });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.issues.map((i) => [i.code, i.path])).toEqual([
+      ['custom', ['nodes', 2, 'id']],
+      ['custom', ['edges', 1, 'id']],
+    ]);
+    expect(result.error.issues[0].message).toMatch(/^Duplicate node id `n` — `nodes\[2\]` reuses the id already declared by `nodes\[1\]`; every node id in a flow must be unique\. /);
+    expect(result.error.issues[1].message).toMatch(/^Duplicate edge id `dup` — `edges\[1\]` reuses the id already declared by `edges\[0\]`; every edge id in a flow must be unique\. /);
+  });
+
+  it('still refuses card control A — a node missing its required `label` — so the refusal above is not a vacuous pass', () => {
+    const result = FlowSchema.safeParse(flowWith([
+      { id: 'start', type: 'start', label: 'Start' },
+      { id: 'n', type: 'assignment' } as never,
+      { id: 'end', type: 'end', label: 'End' },
+    ]));
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.issues.map((i) => [i.code, i.path])).toEqual([['invalid_type', ['nodes', 1, 'label']]]);
+    expect(result.error.issues.some((i) => i.message.includes('Duplicate node id'))).toBe(false);
+  });
+
+  it('still refuses card control B — an unknown key on a node — with `unrecognized_keys`', () => {
+    const result = FlowSchema.safeParse(flowWith([
+      { id: 'start', type: 'start', label: 'Start' },
+      { id: 'n', type: 'assignment', label: 'Assign', bogusKey: 1 } as never,
+      { id: 'end', type: 'end', label: 'End' },
+    ]));
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.issues.map((i) => i.code)).toEqual(['unrecognized_keys']);
+    expect(result.error.issues.some((i) => i.message.includes('Duplicate node id'))).toBe(false);
+  });
+
+  it('accepts the same flow once the ids are unique, keeping the nodes in authored order', () => {
+    const unique = flowWith([
+      { id: 'start', type: 'start', label: 'Start' },
+      { id: 'n', type: 'assignment', label: 'Assign A' },
+      { id: 'n2', type: 'assignment', label: 'Assign B' },
+      { id: 'end', type: 'end', label: 'End' },
+    ]);
+    const result = FlowSchema.safeParse(unique);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.nodes.map((n) => n.id)).toEqual(['start', 'n', 'n2', 'end']);
+    expect(defineFlow(unique).nodes.map((n) => n.id)).toEqual(['start', 'n', 'n2', 'end']);
+  });
+
+  it('defineFlow refuses the duplicate with the same anchored issue', () => {
+    let caught: unknown;
+    try {
+      defineFlow(duplicate);
+    } catch (error) {
+      caught = error;
+    }
+    const issues = (caught as { issues?: Array<{ code: string; path: PropertyKey[]; message: string }> })?.issues;
+    expect(issues).toBeDefined();
+    expect(issues!.map((i) => [i.code, i.path])).toEqual([['custom', ['nodes', 2, 'id']]]);
+    expect(issues![0].message).toContain('Duplicate node id `n`');
+  });
+
+  // Scope boundary, pinned so the rule cannot silently widen: it judges the
+  // flow's OWN top-level `nodes[]`. A region body (`loop.config.body.nodes`) is
+  // `analyzeRegion`'s to judge, at `registerFlow()`, and whether a region node
+  // may reuse a top-level id — one id space or two — is an open decision that
+  // this rule neither takes nor pre-empts. This pin records today's accept set
+  // at that boundary; the decision, when taken, moves it deliberately.
+  it('judges the top-level nodes[] only — a region node reusing a top-level id is outside this rule', () => {
+    const result = FlowSchema.safeParse(flowWith([
+      { id: 'start', type: 'start', label: 'Start' },
+      {
+        id: 'n', type: 'loop', label: 'Loop',
+        config: {
+          collection: '{items}',
+          body: {
+            nodes: [{ id: 'start', type: 'assignment', label: 'Body step (reuses a top-level id)' }],
+          },
+        },
+      },
+      { id: 'end', type: 'end', label: 'End' },
+    ]));
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.nodes.map((n) => n.id)).toEqual(['start', 'n', 'end']);
+  });
+});

--- a/packages/spec/src/automation/flow.zod.ts
+++ b/packages/spec/src/automation/flow.zod.ts
@@ -922,15 +922,44 @@ export const FlowSchema = lazySchema(() => strictObject(
   ...MetadataProtectionFields,
 
 }).superRefine((flow, ctx) => {
-  // Every reader of `edges[].id` assumes the ids are unique — a designer, a
-  // BPMN export, a flow diff, any traversal that dedupes by id — while nothing
-  // enforced it: two edges carrying one id parsed, shipped through green CI
-  // twice, and were inert only because the engine keys out-edges by `source`
-  // (#14964). The id space is hand-authored, so the next author picking a
-  // "free" id from the sequence cannot tell it is taken. Refuse the collision
-  // here, at parse time, naming the id and BOTH positions; the issue is
-  // anchored on the later occurrence so the formatted error points at the
-  // edge to renumber.
+  // Two hand-authored id spaces, one rule each, one shape — a later occurrence
+  // of an already-declared id raises one `custom` issue anchored on the LATER
+  // element and naming BOTH positions, so the formatted error points at the
+  // one to rename.
+  //
+  // Nodes (#15713): every edge's `source` / `target` names a node by id and
+  // the engine picks out-edges by `source`, so two top-level nodes sharing an
+  // id make every edge from that id ambiguous — whichever node wins is decided
+  // by array order, silently. Only region bodies were checked (`analyzeRegion`
+  // in `control-flow.zod.ts`, at `registerFlow()`); the flow's own top-level
+  // `nodes[]` parsed with the collision intact. This pass judges the top-level
+  // array ALONE: a region's nodes are judged by `analyzeRegion`, and whether the
+  // two spaces are one is a separate decision, not taken here.
+  const firstNodeIndexById = new Map<string, number>();
+  flow.nodes.forEach((node, index) => {
+    const first = firstNodeIndexById.get(node.id);
+    if (first === undefined) {
+      firstNodeIndexById.set(node.id, index);
+      return;
+    }
+    ctx.addIssue({
+      code: 'custom',
+      path: ['nodes', index, 'id'],
+      message:
+        `Duplicate node id \`${node.id}\` — \`nodes[${index}]\` reuses the id already declared by ` +
+        `\`nodes[${first}]\`; every node id in a flow must be unique. Rename one of them: a ` +
+        "node id is the handle every edge's `source`/`target` resolves and a designer, a BPMN " +
+        'export or a flow diff keys on, so a collision routes edges by array order silently ' +
+        'rather than failing loudly.',
+    });
+  });
+
+  // Edges (#14964): every reader of `edges[].id` assumes the ids are unique —
+  // a designer, a BPMN export, a flow diff, any traversal that dedupes by id —
+  // while nothing enforced it: two edges carrying one id parsed, shipped
+  // through green CI twice, and were inert only because the engine keys
+  // out-edges by `source`. The id space is hand-authored, so the next author
+  // picking a "free" id from the sequence cannot tell it is taken.
   const firstIndexById = new Map<string, number>();
   flow.edges.forEach((edge, index) => {
     const first = firstIndexById.get(edge.id);

--- a/packages/spec/src/automation/flow.zod.ts
+++ b/packages/spec/src/automation/flow.zod.ts
@@ -934,7 +934,7 @@ export const FlowSchema = lazySchema(() => strictObject(
   // in `control-flow.zod.ts`, at `registerFlow()`); the flow's own top-level
   // `nodes[]` parsed with the collision intact. This pass judges the top-level
   // array ALONE: a region's nodes are judged by `analyzeRegion`, and whether the
-  // two spaces are one is a separate decision, not taken here.
+  // two spaces are one is a separate decision (#16134), not taken here.
   const firstNodeIndexById = new Map<string, number>();
   flow.nodes.forEach((node, index) => {
     const first = firstNodeIndexById.get(node.id);


### PR DESCRIPTION
Fixes #15713

`FlowSchema` gains the top-level `nodes[]` half of the rule #14964 landed for `edges[]` (PR #15716, `52804cdb4`): a flow whose own top-level `nodes[]` declares one `id` twice is refused at parse time, `error` level, one `custom` issue per later occurrence, anchored on the **later** node and naming **both** positions — the same shape, extended inside the same `superRefine`, not a second spelling.

```text
✗ nodes.2.id: Duplicate node id `n` — `nodes[2]` reuses the id already declared by `nodes[1]`; every node id in a flow must be unique. Rename one of them: …
```

## Premise re-measured on `origin/main` `1f2a02ba` before editing (`premise_still_valid: true`)

`FlowSchema` imported from source, the card's four-node flow with `nodes[1].id === nodes[2].id === 'n'`, two lit controls on the same schema instance, plus the landed sibling as a third:

```text
duplicate node ids → success: true   parsed node ids: ["start","n","n","end"]
control A (node missing label)       → success: false  path nodes.1.label
control B (unknown key on a node)    → success: false  code unrecognized_keys
sibling (duplicate edge ids, #14964) → success: false  path edges.1.id
```

Both halves of the dispatch's mechanism assumption hold on that tree: `control-flow.zod.ts:412` (`analyzeRegion`, `duplicate node id 'X'`) is the only node-id uniqueness check in the tree (`git grep` over `packages/**` and `examples/**` excluding dist: one hit; `lint-flow-patterns.ts` builds `nodeIds` only to check edge endpoints), and nothing enforces it for the flow's top-level `nodes[]`. `flow.zod.ts` already carries `superRefine` blocks (`errorHandling` at `:890`, the #14964 edge pass at `:924`), so the node pass extends the existing idiom. After the fix, the same probe reads `duplicate node ids → success: false [custom, nodes.2.id]`, both controls unchanged.

## Scope (Zone 1 rulings, followed as ruled)

- Uniqueness **within the flow's own top-level `nodes[]`** only. A region body's nodes stay `analyzeRegion`'s to judge at `registerFlow()`, one region at a time, exactly as today.
- The "do top-level nodes and region nodes share one id space?" question is **not decided here** — it was implementable without deciding it (the pass never descends into `config.body` / `config.try` / `config.catch` / `config.branches[]`), so there is no fork to report. The decision is filed as **#16134** with its own measurements; this PR pins today's boundary (a region node reusing a top-level id still parses) so that decision moves it deliberately rather than by drift. `control-flow.zod.ts` is untouched.

## Census (Zone 3 lead, taken; tree `1f2a02ba`, AST over `packages/**` + `examples/**`, TS/JS literals)

| key | arrays | elements | literal ids | duplicates |
|:--|--:|--:|--:|--:|
| `nodes: [ … ]`, incl. tests | 997 | 2,186 | 2,011 | **0** |
| `nodes: [ … ]`, excl. tests | 79 | 256 | 255 | **0** |
| `edges: [ … ]`, incl. tests (calibration) | 789 | 1,138 | 1,106 | 0 |

Lit controls on the same instrument: a planted fixture with `nodes[2].id === nodes[1].id` scanned alongside the repo reads **1** at the planted line (edges likewise); the edge calibration agrees with #14964's reading (776 arrays / 1,098 edges, on its older tree); and after this PR's test file landed, the same scan reads **1** edge duplicate at `flow.test.ts:2060` (the combined node+edge fixture written as an `edges:` property) — the instrument sees a real duplicate when one exists. Declared blind spots: fixtures passed as call arguments (`flowWith([ … ])`), flows generated in code, and the pinned objectui / hotcrm trees. So the refusal rejects no shipped example, fixture or seed in this repository ⇒ release note, not migration (changeset `Remedy` paragraph, as #15716 did).

## Changes

- `packages/spec/src/automation/flow.zod.ts` — node pass added to the existing `FlowSchema.superRefine`, before the edge pass; message shape mirrors the edge one.
- `packages/spec/src/automation/flow.test.ts` — nine pins: duplicate refused (issue shape); `formatZodError` line; one issue per later occurrence naming the FIRST declaration; node + edge duplicates in one flow → one issue each, nodes first, same shape; both card controls still refused with no duplicate issue beside them; unique flow accepted in authored order (`safeParse` and `defineFlow`); `defineFlow` refuses; scope boundary (region node reusing a top-level id parses — #16134).
- `.changeset/flow-node-id-uniqueness.md` — `@objectstack/spec` **minor** with the BREAKING banner and the ADR-0087 disposition `not-required (no-migration-prescription)` carrying the census reading, the shape #15716 used. No migration registry entry (nothing renamed or retired).

Clause-②: yes — a published schema's accept set narrows ⇒ `needs:contract-review` expected on this draft.

## Verification (all on `e9d66a1c`, the final head; exit codes captured before any pipe)

- `pnpm --filter @objectstack/spec exec vitest run --maxWorkers=2 src/automation/flow.test.ts` — `Test Files 1 passed (1) · Tests 111 passed (111)`.
- `pnpm --filter @objectstack/spec test` (full package, under the shared verify lock) — `Test Files 481 passed | 1 skipped (482) · Tests 12957 passed | 1 skipped (12958)`, 356s.
- `pnpm --filter @objectstack/spec typecheck` — `tsc --noEmit` + `check:scripts-typecheck` + `check:test-typecheck` all green (`check:test-typecheck: OK — 54 file(s) / 261 error(s) / 145 pinned signature(s)` unchanged ledger).
- `pnpm --filter @objectstack/spec build` then `check:generated` — `✓ All 15 generated artifacts are up to date` (no artifact moved: no describe, export or authorable key changed).
- **Ablation** (source-level; the suite imports `./flow.zod`, so source is the resolution path): fix committed first; node pass deleted from `flow.zod.ts` (on-disk proof: marker `Duplicate node id` count 1 → 0, edge marker still 1, `git diff --stat` = 1 file / 19 deletions, blob `6f074146` ≠ HEAD blob `174bff41`); suite → `Tests 5 failed | 106 passed` — exactly the five node-refusal pins red, controls and accepts green; restore `git checkout HEAD -- ABS_PATH` (absolute path, `REPO_ROOT` from `git rev-parse --show-toplevel`) proven by `git hash-object` = HEAD blob `174bff41`, `git diff HEAD` empty, `git status --porcelain` empty; trap-guarded. Dist leg: `node scripts/ablation-dist-preflight.mjs @objectstack/spec 'Duplicate node id'` → marker present in 20 built files; a runtime probe against `dist/automation/index.mjs` refuses the duplicate at `nodes.2.id` and accepts the unique flow.
- **Derived gates** (`node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack --commands`, real diff, 3 paths): 73 commands, run twice (once at `d8f9861d`, again at the final head `e9d66a1c` after a fresh spec build), `--ran` reconciliation `✓ 73 derived famil(ies) accounted for — 73 run, 0 NOT-MEASURED` both times. 71 exit 0 (`@objectstack/lint check:doc-formula-expressions` refused with exit 3 until `@objectstack/formula` was built, then measured green). Two remain exit **3 = PREREQUISITE NOT MET, not measured** (they need every package's `dist/`, i.e. a whole-tree `pnpm build`): `check:dual-build-cjs-loads`, `check:type-check-debt` — declared to CI.
- **Consumers** (`turbo ls --affected` against BASE = 75 packages — a spec change reaches the whole tree): the three consumers with the most literal flow fixtures in their tests, each run under the shared verify lock against a freshly built dependency closure (`turbo run build --filter="@objectstack/service-automation^..."`, 20 tasks, 0 cached): `@objectstack/service-automation` (95 fixture files) — `Test Files 116 passed (116) · Tests 1395 passed (1395)`; `@objectstack/lint` (19) — `Test Files 98 passed (98) · Tests 3356 passed (3356)`; `@objectstack/metadata-protocol` (17) — `Test Files 165 passed | 2 skipped (167) · Tests 2409 passed | 10 skipped (2419)`. The remaining affected packages are declared to CI (declared narrowing; the census above found no literal duplicate in any of their fixtures).

## Out of scope, filed

- #16134 — decision: one node-id space across top-level `nodes[]` and region bodies, or two (cross-namespace census: 0 in-repo collisions with a lit control; 53 outer arrays hold regions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T6HeZvT9wdSJD1ZxJb5Eno

---
_Generated by [Claude Code](https://claude.ai/code/session_01T6HeZvT9wdSJD1ZxJb5Eno)_