### PR TITLE
docs(client): the README's AI example shows the surface that exists

### DIFF
--- a/.changeset/client-readme-retired-ai-methods.md
+++ b/.changeset/client-readme-retired-ai-methods.md
@@ -1,0 +1,11 @@
+---
+"@objectstack/client": patch
+---
+
+The README's namespace tour documents the `ai` surface that exists, not the three methods v17 removed.
+
+`client.ai.nlq` / `.suggest` / `.insights` were deleted in 17.0.0 (#3718) — and no server in any repo ever mounted `/api/v1/ai/{nlq,suggest,insights}`, so they 404ed for the whole life of the namespace. The README's "AI Services" example still showed all three. Because `files` ships `README.md` inside the tarball, that example is the package's npm front page: a TypeScript reader copying it gets TS2339 on three properties that are not on `client.ai`, and a JavaScript reader gets a runtime `TypeError`.
+
+The block now shows the surface the client really exposes — `ai.chat` (with a read of `answer.content` / `answer.usage`), `ai.complete`, `ai.models`, `ai.conversations.list`, `ai.agents.chat`, `ai.pendingActions.list` — every call type-checked against the package's own published `dist/index.d.ts`. It also names the condition a reader will otherwise hit unexplained: the AI routes are served by `service-ai` (a Cloud/EE package), and an environment without it answers 501 rather than 404, with the remedy discovery reports under `services.ai`.
+
+No behaviour changes. `patch` rather than no changeset because the README is a published file of this package, so correcting it changes what `@objectstack/client` ships; the docs site's Client SDK page already carried this correction and is untouched here.

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -265,7 +265,7 @@ await client.notifications.markRead(['notif-1', 'notif-2']);
 const answer = await client.ai.chat({ messages: [{ role: 'user', content: 'How many open orders this quarter?' }] });
 console.log(answer.content, answer.usage?.totalTokens);
 await client.ai.complete({ prompt: 'Summarise this account in one line:' });
-await client.ai.models();                          // plan-filtered picker list (ADR-0028)
+await client.ai.models();                          // picker list — allowlist objects or bare ids, both live
 await client.ai.conversations.list({ limit: 20 });
 await client.ai.agents.chat('build', { messages: [{ role: 'user', content: 'Draft a follow-up' }] });
 await client.ai.pendingActions.list({ status: 'pending' });   // human-in-the-loop queue

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -259,10 +259,16 @@ await client.approvals.reject(requestId, 'Incomplete');
 await client.notifications.list({ read: false }); // unread only
 await client.notifications.markRead(['notif-1', 'notif-2']);
 
-// AI Services
-await client.ai.nlq({ query: 'Show me all active contacts' });
-await client.ai.suggest({ object: 'contact', field: 'industry' });
-await client.ai.insights({ object: 'sales', recordId: dealId });
+// AI Services — served by an AI service plugin (`service-ai`, a Cloud/EE
+// package). The `/ai` routes are mounted either way, so an environment without
+// it answers 501, not 404; discovery carries the same remedy under `services.ai`.
+const answer = await client.ai.chat({ messages: [{ role: 'user', content: 'How many open orders this quarter?' }] });
+console.log(answer.content, answer.usage?.totalTokens);
+await client.ai.complete({ prompt: 'Summarise this account in one line:' });
+await client.ai.models();                          // plan-filtered picker list (ADR-0028)
+await client.ai.conversations.list({ limit: 20 });
+await client.ai.agents.chat('build', { messages: [{ role: 'user', content: 'Draft a follow-up' }] });
+await client.ai.pendingActions.list({ status: 'pending' });   // human-in-the-loop queue
 
 // Internationalization
 await client.i18n.getLocales();


### PR DESCRIPTION
Fixes #16142

`client.ai.nlq` / `.suggest` / `.insights` were deleted in v17 (#3718), and no server in any repo ever mounted `/api/v1/ai/{nlq,suggest,insights}` — every call 404ed for the whole life of the namespace. The `@objectstack/client` README's namespace tour still showed all three. `packages/client/package.json` declares `files: ["dist", "README.md", "CHANGELOG.md"]`, so that text is the npm front page of the package: a TypeScript reader copying it gets TS2339, a JavaScript reader a runtime `TypeError`.

## What changed

`packages/client/README.md`, the "AI Services" block of the namespace tour — **lines 262-265 on the tree this branch was cut from** (`origin/main` @ `a7cce55038c`). The card said 262-264 and triage corrected it to 263-265; both were counting only the three call lines, and the comment header on 262 is part of the block being replaced. #16144 landed in this same fence after triage read it, but its only hunk starts at old line 269 — below this block — so the numbers did not move.

Replaced with the surface the client really exposes, rather than deleting the section: `ai.chat` (assigning the result and reading `content` / `usage`, matching the payload-read style #16144 just established two blocks down), `ai.complete`, `ai.models`, `ai.conversations.list`, `ai.agents.chat`, `ai.pendingActions.list`.

The block also now names the condition a reader would otherwise hit unexplained: `/ai` is served by `service-ai`, a Cloud/EE package, and an environment without it answers 501 — not 404 — carrying the remedy discovery reports under `services.ai`. Documenting a method that exists but always fails on a default install would have reproduced this card's defect with fresher names.

## How the replacement was driven

Every line was type-checked against the package's **own published declarations** — `packages/client/dist/index.d.ts`, built from this branch — not against `src`, and not by reading the source and trusting it:

- the replacement snippet, verbatim: `tsc --noEmit --strict` → **exit 0**
- the three lines being removed, as a falsifiability control: **exit 2**, `TS2339: Property 'nlq' does not exist on type …`, and the same for `suggest` and `insights`

Argument shapes were checked against the contracts too, not just against the method names: `AiPendingActionStatusSchema` really admits `'pending'`, `ListAiConversationsRequestSchema` really has `limit`, `AiAgentChatRequestSchema` really requires `messages`. The 501 claim is read off `packages/runtime/src/domains/ai.ts` (`capabilityUnavailable(deps, 'ai')`) and `domains/unavailable.ts` (`deps.error(serviceUnavailableMessage(slot), 501)`) — **not** from the client docblock, which still says 404 and is stale (filed as #16211).

## Verification

Gate union derived with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack --commands`, asserted against that tool's own line: `Reconciliation — 46 famil(ies)`. All 46 harvested and run individually, exit code captured before any pipe. **46/46 green** at head `3909a11`, after a full `pnpm build` (72/72 tasks).

Two of the 46 first came back NOT MEASURED on a partially built tree and were re-measured green after the build, rather than being folded into the count: `check:published-readme-exports` (exit **3**, PREREQUISITE NOT MET) and `check:dual-build-cjs-loads` (exit **3**). `check:skill-examples` (exit **1**, "packages/client-react/dist holds no .d.ts") likewise re-measured green.

Artifact rosters — the 39 families that sit outside that total — were run separately: **36 green, 3 NOT MEASURED**, none of them a verdict on this diff:

| family | exit | why |
|---|---|---|
| `node scripts/check-partof-closing-keyword.mjs` | 2 | NOT WIRED — no `PR_BODY`/`PR_NUMBER`. Driven separately against this body, which passes. |
| `node scripts/check-single-claim-paths.mjs` | 2 | NOT WIRED — no `PR_NUMBER`. |
| `check:react-declaration-parity` | 1 | `MANIFEST` unset; no objectui manifest in this checkout. |

Package-level: `pnpm --filter @objectstack/client typecheck` green, `vitest run` green (33 files, 437 tests). The 10 families that declare a population too wide to place are outside all of the above and run unconditionally in CI (`lint.yml` carries no paths filter).

## Changeset

`patch` on `@objectstack/client`. Not "docs-only, so nothing": the README is a published file of this package, so correcting it changes what the tarball ships — the same reading #16144 took on this exact file. Not higher than `patch`: no API is added, removed or renamed, and `dist` is byte-equivalent from unchanged `src`.

## Clause ②, graded per limb

- **Mechanical floor — `no`.** The diff is two Markdown files. It adds no key to any published payload, and touches nothing under `packages/spec/src/**`; the change set `dispatch-gates` derived is exactly `.changeset/client-readme-retired-ai-methods.md` and `packages/client/README.md`, and the spec-side families in the union ran with no spec path to read.
- **Non-mechanizable conformance — `no`.** Nothing here re-selects an input class between two published verdicts on a shipped face. The runtime and type surface are unchanged; the example arguments were chosen to sit inside verdicts the contracts already publish unambiguously (`'pending'` is a member of `AiPendingActionStatusSchema`, `limit` is declared on `ListAiConversationsRequestSchema`), and each was confirmed accepted by the published `.d.ts` before being written down. No case arose where a face had two live readings and this PR picked one.

No governed surface is touched: nothing under `docs/adr/**`, `.claude/**`, `skills/**`, and neither `AGENTS.md` nor `CLAUDE.md`.

## Out of scope, filed separately

- #16209 — `check:published-readme-exports` cannot see a single call in this fence (receiver built by `new`), which is why this defect survived from v17 inside the one gate meant to catch it. Measured by ablation: with the retired lines restored the gate still exits 0, and binding the receiver by import moves the import half 324→325 while leaving the call-site half at 78 / NOT-read at 120.
- #16210 — `approvals.approve(requestId, 'LGTM')` in this same fence: the second parameter is a decision object, TS2559 against the published `.d.ts`. A different defect class, so untouched here.
- #16211 — `packages/client/src/index.ts` and `packages/runtime/src/route-ledger.ts` both still say `/ai/*` 404s; the dispatcher has answered 501 since the shared `capabilityUnavailable` exit landed.

Not addressed here, and left open on their own terms: #14546 is one payload read per example, a separate defect class; #16141 is a different lane (`domain:devx`, `content/docs/`). Neither is touched by this PR.

Draft on purpose — landing is the PM seat's step after contract review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D47qPfEWVPmhguWgBZCi5N

---
_Generated by [Claude Code](https://claude.ai/code/session_01D47qPfEWVPmhguWgBZCi5N)_