### PR TITLE
fix(service-automation): compare the screen caller-provenance record leg by value, so a durable resume cannot skip a screen

### DIFF
--- a/.changeset/screen-provenance-record-leg-by-value.md
+++ b/.changeset/screen-provenance-record-leg-by-value.md
@@ -1,0 +1,15 @@
+---
+"@objectstack/service-automation": patch
+---
+
+A wizard screen is no longer skipped after a durable pause because a record column happens to be an array.
+
+`judgeHeadlessScreen` decides a screen was already answered by proving the negative: a field is **not** caller-supplied when the subject record carries that key and `params` holds the same value — necessary because the params bag a flow action arrives with is `{ ...record, recordId, <object>Id, ...params }`, so every column of the launched row is in there whether the caller named it or not.
+
+That comparison was reference identity (`Object.is`), which is real in memory and does not survive persistence. A suspended run stores its context as JSON and resumes from the parsed copy — and the store is preferred over the in-process cache whenever one is wired, so no restart is needed. After that round trip an **array or object** column is equal but no longer identical: the record leg could not disprove it, the field read as caller-supplied, and a later screen with no required fields of its own was **skipped on a run that had supplied nothing**. An interactive user pressed a button and never saw a form they should have been shown; the run completed carrying the row's own value as if they had typed it. Reproduced end to end against a wired store, not inferred.
+
+The record leg now compares by value (`isDeepStrictEqual`), which survives serialisation. That predicate compares primitives with `Object.is` itself, so this is a strict widening of the "not caller-supplied" set — every pair the old check called equal it still calls equal, plus the structurally identical non-primitives. More screens render, never fewer, which is the direction this module resolves every ambiguity in.
+
+**Accepted cost, precisely.** A caller that genuinely re-sends a value structurally identical to the row's column is no longer distinguishable from the dispatcher's seed, so it now gets the screen rendered instead of skipped — a lost skip on a headless call, never a lost run, and the same trade the module's other legs already make. Scalar columns behave exactly as before, on both sides of a pause. The row-id leg keeps identity comparison deliberately: a row id is a scalar by construction, so serialisation cannot defeat it and there is nothing there to widen. Measured overhead is a deep compare per declared screen field at screen entry: ~1.5 µs added for a deliberately maximal screen that declares a field for every one of a ten-column row, which is about 38% of one `JSON.stringify` of the run context — a cost the durable store already pays on every suspend.
+
+This closes the gap the same release's screen-flow headless-satisfaction note records as known.

