### PR TITLE
chore(devx): the three sequential-double-blank comment-mask callers take maskCommentsAndLiterals (#15776, residual)

### DIFF
--- a/scripts/check-keyed-text-bounds.mjs
+++ b/scripts/check-keyed-text-bounds.mjs
@@ -171,7 +171,7 @@ import { dirname, join, relative, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { isEntrypoint } from './invoked-as.mjs';
-import { blank, scanSource } from './js-comment-mask.mjs';
+import { blank, maskComments, maskCommentsAndLiterals, scanSource } from './js-comment-mask.mjs';
 
 // ── The self-test's own battery roster and floor (#13489) ──────────────────
 //
@@ -398,11 +398,13 @@ function unhintedFiles(relPaths) {
  * READ from. `struct` additionally has literal CONTENT blanked, delimiters
  * kept: it is what brackets are COUNTED on, so a `{` inside a string cannot
  * move the parse.
+ *
+ * Both are `js-comment-mask.mjs`'s own exports (#15776) rather than a
+ * composition re-derived here.
  */
 function project(source) {
-  const { comment, literal } = scanSource(source);
-  const masked = blank(source, comment);
-  return { masked, struct: blank(masked, literal) };
+  const masked = maskComments(source);
+  return { masked, struct: maskCommentsAndLiterals(source) };
 }
 
 const OPEN_TO_CLOSE = { '(': ')', '{': '}', '[': ']' };

--- a/scripts/check-runner-env-posture.mjs
+++ b/scripts/check-runner-env-posture.mjs
@@ -77,7 +77,7 @@ import { readFileSync, readdirSync, statSync, existsSync } from 'node:fs';
 import { join, relative, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { scanSource, blank } from './js-comment-mask.mjs';
+import { maskComments, maskCommentsAndLiterals } from './js-comment-mask.mjs';
 import { isEntrypoint } from './invoked-as.mjs';
 
 // ── The self-test's own battery roster and floor (#13489) ──────────────────
@@ -254,12 +254,13 @@ export const RUNNER_ENV_BRACKET_PATTERN =
  *
  * Offsets are preserved by both maskings, so a reported line number still
  * points at the real line.
+ *
+ * Both are `js-comment-mask.mjs`'s own exports (#15776) rather than a
+ * composition re-derived here.
  */
 export function findRunnerEnvReads(source) {
-  const flags = scanSource(source);
-
-  const commentMasked = blank(source, flags.comment);
-  const bothMasked = blank(commentMasked, flags.literal);
+  const commentMasked = maskComments(source);
+  const bothMasked = maskCommentsAndLiterals(source);
 
   const seen = new Set();
   const out = [];

--- a/scripts/check-widget-option-census.mjs
+++ b/scripts/check-widget-option-census.mjs
@@ -119,7 +119,7 @@ import { fileURLToPath } from 'node:url';
 import process from 'node:process';
 
 import { isEntrypoint } from './invoked-as.mjs';
-import { blank, scanSource } from './js-comment-mask.mjs';
+import { maskCommentsAndLiterals } from './js-comment-mask.mjs';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(HERE, '..');
@@ -179,10 +179,12 @@ const NON_DECLARED_MEMBERS = [
  *
  * Delimiters survive (the scanner flags literal content, not its quotes), so a
  * quoted object key and an array of string literals are both still locatable.
+ *
+ * `js-comment-mask.mjs`'s own `maskCommentsAndLiterals` (#15776), not a
+ * composition re-derived here.
  */
 export function structureMask(source) {
-  const flags = scanSource(source);
-  return blank(blank(source, flags.comment), flags.literal);
+  return maskCommentsAndLiterals(source);
 }
 
 /**


### PR DESCRIPTION
Fixes #15776

`js-comment-mask.mjs` publishes `maskCommentsAndLiterals` (#15594, PR #15774). PR
#16300 converted the eight callers the card originally named that spelled the
comments+literals projection as `comment[i] | literal[i]` -> `blank`. Its Release
comment (`5559693595`) recorded a third spelling three more files carry — a
**sequential double `blank`**: `blank(source, comment)` then `blank(masked,
literal)` — a shape the card's original grep could not match, measured at 0
disagreements over 6,206 files vs the export (live control 6,176). This PR
converts those three, closing the card's class.

## Per-file table

| file | line (pre-edit) | spelled as | shape | verdict |
|:--|:--|:--|:--|:--|
| `scripts/check-keyed-text-bounds.mjs` | `:402` | `project` | wrapper, keeps pair `{ masked, struct }` | converted |
| `scripts/check-runner-env-posture.mjs` | `:258` (inline in `findRunnerEnvReads`) | `commentMasked` / `bothMasked` | inline composition, not extracted | converted |
| `scripts/check-widget-option-census.mjs` | `:183` | `structureMask` (exported, no external importers) | straight substitution | converted |

All three now call `maskComments` / `maskCommentsAndLiterals` from
`js-comment-mask.mjs` instead of re-deriving the composition by hand.
`js-comment-mask.mjs` itself is untouched: no new export, no semantics change.
`check-keyed-text-bounds.mjs` keeps one unrelated `scanSource`/`blank` call site
(`:1443`, `blank(ownSource, scanSource(ownSource).comment)` — a single
comments-only mask, not the comments+literals class this card is about) — out
of this card's scope, left alone.

## Residual check

A recursive scan of `scripts/**` for the sequential double-`blank` spelling
(`blank(blank(`) and for the `comment[i] | literal[i]` spelling, after this
PR's edits, finds nothing outside `js-comment-mask.mjs` itself and the
Release's adopted out-of-class list (`check-entry-guard.mjs`,
`pm/dispatch-gates.mjs`'s `maskSelfTests`, and the two per-index guards in
`check-undeclared-dep-imports.mjs` / `eslint-fatal-guard.mjs`, all of which
materialise no comments+literals mask). The card's class is empty after this PR.

## Acceptance — byte-identical before/after

Method: plain + `--self-test` output captured on `origin/main` (`3e270d4e2`)
before the edits and again on the edited tree after; exit code captured by
redirect-then-`$?`, never across a pipe.

| gate | plain (stdout+stderr) | `--self-test` (stdout+stderr) |
|:--|:--|:--|
| `check-keyed-text-bounds` | EMPTY diff, exit 0→0 | EMPTY diff, exit 0→0 |
| `check-runner-env-posture` | EMPTY diff, exit 0→0 | EMPTY diff, exit 0→0 |
| `check-widget-option-census` | EMPTY diff, exit 0→0 | EMPTY diff, exit 0→0 |

6 runs, 6 empty diffs, exit 0 on every side.

## Ablation control (proves the diff could have failed)

Two legs against `js-comment-mask.mjs`'s `maskCommentsAndLiterals`, each
trap-restored (proven by `git diff HEAD` empty and the blob hash returning to
`7956343dd85bdef8924372cb2cdec45fcd54501d`):

- **Leg 1 — literal half dropped** (degrades to comments-only)
- **Leg 2 — identity** (nothing blanked at all)

| gate | plain / leg1 | plain / leg2 | self-test / leg1 | self-test / leg2 |
|:--|:--|:--|:--|:--|
| `check-keyed-text-bounds` | MOVED (red: 3 unclassifiable declarations) | MOVED (same) | unmoved | MOVED |
| `check-runner-env-posture` | unmoved | MOVED (red) | MOVED (red, 3/34 self-test cases fail) | MOVED (red, 6/34 fail) |
| `check-widget-option-census` | unmoved | unmoved | unmoved | MOVED (red) |

Every gate has at least one reading that moves under at least one leg, so the
byte-identical acceptance above is not vacuous for any of the three. Honest
exception: **`check-widget-option-census`'s plain run is unmoved by BOTH
legs** — the real spec/parser corpus this gate reads today does not happen to
contain comment or string-literal content that a degraded mask would
mis-parse (its self-test's own literal-masking fixture sits at a nested
bracket depth the depth-walker already excludes regardless of masking, so it
does not discriminate this ablation either — a pre-existing property of that
fixture, not introduced here). Not filed separately: unlike #16299 (fully
vacuous under both legs, both plain and self-test), this file's self-test
channel **does** move under leg 2, so the gate's overall acceptance is not
fully unpinned — only its plain-run channel is silent on this particular
degradation today.

## Differential proof (closes the gap regardless)

Because behaviour cannot be told apart from output alone, the deleted
sequential-double-blank spelling was run against its replacement
(`maskCommentsAndLiterals`) directly, over the whole tree, with a live
control:

```
files read:                    6,192  (106,979,676 chars)
old spelling vs new export:    0 disagreements
comments-only vs new (control): 6,167 files disagree
```

Zero disagreements over the full corpus is what actually retires the risk —
identical to the equivalence PR #16300's own report measured for the other
spelling variant.

## Gates

`node scripts/pm/dispatch-gates.mjs --changed --commands --repo
objectstack-ai/objectstack` on the final tree (`10691a60e`) derives 34
commands over the 3 changed paths. `--ran` reconciliation: 34 derived, 34 run,
0 NOT-MEASURED, 0 UNRUN. **All 34 of 34 exit 0** — `pnpm check:pm-dispatch-gates`
(initially still running at draft-open time) finished green (1,534 self-test
cases pass) shortly after. `check-comment-mask-corpus`, `check-scripts-symbol-anchors`,
`check-self-test-wired`, `check-declaration-mirrors` (the families that would
redden on a dropped export, an unwired self-test, or a stale mirror) all exit
0. `check:nul-bytes` exit 0, plus an independent
`grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]'` over the three files, no hits.

`TURBO_SCM_BASE=3e270d4e2 pnpm exec turbo ls --affected` → 0 packages: the
diff is `scripts/**` only, so no package test/typecheck is owed.

## Scope note

`skip-changeset` applied: internal gate scripts, nothing published from any
package. No `content/docs/releases/` change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vbw3RPgdtqesx4azk9SbW8)_