### PR TITLE
docs(plugin-approvals): recall's docblock summary line states the status, not an exclusive actor set

### DIFF
--- a/.changeset/recall-docblock-summary-line-drops-submitter-only.md
+++ b/.changeset/recall-docblock-summary-line-drops-submitter-only.md
@@ -1,0 +1,11 @@
+---
+"@objectstack/plugin-approvals": patch
+---
+
+Documentation: `ApprovalService.recall`'s docblock summary line no longer claims the submitter is the only actor.
+
+The block opened with "Withdraw a pending request (submitter only)" and then, three paragraphs down, stated the #3424 privileged override correctly — "The #3424 privileged override reaches a PENDING request only (#12775, maintainer ruling 2026-09-02)". Both cannot be true, and the code settles it in the paragraph's favour: `overrideAdmits` short-circuits the non-submitter guard on a `pending` request. A reader who finishes the block is not misled, but the summary line is the one an editor shows on hover and the one any single-line extraction takes.
+
+The summary line now reads "Withdraw an undecided request." — status is the axis and the actor rules are left to the paragraphs that already state them correctly, the same structural move the `IApprovalService.recall` docstring makes on the spec side.
+
+Prose only: no guard, no branch and no signature changed. It earns a changeset rather than `skip-changeset` because `@objectstack/plugin-approvals` publishes `dist/`, and this text ships inside the published `dist/index.d.ts` for `ApprovalService.recall`.

--- a/packages/plugins/plugin-approvals/src/approval-service.ts
+++ b/packages/plugins/plugin-approvals/src/approval-service.ts
@@ -3146,7 +3146,7 @@ export class ApprovalService implements IApprovalService {
   }
 
   /**
-   * Withdraw a pending request (submitter only). Finalises the row as
+   * Withdraw an undecided request. Finalises the row as
    * `recalled`, releases the record lock (keyed on pending status), mirrors
    * the status field when configured, and resumes the owning flow run down
    * the `reject` branch with `output.decision = 'recall'` — leaving the run


### PR DESCRIPTION
Fixes #15643

`ApprovalService.recall`'s docblock opened with `Withdraw a pending request (submitter only).` and then, three paragraphs down, stated the privileged override correctly — `The #3424 privileged override reaches a PENDING request only (#12775, maintainer ruling 2026-09-02).` Both cannot be true, and the code settles it in the paragraph's favour: `overrideAdmits` short-circuits the non-submitter guard on a `pending` row.

Nobody who reads the whole block is misled — it corrects itself before the reader leaves it. What is wrong is the **summary line**: the one an editor shows on hover and the one any single-line extraction takes, and often the only line that gets read.

## The change

One line, inside the docblock:

```
-   * Withdraw a pending request (submitter only). Finalises the row as
+   * Withdraw an undecided request. Finalises the row as
```

Status becomes the axis instead of one general rule plus corrections, and the actor rules stay with the paragraphs that already state them correctly — the same structural move the `IApprovalService.recall` docstring makes on the spec side (#14670). "Undecided" is this contract's own vocabulary: `ApprovalRecallInput` is already documented as *"Input for recalling (withdrawing) an undecided request"*, and the two statuses the method accepts (`pending`, `returned`) are exactly the undecided ones — every other status throws `INVALID_STATE`.

## Deliberately untouched

- `overrideAdmits` and the non-submitter guard under it — not one character. No behaviour moves.
- `isOverrideActor`'s docblock — it already names all four levers (approve / reject / reassign / recall). It is the evidence here, not the defect.
- `packages/spec` — that half belongs to #14670 and is outside this PR's fence.

## Evidence

**Comment-only, mechanically.** `git diff -U0` is one hunk of one line; both sides begin with ` * ` and sit inside the docblock spanning lines 3148-3167 (`/**` .. `*/`). Changed non-comment lines: 0.

**The same reading before and after, not merely green.**

- before, on the unmodified tree at base `3e270d4e2`: `pnpm --filter @objectstack/plugin-approvals test` -> `Test Files  41 passed (41)` / `Tests  690 passed (690)`
- after, on head `a6d91b289`: identical -> `Test Files  41 passed (41)` / `Tests  690 passed (690)`

**Typecheck, with its coverage confirmed rather than assumed.** `pnpm --filter @objectstack/plugin-approvals typecheck` exits 0, echoing the script it ran (`tsc --noEmit && tsc --noEmit -p tsconfig.scripts.json && pnpm check:test-typecheck`). `tsc -p tsconfig.json --listFilesOnly` lists 480 files, and `approval-service.ts` is one of them.

**Gates.** The family was derived mechanically on the final head — `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack --commands` at `a6d91b289` — and all 51 commands were run, each exit code captured immediately after a single redirect, never through a pipe. 49 were green on the first pass. `check:dual-build-cjs-loads` and `check:i18n` returned exit 3 `PREREQUISITE NOT MET` (both read built output); after `turbo run build --filter='!@objectstack/docs'` both were re-run into real readings and are green — 103 published require entry points across 66 packages load, and 9 i18n packages report in sync. The four artifact-roster families the deriver flagged as keeping their roster under one of these paths were run too: `check-changeset-fixed`, `check:authz-resolver`, `check:error-code-casing`, `check:filter-alias-parity` — all exit 0.

## Changeset: `patch`, and why not `skip-changeset`

Judged, not defaulted. `skip-changeset` is for a diff that publishes nothing from any released package. `@objectstack/plugin-approvals` is published and ships `dist`, and this docblock sits on a public method of an exported class, so the prose ships: after the build, `packages/plugins/plugin-approvals/dist/index.d.ts` carries the new summary line. Repo practice agrees — documentation-only docstring corrections in a published package took a patch changeset in #16246 and #16191, and the spec-side correction from #14670 is a pending `@objectstack/spec: patch`; the comment-only change that carried no changeset (`b45c3f6c8`) edited comments **inside a method body**, which never reach the emitted declarations.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpTx2tbq3pZRYAdoGt6E6Y)_