### PR TITLE
fix(cli): guard `convention/label-case` on a localized label

### DIFF
--- a/.changeset/lint-label-case-localized-guard.md
+++ b/.changeset/lint-label-case-localized-guard.md
@@ -1,0 +1,13 @@
+---
+"@objectstack/cli": patch
+---
+
+`os lint` no longer crashes on a localized label.
+
+`convention/label-case` indexed its argument (`label[0].toUpperCase()`) on a parameter annotated `string`, while every call site reaches it through `any`-typed config walking and the spec does not require a label to be a string: `I18nLabelSchema` is `z.union([z.string(), InlineLocaleMapSchema])`. On the map form `label[0]` is `undefined`, the rule threw a `TypeError`, and the throw escaped `lintConfig` into the command's catch-all — so an author who localized an app label or a list-view label could not lint the project at all. Every face exited 1 with `Cannot read properties of undefined (reading 'toUpperCase')`, naming no rule, no path and no remedy, on input `ObjectStackDefinitionSchema` parses clean.
+
+The rule now checks `typeof label === 'string'` first. Two of the four carriers it walks accept the inline locale map — `apps[].label` (`AppSchema`) and a view's `list` / `listViews.*` labels (`ListViewShapeSchema`); the other two are `z.string()` and reject the map at the schema door (`objects[].label`, `objects[].fields.*.label`).
+
+**Nothing about a plain string label moves.** Same warning, same message, same `fix`, same path, on all four carriers — that is pinned per carrier rather than asserted.
+
+**The rule deliberately says nothing about a localized label**, rather than resolving the map and case-checking one of its entries. Case is a property of a literal, and deciding which locale entry a case verdict is taken against is a product call, not a lint call. Widening the rule that way is a separate change.

--- a/.changeset/lint-label-case-localized-guard.md
+++ b/.changeset/lint-label-case-localized-guard.md
@@ -1,5 +1,5 @@
 ---
-"@objectstack/cli": patch
+"@objectstack/cli": minor
 ---
 
 `os lint` no longer crashes on a localized label.

--- a/packages/cli/src/commands/lint.ts
+++ b/packages/cli/src/commands/lint.ts
@@ -98,7 +98,31 @@ function checkLabelExists(item: any, path: string, kind: string): LintIssue | nu
   return null;
 }
 
