### PR TITLE
test(plugin-auth): register sys_position / sys_user_position in the sso-register harness

### DIFF
--- a/packages/plugins/plugin-auth/src/sso-register-platform-admin-gate.test.ts
+++ b/packages/plugins/plugin-auth/src/sso-register-platform-admin-gate.test.ts
@@ -46,12 +46,33 @@
  *
  * ## Fixture note
  *
- * The RBAC objects (`sys_permission_set`, `sys_user_permission_set`) live in
- * `@objectstack/plugin-security`. They are declared locally here — the
- * `last-admin-guard.test.ts` precedent — with only the columns the judge reads,
- * so a fixture does not add a dependency edge to plugin-auth. Everything else is
- * real: a real ObjectQL engine over real better-sqlite3, the real `AuthManager`
- * with the real `sso()` plugin, real sign-up and real session cookies.
+ * The RBAC objects (`sys_permission_set`, `sys_user_permission_set`,
+ * `sys_position`, `sys_user_position`) live in `@objectstack/plugin-security`.
+ * They are declared locally here — the `last-admin-guard.test.ts` precedent —
+ * with only the columns the judge reads, so a fixture does not add a dependency
+ * edge to plugin-auth. Everything else is real: a real ObjectQL engine over real
+ * better-sqlite3, the real `AuthManager` with the real `sso()` plugin, real
+ * sign-up and real session cookies.
+ *
+ * ## ⚠️ Why the POSITION pair is registered, when no assertion mentions it
+ *
+ * [#14846] `resolveAuthzContext` reads `sys_user_position` on every resolution,
+ * and `sys_position` whenever the principal holds any position — which is
+ * always, because every authenticated member implicitly holds the ADR-0090 D5
+ * `everyone` anchor. Until those two objects were registered here the tables did
+ * not exist, so both reads were REFUSED by the driver and `tryFind`'s
+ * loud-failure arm logged a `[sql-driver] DATABASE_ERROR … no such table` line
+ * while the resolver carried on treating the refusal as "this principal holds no
+ * positions". Measured on this file alone: `Tests 4 passed (4)` sitting on top of
+ * EIGHT refused reads, four per table, and not one assertion able to notice.
+ *
+ * That is a latent false green on a security-adjacent resolver, not untidy log
+ * output: a future change that made platform-admin standing genuinely depend on
+ * a position row would have been measured against an engine that can never
+ * return one, and this file would have stayed green. It is the same shape
+ * #14756 exists to remove — a harness whose registered object set is narrower
+ * than the code path it drives — kept invisible because the errors are logged
+ * rather than thrown.
  */
 
 import { describe, it, expect, afterEach, vi } from 'vitest';
@@ -98,6 +119,39 @@ const sysUserPermissionSet = {
   },
 };
 
