### PR TITLE
docs(spec): name every accepted key in the two action convention docblocks

### DIFF
--- a/.changeset/translation-actions-convention-docblock-keys.md
+++ b/.changeset/translation-actions-convention-docblock-keys.md
@@ -1,0 +1,14 @@
+---
+"@objectstack/spec": patch
+---
+
+Documentation: the `_actions` and `globalActions` convention lists in `translation.zod.ts` now name every key the schema accepts.
+
+Both docblocks are hand-written prose copies of what one factory declares. `actionTranslationSchema(...)` builds both surfaces — the file says so outright, "Shared by object `_actions` and `globalActions`" — so the two lists carried the identical four addresses (`label`, `confirmText`, `successMessage`, `resultDialog.*`) and the identical two omissions. An author reading either list to learn which keys exist saw a strict subset of what the schema has accepted all along.
+
+Added to both lists, in the order the factory declares them and matching the spelling already landed in `i18n-resolver.ts`'s own header:
+
+- `description` — the explanatory line under the title in the action's param dialog, resolved at `objects.<object>._actions.<action>.description` with a `globalActions.<action>.description` fallback.
+- `params.<param_name>.{label, helpText, placeholder, options.<value>}` — the per-parameter translations for an action's param dialog.
+
+Prose only. No schema, factory or resolver changed: the keys were already declared and already accepted, so nothing about what a bundle validates to moves. `packages/spec` publishes `src/**/*.zod.ts`, which is why documentation-only text still ships and still earns a changeset.