-function checkLabelCase(label: string, path: string): LintIssue | null {
+// A label is not required to be a string. `I18nLabelSchema` (spec
+// `ui/i18n.zod`) is `z.union([z.string(), InlineLocaleMapSchema])`, and it is
+// the label primitive the whole `ui/` tree imports — so of the four carriers
+// this rule is called on, two accept the inline locale map:
+// `views[].list.label` / `views[].listViews.*.label` (`ListViewShapeSchema`)
+// and `apps[].label` (`AppSchema`). The other two are `z.string()` and reject
+// the map at the schema door (`objects[].label`, `objects[].fields.*.label`).
+//
+// Every call site reaches this function through `any`-typed config walking, so
+// the annotation below used to say `string` and be wrong: on a map,
+// `label[0]` is `undefined` and `undefined.toUpperCase()` threw. The throw
+// escaped `lintConfig` into the command's catch-all, so an author who
+// localized an app or list-view label could not lint the project at all —
+// every face exited 1 naming no rule, no path and no remedy, on input
+// `ObjectStackDefinitionSchema` parses clean.
+//
+// ⛔ The guard deliberately says NOTHING about a localized label rather than
+// resolving the map and case-checking an entry. Case is a property of a
+// literal; picking WHICH locale entry a case verdict is taken against is a
+// product decision (`resolveI18nLabel` exists, but which entry is
+// authoritative for a lint verdict is not this rule's to answer). Widening
+// the rule to localized labels is an extension, filed separately; this guard
+// is the floor, and it leaves the string branch below byte-identical.
+function checkLabelCase(label: unknown, path: string): LintIssue | null {
+  if (typeof label !== 'string') return null;
   if (label && label[0] !== label[0].toUpperCase()) {
     return {
       severity: 'warning',
@@ -111,7 +135,11 @@ function checkLabelCase(label: string, path: string): LintIssue | null {
   return null;
 }
 
-function getViewLabel(view: any, viewPath: string): { label?: string; path: string } {
+// ⚠️ `label` is `unknown`, not `string`: it is read straight off `any`-typed
+// config and `ListViewShapeSchema.label` is `I18nLabelSchema`, so the value
+// can legitimately be an inline locale map. Annotating it `string` here is
+// what let the map reach `checkLabelCase`'s indexing unchecked.
+function getViewLabel(view: any, viewPath: string): { label?: unknown; path: string } {
   if (view?.list?.label) {
     return { label: view.list.label, path: `${viewPath}.list.label` };
   }

--- a/packages/cli/test/lint-label-case-localized.test.ts
+++ b/packages/cli/test/lint-label-case-localized.test.ts
@@ -1,0 +1,234 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * `convention/label-case` must not crash `os lint` on a localized label.
+ *
+ * ## What this file pins, and how each half can fail
+ *
+ * The rule indexed its argument (`label[0].toUpperCase()`) on a parameter
+ * annotated `string` that every call site reaches through `any`-typed config
+ * walking. `I18nLabelSchema` is `z.union([z.string(), InlineLocaleMapSchema])`,
+ * so on the map form `label[0]` is `undefined` and the rule threw — out of
+ * `lintConfig`, into the command's catch-all, exit 1 on every face with a
+ * message naming no rule, no path and no remedy.
+ *
+ * Two independent properties, and neither one covers the other:
+ *
+ *  1. **NO MOVE** — the check on a plain string label is unchanged. This is
+ *     the property that makes a guard the uncontroversial floor, so it is
+ *     pinned per carrier rather than asserted in prose. Falsified by any guard
+ *     that also swallows strings (a `typeof` typo, an early return placed
+ *     above the string branch, a `label != null` guard that changes the
+ *     empty-string case): every lowercase row below stops reporting.
+ *  2. **NO CRASH** — a localized label is walked without throwing, on every
+ *     carrier whose schema accepts the map. Falsified by removing the guard:
+ *     each of those rows throws a `TypeError` instead of returning issues.
+ *
+ * ## Why the carriers are enumerated rather than sampled
+ *
+ * The filed mutation sweep hit exactly two paths (`apps.0.label`,
+ * `views.0.list.label`) because the fixture it swept had exactly those two.
+ * The class is the set of call sites, not the set of sweep hits:
+ * `lintConfig` calls this rule from four places, and the schema decides which
+ * of them can carry a map —
+ *
+ *   | call site                       | governing schema                        | map?  |
+ *   | `objects[].label`               | `ObjectSchema.label` — `z.string()`     | no    |
+ *   | `objects[].fields.*.label`      | field base — `z.string()`               | no    |
+ *   | `views[].list{,Views.*}.label`  | `ListViewShapeSchema` — `I18nLabelSchema` | yes |
+ *   | `apps[].label`                  | `AppSchema.label` — `I18nLabelSchema`   | yes   |
+ *
+ * — which is why `views[].listViews.*.label` is pinned below even though no
+ * sweep ever reached it: it is the same primitive behind a second path, and
+ * `getViewLabel` only falls through to it when `list.label` is absent.
+ *
+ * ## What the rule now SAYS about a localized label: nothing
+ *
+ * Deliberately. Case is a property of a literal; deciding which locale entry a
+ * case verdict is taken against is a product call this card does not make. So
+ * the localized rows assert the ABSENCE of a `convention/label-case` issue —
+ * if someone later widens the rule to resolve the map, these are the
+ * assertions that must be rewritten on purpose rather than silently satisfied.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { ObjectStackDefinitionSchema, normalizeStackInput } from '@objectstack/spec';
+import { lintConfig } from '../src/commands/lint';
+import { scoreMetadata } from '../src/lint/score';
+
+const MANIFEST = {
+  id: 'todo',
+  namespace: 'todo',
+  version: '1.0.0',
+  name: 'Todo',
+  type: 'app' as const,
+};
+
+/** The card's own fixture value, plus the sweep's literal hit value. */
+const LOCALIZED = { en: 'Todos', 'zh-CN': '待办' };
+const EMPTY_MAP = {};
+
+const caseIssues = (issues: { rule: string }[]) =>
+  issues.filter((i) => i.rule === 'convention/label-case');
+
+/** `objects[]` needs fields to avoid drowning the label rows in structure issues. */
+const objectWith = (label: unknown) => ({
+  name: 'invoice',
+  label,
+  fields: { name: { type: 'text', label: 'Invoice Number' } },
+});
+
+const objectWithFieldLabel = (label: unknown) => ({
+  name: 'invoice',
+  label: 'Invoice',
+  fields: { name: { type: 'text', label } },
+});
+
+const stackWithApp = (label: unknown) => ({
+  manifest: MANIFEST,
+  apps: [{ name: 'todo_app', label }],
+});
+
+const stackWithListLabel = (label: unknown) => ({
+  manifest: MANIFEST,
+  views: [{ name: 'invoice_views', object: 'invoice', list: { label, type: 'grid', columns: ['name'] } }],
+});
+
+const stackWithNamedListLabel = (label: unknown) => ({
+  manifest: MANIFEST,
+  views: [{
+    name: 'invoice_views',
+    object: 'invoice',
+    listViews: { all: { label, type: 'grid', columns: ['name'] } },
+  }],
+});
+
+describe('convention/label-case — the plain-string check does not move', () => {
+  // Falsification for every row: a guard that swallows strings as well as
+  // maps makes the lowercase rows report nothing and this whole block red.
+  const rows: [string, unknown, string][] = [
+    ['objects[].label', { objects: [objectWith('invoice')] }, 'objects[0].label'],
+    ['objects[].fields.*.label', { objects: [objectWithFieldLabel('invoice number')] }, 'objects[0].fields.name.label'],
+    ['views[].list.label', stackWithListLabel('accounts'), 'views[0].list.label'],
+    ['views[].listViews.*.label', stackWithNamedListLabel('all accounts'), 'views[0].listViews.all.label'],
+    ['apps[].label', stackWithApp('todos'), 'apps[0].label'],
+  ];
+
+  for (const [carrier, config, path] of rows) {
+    it(`still warns on a lowercase string at ${carrier}`, () => {
+      const issues = caseIssues(lintConfig(config as any));
+      expect(issues).toHaveLength(1);
+      expect(issues[0]).toEqual({
+        severity: 'warning',
+        rule: 'convention/label-case',
+        message: expect.stringContaining('should start with an uppercase letter'),
+        path,
+        fix: expect.any(String),
+      });
+    });
+  }
+
+  it('carries the label verbatim in the message and the capitalized value in `fix`', () => {
+    // The message/fix wording is what an author reads, so it is pinned whole
+    // on one row rather than left to `stringContaining` everywhere.
+    const [issue] = caseIssues(lintConfig(stackWithApp('todos') as any));
+    expect(issue).toMatchObject({
+      message: 'Label "todos" should start with an uppercase letter',
+      fix: 'Todos',
+    });
+  });
+
+  it('stays silent on an already-uppercase string', () => {
+    expect(caseIssues(lintConfig(stackWithApp('Todos') as any))).toEqual([]);
+  });
+
+  it('stays silent on a label whose first character has no case (unchanged)', () => {
+    // `'1st quarter'[0].toUpperCase()` === `'1'`, so the rule never fired here
+    // and must still not. A guard written as `label.length && ...` would keep
+    // this green; one written as "warn unless the first char is uppercase"
+    // would flip it. That is the distinction this row protects.
+    expect(caseIssues(lintConfig(stackWithApp('1st quarter') as any))).toEqual([]);
+  });
+});
+
+describe('convention/label-case — a localized label is walked, not indexed', () => {
+  // Falsification for every row: drop the `typeof label !== 'string'` guard
+  // and each of these throws `TypeError: Cannot read properties of undefined
+  // (reading 'toUpperCase')` instead of returning.
+  const rows: [string, (label: unknown) => unknown][] = [
+    ['apps[].label', stackWithApp],
+    ['views[].list.label', stackWithListLabel],
+    ['views[].listViews.*.label', stackWithNamedListLabel],
+  ];
+
+  for (const [carrier, build] of rows) {
+    it(`does not throw on an inline locale map at ${carrier}`, () => {
+      expect(() => lintConfig(build(LOCALIZED) as any)).not.toThrow();
+    });
+
+    it(`does not throw on an EMPTY locale map at ${carrier}`, () => {
+      // `{}` is the value the filed sweep actually mutated in, and it is a
+      // valid `InlineLocaleMapSchema` (a `z.record` with no entries).
+      expect(() => lintConfig(build(EMPTY_MAP) as any)).not.toThrow();
+    });
+
+    it(`reports no case verdict for the localized label at ${carrier}`, () => {
+      expect(caseIssues(lintConfig(build(LOCALIZED) as any))).toEqual([]);
+    });
+
+    it(`does not report the localized label as MISSING at ${carrier}`, () => {
+      // The other failure mode a careless guard produces: treat a non-string
+      // as absent and emit `required/label`, which would be a NEW error on a
+      // schema-valid config — the opposite of leaving behaviour where it was.
+      const issues = lintConfig(build(LOCALIZED) as any) as { rule: string }[];
+      expect(issues.filter((i) => i.rule === 'required/label')).toEqual([]);
+    });
+  }
+
+  it('does not throw on a non-string, non-map label either', () => {
+    // Schema-INVALID input (no label carrier accepts a number), so this is
+    // not the defect's class — but the guard is written on the type, not on
+    // the map shape, and a linter that dies on bad input still cannot report
+    // the bad input. Falsified by a guard spelled `if (isLocaleMap(label))`.
+    expect(() => lintConfig(stackWithApp(42) as any)).not.toThrow();
+    expect(caseIssues(lintConfig(stackWithApp(42) as any))).toEqual([]);
+  });
+});
+
+describe('the localized fixtures are schema-VALID — this is not bad input', () => {
+  // Falsification: if any of these stopped parsing, the crash rows above
+  // would be pinning a diagnostic degrading on bad input (acceptable) rather
+  // than a tool that cannot walk a supported authoring shape (the defect).
+  const stacks: [string, unknown][] = [
+    ['apps[].label', stackWithApp(LOCALIZED)],
+    ['views[].list.label', stackWithListLabel(LOCALIZED)],
+    ['views[].listViews.*.label', stackWithNamedListLabel(LOCALIZED)],
+    ['apps[].label, empty map', stackWithApp(EMPTY_MAP)],
+  ];
+
+  for (const [carrier, stack] of stacks) {
+    it(`${carrier} parses clean`, () => {
+      const parsed = ObjectStackDefinitionSchema.safeParse(normalizeStackInput(stack as any).stack);
+      expect(parsed.success).toBe(true);
+    });
+  }
+
+  it('CONTROL: a number label does NOT parse, so the parse check discriminates', () => {
+    const parsed = ObjectStackDefinitionSchema.safeParse(normalizeStackInput(stackWithApp(42) as any).stack);
+    expect(parsed.success).toBe(false);
+  });
+});
+
+describe('the scorer reaches a verdict on a localized stack', () => {
+  // The join with the swallowed-crash repair one module over: that repair
+  // makes `scoreMetadata` REFUSE when a rule throws. With the guard there is
+  // no throw, so the refusal must not fire here. Falsification: drop the
+  // guard and `lintError` is set, `valid` is false, `grade` is 'F'.
+  it('scores it without a lint crash', () => {
+    const r = scoreMetadata(stackWithApp(LOCALIZED));
+    expect(r.lintError).toBeUndefined();
+    expect(r.valid).toBe(true);
+    expect(r.counts.schemaErrors).toBe(0);
+    expect(r.grade).not.toBe('F');
+  });
+});

--- a/packages/cli/test/lint-label-case-localized.test.ts
+++ b/packages/cli/test/lint-label-case-localized.test.ts
@@ -208,13 +208,13 @@ describe('the localized fixtures are schema-VALID — this is not bad input', ()
 
   for (const [carrier, stack] of stacks) {
     it(`${carrier} parses clean`, () => {
-      const parsed = ObjectStackDefinitionSchema.safeParse(normalizeStackInput(stack as any).stack);
+      const parsed = ObjectStackDefinitionSchema.safeParse(normalizeStackInput(stack as any));
       expect(parsed.success).toBe(true);
     });
   }
 
   it('CONTROL: a number label does NOT parse, so the parse check discriminates', () => {
-    const parsed = ObjectStackDefinitionSchema.safeParse(normalizeStackInput(stackWithApp(42) as any).stack);
+    const parsed = ObjectStackDefinitionSchema.safeParse(normalizeStackInput(stackWithApp(42) as any));
     expect(parsed.success).toBe(false);
   });
 });

--- a/packages/cli/test/lint-label-case-localized.test.ts
+++ b/packages/cli/test/lint-label-case-localized.test.ts
@@ -18,8 +18,9 @@
  *     the property that makes a guard the uncontroversial floor, so it is
  *     pinned per carrier rather than asserted in prose. Falsified by any guard
  *     that also swallows strings (a `typeof` typo, an early return placed
- *     above the string branch, a `label != null` guard that changes the
- *     empty-string case): every lowercase row below stops reporting.
+ *     above the string branch, or the guard inverted to
+ *     `typeof label === 'string'`): every lowercase row below stops
+ *     reporting.
  *  2. **NO CRASH** — a localized label is walked without throwing, on every
  *     carrier whose schema accepts the map. Falsified by removing the guard:
  *     each of those rows throws a `TypeError` instead of returning issues.

--- a/packages/cli/test/score-lint-crash.test.ts
+++ b/packages/cli/test/score-lint-crash.test.ts
@@ -6,12 +6,15 @@
  *
  * ## Why the linter is mocked here rather than driven
  *
- * The crash IS reachable on a schema-valid stack — a localized `label`
+ * The crash WAS reachable on a schema-valid stack — a localized `label`
  * (`{ en: …, 'zh-CN': … }`) on an app, or on a view's `list`, parses clean and
- * makes the label-case rule throw a `TypeError`. That is a defect in the rule,
- * filed on its own; pinning it here would make this suite depend on a bug
- * staying unfixed, and the day someone repairs the rule these assertions would
- * go green for the wrong reason — or be deleted to make them pass.
+ * made the label-case rule throw a `TypeError`. That was a defect in the rule,
+ * filed and fixed on its own (`convention/label-case` now guards on
+ * `typeof label === 'string'`; the pins live in
+ * `lint-label-case-localized.test.ts`). Pinning it here would have made this
+ * suite depend on a bug staying unfixed — and that day has since come: the
+ * repair landed, and had these assertions been driven through the real rule
+ * they would now be green for the wrong reason, or deleted to make them pass.
  *
  * What this file pins is the SCORER's contract, which holds for any throw from
  * any rule: a crash is recorded, never swallowed into `issues: []`. So the


### PR DESCRIPTION
Fixes #15880

`os lint` crashed with a bare `TypeError: Cannot read properties of undefined (reading 'toUpperCase')` on a config that `ObjectStackDefinitionSchema` parses clean.

`checkLabelCase` in `packages/cli/src/commands/lint.ts` indexed its argument (`label[0].toUpperCase()`) on a parameter annotated `string`, while every call site reaches it through `any`-typed config walking. `I18nLabelSchema` is `z.union([z.string(), InlineLocaleMapSchema])`, so on the inline locale map form `label[0]` is `undefined`. The throw escaped `lintConfig` into the command's catch-all: an author who localized an app label or a list-view label could not lint the project at all, on either face, and the message named no rule, no path and no remedy.

The rule now returns early unless `typeof label === 'string'`. That is the whole change.

## Scope: the guard, deliberately not a locale-aware case check

Per triage, the deliverable is that `os lint` stops crashing — not a decision about how a localized label should be case-checked. Resolving the map and case-checking one entry would decide which locale entry is authoritative for a lint verdict, which is a product call this PR does not make. So the rule says **nothing** about a localized label, and the tests assert the *absence* of a `convention/label-case` issue, so that widening the rule later has to rewrite those assertions on purpose rather than satisfy them silently.

## How many call sites reach the rule

`lintConfig` walks five collections — `objects`, `views`, `apps`, `flows`, `agents` — and calls `checkLabelCase` from **4 sites**, reaching **5 authoring paths** (`getViewLabel` resolves to either the `list` or the `listViews.*` path):

| call site | authoring path | governing schema | accepts the map |
| --- | --- | --- | --- |
| `lint.ts:202` | `objects[].label` | `object.zod.ts:1621` — `z.string().optional()` | no |
| `lint.ts:229` | `objects[].fields.*.label` | `field.zod.ts:933` — `z.string().optional()` | no |
| `lint.ts:254` | `views[].list.label` / `views[].listViews.*.label` | `view.zod.ts:1819` — `I18nLabelSchema.optional()` | yes |
| `lint.ts:268` | `apps[].label` | `app.zod.ts:1291` — `I18nLabelSchema` | yes |

The sweep filed on the card found exactly two hits because its fixture reached exactly two. The class is the set of call sites, not the set of sweep hits — which is why `views[].listViews.*.label` is pinned here even though no sweep reached it.

## Reachability observation (measured, not fixed here)

`I18nLabelSchema` is imported by nine `ui/` schemas — `app`, `view`, `page`, `dashboard`, `chart`, `report`, `action`, `bulk-action`, `component` — but `lintConfig` never walks `pages`, `dashboards`, `charts`, `reports`, `actions`, `bulkActions` or `components`. So `convention/label-case` never reaches those labels at all, before or after this change. The rule's coverage is narrower than the schema surface it nominally governs. Reported for triage, not touched here.

## Both faces, before and after

Fixture: an app with `label: { en: 'Todos', 'zh-CN': ... }` plus a minimal manifest, driven through the built CLI.

Before (main's `lint.ts` restored over the fix, CLI rebuilt):

```
os lint --score           EXIT=1    ✗ Cannot read properties of undefined (reading 'toUpperCase')
os lint --score --json    EXIT=1    {"error":"Cannot read properties of undefined (reading 'toUpperCase')","conversions":[]}
```

After:

```
os lint --score           EXIT=0    1 warning(s) · Metadata quality: 97/100  (A)
os lint --score --json    EXIT=0    "passed": true, "score": 97, "grade": "A", no `error` key
```

**What it now says, and that it is true:** the linter finishes and reports exactly one warning — `protocol/missing-engines-range` at `manifest.engines.protocol`, which is a real property of the fixture and unrelated to the label — with `0 errors`, `0 schema` and grade A. It emits no `convention/label-case` issue for the localized label, and it does not report that label as missing either. A guard that merely silenced the crash while emitting a spurious `required/label` is pinned against explicitly.

## Behaviour on a plain string label does not move

Pinned per carrier rather than asserted: all five carriers keep the same warning, message, `fix` value and path. The ablation below is what proves it — under the mutation those rows stay **green**, i.e. this branch and `main` agree on every string carrier.

## Ablation

Falsification conditions named and directions predicted before running. Mutation = `main`'s `lint.ts` restored over the fix; proven on disk by blob hash both ways, restored under an `EXIT INT TERM` trap with absolute paths, restore proven by observed state.

| falsifier | predicted | observed |
| --- | --- | --- |
| `os lint --score` | red | red — exit 1, bare `TypeError` |
| `os lint --score --json` | red | red — `{"error": ..., "conversions": []}` |
| localized rows, 3 map-accepting carriers (13 rows) | red | red — 13 red |
| plain-string carrier rows (8 rows) | **green** | **green — 8 green** |
| schema-valid fixture block (5 rows) | green | green — independent of `lint.ts` |
| scorer reaches a verdict | red | red — `lintError` set |
| `score-lint-crash.test.ts` | green | green — mocks the linter |

Mutation proof: source blob `d6c14bb15f16...` (main) with the guard marker absent, and the marker confirmed absent in `dist/` so the CLI ran mutated code. Restore proof: blob back to `611e6613c33b...`, `git diff HEAD` empty, marker present in source and in `dist/` again — observed state, not an exit code.

## A repair to the pins themselves

The schema-valid block called `normalizeStackInput(stack).stack`, but `normalizeStackInput` returns the normalized stack directly, not a wrapper. `.stack` was `undefined`, so all four rows were parsing `undefined` and were **red**. Its CONTROL row — "a number label does NOT parse, so the parse check discriminates" — was passing for the wrong reason, since `undefined` does not parse either. The block that exists to prove the localized fixtures are supported authoring input was measuring nothing. Dropping `.stack` makes the four positives parse clean and leaves the control rejecting, so the control discriminates on the label for the first time.

## For triage: a schema asymmetry this PR deliberately did not touch

Measured here, not changed, per the binding instruction not to unify the two declarations in this PR:

- `objects[].label` (`packages/spec/src/data/object.zod.ts:1621`) is `z.string().optional()`
- `objects[].fields.*.label` (`packages/spec/src/data/field.zod.ts:933`, `FieldSchema`) is `z.string().optional()`
- `apps[].label` (`packages/spec/src/ui/app.zod.ts:1291`, `AppSchema`) is `I18nLabelSchema`
- `views[].list.label` (`packages/spec/src/ui/view.zod.ts:1819`) is `I18nLabelSchema.optional()`

So an app label may be localized and an object label may not. Narrowing or widening either is a published-declaration change and needs a human floor. Flagged for the dispatching seat to file; not filed from here.

**Two anchors above were corrected after review.** They were inherited from triage and were pointing at the wrong member; both were re-measured against the tree at this PR's merge base and the citations now name the schema each line actually belongs to.

| claim as first written | what that line actually is | corrected anchor |
| --- | --- | --- |
| `app.zod.ts:300` is `AppSchema.label` | `BaseNavItemSchema.label` (`BaseNavItemSchema` opens at `app.zod.ts:295`) | `app.zod.ts:1291` |
| `field.zod.ts:299` is the field base label, `z.string()` | `SelectOptionSchema.label` (`SelectOptionSchema` opens at `field.zod.ts:288`) | `field.zod.ts:933`, and it is `z.string().optional()`, not `z.string()` |

Both replacements are still `I18nLabelSchema` and still a plain string respectively, so **every conclusion drawn above is unchanged** — the accepts-the-map column, the 4-call-site/5-authoring-path count and the asymmetry itself were all driven independently of these line numbers. The one substantive correction is `.optional()`: with it, both object-side labels are `z.string().optional()`, so there is no required-vs-optional asymmetry between them. The only asymmetry is plain string vs `I18nLabelSchema`, which is what #16282 records. The other two anchors (`object.zod.ts:1621`, `view.zod.ts:1819`) were re-measured too and are correct as written.

## Verification

### At head `c8d31a3fe0e` — the implementation

- `pnpm --filter '@objectstack/cli^...' build` — `VERDICT command-exit 0`
- `pnpm --filter @objectstack/cli exec vitest run` over 7 lint/score files — `VERDICT command-exit 0`, **7 files / 68 tests passed**
- `pnpm --filter @objectstack/cli typecheck` — `VERDICT command-exit 0`; `check:test-typecheck: OK`. All three edited files confirmed present in the `tsconfig.test.json` program via `--listFiles`, and zero errors in them (the ledger's 3 files / 28 errors are pre-existing and untouched)
- Gate roster: `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` — `Reconciliation — 57 famil(ies)`. Targeted subset run locally, all exit 0: `check-changeset-no-major`, `check-empty-changeset`, `check:nul-bytes`, `check:test-source-alias`, `check-changeset-fixed`, `check:objectui-changeset`, `check:changeset-gate-self-tests`. The farm is CI's to run in full.

### At head `764c049adb8` — the changeset level

The first head graded `@objectstack/cli` `patch` while declaring clause ②, and `Check Changeset` refused it. The level is now `minor`.

That axis is only readable from a `pull_request` payload, so it is driven here with `--event` carrying this PR's live label set (`documentation`, `size/m`, `tests`, `tooling`, `needs:contract-review`) and its body. Same payload and same `--base origin/main` in both runs — only the tree differs, by the one word:

```
CONTROL  --head c8d31a3fe0e  (patch)   EXIT=1
  This PR declares clause-2 YES and grades a package it grew `patch`.
    - @objectstack/cli: patch   ← this PR moves @objectstack/cli's packages/*/src/**

HEAD     (764c049adb8, minor)     EXIT=0
  LEVEL AXIS: this PR declares clause-2 `yes`, and no package whose
  `packages/*/src/**` it moves is graded `patch`.
    carrier: `needs:contract-review` IS on this PR
```

The control is what makes the green informative: it reproduces the exact CI refusal from the same payload, so the pass is a read axis rather than an unread one.

⚠️ For anyone re-running this: the bare `node scripts/check-changeset-no-major.mjs --base origin/main` form prints `LEVEL AXIS: NOT MEASURED` **and exits 0** on both trees. It cannot distinguish them, and reading that exit code as a pass is what let the wrong level reach CI. Drive it with `--event`.

A falsification condition in the test header was also replaced, because it did not falsify. The NO MOVE property offered `a label != null guard that changes the empty-string case` as a third way to swallow strings. It is neither: on a lowercase string `label != null` is true, so the row still reports; on `''` both spellings reach the falsy `label &&` test and return null. Measured as a pair, mutating `lint.ts` on disk each way (blob hash before/after, restored under an `EXIT INT TERM` trap, restore proven by `git diff HEAD` empty):

| guard put in place of the real one | NO MOVE lowercase rows that went red | falsifies NO MOVE? |
| --- | --- | --- |
| `if (label == null) return null;` — as the header claimed | **0 of 5** | no |
| `if (typeof label === 'string') return null;` — the replacement | **5 of 5** | yes |

The header now names the inverted guard, which produces the observable it claims: every lowercase row stops reporting.

Also at this head, all exit 0: `check:nul-bytes`, `check:changeset-gate-self-tests`, `check:empty-changeset`, `check:objectui-changeset`, `check:changeset-fixed`, `check:doc-authoring`, `check-comment-mask-adoption`, `check-adr-0087-registration --base origin/main`, plus the `@objectstack/cli` dependency-closure build and the package's own build, `@objectstack/cli` typecheck (`check:test-typecheck: OK`, the 3-file / 28-error debt ledger unchanged), and the full `@objectstack/cli` vitest suite — **all 270 test files green at this head**, measured in two passes: 263 files in the first (`3194 passed | 6 expected fail | 31 skipped`), and the remaining 7 in a second pass (`7 passed`, 31 tests). Those 7 drive the PUBLISHED entry and need `packages/cli/dist`, which the first pass lacked because it had built only the dependency closure (`@objectstack/cli^...`, which excludes the package itself); they reported `packages/cli is not built` — a missing prerequisite, not a finding — and pass once the package's own build exists.

Changeset: `minor` on `@objectstack/cli`. A bug fix by shape, but the PR declares clause ② and the conformance limb fires — the JSON face moves from `{"error": ...}` / exit 1 to `{"passed": true, ...}` / exit 0 on an input class `ObjectStackDefinitionSchema` parses clean — and a declared widening of a published surface takes at least `minor` (maintainer ruling, 2026-09-04 decision batch #35).

---
_Generated by [Claude Code](https://claude.ai/code/session_01D47qPfEWVPmhguWgBZCi5N)_