--- a/packages/services/service-automation/src/builtin/screen-headless-provenance-durable-resume.test.ts
+++ b/packages/services/service-automation/src/builtin/screen-headless-provenance-durable-resume.test.ts
@@ -164,7 +164,7 @@ describe('caller-provenance survives a durable resume (#15812)', () => {
         expect(resumed.screen?.nodeId).toBe('review');
         // Not merely "it stopped": it stopped WITHOUT having answered itself
         // from the row.
-        expect(resumed.output?.tags).toBeUndefined();
+        expect((resumed.output as Record<string, unknown> | undefined)?.tags).toBeUndefined();
     });
 
     /**

--- a/packages/services/service-automation/src/builtin/screen-headless-provenance-durable-resume.test.ts
+++ b/packages/services/service-automation/src/builtin/screen-headless-provenance-durable-resume.test.ts
@@ -1,0 +1,238 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * The caller-provenance record leg survives a DURABLE resume (#15812).
+ *
+ * `judgeHeadlessScreen` (#15705) lets a screen continue when the CALLER already
+ * answered it. It cannot read that off `context.params`, because the params bag
+ * a flow action reaches the engine with is not the caller's bag —
+ * `seedFlowActionParams` spreads the whole subject row in first. So it proves
+ * the NEGATIVE instead: a key is not caller-supplied when the record carries it
+ * and `params` holds the same value.
+ *
+ * That leg was written as `Object.is`, i.e. as reference identity, and the
+ * record spread does copy the record's own value by reference — so in memory a
+ * run that supplied nothing IS identity-equal there. **Persistence destroys
+ * that.** A suspended run persists its `context` as JSON
+ * (`suspended-run-store.ts`: `context_json: JSON.stringify(...)` on save,
+ * `parseJson` on load) and `resumeInternal` continues the run with the parsed
+ * value — and `loadSuspendedRunStrict` prefers the STORE over the hot cache
+ * whenever one is wired, so it does not take a process restart. After that
+ * round trip `params.tags` and `record.tags` are equal but no longer identical:
+ * the record leg could not disprove them, the field read as caller-supplied,
+ * and a later all-optional screen was SKIPPED on a run that had supplied
+ * nothing.
+ *
+ * The direction is the one #15705 exists to prevent: an INTERACTIVE run
+ * skipping a screen it should have rendered. Hence the remedy here — compare by
+ * VALUE, which survives serialisation.
+ *
+ * ## The rig, and why it is shaped like this
+ *
+ * The card lists the conjunction that has to hold together, and every clause is
+ * load-bearing, so the rig satisfies all of them at once rather than stubbing
+ * any: the **actions door** (so the row is spread into `params`), a **wired
+ * durable store**, **a later screen in the same run** entered after the resume,
+ * a **non-primitive** colliding column, and **no other required field** on that
+ * screen to force the pause anyway. Remove any one and the run pauses for a
+ * different reason, which is what the controls below are for — they are not
+ * decoration, they are the evidence that the pause the fixed code produces
+ * comes from this leg and not from one of the others.
+ *
+ * ⚠️ Primitive columns were never affected: `Object.is('x','x')` is true across
+ * a round trip. `records the primitive column` below is the control that keeps
+ * that boundary honest — it passes before AND after the fix, so it cannot be
+ * mistaken for evidence of the fix.
+ *
+ * REVERT-PROOF: put `Object.is` back on the record leg of `callerSupplied` and
+ * `THE BUG` fails (the run completes instead of pausing) while every control
+ * here stays green.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { AutomationEngine } from '../engine.js';
+import { registerScreenNodes } from './screen-nodes.js';
+import { InMemorySuspendedRunStore } from '../suspended-run-store.js';
+import type { SuspendedRunStore } from '../engine.js';
+import type { AutomationContext } from '@objectstack/spec/contracts';
+
+function silentLogger() {
+    return { info() {}, warn() {}, error() {}, debug() {}, child() { return silentLogger(); } } as any;
+}
+
+/**
+ * Two screens, deliberately. The FIRST one pauses (a required field nobody
+ * supplied) — that is what puts the context through the store. The SECOND is
+ * the one under test: a single OPTIONAL field, so nothing but the provenance
+ * verdict can decide whether it renders.
+ */
+function twoScreenFlow(secondField: string) {
+    return {
+        name: 'lead_review',
+        label: 'Lead review',
+        type: 'screen',
+        status: 'active',
+        version: 1,
+        variables: [
+            { name: 'full_name', type: 'text', isInput: true, isOutput: true },
+            { name: secondField, type: 'text', isInput: true, isOutput: true },
+        ],
+        nodes: [
+            { id: 'start', type: 'start', label: 'Start' },
+            {
+                id: 'collect', type: 'screen', label: 'Your details',
+                config: { title: 'Your details', fields: [{ name: 'full_name', label: 'Full name', type: 'text', required: true }] },
+            },
+            {
+                id: 'review', type: 'screen', label: 'Review',
+                // All-optional and single-field: no `required` can force this
+                // pause, so "it paused" means exactly "nothing was judged
+                // caller-supplied".
+                config: { title: 'Review', fields: [{ name: secondField, label: 'Review', type: 'text' }] },
+            },
+            { id: 'end', type: 'end', label: 'End' },
+        ],
+        edges: [
+            { id: 'e1', source: 'start', target: 'collect', type: 'default' },
+            { id: 'e2', source: 'collect', target: 'review', type: 'default' },
+            { id: 'e3', source: 'review', target: 'end', type: 'default' },
+        ],
+    } as any;
+}
+
+/** A fresh engine over `store` (or none) — one per simulated process lifetime. */
+function buildEngine(secondField: string, store?: SuspendedRunStore) {
+    const e = new AutomationEngine(silentLogger(), store);
+    registerScreenNodes(e, { logger: silentLogger() } as any);
+    e.registerFlow('lead_review', twoScreenFlow(secondField));
+    return e;
+}
+
+/**
+ * The bag a flow ACTION actually reaches the engine with — the subject row
+ * first, the caller's own params last, exactly as `seedFlowActionParams`
+ * (`@objectstack/runtime`) composes it. Reproduced rather than imported so this
+ * package's pins do not depend on the other package's build, matching
+ * `screen-headless-satisfaction.test.ts`.
+ */
+function actionContext(
+    record: Record<string, unknown>,
+    params: Record<string, unknown> = {},
+): AutomationContext {
+    return {
+        record,
+        object: 'crm_lead',
+        params: { ...record, recordId: record.id, crmLeadId: record.id, ...params },
+    } as AutomationContext;
+}
+
+/** A row whose `tags` column is an ARRAY — the shape identity cannot survive. */
+function lead() {
+    return { id: 'lead_1', tags: ['a', 'b'], company: 'Acme Inc' };
+}
+
+/**
+ * Drive the whole conjunction: launch through the actions door, pause on the
+ * first screen, resume, and report what the SECOND screen did.
+ */
+async function driveThroughResume(
+    secondField: string,
+    store: SuspendedRunStore | undefined,
+    context: AutomationContext,
+) {
+    const engine = buildEngine(secondField, store);
+    const paused = await engine.execute('lead_review', context);
+    // Precondition, asserted rather than assumed: if the first screen did not
+    // park, nothing below went through the store and the case is vacuous.
+    expect(paused.status).toBe('paused');
+    expect(paused.screen?.nodeId).toBe('collect');
+    return engine.resume(paused.runId!, { variables: { full_name: 'Ada' } });
+}
+
+describe('caller-provenance survives a durable resume (#15812)', () => {
+    /**
+     * THE BUG. Every clause of the card's conjunction holds: actions door,
+     * wired store, a later screen after the resume, a non-primitive colliding
+     * column, and no other required field.
+     *
+     * The caller supplied NOTHING — `params.tags` is there only because the
+     * dispatcher spread the row in. So the review screen must render.
+     */
+    it('THE BUG — an array column does not answer a later screen after a durable resume', async () => {
+        const resumed = await driveThroughResume('tags', new InMemorySuspendedRunStore(), actionContext(lead()));
+        expect(resumed.status).toBe('paused');
+        expect(resumed.screen?.nodeId).toBe('review');
+        // Not merely "it stopped": it stopped WITHOUT having answered itself
+        // from the row.
+        expect(resumed.output?.tags).toBeUndefined();
+    });
+
+    /**
+     * The same run with NO store: the engine resumes from its hot cache, where
+     * `params.tags` is still the very array `record.tags` is, so identity holds
+     * and the leg worked even before the fix. Green on both sides — its job is
+     * to localise the defect to the serialisation boundary, not to the screen
+     * logic.
+     */
+    it('CONTROL — with no store wired the same run pauses too (identity never left memory)', async () => {
+        const resumed = await driveThroughResume('tags', undefined, actionContext(lead()));
+        expect(resumed.status).toBe('paused');
+        expect(resumed.screen?.nodeId).toBe('review');
+    });
+
+    /**
+     * The card's own ⚠️: a PRIMITIVE column is unaffected, because
+     * `Object.is('Acme Inc', 'Acme Inc')` is true across a round trip. Green
+     * before and after — ⛔ never read this one as evidence of the fix.
+     */
+    it('CONTROL — a primitive colliding column was already refused across the round trip', async () => {
+        const resumed = await driveThroughResume('company', new InMemorySuspendedRunStore(), actionContext(lead()));
+        expect(resumed.status).toBe('paused');
+        expect(resumed.screen?.nodeId).toBe('review');
+    });
+
+    /**
+     * The row-id leg reads scalars, so serialisation cannot defeat it either.
+     * Pinned because the fix deliberately leaves that leg on `Object.is` — this
+     * is the case that says the decision was measured, not overlooked.
+     */
+    it('CONTROL — the row-id seed leg still refuses across a durable resume', async () => {
+        const resumed = await driveThroughResume('recordId', new InMemorySuspendedRunStore(), actionContext(lead()));
+        expect(resumed.status).toBe('paused');
+        expect(resumed.screen?.nodeId).toBe('review');
+    });
+
+    /**
+     * #15705's own purpose, preserved: a caller who genuinely drove the screen
+     * still continues past it after a durable resume. Without this the fix
+     * could "pass" by making everything pause.
+     */
+    it('a caller who genuinely supplied a DIFFERENT value still continues after the resume', async () => {
+        const resumed = await driveThroughResume(
+            'tags', new InMemorySuspendedRunStore(), actionContext(lead(), { tags: ['urgent'] }),
+        );
+        expect(resumed.status).not.toBe('paused');
+        expect(resumed.success).toBe(true);
+        expect(resumed.output).toMatchObject({ tags: ['urgent'] });
+    });
+
+    /**
+     * THE WIDENING, pinned as behaviour rather than left as prose.
+     *
+     * Value equality enlarges the not-caller-supplied set: a caller that
+     * re-sends a value structurally identical to the row's now reads as
+     * indistinguishable from the record seed and the screen renders. Under
+     * `Object.is` this run CONTINUED (two distinct arrays), so this case is a
+     * deliberate behaviour change and it changes in this module's standing
+     * direction — every ambiguity resolves to pausing, which costs a headless
+     * run a skip and costs an interactive run nothing.
+     *
+     * No store here: the widening is a property of the comparison, not of
+     * persistence.
+     */
+    it('WIDENING — a caller re-sending a value equal to the row is now indistinguishable, so it pauses', async () => {
+        const resumed = await driveThroughResume('tags', undefined, actionContext(lead(), { tags: ['a', 'b'] }));
+        expect(resumed.status).toBe('paused');
+        expect(resumed.screen?.nodeId).toBe('review');
+    });
+});