--- a/packages/spec/src/system/translation.zod.ts
+++ b/packages/spec/src/system/translation.zod.ts
@@ -332,8 +332,13 @@ export const ObjectTranslationDataSchema = lazySchema(() => strictObject({
    * Action translations keyed by action name (snake_case).
    * Convention (auto-resolved by `resolveActionLabel`/`resolveActionConfirm`/`resolveActionSuccess`):
    *   objects.<object>._actions.<action_name>.label
+   *   objects.<object>._actions.<action_name>.description
    *   objects.<object>._actions.<action_name>.confirmText
    *   objects.<object>._actions.<action_name>.successMessage
+   *   objects.<object>._actions.<action_name>.params.<param_name>.label
+   *   objects.<object>._actions.<action_name>.params.<param_name>.helpText
+   *   objects.<object>._actions.<action_name>.params.<param_name>.placeholder
+   *   objects.<object>._actions.<action_name>.params.<param_name>.options.<value>
    *   objects.<object>._actions.<action_name>.resultDialog.*
    */
   _actions: z.record(z.string(), actionTranslationSchema('this object action translation'))
@@ -664,8 +669,13 @@ const translationDataShape = () => ({
    * specific object via `objectName`. Convention (auto-resolved by
    * `resolveActionLabel`/`resolveActionConfirm`/`resolveActionSuccess`):
    *   globalActions.<action_name>.label
+   *   globalActions.<action_name>.description
    *   globalActions.<action_name>.confirmText
    *   globalActions.<action_name>.successMessage
+   *   globalActions.<action_name>.params.<param_name>.label
+   *   globalActions.<action_name>.params.<param_name>.helpText
+   *   globalActions.<action_name>.params.<param_name>.placeholder
+   *   globalActions.<action_name>.params.<param_name>.options.<value>
    *   globalActions.<action_name>.resultDialog.*
    */
   globalActions: z.record(z.string(), actionTranslationSchema('this global action translation'))


### PR DESCRIPTION
Fixes #14708

`_actions` and `globalActions` are built from one factory, `actionTranslationSchema(...)` — the file says so outright, "Shared by object `_actions` and `globalActions`" — so their hand-written convention lists carried the identical four addresses and the identical two omissions. An author reading either list to learn which keys exist saw a strict subset of what the schema has accepted all along.

Placeholders below are written as bare words (OBJECT / ACTION / PARAM / VALUE) because the body sanitizer eats angle-bracket fragments. The file itself keeps its own angle-bracket spelling, unchanged.

## What changed

Ten added comment lines in one file, `packages/spec/src/system/translation.zod.ts`, plus a changeset. Both lists now name, in the factory's declaration order and in the spelling already landed in `i18n-resolver.ts`'s own file header (PR #14707):

- `description`, after `label`
- `params.PARAM.label`, `.helpText`, `.placeholder`, `.options.VALUE`, before `resultDialog.*`

Nothing else. No schema, no factory, no resolver. `resultDialog.*` keeps its position and its wildcard — its leaves are enumerated at `ActionResultDialogTranslationSchema`'s own docblock, which is the file's existing convention for a nested sub-schema that documents itself.

Both sites were re-located by pattern, not by the line numbers in the card or the claim comment; both of those had already rotted.

## Does this move the contract? No — measured, not assumed

The keys were already declared and already accepted, so nothing about what a bundle validates to moves. The one measurable precondition on that verdict is whether the text projects into a generated artifact. It does not, and the control was reproduced on **this file's own** generated page, `content/docs/references/system/translation.mdx`:

| probe | occurrences |
|:---|---:|
| lit control — the `.describe()` string "Action translations keyed by action name" | 3 |
| lit control — the `.describe()` string "Global action translations keyed by action name" | 2 |
| docblock prose — "Convention (auto-resolved by" | 0 |
| docblock prose — "Action translations keyed by action name (snake_case)" | 0 |
| docblock prose — "Global (object-less) action translations keyed by action name (snake_case)" | 0 |
| the two address rows themselves (confirmText, successMessage) | 0 |

The third and fourth rows are the sharp pair: the `.describe()` string is a prefix of the docblock's opening sentence, so the same words score 3 as a describe string and 0 the moment the docblock-only suffix is included. `.describe()` reaches the page; the docblock does not.

Mechanically confirmed: `pnpm --filter @objectstack/spec check:generated` reports **all 15** checked-in generated artifacts up to date after the edit — `check:docs`, `check:api-surface`, `check:authorable-surface` and the rest — so zero regeneration is owed.

**Where the text does land, which is why a changeset is owed.** `packages/spec` publishes `src/**/*.zod.ts` through its `package.json` `files` array, and the build output preserves JSDoc: 9 of 22 emitted `.js` chunks and 1 of 64 emitted declaration files carry the new lines. All three are comment positions, and `check:api-surface` is green, so no export signature moved. Documentation-only, `patch`.

## Verification

Run at `a6879f8b6`, the branch tip.

| check | result |
|:---|:---|
| `pnpm --filter @objectstack/spec build` | exit 0, 34/34 declaration files present |
| `pnpm --filter @objectstack/spec check:generated` | 15/15 artifacts up to date |
| `pnpm --filter @objectstack/spec typecheck` | exit 0 (`tsc --noEmit`, `check:scripts-typecheck`, `check:test-typecheck`) |
| targeted vitest (translation, translation-typegen, i18n-resolver, action, action-description) | 5 files / 538 tests passed |
| gate families derived by `scripts/pm/dispatch-gates.mjs --commands --repo objectstack-ai/objectstack` | 67 of 68 run, all green; reconciled with `--ran` |
| `pnpm check:nul-bytes` | exit 0 |
| full-repo `eslint . --no-inline-config --format json` | 6196 files, 0 errors, 0 warnings, 64s |

`check:i18n-walk-parity` is the family most directly about this file: green, "11 declared group(s), 8 walked, 3 exempted — every declared group has an extractor face."

Two gates first returned `PREREQUISITE NOT MET` and were read as NOT MEASURED rather than as findings — `check:doc-formula-expressions` (exit 3, unbuilt `@objectstack/formula` and `@objectstack/lint`) and `check:i18n-walk-parity` (exit 1, unbuilt `@objectstack/cli`). Both prerequisites were built and both gates re-run green; the numbers above are the re-runs. Every exit code was captured before any pipe.

**Declared narrowings**, both handed to CI:

- `pnpm check:dual-build-cjs-loads` — the one derived family not run. Its prerequisite is a whole-repo `pnpm build`; it named 86 unbuilt packages and measured nothing. This diff changes no `exports` map, no package manifest and no emitted module format.
- Package tests. `turbo ls --affected` against the merge base lists roughly 45 packages, all downstream of `@objectstack/spec` and all reached only through its build output. Ran the five translation and action test files rather than all 482 spec test files or any downstream package.

The lint reading needed no narrowing at all: the full population, 6196 files as counted by eslint itself, was linted.

## Not in scope

Triage names the mechanism behind this card: both lists are hand-maintained prose copies of what one factory declares, and nothing binds them, which makes the docblocks a fourth consumer of one declaration alongside the resolver and the i18n extractor. That class belongs to #14653, which is untouched by this PR and stays open. Out-of-scope findings from this run: none.

---
_Generated by [Claude Code](https://claude.ai/code/session_01T6HeZvT9wdSJD1ZxJb5Eno)_