### PR TITLE
fix(plugin-email): use the shared read-decoration strip, not a blanket underscore sweep

### DIFF
--- a/.changeset/email-template-shared-read-decoration-strip.md
+++ b/.changeset/email-template-shared-read-decoration-strip.md
@@ -1,0 +1,14 @@
+---
+"@objectstack/plugin-email": patch
+---
+
+`plugin-email` strips read decorations with the shared list, not a blanket underscore sweep.
+
+`readEffectiveTemplate` — the layered read a `DELETE /meta/email_template/:name` runs to restore the packaged baseline an overlay was hiding — removed decorations with a module-local copy of `stripReadDecorations` that dropped **every** key beginning with `_`. The shared list it drifted from, `METADATA_READ_DECORATIONS` in `@objectstack/spec/kernel`, is exactly `['_diagnostics', '_draft']`, and its module header names the ADR-0010 protection envelope (`_lock`, `_lockReason`, `_lockSource`, `_provenance`, `_packageId`, `_packageVersion`, `_lockDocsUrl`) as deliberately **not** a member: it is envelope state the write path legitimately carries, and the closed metadata schemas allowlist it so a served document keeps its provenance on re-parse.
+
+The private copy justified its sweep on the claim that `EmailTemplateDefinitionSchema` "declares no underscore key". That is false — `email-template.zod.ts` spreads `MetadataProtectionFields` into its `strictObject`, so every envelope key is declared and parses clean. The copy was removing keys the schema was deliberately widened to accept, and the list lives in `spec` precisely so a producer and its consumers cannot drift like this.
+
+The path now calls the shared helper, matching the other read-back-envelope consumers (the dataset query in `rest-server.ts`, the cold-boot flow bind in `service-automation`, `saveMetaItem`'s verbatim persist, and the route-level seed apply). Two behavioural consequences:
+
+- An underscore key that is neither a decoration nor declared is no longer swallowed before validation. The closed schemas exist to reject exactly that (protocol 17), and the rejection is now reported on the write's own response through the mutation projector, instead of the reset quietly succeeding against a body the schema would have refused.
+- The ADR-0010 envelope survives the strip. It still does not reach `sys_email_template`: `upsertDeclaredEmailTemplate` projects the parsed template through `mapTemplateToRow`, a closed column list, and the object declares no underscore column — so no stored row changes shape. There is deliberately no second, envelope-stripping pass beside the shared one; spelling one would re-create the drift this fixes, one layer up.

--- a/packages/plugins/plugin-email/src/email-plugin.template-runtime-write.test.ts
+++ b/packages/plugins/plugin-email/src/email-plugin.template-runtime-write.test.ts
@@ -27,6 +27,7 @@
 
 import { describe, it, expect, vi } from 'vitest';
 import { assertEngineUpdateDispatch } from '@objectstack/objectql';
+import { EmailTemplateDefinitionSchema } from '@objectstack/spec/system';
 import { EmailServicePlugin } from './email-plugin.js';
 
 const TABLE = 'sys_email_template';
@@ -415,14 +416,12 @@ describe('#16152 read-decoration strip uses the shared list, not a blanket `_` s
     _lockDocsUrl: 'https://example.invalid/locks',
   } as const;
 
-  it('the schema declares the ADR-0010 envelope and rejects the read decorations', async () => {
+  it('the schema declares the ADR-0010 envelope and rejects the read decorations', () => {
     // The premise the deleted docblock got backwards, asserted directly
     // against the schema rather than inferred from it. `email-template.zod.ts`
     // spreads `MetadataProtectionFields` into its `strictObject`, so every
     // envelope key is authorable surface here; `_diagnostics` / `_draft` are
     // not declared anywhere in that shape, which is why they must be stripped.
-    const { EmailTemplateDefinitionSchema } = await import('@objectstack/spec/system');
-
     const withEnvelope = EmailTemplateDefinitionSchema.safeParse({ ...template(), ...ENVELOPE });
     expect(withEnvelope.success).toBe(true);
     // Guarding a KEY's reachability: no `unrecognized_keys` on any envelope key.

--- a/packages/plugins/plugin-email/src/email-plugin.template-runtime-write.test.ts
+++ b/packages/plugins/plugin-email/src/email-plugin.template-runtime-write.test.ts
@@ -263,8 +263,13 @@ describe('#7733 runtime email_template write materializes without a restart', ()
     // `getMetaItem` returns a DECORATED item (`_diagnostics` from
     // `decorateMetadataItem`, `_packageId` / `_provenance` from the registry
     // and the overlay row). `EmailTemplateDefinitionSchema` is a strictObject
-    // that declares no underscore key, so an unstripped body would reject the
-    // very baseline the reset exists to restore.
+    // that declares neither `_diagnostics` nor `_draft`, so an unstripped body
+    // would reject the very baseline the reset exists to restore.
+    //
+    // [#16152] It DOES declare the ADR-0010 envelope (`_packageId` /
+    // `_provenance` and the `_lock*` family, via `MetadataProtectionFields`) —
+    // those parse clean and are not stripped. See the `#16152` describe block
+    // below for the pins that hold that apart.
     const protocol = withEffectiveRead(fakeProtocol(), async () => ({
       type: 'email_template',
       name: 'auth.password_reset',
@@ -376,5 +381,112 @@ describe('#7733 runtime email_template write materializes without a restart', ()
     await protocol.save('auth.password_reset', template());
 
     expect(engine.rows).toHaveLength(0);
+  });
+});
+
+// ── #16152 ─────────────────────────────────────────────────────────────────
+//
+// `readEffectiveTemplate` used to strip read decorations with a MODULE-LOCAL
+// copy of `stripReadDecorations` that dropped every key starting with `_`.
+// The shared list it drifted from (`spec/kernel/metadata-read-decorations.ts`)
+// carries exactly `['_diagnostics', '_draft']` and names the ADR-0010
+// protection envelope as "Deliberately NOT" a member — envelope state the
+// write path legitimately carries, allowlisted by the closed schemas so a
+// served document keeps its provenance on re-parse.
+//
+// The copy's docblock justified the blanket sweep on the claim that
+// `EmailTemplateDefinitionSchema` "declares no underscore key". These pin why
+// that claim is false and what the narrow strip must do instead.
+
+describe('#16152 read-decoration strip uses the shared list, not a blanket `_` sweep', () => {
+  /** The full ADR-0010 envelope, as `MetadataProtectionFields` declares it. */
+  const ENVELOPE = {
+    _lock: 'no-delete',
+    _lockReason: 'Shipped by the auth package.',
+    _lockSource: 'artifact',
+    _provenance: 'package',
+    _packageId: 'com.objectstack.auth',
+    _packageVersion: '1.4.2',
+    _lockDocsUrl: 'https://example.invalid/locks',
+  } as const;
+
+  it('the schema declares the ADR-0010 envelope and rejects the read decorations', async () => {
+    // The premise the deleted docblock got backwards, asserted directly
+    // against the schema rather than inferred from it. `email-template.zod.ts`
+    // spreads `MetadataProtectionFields` into its `strictObject`, so every
+    // envelope key is authorable surface here; `_diagnostics` / `_draft` are
+    // not declared anywhere in that shape, which is why they must be stripped.
+    const { EmailTemplateDefinitionSchema } = await import('@objectstack/spec/system');
+
+    const withEnvelope = EmailTemplateDefinitionSchema.safeParse({ ...template(), ...ENVELOPE });
+    expect(withEnvelope.success).toBe(true);
+    // Guarding a KEY's reachability: no `unrecognized_keys` on any envelope key.
+    expect(
+      (withEnvelope as any).error?.issues?.filter((i: any) => i.code === 'unrecognized_keys') ?? [],
+    ).toEqual([]);
+
+    for (const decoration of ['_diagnostics', '_draft']) {
+      const served = EmailTemplateDefinitionSchema.safeParse({
+        ...template(),
+        [decoration]: decoration === '_draft' ? true : { valid: true },
+      });
+      expect(served.success).toBe(false);
+      const keys = (served as any).error.issues
+        .filter((i: any) => i.code === 'unrecognized_keys')
+        .flatMap((i: any) => i.keys);
+      expect(keys).toContain(decoration);
+    }
+  });
+
+  it('re-materializes a baseline served with the FULL protection envelope on it', async () => {
+    // The envelope rides along on the layered read (`_packageId` /
+    // `_provenance` from the registry, `_lock*` from the artifact layer). It
+    // parses clean, so the reset restores the packaged baseline with no
+    // projector failure — and `mapTemplateToRow`'s closed column list is what
+    // keeps it out of the row, not a strip.
+    const protocol = withEffectiveRead(fakeProtocol(), async () => ({
+      item: {
+        ...template({ subject: 'The packaged subject' }),
+        ...ENVELOPE,
+        _diagnostics: { valid: true },
+        _draft: false,
+      },
+    }));
+    const { engine } = await boot({ protocol });
+
+    await protocol.save('auth.password_reset', template({ subject: 'An operator override' }));
+    await protocol.remove('auth.password_reset');
+
+    expect(protocol.projectorFailures).toEqual([]);
+    const rows = rowsOf(engine, 'auth.password_reset');
+    expect(rows).toHaveLength(1);
+    expect(rows[0].subject).toBe('The packaged subject');
+    // `sys_email_template` declares no underscore column, and
+    // `mapTemplateToRow` projects a closed list — so the envelope cannot reach
+    // the row whatever the strip does. This is the measured reason there is no
+    // second, envelope-stripping pass beside the shared one.
+    for (const k of Object.keys(ENVELOPE)) expect(rows[0]).not.toHaveProperty(k);
+  });
+
+  it('does not silently swallow an underscore key the schema never declared', async () => {
+    // The blanket sweep dropped EVERY `_` key before the parse, so a key that
+    // is neither a decoration nor declared — a producer's typo, a decoration
+    // added upstream and never added to the shared list — vanished and the
+    // reset reported success. That is precisely the silent-strip failure the
+    // closed schemas (#4001) exist to end, and the shared list keeps loud:
+    // the projector surfaces it on the write's own response.
+    const protocol = withEffectiveRead(fakeProtocol(), async () => ({
+      item: { ...template({ subject: 'The packaged subject' }), _notADeclaredKey: 'x' },
+    }));
+    const { engine } = await boot({ protocol });
+
+    await protocol.save('auth.password_reset', template({ subject: 'An operator override' }));
+    await protocol.remove('auth.password_reset');
+
+    expect(protocol.projectorFailures).toHaveLength(1);
+    expect(protocol.projectorFailures[0]).toContain('_notADeclaredKey');
+    // The override row is left exactly as it was — a body the schema refuses
+    // never becomes a write.
+    expect(rowsOf(engine, 'auth.password_reset')[0].subject).toBe('An operator override');
   });
 });

--- a/packages/plugins/plugin-email/src/email-plugin.template-runtime-write.test.ts
+++ b/packages/plugins/plugin-email/src/email-plugin.template-runtime-write.test.ts
@@ -277,7 +277,12 @@ describe('#7733 runtime email_template write materializes without a restart', ()
         ...template({ subject: 'The packaged subject' }),
         _diagnostics: { valid: true },
         _packageId: 'com.objectstack.auth',
-        _provenance: { source: 'code' },
+        // [#16152] Was `{ source: 'code' }` — an object, where
+        // `MetadataProvenanceSchema` is `z.enum(['package','org','env-forced'])`.
+        // It was never spec-legal; the blanket `_` sweep deleted it before the
+        // parse could say so, which is the silent swallow this card removes.
+        // Corrected to the spelling the rest of the repo's fixtures use.
+        _provenance: 'package',
       },
     }));
     const { engine } = await boot({ protocol });

--- a/packages/plugins/plugin-email/src/email-plugin.ts
+++ b/packages/plugins/plugin-email/src/email-plugin.ts
@@ -2,6 +2,7 @@
 
 import type { Plugin, PluginContext } from '@objectstack/core';
 import type { IDataEngine } from '@objectstack/spec/contracts';
+import { stripReadDecorations } from '@objectstack/spec/kernel';
 import type {
   IEmailTransport,
   EmailAddress,
@@ -65,23 +66,6 @@ const SYSTEM_CTX = { isSystem: true, positions: [], permissions: [] } as const;
  * row; see {@link EmailServicePlugin.readEffectiveTemplate}.
  */
 const FAILED_READ = Symbol('email-template-read-failed');
-
-/**
- * Drop the underscore-prefixed keys a SERVED metadata item carries
- * (`_diagnostics`, `_packageId`, `_provenance`, `_draft`, …). Every one of
- * them is a read-time verdict the protocol attaches, never an authored field:
- * `EmailTemplateDefinitionSchema` is a `strictObject` and declares no
- * underscore key, so leaving them on turns a perfectly good declaration into a
- * validation failure.
- */
-function stripReadDecorations(item: unknown): unknown {
-  if (!item || typeof item !== 'object' || Array.isArray(item)) return item;
-  const out: Record<string, unknown> = {};
-  for (const [k, v] of Object.entries(item as Record<string, unknown>)) {
-    if (!k.startsWith('_')) out[k] = v;
-  }
-  return out;
-}
 
 /**
  * Plugin configuration.
@@ -1282,13 +1266,45 @@ export class EmailServicePlugin implements Plugin {
    * registry, which for a delete is the same baseline. The three outcomes are
    * kept apart on purpose: only "nothing declares it" may deactivate a row.
    *
-   * The body is stripped of read decorations before it is returned. A served
-   * item carries the protocol's own underscore keys (`_diagnostics` from
-   * `decorateMetadataItem`, `_packageId` / `_provenance` from the registry and
-   * the overlay row), `EmailTemplateDefinitionSchema` is a `strictObject`, and
-   * it declares no underscore key — so handing the decorated body to the
-   * upsert would reject the very baseline this read exists to restore. This is
+   * The body is stripped of read decorations before it is returned, using the
+   * SHARED `stripReadDecorations` from `@objectstack/spec/kernel` — the same
+   * helper the other read-back-envelope consumers call (the dataset query in
+   * `rest-server.ts`, the cold-boot flow bind in `service-automation`,
+   * `saveMetaItem`'s verbatim persist, and the route-level seed apply). This is
    * the read-side twin of the strip `saveMetaItem` does on the write side.
+   *
+   * ## [#16152] Why this is the shared list and NOT a blanket `_`-sweep
+   *
+   * This call used to be a module-local copy that dropped **every** key
+   * starting with `_`, justified in its own docblock by the claim that
+   * `EmailTemplateDefinitionSchema` "declares no underscore key". That claim is
+   * false, and the schema disagrees in both directions:
+   *
+   *  - `METADATA_READ_DECORATIONS` is `['_diagnostics', '_draft']`, and those
+   *    two genuinely must go: the schema is a `strictObject`, neither key is
+   *    declared, so an unstripped body rejects the very baseline this read
+   *    exists to restore.
+   *  - The ADR-0010 protection envelope (`_lock`, `_lockReason`, `_lockSource`,
+   *    `_provenance`, `_packageId`, `_packageVersion`, `_lockDocsUrl`) is
+   *    **declared** — `email-template.zod.ts` spreads `MetadataProtectionFields`
+   *    into the shape — and `metadata-read-decorations.ts` names it
+   *    "Deliberately NOT" a member of the strip list, because it is envelope
+   *    state the write path legitimately carries. Sweeping it here removed keys
+   *    the schema was deliberately widened to accept.
+   *
+   * A blanket sweep is also a silent swallow: an underscore key that is neither
+   * a decoration nor declared is exactly what the closed schema exists to
+   * reject (#4001), and dropping it before the parse converts a loud
+   * `unrecognized_keys` into a quiet success.
+   *
+   * ⭐ There is deliberately **no** second, envelope-stripping pass beside this
+   * one. The envelope cannot reach the written row in the first place:
+   * `upsertDeclaredEmailTemplate` projects the parsed template through
+   * `mapTemplateToRow`, a closed column list, and `sys_email_template` declares
+   * no underscore column. Spelling an envelope strip here would encode a rule
+   * this path does not have, as a second copy of a truth that already lives in
+   * that projection — which is the drift this fix removes, re-introduced one
+   * layer up.
    */
   private async readEffectiveTemplate(
     ctx: PluginContext,


### PR DESCRIPTION
Fixes #16152

`plugin-email` kept a module-local `stripReadDecorations` that dropped **every** key starting with `_`, drifting from the shared list in `packages/spec/src/kernel/metadata-read-decorations.ts` — the module whose header says the list lives in `spec` precisely so producer and consumers cannot drift. This PR deletes the private copy and calls the shared helper.

Located by content, not by name: the same identifier is exported from `@objectstack/spec/kernel`, so a grep finds both. ⛔ `metadata-read-decorations.ts` is not touched — the shared list is correct as it stands.

## The schema fact, re-verified on this branch's merge base

The private copy justified its blanket sweep in its own docblock by claiming `EmailTemplateDefinitionSchema` "declares no underscore key". Re-measured rather than inherited from the card:

- `packages/spec/src/system/email-template.zod.ts:5` imports `MetadataProtectionFields`, and **line 141** spreads it into the shape: `...MetadataProtectionFields,`.
- `packages/spec/src/shared/strict-object.ts` — `strictObject` is `z.object(shape, { error }).strict()`, so the shape really is closed.
- `MetadataProtectionFields` (`packages/spec/src/kernel/metadata-protection.zod.ts:81`) declares exactly seven keys: `_lock`, `_lockReason`, `_lockSource`, `_provenance`, `_packageId`, `_packageVersion`, `_lockDocsUrl`.
- Neither `_diagnostics` nor `_draft` appears anywhere in that chain (grep count 0 in both files).

⇒ The claim is **false**. Every ADR-0010 envelope key is declared and parses clean; the two read decorations are undeclared and genuinely must go. The copy was removing keys the schema was deliberately widened to accept, and keeping the two it had to remove — disagreeing with the shared list in both directions, exactly as the card states.

## What the dropped provenance actually costs: measured

The card and the triage comment both left this open, and the triage seat's census stopped at the package boundary. Measured through to the write, and the answer is **structural rather than a census result**:

1. `readEffectiveTemplate` has exactly **one** consumer in the repo — `email-plugin.ts:1240`, feeding `upsertDeclaredEmailTemplate`. Nothing else sees its return value.
2. `upsertDeclaredEmailTemplate` (`bootstrap-declared-email-templates.ts:187`) parses the body and then projects it through `mapTemplateToRow` (`:76`), a **closed column list**: `name, label, category, locale, subject, body_html, body_text, from_address, from_name, reply_to, active, is_system, description, variables_json`. No underscore key is projected.
3. `sys_email_template` (`packages/platform-objects/src/audit/sys-email-template.object.ts`) declares 19 columns and **zero** underscore columns.

⇒ **The dropped provenance costs nothing on this path, and could not have cost anything.** The stronger reading is not "nothing reads it" but "nothing *can* read it": the envelope cannot reach the written row whatever the strip does. This also answers the triage seat's pre-registered escalation clause — trigger (a) does not fire, and neither does (b): the `_lock*` family cannot make a written row lose protection, because `sys_email_template` never carried lock state; ADR-0010 protection lives on `sys_metadata`. **p3 stands on both triggers.**

## Which repair, and why the other one is wrong here

Took the **first branch — call the shared helper** — matching the four consumers that already do (the dataset query in `rest-server.ts:10502`, the cold-boot flow bind in `service-automation/plugin.ts:1906`, `saveMetaItem`'s verbatim persist, and the route-level seed apply in `runtime/domains/packages.ts:1572`).

The second branch — a separately named envelope strip beside it — would have been **wrong for this path**, and the measurement above is why. A second strip would encode the rule "this path needs the envelope gone". That rule is not true here: the envelope's absence from the row is already guaranteed by `mapTemplateToRow`'s closed projection. Spelling it as a strip would put a second copy of that truth one layer up — which is the very drift this PR removes, re-created in a new place. There is deliberately no second pass, and the docblock says so.

Safety of the narrower list was checked rather than assumed: the only producers of underscore keys on a served item are `_diagnostics` (`decorateMetadataItem`, `metadata-diagnostics.ts:159`), `_draft` (draft/preview reads), and the ADR-0010 envelope (registry / overlay row). That is exactly `METADATA_READ_DECORATIONS` plus the declared envelope, with nothing left over.

## A second, unplanned finding: the sweep was hiding a malformed fixture

Switching to the narrow list turned the pre-existing test `restores a baseline served WITH read decorations on it` red. The cause is not the repair — the fixture carried `_provenance: { source: 'code' }`, an **object**, where `MetadataProvenanceSchema` is `z.enum(['package','org','env-forced'])`. It was never spec-legal; the blanket sweep deleted it before the parse could say so. Corrected to `_provenance: 'package'`, the spelling every other fixture in the repo uses.

This is the silent-swallow failure demonstrated on the repo's own test data, and it is the concrete reason the blanket form is worse than a wrong list: it also swallows *malformed values* of the keys it sweeps.

## Each pin's population

Ablation restored the pre-fix blanket copy. Mutation proved on disk — `git hash-object` delta `d5293255…` to `91191c53…`, injected-marker count 1, surviving shared-import count 0 — and the restore proved by blob equality back to `d5293255…` plus an empty `git diff HEAD`, under a `trap … EXIT INT TERM` with an absolute path.

| Pin | Populates under ablation? |
|---|---|
| `does not silently swallow an underscore key the schema never declared` | **Yes — red.** `expected [] to have a length of 1`: under the blanket sweep the undeclared key vanishes before the parse and the reset reports success. |
| `the schema declares the ADR-0010 envelope and rejects the read decorations` | **No** — a pure spec assertion; it guards the falsified justification, not the plugin. |
| `re-materializes a baseline served with the FULL protection envelope on it` | **No** — and this is the measurement, not a weak test: the envelope is unobservable at the row either way, because `mapTemplateToRow` drops it. It stands as a regression guard that the envelope does not break the parse. |

Reported plainly because only one of the three is defect-discriminating: the other two are premise and regression guards, and calling them pins of the fix would overstate them.

## Verification

Gate family derived mechanically on the **final** head `b454fc09d` via `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack`; the Reconciliation line reads **56 families**, and `--commands` on the final head is byte-identical to the list that was run. All 56 measured green, exit codes captured immediately after a single redirected command, never through a pipe.

Two came back **exit 3 — PREREQUISITE NOT MET**, read as unmeasured rather than as passes: `check:dual-build-cjs-loads` and `check:type-check-debt` both need the built closure. Ran `turbo run build --filter='./packages/*' --filter='./packages/*/*'` and re-ran both — green (`103/66/619/1` against floors `90/58/520/1`; 12 ledger entries re-measured, none above its recorded number).

One came back a genuine **exit 1**: `check:test-source-alias` rejected a dynamic `import('@objectstack/spec/system')` inside a test body — this package resolves that specifier through `dist/`, so the first call would transform the dependency's module graph inside a clocked window. Hoisted to a module-scope import, as the gate prescribes; re-run green.

Also ran the 4 artifact-roster gates the derivation flags as keeping their roster in a directory one of these paths is in, whose silence is not evidence either way: `check-changeset-fixed`, `check:authz-resolver`, `check:error-code-casing`, `check:filter-alias-parity` — all exit 0.

- `pnpm --filter @objectstack/plugin-email test` — **30 files / 468 tests passed**
- `pnpm --filter @objectstack/plugin-email typecheck` — exit 0, and its `check:test-typecheck` leg confirms the test layer really is compiled, so the new test file is measured rather than merely excluded
- Ratchet families re-run on the final head after the last commit: `type-check-coverage`, `type-check-debt`, `test-source-alias`, `cross-package-test-inputs`, `dts-closure`, `nul-bytes` — all exit 0

Heavy runs were serialized through `scripts/pm/os-verify-lock.sh`; the wall-clock figures in its VERDICT lines are shared-box readings, not idle-machine numbers.

## Changeset

Included, `patch`. Judged rather than defaulted: `@objectstack/plugin-email` is `private: false` at `17.3.0`, and the diff changes observable runtime behaviour of that published package — an undeclared underscore key now surfaces on the write's response instead of being swallowed. Not a `skip-changeset` case, which is for diffs that publish nothing.

## Out of scope

`packages/plugins/plugin-security/src/permission-set-projection.test.ts:1231` pins `mergeRowPatchIntoBody` stripping `_packageId` and `_provenance` from a body — the same drift as this card, in a third package, and its fixture carries the same malformed `_provenance: { a: 1 }` object shape. Deliberately **not** fixed here: different package, and it would pull in a separate test and gate surface. It could not be filed as an issue during this run — the MCP `search_issues` channel needed for the duplicate check returned `API rate limit already exceeded` (repo-scoped REST is 403 for this session), and filing without a duplicate check is not an option this seat takes. Handed to the PM in the structured report for filing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpTx2tbq3pZRYAdoGt6E6Y)_