### PR TITLE
fix(service-analytics): a draft-preview dataset response describes its columns like the live one (#16097)

### DIFF
--- a/.changeset/preview-column-enrichment.md
+++ b/.changeset/preview-column-enrichment.md
@@ -1,0 +1,19 @@
+---
+'@objectstack/service-analytics': patch
+---
+
+Analytics: a draft-preview dataset response now describes its columns like the live one
+
+`AnalyticsService.queryDataset`'s ADR-0037 P3 draft-preview branch returned before the
+ADR-0021 result-column enrichment ever ran, so a dataset queried while the base object had a
+pending seed draft came back with none of its column metadata: `fields[].label`, `format`,
+`currency`, `percentScale`, `builtinAggregate`, and the temporal `type` correction were all
+absent, on measure and dimension columns alike. A renderer then fell back to humanizing the
+raw measure name and guessing a percent scale from magnitude — so the same dataset in the
+same widget described its columns differently depending only on whether a pending seed draft
+existed, which is the surface an author is looking at while authoring the dataset.
+
+Every one of those keys is read off the authored dataset and the source object's field
+metadata, never off the rows, so the enrichment is now one method both paths call. Dimension
+VALUE label resolution (resolving a lookup id to a display name) stays skipped on the preview
+path deliberately: drafted seed rows reference lookups by name, so there is no id to resolve.

--- a/packages/services/service-analytics/src/__tests__/preview-column-enrichment.test.ts
+++ b/packages/services/service-analytics/src/__tests__/preview-column-enrichment.test.ts
@@ -1,0 +1,375 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * #16097 — a draft-preview dataset response must describe its COLUMNS the same
+ * way the live response does.
+ *
+ * `AnalyticsService.queryDataset` has an ADR-0037 P3 branch: when the request
+ * renders the as-if-published world and the base object has a PENDING seed
+ * draft, the selection is evaluated over the seed rows in memory and returned
+ * immediately. Measured on `main` @ `7d7ca6c0c` (after #16101 landed in this
+ * same file and moved both line numbers the card quoted), that early `return`
+ * sat at `analytics-service.ts:1115` and the ADR-0021 result-column enrichment
+ * began at `:1367` — ~250 lines it could never reach.
+ *
+ * ## What that cost, driven rather than read
+ *
+ * One dataset, one row set, two services differing ONLY in whether a pending
+ * seed exists — so the only thing that can differ between the two responses is
+ * the enrichment. Before this change:
+ *
+ * ```
+ * live    {"name":"total_amount","type":"number","label":"Total Amount","format":"$0,0","currency":"EUR"}
+ * preview {"name":"total_amount","type":"number"}
+ * live    {"name":"avg_margin","type":"number","label":"Avg Margin","format":"0.0%","percentScale":"whole"}
+ * preview {"name":"avg_margin","type":"number"}
+ * live    {"name":"expense_count","type":"number","builtinAggregate":"count"}
+ * preview {"name":"expense_count","type":"number"}
+ * live    {"name":"latest_spend","type":"time","label":"Latest Spend"}
+ * preview {"name":"latest_spend","type":"number"}
+ * live    {"name":"category","type":"string","label":"Category"}
+ * preview {"name":"category","type":"string"}
+ * ```
+ *
+ * A renderer then falls back to humanizing the raw measure name and guessing a
+ * percent scale from magnitude — the failures #5537, objectui#3136 and #14492
+ * each closed on the live path — and it does so only because a pending seed
+ * draft exists, a state that has nothing to do with how a column is described.
+ *
+ * ## Per-key: why each one is answerable over a seed row set
+ *
+ * Every key asserted here is read off the DATASET (the authored measure or
+ * dimension) and `sourceFieldMeta` (the source object's declared field
+ * metadata). None is read off `rows`, which is the whole reason one seam can
+ * serve both paths:
+ *
+ * | key                | resolved from                                   |
+ * |:-------------------|:------------------------------------------------|
+ * | `label`            | `measure.label` / `dimension.label` + `ctx.locale` (#6761) |
+ * | `format`           | `measure.format`                                 |
+ * | `builtinAggregate` | `measure.aggregate` + `measure.label == null` (#14492) |
+ * | `currency`         | ADR-0053 chain: `measure.currency` → `sourceFieldMeta().defaultCurrency` → `ctx.currency` |
+ * | `percentScale`     | `measure.derived.op === 'ratio'`, else `percentScaleOf(sourceFieldMeta())` (objectui#3136) |
+ * | `type`             | `measureResultType(measure.aggregate, sourceFieldMeta().type)` (#16101) |
+ *
+ * The two chains that reach OUTSIDE the measure are pinned deliberately: the
+ * currency chain's `ExecutionContext` limb and its `sourceFieldMeta` limb both
+ * have a case below, because "the block is self-contained" was an assumption
+ * worth measuring rather than believing.
+ *
+ * ## ⛔ What stays skipped, and why that is not the same question
+ *
+ * Dimension VALUE label resolution — turning a stored lookup id into the
+ * related record's display name — remains skipped on the preview path, and the
+ * last describe block pins it: `fetchRecordLabels` is not called at all there.
+ * Drafted seed rows reference lookups by NAME (the seed convention), so there is
+ * no id to resolve and the value already reads well. That reasoning is about ROW
+ * VALUES; it never covered COLUMN descriptors, which come from the authored
+ * measure and which no property of the seed rows can supply.
+ *
+ * ## Known-divergent and deliberately NOT asserted
+ *
+ * Two preview/live differences survive this change because they are produced
+ * BEFORE any enrichment, by `evaluateAnalyticsQueryOverRows` (`preview-
+ * evaluator.ts`), and no descriptor pass can reach them. They are filed
+ * separately rather than pinned here, so that fixing them does not have to red
+ * this file:
+ *
+ *   - a time dimension's `fields[].type` is minted `'string'` on preview and
+ *     `'time'` on live (`evaluateAnalyticsQueryOverRows` mints every dimension
+ *     as `'string'`);
+ *   - `min`/`max` over a non-numeric field returns `0` on preview
+ *     (`aggregate()` coerces with `Number()` and drops non-finite values), so
+ *     `latest_spend` is `0` there and `'2026-05-12'` on live.
+ *
+ * The second one meets this card at exactly one point: `latest_spend` is now
+ * correctly described as `type: 'time'` on BOTH paths, which is what its
+ * authored `max` over a `date` field means, while the preview VALUE beside it
+ * stays wrong until the evaluator is fixed. The descriptor is not withheld to
+ * accommodate a producer defect — that would be a consumer-side `??` in
+ * descriptor form (Prime Directive #12), and it would make the response's
+ * account of the column depend on a bug.
+ *
+ * ## Reverse verification, direction predicted BEFORE running
+ *
+ * Deleting the `enrichResultColumns(previewResult, …)` call from the preview
+ * branch must turn RED every `preview` assertion below and leave every `live`
+ * assertion GREEN. Ordinary direction, no inversion: the change ADDS descriptor
+ * keys that were absent, narrows no rule and removes no limb, so nothing
+ * downstream can gain a finding from it. The dimension-value-label block is
+ * predicted GREEN under that mutation too — it pins what the preview path does
+ * NOT do, which the mutation does not change.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { DatasetSchema } from '@objectstack/spec/ui';
+import type { ExecutionContext } from '@objectstack/spec/kernel';
+import { AnalyticsService } from '../analytics-service.js';
+import type { DimensionLabelDeps, FieldMetaLite } from '../dimension-labels.js';
+
+// ── one fixture, two paths ──────────────────────────────────────────────────
+
+interface Expense extends Record<string, unknown> {
+  amount: number;
+  fee: number;
+  margin: number;
+  category: string;
+  vendor: string;
+  spent_on: string;
+}
+
+/**
+ * `vendor` is a LOOKUP carrying the SEED convention: the drafted row references
+ * the related record by NAME (`Acme Air`), not by the FK id the live table
+ * stores. That is the fixture the standing skip is about.
+ */
+const ROWS: Expense[] = [
+  { amount: 1200, fee: 30, margin: 40, category: 'travel', vendor: 'Acme Air', spent_on: '2026-05-03' },
+  { amount: 800, fee: 20, margin: 20, category: 'travel', vendor: 'Acme Air', spent_on: '2026-05-12' },
+  { amount: 60, fee: 5, margin: 10, category: 'meals', vendor: 'Bistro Ltd', spent_on: '2026-06-01' },
+];
+
+const DATASET = DatasetSchema.parse({
+  name: 'expense_ds',
+  label: 'Expense',
+  object: 'expense',
+  dimensions: [
+    { name: 'category', field: 'category', type: 'string', label: 'Category' },
+  ],
+  measures: [
+    // aggregate + NO label ⇒ `builtinAggregate`, and no invented header.
+    { name: 'expense_count', aggregate: 'count' },
+    // label + format + the currency chain's `sourceFieldMeta` limb.
+    { name: 'total_amount', aggregate: 'sum', field: 'amount', label: 'Total Amount', format: '$0,0' },
+    // the currency chain's ExecutionContext limb (no measure currency, no
+    // field default) — the limb that lives furthest from the measure.
+    { name: 'total_fee', aggregate: 'sum', field: 'fee', label: 'Total Fee' },
+    // percentScale from the source field (`percent`, max 100 ⇒ 'whole').
+    { name: 'avg_margin', aggregate: 'avg', field: 'margin', label: 'Avg Margin', format: '0.0%' },
+    // percentScale from the measure shape (`ratio` ⇒ 'fraction').
+    { name: 'amount_per_item', derived: { op: 'ratio', of: ['total_amount', 'expense_count'] }, label: 'Per Item', format: '0.0%' },
+    // #16101 — `max` over a `date` field is temporal, not a number.
+    { name: 'latest_spend', aggregate: 'max', field: 'spent_on', label: 'Latest Spend' },
+  ],
+});
+
+/** The `vendor` variant, used only by the dimension-value-label block. */
+const VENDOR_DATASET = DatasetSchema.parse({
+  name: 'expense_by_vendor',
+  label: 'Expense by Vendor',
+  object: 'expense',
+  dimensions: [{ name: 'vendor', field: 'vendor', type: 'lookup', label: 'Vendor' }],
+  measures: [{ name: 'total_amount', aggregate: 'sum', field: 'amount', label: 'Total Amount' }],
+});
+
+const sourceFieldMeta = (object: string, field: string) => {
+  if (object !== 'expense') return undefined;
+  if (field === 'amount') return { type: 'currency', defaultCurrency: 'EUR' };
+  if (field === 'fee') return { type: 'currency' };
+  if (field === 'margin') return { type: 'percent', max: 100 };
+  if (field === 'spent_on') return { type: 'date' };
+  return undefined;
+};
+
+const FIELDS: Record<string, Record<string, FieldMetaLite>> = {
+  expense: { vendor: { type: 'lookup', reference: 'crm_account' } },
+  crm_account: { name: { type: 'text' } },
+};
+
+const CTX = { tenantId: 'org_A', currency: 'USD' } as ExecutionContext;
+
+/** Enough of a GROUP BY for this fixture — the LIVE path's engine. */
+function evaluateAggregate(opts: { groupBy?: unknown; aggregations?: unknown }) {
+  const groupBy = (opts.groupBy ?? []) as Array<string | { field: string }>;
+  const aggs = (opts.aggregations ?? []) as Array<{ field: string; method: string; alias: string }>;
+  const buckets = new Map<string, { key: Record<string, unknown>; rows: Expense[] }>();
+  for (const r of ROWS) {
+    const key: Record<string, unknown> = {};
+    for (const g of groupBy) {
+      const f = typeof g === 'string' ? g : g.field;
+      key[f] = r[f];
+    }
+    const id = JSON.stringify(Object.values(key));
+    let b = buckets.get(id);
+    if (!b) { b = { key, rows: [] }; buckets.set(id, b); }
+    b.rows.push(r);
+  }
+  return [...buckets.values()].map(({ key, rows }) => {
+    const row: Record<string, unknown> = { ...key };
+    for (const a of aggs) {
+      const vals = rows.map((r) => r[a.field]);
+      const sorted = vals.map(String).sort();
+      row[a.alias] =
+        a.method === 'sum' ? vals.reduce((s: number, v) => s + Number(v ?? 0), 0)
+          : a.method === 'avg' ? vals.reduce((s: number, v) => s + Number(v ?? 0), 0) / rows.length
+            : a.method === 'max' ? sorted[sorted.length - 1]
+              : rows.length;
+    }
+    return row;
+  });
+}
+
+/**
+ * The two services differ in exactly one config key. Everything else — the
+ * dataset, the rows, the field metadata, the ExecutionContext — is shared, so a
+ * difference in the response is a difference the preview branch caused.
+ */
+function svc(opts: { preview: boolean; labels?: DimensionLabelDeps } = { preview: false }) {
+  return new AnalyticsService({
+    sourceFieldMeta,
+    queryCapabilities: () => ({ nativeSql: false, objectqlAggregate: true, inMemory: false }),
+    executeAggregate: async (_object: string, options: Record<string, unknown>) => evaluateAggregate(options),
+    ...(opts.labels ? { labelResolver: opts.labels } : {}),
+    ...(opts.preview ? { draftRowsResolver: async () => ROWS as Record<string, unknown>[] } : {}),
+  });
+}
+
+const SELECTION = {
+  dimensions: ['category'],
+  measures: ['expense_count', 'total_amount', 'total_fee', 'avg_margin', 'amount_per_item', 'latest_spend'],
+};
+
+type Field = Awaited<ReturnType<AnalyticsService['queryDataset']>>['fields'][number];
+
+async function bothPaths() {
+  const live = await svc({ preview: false }).queryDataset(DATASET, SELECTION, CTX);
+  const preview = await svc({ preview: true }).queryDataset(DATASET, SELECTION, CTX, { previewDrafts: true });
+  const by = (fields: Field[]) => Object.fromEntries(fields.map((f) => [f.name, f]));
+  return { live: by(live.fields), preview: by(preview.fields) };
+}
+
+/** The six keys the card tabulates, absent ones dropped so they read as absent. */
+function descriptor(f: Field | undefined): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const k of ['label', 'format', 'currency', 'percentScale', 'builtinAggregate', 'type'] as const) {
+    const v = (f as Record<string, unknown> | undefined)?.[k];
+    if (v != null) out[k] = v;
+  }
+  return out;
+}
+
+describe('#16097 — a preview response describes its measure columns like the live one', () => {
+  it('carries every measure descriptor the live path carries, key for key', async () => {
+    const { live, preview } = await bothPaths();
+    for (const name of ['expense_count', 'total_amount', 'total_fee', 'avg_margin', 'amount_per_item', 'latest_spend']) {
+      expect(descriptor(preview[name]), `measure "${name}"`).toEqual(descriptor(live[name]));
+    }
+  });
+
+  it('label — the authored measure label, on both paths', async () => {
+    const { live, preview } = await bothPaths();
+    expect(live.total_amount.label).toBe('Total Amount');
+    expect(preview.total_amount.label).toBe('Total Amount');
+  });
+
+  it('format — the authored measure format, on both paths', async () => {
+    const { live, preview } = await bothPaths();
+    expect(live.total_amount.format).toBe('$0,0');
+    expect(preview.total_amount.format).toBe('$0,0');
+  });
+
+  it('builtinAggregate (#14492) — present exactly where the measure has no authored label', async () => {
+    const { live, preview } = await bothPaths();
+    expect(live.expense_count.builtinAggregate).toBe('count');
+    expect(preview.expense_count.builtinAggregate).toBe('count');
+    // …and the enrichment still invents no header for it, on either path.
+    expect(live.expense_count.label).toBeUndefined();
+    expect(preview.expense_count.label).toBeUndefined();
+    // An authored label keeps its text and gets no discriminator.
+    expect(preview.total_amount.builtinAggregate).toBeUndefined();
+  });
+
+  it('currency (ADR-0053) — the sourceFieldMeta limb resolves on the preview path', async () => {
+    const { live, preview } = await bothPaths();
+    expect(live.total_amount.currency).toBe('EUR');
+    expect(preview.total_amount.currency).toBe('EUR');
+  });
+
+  it('currency (ADR-0053) — the ExecutionContext limb reaches the preview path too', async () => {
+    const { live, preview } = await bothPaths();
+    // No measure currency, no field default ⇒ the tenant default on `ctx`.
+    expect(live.total_fee.currency).toBe('USD');
+    expect(preview.total_fee.currency).toBe('USD');
+    // A non-monetary measure never acquires one, on either path.
+    expect(preview.avg_margin.currency).toBeUndefined();
+    expect(preview.expense_count.currency).toBeUndefined();
+  });
+
+  it('percentScale (objectui#3136) — both limbs resolve on the preview path', async () => {
+    const { live, preview } = await bothPaths();
+    expect(live.avg_margin.percentScale).toBe('whole');       // from the percent field's max
+    expect(preview.avg_margin.percentScale).toBe('whole');
+    expect(live.amount_per_item.percentScale).toBe('fraction'); // from `derived.op === 'ratio'`
+    expect(preview.amount_per_item.percentScale).toBe('fraction');
+  });
+
+  it('type (#16101) — a `max` over a date field is temporal on the preview path too', async () => {
+    const { live, preview } = await bothPaths();
+    expect(live.latest_spend.type).toBe('time');
+    expect(preview.latest_spend.type).toBe('time');
+    // Every other measure keeps the `number` its producer minted.
+    expect(preview.total_amount.type).toBe('number');
+    expect(preview.expense_count.type).toBe('number');
+  });
+
+  it('resolves the label through the #6761 i18n map with the REQUEST locale', async () => {
+    const localized = DatasetSchema.parse({
+      ...DATASET,
+      name: 'expense_localized',
+      measures: [{ name: 'total_amount', aggregate: 'sum', field: 'amount', label: { en: 'Total Amount', 'zh-CN': '总金额' } }],
+    });
+    const selection = { dimensions: ['category'], measures: ['total_amount'] };
+    const zh = { ...CTX, locale: 'zh-CN' } as ExecutionContext;
+    const preview = await svc({ preview: true }).queryDataset(localized, selection, zh, { previewDrafts: true });
+    const live = await svc({ preview: false }).queryDataset(localized, selection, zh);
+    expect(live.fields.find((f) => f.name === 'total_amount')?.label).toBe('总金额');
+    expect(preview.fields.find((f) => f.name === 'total_amount')?.label).toBe('总金额');
+  });
+});
+
+describe('#16097 — dimension COLUMN headers, same authored source, same answer', () => {
+  it('gives the grouped column its authored header on both paths', async () => {
+    const { live, preview } = await bothPaths();
+    expect(live.category.label).toBe('Category');
+    expect(preview.category.label).toBe('Category');
+  });
+});
+
+describe('⛔ the fence: dimension VALUE label resolution stays skipped on preview', () => {
+  it('resolves the lookup value on the live path and leaves the seed name alone on preview', async () => {
+    const fetchRecordLabels = vi.fn(async (_t: string, ids: unknown[]) => {
+      const m = new Map<unknown, string>();
+      for (const id of ids) m.set(id, `Resolved(${String(id)})`);
+      return m;
+    });
+    const labels: DimensionLabelDeps = { getObjectFields: (o) => FIELDS[o], fetchRecordLabels };
+
+    const selection = { dimensions: ['vendor'], measures: ['total_amount'] };
+    const live = await svc({ preview: false, labels }).queryDataset(VENDOR_DATASET, selection, CTX);
+    const liveCalls = fetchRecordLabels.mock.calls.length;
+    expect(liveCalls).toBeGreaterThan(0);
+    expect(live.rows.map((r) => r.vendor)).toContain('Resolved(Acme Air)');
+
+    fetchRecordLabels.mockClear();
+    const preview = await svc({ preview: true, labels })
+      .queryDataset(VENDOR_DATASET, selection, CTX, { previewDrafts: true });
+    // The row value is the seed's own name, untouched — and NOTHING was fetched.
+    expect(preview.rows.map((r) => r.vendor).sort()).toEqual(['Acme Air', 'Bistro Ltd']);
+    expect(fetchRecordLabels).not.toHaveBeenCalled();
+  });
+
+  it('but the preview still describes that dimension COLUMN — the two are different questions', async () => {
+    const labels: DimensionLabelDeps = {
+      getObjectFields: (o) => FIELDS[o],
+      fetchRecordLabels: async () => new Map(),
+    };
+    const preview = await svc({ preview: true, labels }).queryDataset(
+      VENDOR_DATASET,
+      { dimensions: ['vendor'], measures: ['total_amount'] },
+      CTX,
+      { previewDrafts: true },
+    );
+    expect(preview.fields.find((f) => f.name === 'vendor')?.label).toBe('Vendor');
+    expect(preview.fields.find((f) => f.name === 'total_amount')?.label).toBe('Total Amount');
+  });
+});

--- a/packages/services/service-analytics/src/analytics-service.ts
+++ b/packages/services/service-analytics/src/analytics-service.ts
@@ -1110,27 +1110,28 @@ export class AnalyticsService implements IAnalyticsService {
           query: async (q: AnalyticsQuery) => evaluateAnalyticsQueryOverRows(q, compiled.cube, seedRows!),
         } as IAnalyticsService;
         const previewResult = await new DatasetExecutor(previewService).execute(compiled, selection, context);
-        // Label resolution is skipped on purpose: drafted seed rows reference
-        // lookups by NAME (the seed convention), which already reads well.
+        // ADR-0021 result-column enrichment runs on this path too. Every key it
+        // writes describes the dataset's OWN authored columns — a measure's
+        // `label` / `format` / `currency` / `percentScale` / `builtinAggregate`
+        // and the `type` its aggregate really returns, plus a dimension column's
+        // header `label` — all read off the dataset definition and
+        // `sourceFieldMeta`, never off the rows. #16097: this early `return`
+        // used to sit ~250 lines ahead of that block, so the same dataset in the
+        // same widget described its columns differently depending only on
+        // whether a pending seed draft existed — and preview is what an author
+        // is looking at WHILE authoring the dataset, which is when column
+        // metadata matters most.
+        this.enrichResultColumns(previewResult, dataset, selection, context);
+        // ⛔ What stays skipped here, deliberately, is dimension VALUE label
+        // resolution — turning a stored lookup id into the related record's
+        // display name. Drafted seed rows reference lookups by NAME (the seed
+        // convention), so the value already reads well and there is no id to
+        // resolve. That reasoning is about ROW VALUES and only about them; it
+        // never covered the COLUMN descriptors above, which come from the
+        // authored measure and so are neither unnecessary nor unavailable here.
         return previewResult;
       }
     }
-
-    // [#6761] The audience's language for THIS request, and the only locale
-    // either field-label enrichment site below is entitled to use.
-    //
-    // `ExecutionContext.locale` is the BCP-47 tag `resolveExecutionContext`
-    // resolves per request — the caller's `Accept-Language` when it expressed a
-    // preference, else the workspace `localization` setting. It is the same
-    // context field the currency chain a few lines down already reads, so both
-    // display decisions in this response answer to one request identity.
-    //
-    // `undefined` (no context, or an anonymous request that skips localization)
-    // is passed through deliberately rather than defaulted here: the shared
-    // resolver documents nullish as "no locale known" and answers `en`, the
-    // platform's source language. Choosing a different default in this file
-    // would be this service disagreeing with the renderer about the same map.
-    const requestLocale = context?.locale;
 
     // #3602 — every label lookup in this request (sort keys below, display
     // labels further down) reads the REFERENCED object, so bind that object's
@@ -1223,9 +1224,7 @@ export class AnalyticsService implements IAnalyticsService {
 
     // Selected dimensions resolved against the dataset definition — shared by
     // drill metadata, label resolution, and dimension field-label enrichment.
-    const selectedDims = (selection.dimensions ?? [])
-      .map((name) => dataset.dimensions?.find((d) => d.name === name))
-      .filter((d): d is NonNullable<typeof d> => !!d);
+    const selectedDims = this.selectedDimensions(dataset, selection);
 
     // ADR-0021 D2 — drill-through metadata. A host (dashboard/report) drills a
     // clicked bucket back to the underlying records, but it only knows the
@@ -1364,6 +1363,72 @@ export class AnalyticsService implements IAnalyticsService {
       }
     }
 
+    this.enrichResultColumns(result, dataset, selection, context);
+    return result;
+  }
+
+  /**
+   * The dataset dimensions this selection GROUPED THE GRID BY, resolved against
+   * the dataset definition. Shared by drill metadata, row-value label
+   * resolution and — through {@link enrichResultColumns} — the dimension column
+   * headers, so all three answer "which dimensions" the same way.
+   */
+  private selectedDimensions(dataset: Dataset, selection: DatasetSelection) {
+    return (selection.dimensions ?? [])
+      .map((name) => dataset.dimensions?.find((d) => d.name === name))
+      .filter((d): d is NonNullable<typeof d> => !!d);
+  }
+
+  /**
+   * ADR-0021 — describe the result's COLUMNS from the dataset's own authored
+   * definition: a measure's `label` / `format` / `currency` / `percentScale` /
+   * `builtinAggregate` and the `type` its aggregate really returns, then a
+   * dimension column's header `label`.
+   *
+   * **Every key here is read off the DATASET** (the authored measure or
+   * dimension) **and `sourceFieldMeta`** (the source object's declared field
+   * metadata). Not one is read off `result.rows`. That is what makes this one
+   * seam serve both paths that produce a dataset response — the live engine
+   * query and the ADR-0037 P3 draft-data preview — and it is why #16097 was a
+   * defect rather than a deliberate omission: the preview branch returns ~250
+   * lines before this ran, so a response over drafted seed rows carried none of
+   * these keys and a renderer fell back to humanizing the raw measure name and
+   * guessing a percent scale from magnitude — the exact failures #5537,
+   * objectui#3136 and #14492 each closed on the live path.
+   *
+   * Extracted rather than copied onto the second path, for the reason the
+   * `type` correction below already gives for living here at all: this is ONE
+   * rule holding both halves of the question, and a per-path copy would be two
+   * implementations of it, free to drift.
+   *
+   * ⛔ Not here, and deliberately: dimension VALUE label resolution
+   * ({@link resolveDimensionLabels}), which rewrites the grouped value in each
+   * ROW. That reads the rows, it is the one enrichment a seed-draft row set can
+   * make unnecessary, and the preview path skips it on purpose — see the note
+   * at that early return.
+   */
+  private enrichResultColumns(
+    result: AnalyticsResult,
+    dataset: Dataset,
+    selection: DatasetSelection,
+    context: ExecutionContext | undefined,
+  ): void {
+    // [#6761] The audience's language for THIS request, and the only locale
+    // either field-label enrichment site below is entitled to use.
+    //
+    // `ExecutionContext.locale` is the BCP-47 tag `resolveExecutionContext`
+    // resolves per request — the caller's `Accept-Language` when it expressed a
+    // preference, else the workspace `localization` setting. It is the same
+    // context field the currency chain a few lines down already reads, so both
+    // display decisions in this response answer to one request identity.
+    //
+    // `undefined` (no context, or an anonymous request that skips localization)
+    // is passed through deliberately rather than defaulted here: the shared
+    // resolver documents nullish as "no locale known" and answers `en`, the
+    // platform's source language. Choosing a different default in this file
+    // would be this service disagreeing with the renderer about the same map.
+    const requestLocale = context?.locale;
+
     // ADR-0021 — enrich measure columns with their display `label` + `format`
     // so presentations show "Tasks" / "$616,000" instead of the raw measure
     // name "task_count" / "616000". Carried on the result fields; the renderer
@@ -1476,12 +1541,13 @@ export class AnalyticsService implements IAnalyticsService {
     // `result.fields` already carries, so an entry that stays a pure window
     // contributes no column and receives no descriptor.
     //
-    // Kept out of `selectedDims` deliberately. Drill metadata and row-value
-    // label resolution above answer a different question — which dimensions the
-    // caller GROUPED THE GRID BY, i.e. what a click can be turned back into
-    // records — and widening those would change drill payloads and row values,
-    // not table headers.
-    const describableDims = [...selectedDims];
+    // Kept out of the SELECTED set deliberately, which is why the widening
+    // happens here and not in {@link selectedDimensions}. Drill metadata and
+    // row-value label resolution (both in `queryDataset`) answer a different
+    // question — which dimensions the caller GROUPED THE GRID BY, i.e. what a
+    // click can be turned back into records — and widening those would change
+    // drill payloads and row values, not table headers.
+    const describableDims = [...this.selectedDimensions(dataset, selection)];
     for (const t of selection.timeDimensions ?? []) {
       if (describableDims.some((d) => d.name === t.dimension)) continue;
       const d = dataset.dimensions?.find((x) => x.name === t.dimension);
@@ -1502,7 +1568,6 @@ export class AnalyticsService implements IAnalyticsService {
         if (label !== undefined) f.label = label;
       }
     }
-    return result;
   }
 
   /**


### PR DESCRIPTION
Fixes #16097

A dataset queried while its base object had a pending seed draft came back with **no column metadata at all**. `AnalyticsService.queryDataset`'s ADR-0037 P3 draft-preview branch returns immediately, and the ADR-0021 result-column enrichment runs ~250 lines later, so a preview response never reached it.

## Both sites, re-located on current head

The card quoted `1115` / `1367` and triage quoted `1107` / `1401`; #16101 landed in this same file in between and moved both. Measured on `main` @ `7d7ca6c0c`, the branch point of this PR:

| site | line on `7d7ca6c0c` |
|:--|:--|
| preview branch's early `return previewResult;` | `analytics-service.ts:1115` |
| ADR-0021 measure-column enrichment begins | `analytics-service.ts:1367` |
| dimension-column header enrichment begins | `analytics-service.ts:1454` |
| `queryDataset` returns | `analytics-service.ts:1505` |

## Driven, not read

One dataset, one row set, two `AnalyticsService` instances differing in exactly one config key (`draftRowsResolver`), so the only thing that can differ between the two responses is the enrichment. **Before:**

```
live    {"name":"category","type":"string","label":"Category"}
preview {"name":"category","type":"string"}
live    {"name":"expense_count","type":"number","builtinAggregate":"count"}
preview {"name":"expense_count","type":"number"}
live    {"name":"total_amount","type":"number","label":"Total Amount","format":"$0,0","currency":"EUR"}
preview {"name":"total_amount","type":"number"}
live    {"name":"avg_margin","type":"number","label":"Avg Margin","format":"0.0%","percentScale":"whole"}
preview {"name":"avg_margin","type":"number"}
live    {"name":"latest_spend","type":"time","label":"Latest Spend"}
preview {"name":"latest_spend","type":"number"}
```

**After:** every one of those preview rows equals its live row. The regression test asserts it per key and as a block, and the fixture lives in `preview-column-enrichment.test.ts`.

## Per-key decision — each key checked, not copied wholesale

Every key the block writes is read off the **dataset** (the authored measure or dimension) and **`sourceFieldMeta`** (the source object's declared field metadata). **None** is read off `rows`. That is the whole reason one seam can serve both paths, and it is checked per key rather than assumed:

| key | resolves from | meaningful on a preview row set? |
|:--|:--|:--|
| `label` | `measure.label` / `dimension.label` through `resolveI18nLabel` + `context.locale` (#6761) | yes — authored text; the i18n-map limb has its own case |
| `format` | `measure.format` | yes — authored |
| `builtinAggregate` | `measure.aggregate` when `measure.label == null` (#14492) | yes — judged on the authored key, never on the rows |
| `currency` | ADR-0053 chain: `measure.currency` then `sourceFieldMeta().defaultCurrency` then `context.currency` | yes — **both outer limbs pinned separately**, because "the block is self-contained" was worth measuring rather than believing |
| `percentScale` | `measure.derived.op === 'ratio'`, else `percentScaleOf(sourceFieldMeta())` (objectui#3136) | yes — both limbs pinned |
| `type` | `measureResultType(measure.aggregate, sourceFieldMeta().type)` (#16101) | yes — see the ordering note below |

**Ordering, per triage's second note:** #16101 landed first, so this PR carries the correction TO preview rather than the other way round. The acceptance table is six rows, not five.

## What is left skipped, and why that is a different question

**Dimension VALUE label resolution stays skipped on the preview path.** The standing comment's reasoning holds and is untouched in substance: drafted seed rows reference lookups by NAME (the seed convention), so there is no id to resolve and the value already reads well. What changed is that the comment now says which question it answers — it is a statement about ROW VALUES, and it never covered COLUMN descriptors, which come from the authored measure and which no property of the seed rows can supply.

That fence is pinned, not just asserted in prose: the test drives a lookup dimension both ways, shows the live path rewriting the row value to the resolved name, shows the preview path leaving the seed's own name, and asserts `fetchRecordLabels` **was not called at all** on the preview path.

## Scope call worth a reviewer's eye

The card and triage enumerate the five measure keys. The measured before/after shows the **dimension column header** (`category` losing `Category`) going missing on the same path, from the same cause — a second `result.fields` descriptor pass, ~40 lines after the measure one, reading `dimension.label` off the authored dataset. It is included here because it is the same defect class in the same seam, and because shipping measure headers while leaving dimension headers bare would be a new inconsistency nobody asked for. It is emphatically **not** the fenced skip: that one rewrites row values, this one only describes columns. Happy to split it out if the lane wants the narrower diff.

## Shape

Rather than copy the block onto a second path, it is extracted into one `enrichResultColumns` seam both paths call — the same argument #16101's `type` correction already makes for living in this method at all: one rule, not two implementations free to drift. A small `selectedDimensions` helper is extracted alongside it so drill metadata, row-value label resolution and the column headers keep answering "which dimensions" the same way.

## Known-divergent, deliberately not pinned, handed to the PM to file

Two preview/live differences survive this change. Both are produced **before** any enrichment, by `evaluateAnalyticsQueryOverRows` in `preview-evaluator.ts`, so no descriptor pass can reach them:

1. `aggregate()` coerces with `Number()` and drops non-finite values, so `min`/`max` over a non-numeric field returns **`0`** on the preview path. Measured: `latest_spend` is `"2026-05-12"` on live and `0` on preview.
2. The `fields` mint types every dimension column `'string'`, so a time dimension is `'string'` on preview and `'time'` on live.

Finding 1 meets this PR at exactly one point: `latest_spend` is now correctly described as `type: 'time'` on both paths, which is what its authored `max` over a `date` field means, while the preview VALUE beside it stays wrong until the evaluator is fixed. **The descriptor is not withheld to accommodate a producer defect** — that would be a consumer-side fallback in descriptor form (Prime Directive #12), and it would make the response's account of a column depend on a bug. Before this change the preview was wrong twice (no descriptor AND a zeroed value); now it is wrong once, visibly.

Neither is asserted in the new test, so fixing them will not have to red this file.

⚠️ **Neither could be filed from this seat.** Repo-scoped REST reads answer `403` for this session (`GitHub access is not enabled for this session`) and `gh` is absent, so the fallback is one targeted MCP `search_issues` for de-duplication — which answered `API rate limit already exceeded`. Filing without that de-duplication read is the one thing worse than not filing, so both findings are handed to the PM in the structured report with this reason attached, for filing against `preview-evaluator.ts`. They are recorded here so they cannot be lost with this session.

## Verification

All exit codes captured immediately after a single redirected command, never through a pipe.

| step | result |
|:--|:--|
| `pnpm --filter '@objectstack/service-analytics^...' build` | exit 0 |
| `pnpm --filter @objectstack/service-analytics test` | exit 0 — 95 files, 2050 tests |
| `pnpm --filter @objectstack/service-analytics typecheck` | exit 0 (its first run red on a real TS2550 in the new test — proof this package's tsc program does reach test files) |
| downstream consumers `@objectstack/rest` / `@objectstack/runtime` / `@objectstack/client` | exit 0 — 186/3168, 233/3312, 33/437 |
| `pnpm build` (full workspace) | exit 0 — 72/72 tasks |
| `pnpm lint` (repo-wide `eslint . --no-inline-config`, no narrowing) | exit 0 |
| the 56 gate families from `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack --commands` | **56/56 exit 0** |

The gate family was derived mechanically, never hand-built, and re-derived on the final head. Two of the 56 first answered `3 = PREREQUISITE NOT MET` and were converted into real measurements rather than reported as passes: `check:dual-build-cjs-loads` needed the full workspace build, and `check:type-check-debt` OOMed under `--max-old-space-size=4096` (the gate names the caller's `NODE_OPTIONS` as the constraint) and was re-run at 8192, where its re-measure leg reports `140 raw tsc error(s) total, none above its recorded number`.

**Reverse verification, direction predicted before running.** Deleting the `enrichResultColumns(previewResult, …)` call from the preview branch must red every preview assertion and leave the dimension-value-label fence case green — ordinary direction, no inversion, since the change only ADDS descriptor keys. Committed first, then mutated; mutation proven on disk by a `git hash-object` delta (`e7a40f97…` to `667e7c59…`) plus anchored counts (1 to 0, with the live-path call still present at 1); restored under `trap … EXIT INT TERM` on an absolute path; restore proven by blob equality to `HEAD:` and an empty `git diff HEAD`. **Measured 11 red / 1 green, and the 1 green is exactly the fence case.**

## Changeset

`patch` on `@objectstack/service-analytics`. It changes what a published wire surface produces on one path — `POST /analytics/dataset/query` with `preview=draft` now returns column descriptors it previously omitted. Additive on the response: no key changes meaning, none is removed, and the live path is byte-identical.

## Not addressed here

- out of scope: #16098 — `min`/`max` over text/select/lookup still typed `number`. Different population, its own card; `measure-result-type.ts` is untouched by this PR.
- out of scope: #16028 — `text-match-sql.ts` is untouched.

Every reading above — the union of gates, lint, the package suite, the consumers and the full build — was taken on final head `4636bcb2b`, which is what this branch points at. No prediction is made here about CI state.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XpTx2tbq3pZRYAdoGt6E6Y

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpTx2tbq3pZRYAdoGt6E6Y)_