--- a/packages/services/service-automation/src/builtin/screen-headless-satisfaction.test.ts
+++ b/packages/services/service-automation/src/builtin/screen-headless-satisfaction.test.ts
@@ -396,7 +396,7 @@ describe('screen headless satisfaction (#15705)', () => {
      * The record-change trigger's shape, pinned for the MECHANISM as well as
      * the outcome: it sets `params` to the SAME object it sets as `record`
      * (`record-change-trigger.ts`), so `params` is emphatically NOT empty — it
-     * pauses because every key is identity-equal to the record's own value, not
+     * pauses because every key still holds the record's own value, not
      * because there was nothing to read.
      */
     it('CONTROL — record-change trigger shape: params IS the record, and it still pauses', async () => {

--- a/packages/services/service-automation/src/screen-input-contract.ts
+++ b/packages/services/service-automation/src/screen-input-contract.ts
@@ -21,6 +21,8 @@
  * caller.
  */
 
+import { isDeepStrictEqual } from 'node:util';
+
 import type { ScreenFieldSpec, ScreenSpec } from '@objectstack/spec/contracts';
 import type { FieldErrorCode } from '@objectstack/spec/api';
 
@@ -195,23 +197,42 @@ const NOTHING_SUPPLIED: HeadlessScreenVerdict = { satisfied: false, supplied: []
  *
  *  - the record has no such key at all ⇒ the record leg cannot be the source;
  *  - the record HAS the key but `params` holds a different value ⇒ the
- *    caller's bag overwrote it. The record spread copies the record's own value
- *    by reference/primitive, so a run that supplied nothing is `Object.is`-equal
- *    here. Equality is therefore "indistinguishable", not "caller-set".
+ *    caller's bag overwrote it. The record spread copies the record's own
+ *    value, so a run that supplied nothing carries the row's value here.
+ *    Equality is therefore "indistinguishable", not "caller-set".
  *
  * The ambiguous case (same key, same value) resolves to NOT caller-supplied,
  * which costs a headless run a pause it might have been allowed to skip and
  * costs an interactive run nothing. That asymmetry is deliberate: every
  * uncertainty in this module must land on today's behaviour.
  *
- * ⚠️ **The identity leg is weaker across a durable resume.** A suspended run
- * persists its `context` as JSON (`suspended-run-store.ts`), so a run continued
- * from the store judges against a `JSON.parse`d copy: a NON-primitive column
- * value (an array, an object) is no longer `Object.is`-equal to the one in
- * `params`, and a later wizard screen colliding with such a column can read as
- * caller-supplied. Primitive columns are unaffected. Stated, not fixed here —
- * the remedy is value comparison rather than identity, which is a different
- * change and has its own card.
+ * **The record leg compares by VALUE, and had to (#15812).** Written as
+ * `Object.is` it asked about reference identity, which is real in memory — the
+ * record spread copies by reference — and is destroyed by persistence. A
+ * suspended run persists its `context` as JSON (`suspended-run-store.ts`:
+ * `JSON.stringify` on save, `parseJson` on load) and `resumeInternal` continues
+ * the run with the parsed value; `loadSuspendedRunStrict` prefers the store
+ * over the hot cache whenever one is wired, so this needs no process restart.
+ * After that round trip a NON-primitive column value (an array, an object) is
+ * equal but no longer identical, the record leg could not disprove it, and a
+ * later all-optional screen was SKIPPED on a run that had supplied nothing —
+ * measured end to end through a wired store, which is the failure #15705 exists
+ * to prevent. Primitive columns were never affected (`Object.is('x','x')` is
+ * true across a round trip), which is exactly why the hole was invisible to
+ * every in-memory unit test.
+ *
+ * `isDeepStrictEqual` compares primitives with `Object.is` itself, so this is a
+ * strict WIDENING of the old predicate: every pair the identity check called
+ * equal it still calls equal, plus the structurally-identical non-primitives.
+ * The widened set is "not caller-supplied", i.e. more pauses, so the change can
+ * only move runs toward this module's standing direction. The price is that a
+ * caller who genuinely re-sends a value identical to the row's is no longer
+ * distinguishable from the seed and gets the screen rendered — a lost skip, not
+ * a lost run, and the same trade every other leg here already makes.
+ *
+ * ⛔ The row-id leg above deliberately keeps `Object.is`: a row id is a scalar
+ * by construction (`params.recordId` is seeded as one, `record.id` is one), so
+ * serialisation cannot defeat it and there is nothing there to widen.
  */
 function callerSupplied(
   name: string,
@@ -251,7 +272,10 @@ function callerSupplied(
   if (seededRowIds.some((id) => id !== undefined && Object.is(value, id))) return false;
 
   if (!record || !Object.prototype.hasOwnProperty.call(record, name)) return true;
-  return !Object.is(value, record[name]);
+  // BY VALUE, not by identity (#15812) — see the note above. `Object.is` here
+  // read as "the caller overwrote the column" for any non-primitive value that
+  // had been through the durable store's JSON round trip.
+  return !isDeepStrictEqual(value, record[name]);
 }
 
 /**


### PR DESCRIPTION
Fixes #15812

## The card reproduces end to end against a wired store

That was the first job here, and the outcome was not preordained — "does not reproduce" would have been a perfectly good delivery. It reproduces.

The rig satisfies every clause of the card's conjunction at once, none stubbed: the **actions door** (so `seedFlowActionParams`' `{ ...record, recordId, the camelCase objectName-plus-Id alias, ...params }` spreads the row into `params`), a **wired durable store** (`InMemorySuspendedRunStore`, which JSON-clones on save *and* on load, the same boundary `sys_automation_run`'s `context_json` imposes), **a later screen in the same run** entered after the resume, a **non-primitive** colliding column (`tags: ['a','b']`), and **no other required field** on that screen to force the pause anyway.

Measured on the unmodified tree at `0374bcba9`, driving a real suspend then a real resume:

```
PROBE first screen status= paused node= collect
PROBE resumed status= undefined screen= undefined success= true
      output= {"full_name":"Ada","tags":["a","b"]}
```

The review screen was **skipped**, and the run completed carrying the row's own `tags` as if a caller had typed it. A human pressed a button and never saw a form they should have been shown — the failure direction #15705 exists to prevent.

One correction to the card's own mechanism note, worth recording because it widens reachability: this needs **no process restart**. `loadSuspendedRunStrict` prefers the store over the hot cache whenever one is wired (`if (!this.store) return this.suspendedRuns.get(runId)`), so any resume on a store-backed engine judges against the parsed copy.

## The change

One predicate, in `callerSupplied`'s record leg:

```ts
return !isDeepStrictEqual(value, record[name]);   // was: !Object.is(...)
```

`isDeepStrictEqual` compares primitives with `Object.is` itself (verified: `0`/`-0` unequal, `NaN` equal, no cross-type coercion), so this is a **strict widening** of the old predicate — every pair identity called equal it still calls equal, plus the structurally identical non-primitives. The widened set is "not caller-supplied", i.e. more pauses. The safe direction is therefore a property of the substitution, not a claim about it.

⛔ The row-id leg deliberately keeps `Object.is`: a row id is a scalar by construction (`params.recordId` is seeded as one, `record.id` is one), so serialisation cannot defeat it and there is nothing there to widen. That decision is pinned by a control, not left as prose.

## The two trade-offs, answered head-on

### 1. Cost — with magnitude, measured

Per-comparison, on structurally equal values that are not identical (the round trip's output, and the worst case for a deep compare since it must walk the whole structure to say "equal"), 200,000 iterations each:

| colliding column shape | `Object.is` | `isDeepStrictEqual` | delta |
|---|---:|---:|---:|
| string column (the common case) | 10.3 ns | 19.2 ns | +8.9 ns |
| `tags`: 3 short strings | 7.3 ns | 266.0 ns | +258.7 ns |
| `tags`: 10 short strings | 6.0 ns | 309.8 ns | +303.8 ns |
| address object, 6 keys | 5.3 ns | 415.7 ns | +410.4 ns |
| multiselect: 50 strings | 5.3 ns | 722.0 ns | +716.7 ns |
| nested blob, 20 rows x 6 keys | 5.2 ns | 13,002.4 ns | +12,997.2 ns |

Per **screen entry**, which is the unit that matters — the comparison runs at most once per declared field whose name is present in `params`. A deliberately maximal screen that declares a field for every one of a ten-column row (string, array, nested object, 50-element multiselect, scalars):

```
record leg, Object.is                227 ns
record leg, isDeepStrictEqual       1700 ns   (+1474 ns)
JSON.stringify(context) — already paid per suspend:  3913 ns
added cost as a fraction of that one existing serialisation:  37.7%
```

So the added work is ~1.5 µs on a maximal screen, against a code path that already spends ~3.9 µs serialising the same context on every suspend, at an event that is a user-facing form entry rather than a hot loop. ⚠️ Shared-box readings — this container runs parallel agents; the ratios are the durable half.

The unbounded tail is real and stated rather than waved away: the last table row is 13 µs for a blob nothing in a screen field should be, and a deep compare is O(size). It is bounded by the same value the store already stringifies on every suspend, so it cannot be asymptotically worse than the persistence this leg exists to survive.

### 2. Semantic widening — and why the direction is the safe one

Value equality enlarges "not caller-supplied": a caller that genuinely **re-sends a value structurally identical to the row's** moves from *continue* to *pause*. Under `Object.is` two distinct-but-equal arrays read as caller-supplied and the screen was skipped; now they are indistinguishable from the dispatcher's seed and it renders.

That is a lost skip on a headless call, never a lost run, and it is the direction this module resolves **every** ambiguity in — condition 1 of `judgeHeadlessScreen` refuses on every uncertainty, the row-id legs refuse a value merely equal to the row id, and an unevaluable `visibleWhen` keeps the screen interactive. Landing this one anywhere else would make the module's newest leg the only one that resolves doubt toward *skipping a screen a human should see*. It is pinned as a behaviour change (`WIDENING —` below), not left to be discovered.

## Tests

`packages/services/service-automation/src/builtin/screen-headless-provenance-durable-resume.test.ts` — six cases, and the controls outnumber the bug deliberately, because the pause the fixed code produces has to be attributable to *this* leg:

| case | before | after |
|---|---|---|
| **THE BUG** — array column, durable resume, all-optional later screen, nothing supplied | skipped ❌ | pauses ✅ |
| **WIDENING** — caller re-sends a value deep-equal to the row's | continued | pauses (deliberate change) |
| CONTROL — no store wired, same run | pauses | pauses |
| CONTROL — **primitive** colliding column across the round trip | pauses | pauses |
| CONTROL — row-id seed leg across the round trip | pauses | pauses |
| a caller who supplied a genuinely **different** value | continues | continues |

The last two are the ones that stop a false positive: the primitive control passes on **both** sides, so it can never be misread as evidence of the fix, and the "different value" case is what keeps the fix from "passing" by pausing everything.

**Red before green.** The prediction was written before the first run: cases 1 and 5 red, four green. Measured on the unmodified tree — `Tests 2 failed | 4 passed (6)`, exactly those two, both `expected undefined to be 'paused'`.

**Ablation**, from the committed implementation at `32b008c5e`. The record leg was reverted to `Object.is`; the mutation was confirmed on disk before the run (injected-marker count 1, deleted-marker count 0, blob hash moved off `c2f87e13`), giving `Tests 2 failed | 4 passed (6)` — the same two cases, every control still green. A test resolving a stale `dist` would have stayed green here, so the red is also the proof the mutation was read. The restore leg was proven three ways rather than trusted to its trap: `git checkout HEAD -- (absolute path)`, then blob hash equal to the HEAD blob (`c2f87e13704d36d9445f800e0a4c3e117fe52d3f`), `git diff HEAD` empty, and marker counts back at 1/0.

Verification at the final head `2e5899656`:

- `pnpm --filter @objectstack/service-automation test` — **122 files, 1432 tests, all passing**
- `pnpm --filter @objectstack/service-automation typecheck` — clean, `check:test-typecheck` OK. It first went **red on the new test file** (`TS2339: Property 'tags' does not exist on type '{}'`), which is the direct evidence that this package's test layer really is type-checked rather than excluded.
- the gate family derived mechanically at that head — `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack --commands`, 57 commands, **all run, all green**. Two returned exit 3 `PREREQUISITE NOT MET` (`check:dual-build-cjs-loads`, `check:type-check-debt`) — neither pass nor finding; the closure was built and both re-run to real green readings.
- `pnpm lint` — the whole-repo `eslint . --no-inline-config`, green (80 s). Run in full, so nothing here rests on a narrowing.

## Scope

`.changeset` is a `patch` on `@objectstack/service-automation`, not `skip-changeset`: the package publishes from `dist`, and this changes a runtime disposition a flow author and an end user can both observe. It also names the gap that release's screen-flow headless-satisfaction note records as known, so the compiled notes do not contradict themselves.

Clause-② holds as declared: `packages/spec/**` is untouched and no exported signature moves. `screen-input-contract.ts` is not re-exported from the package index — `judgeHeadlessScreen` and `callerSupplied` are package-internal, and nothing outside this package references either.

⛔ Boundaries kept: this is **not** a defect in PR #15787 and **not** an argument against it — that provenance check is what makes headless screen satisfaction safe at all, and nothing here reverts or weakens it. Out of scope: the dispatcher-seeded id keys that PR handles internally, and #15646's pausing-`map` residue, which is the opposite direction (state outliving what wrote it, rather than identity failing to survive).

⛔ Not widened into option B (an explicit caller-provenance signal on `AutomationContext`) — a spec + runtime contract change the PM scoped out deliberately. But the #15705 dev's observation belongs on the record, because it describes the shape accurately:

> **B is the only option that removes the CLASS rather than its instances** — every leg in this module is an inference about what the caller meant, and **each new dispatcher seed re-opens it, which is precisely how X1 happened**.

This change closes an instance. The module now has three legs, all of them inferences about what the caller meant, and the count is a function of how many things the dispatch doors put in `params` without saying so. If a **third** dispatcher seed ever forces a **fourth** leg, that is the signal the class rather than the instance is what needs closing, and B is where it goes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XpTx2tbq3pZRYAdoGt6E6Y


---
_Generated by [Claude Code](https://claude.ai/code/session_01XpTx2tbq3pZRYAdoGt6E6Y)_