+/**
+ * [#14846] The ADR-0057 D4 position pair, in the same shape and for the same
+ * reason as the permission-set pair above — these are read by the resolver this
+ * file drives, so the harness has to be able to answer them.
+ *
+ * `active` is the ADR-0049 predicate the resolver applies to `sys_position`
+ * (`isRowActive`, §6a). `organization_id` is what the driver's
+ * `applyTenantScope` filters the organization-scoped `sys_position` read on, and
+ * what §4 tests to decide whether a `sys_user_position` row is global or belongs
+ * to another tenant.
+ */
+const sysPosition = {
+  name: 'sys_position',
+  label: 'Position',
+  fields: {
+    id: { name: 'id', type: 'text' as const, primaryKey: true },
+    name: { name: 'name', type: 'text' as const },
+    active: { name: 'active', type: 'boolean' as const },
+    organization_id: { name: 'organization_id', type: 'text' as const },
+  },
+};
+
+const sysUserPosition = {
+  name: 'sys_user_position',
+  label: 'User Position',
+  fields: {
+    id: { name: 'id', type: 'text' as const, primaryKey: true },
+    user_id: { name: 'user_id', type: 'text' as const },
+    position: { name: 'position', type: 'text' as const },
+    organization_id: { name: 'organization_id', type: 'text' as const },
+  },
+};
+
 const engines: ObjectQL[] = [];
 afterEach(async () => {
   while (engines.length) {
@@ -127,6 +181,8 @@ async function bootEngine(): Promise<ObjectQL> {
   }
   engine.registry.registerObject(sysPermissionSet as never, '@objectstack/plugin-auth');
   engine.registry.registerObject(sysUserPermissionSet as never, '@objectstack/plugin-auth');
+  engine.registry.registerObject(sysPosition as never, '@objectstack/plugin-auth');
+  engine.registry.registerObject(sysUserPosition as never, '@objectstack/plugin-auth');
   await engine.syncSchemas();
   return engine;
 }


### PR DESCRIPTION
Fixes #14846

## What this changes

`bootEngine()` in `packages/plugins/plugin-auth/src/sso-register-platform-admin-gate.test.ts`
registered the auth identity objects plus hand-declared `sys_permission_set` and
`sys_user_permission_set` fixtures, but never the position pair the platform-admin standing
resolver also reads. This registers `sys_position` and `sys_user_position` the same
hand-declared way, with only the columns the judge reads. Test-only; no source, contract or
export surface is touched.

## The defect, and why the suite could not see it

`resolveAuthzContext` reads `sys_user_position` on every resolution, and `sys_position`
whenever the principal holds any position — which is always here, because every
authenticated member implicitly holds the ADR-0090 D5 `everyone` anchor. With neither table
registered, both reads were refused by the driver and `tryFind`'s loud-failure arm logged
them, while the resolver went on treating each refusal as "this principal holds no
positions".

So the file reported `Tests  4 passed (4)` sitting on top of **eight**
`[sql-driver] DATABASE_ERROR ... no such table` lines, four per table, and not one assertion
could notice.

That is a latent false green on a security-adjacent resolver, not untidy log output:
**a future change that made platform-admin standing genuinely depend on a position row would
have been measured against an engine that can never return one, and this file would have
stayed green.** It is the same shape #14756 exists to remove — a harness whose registered
object set is narrower than the code path it drives — kept invisible because the errors are
logged rather than thrown.

## Measurement

The acceptance instrument is one `vitest run` of that single file, counting
`[sql-driver] DATABASE_ERROR ... no such table` lines. Re-derived on this branch's own head
rather than quoting the card's two-day-old tally. The before-leg was measured by restoring
the file to `origin/main` on the same tree; the mutation and the restore were both proven by
blob hash (`git hash-object` against the `HEAD` blob), and the tree was verified clean
afterwards.

| line class | before | after |
| --- | --- | --- |
| refused read on `sys_position` | 4 | 0 |
| refused read on `sys_user_position` | 4 | 0 |
| **total driver refusals** | **8** | **0** |
| non-deterministic paging warnings | 6 | 0 |
| suite result | `Tests  4 passed (4)` | `Tests  4 passed (4)` |

The six paging warnings fall out for the same root cause and are not a second fix: the driver
emitted them because it had not created those tables and therefore could not name a unique
column to order by. Its own remedy line says "declare the object so this driver manages its
table", which is exactly what registering them does.

No test turned red.

## Which columns, and why

Both fixtures follow the permission-set pair already in the file — a plain object literal
with the columns the resolver actually touches, so a fixture adds no dependency edge from
plugin-auth to plugin-security.

- `sys_position`: `id`, `name`, `active`, `organization_id`. `active` is the ADR-0049
  predicate the resolver applies through `isRowActive` in section 6a; `organization_id` is
  what the driver's `applyTenantScope` filters the organization-scoped `sys_position` read
  on, so omitting it would have quietly dropped that wall from the harness.
- `sys_user_position`: `id`, `user_id`, `position`, `organization_id` — the where key plus
  the three columns section 4 reads to place a row as global or another tenant's.

## Scope

The card offered a second direction — deciding the resolver's absent-table read is a benign
discriminated case and no longer logging it. That one is not taken here: it overlaps the
fenced arm of #14615 and belongs to that card, per triage. Also untouched, deliberately:
`packages/core/src/security/admin-standing-surface.ts`, the two plugin-security object
definitions, and the other four plugin-auth harnesses.

## Verification

Run at `519a76915`, the head this PR carries.

- `pnpm --filter @objectstack/plugin-auth exec vitest run --maxWorkers=2 src/sso-register-platform-admin-gate.test.ts`
  — `Test Files  1 passed (1)` / `Tests  4 passed (4)`, zero `DATABASE_ERROR` lines.
- `pnpm --filter @objectstack/plugin-auth exec vitest run --maxWorkers=2`
  — `Test Files  102 passed (102)` / `Tests  2158 passed (2158)`.
- `pnpm --filter @objectstack/plugin-auth typecheck` — green, including the
  `check:test-typecheck` leg that covers the test layer (the package's own `tsconfig.json`
  excludes `**/*.test.ts`, so that third leg is the one that measures this file). Its debt
  ledger is unmoved: 10 files / 94 errors / 23 pinned signatures held.
- Gate family derived mechanically at this head with
  `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack --commands`, plus the
  four artifact rosters the tool flags as sitting in a directory this diff's path is in
  (`check:auth-mount-ledger`, `check:authz-resolver`, `check:error-code-casing`,
  `check:filter-alias-parity`). All 50 commands run, all exit 0, each exit code captured
  immediately after a single redirect and never through a pipe. Two of them
  (`check:dual-build-cjs-loads`, `check:type-check-debt`) first answered exit 3
  PREREQUISITE NOT MET; the closure was built with
  `pnpm exec turbo run build --filter='./packages/*' --filter='./packages/*/*'` and both were
  re-run to a real green rather than recorded as passes.

## Changeset

Carries `skip-changeset`, judged rather than assumed: the diff is one `*.test.ts` file, and
plugin-auth publishes `files: ["dist", "README.md", "CHANGELOG.md"]` with two tsup entries
(`src/index.ts`, `src/rate-limit-storage.ts`). No test file reaches `dist`, so this PR
releases nothing from any package and there is no user-visible change to describe.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpTx2tbq3pZRYAdoGt6E6Y)_