### PR TITLE
test(service-automation): pin the measured semantics of overlapping decision out-edge conditions

### DIFF
--- a/packages/services/service-automation/src/builtin/decision-overlapping-edge-conditions.pin.test.ts
+++ b/packages/services/service-automation/src/builtin/decision-overlapping-edge-conditions.pin.test.ts
@@ -1,0 +1,249 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { AutomationEngine } from '../engine.js';
+import { registerLogicNodes } from './logic-nodes.js';
+
+/**
+ * ⭐ A STATUS-QUO PIN, NOT A CONTRACT (#15429).
+ *
+ * Every assertion below records what the engine **does today** when two
+ * out-edges of one `decision` node carry conditions that both hold. None of it
+ * says the behaviour is right, and nothing here blesses it. The card that asked
+ * for this file is explicit that changing evaluation semantics on a shipped node
+ * type is a behaviour change with its own ruling, ⛔ not a bug fix — so the
+ * first step is a baseline that cannot drift while that ruling is pending.
+ *
+ * ⇒ When the ruling lands, **this file is rewritten with it**. A failure here
+ * after a deliberate semantic change is the pin doing its job, not a regression:
+ * update the assertions and the prose together. A failure here after a change
+ * that did NOT intend to touch branch selection is the drift it exists to catch.
+ *
+ * What the card reported, and what this file measured against it:
+ *
+ *  • REPORTED (from one hotcrm deployment, reasoned backwards from a
+ *    reproduction): a decision with no declared `config.conditions` takes every
+ *    out-edge whose condition holds, **in parallel**.
+ *  • MEASURED here: the take-every-match half is real. The **in parallel** half
+ *    is not — matching conditional edges are traversed one at a time, each
+ *    successor fully executed before the next is evaluated (`traverseNext`
+ *    awaits inside the loop). Only the *unconditional* bucket fans out through
+ *    `Promise.all`, and this file keeps that fan-out as a positive control so
+ *    the interleaving instrument is shown to detect parallelism where it exists.
+ *
+ * The distinction matters for whoever writes the ruling: the hazard is
+ * multi-branch execution, not concurrency. Two branches that both write the same
+ * record run in a defined order, which is a different (and easier) starting
+ * point than a genuine race.
+ *
+ * The two modes are separate on purpose (`logic-nodes.ts`, #4414): a decision
+ * that DECLARES `config.conditions` reports the first matching entry's label and
+ * traversal narrows to the edge carrying it; a decision that declares none
+ * reports no branch at all and is a plain gateway whose out-edges route. The
+ * last two tests pin both halves of that split, because "is undeclared a
+ * distinct mode?" is the other question the ruling has to start from.
+ *
+ * On provenance, stated because the answer is "none": the take-every-match loop
+ * predates the buckets it lives in. Before `cc8484224` (2026-02-21) traversal
+ * was one loop that `continue`d past a closed gate and executed everything else;
+ * that commit split conditional from unconditional edges, recorded a decision
+ * about the unconditional half ("parallel branch execution (Promise.all for
+ * unconditional edges)") and carried the conditional half over unchanged, under
+ * a new comment reading `// Conditional edges: evaluate sequentially (mutually
+ * exclusive)`. That comment is the only written trace of the assumption, and it
+ * is an assumption: nothing in the engine, the schema or the linter makes
+ * sibling conditions exclusive. ⛔ No commit message, ADR or doc records the
+ * multi-take as a decision — searched with `git log -S` over `engine.ts` for the
+ * loop's symbols, and `content/docs/automation/flows.mdx` describes the mode
+ * ("BPMN exclusive gateway") without ever saying what happens when two
+ * conditions hold at once.
+ */
+
+/** One captured `warn` call, so "nothing reports this" is measured, not assumed. */
+const warnings: Array<{ msg: string; meta?: Record<string, unknown> }> = [];
+
+function createTestLogger(): any {
+    const logger: any = {
+        info: () => {},
+        warn: (msg: string, meta?: Record<string, unknown>) => { warnings.push({ msg: String(msg), meta }); },
+        error: () => {},
+        debug: () => {},
+        child: () => logger,
+    };
+    return logger;
+}
+
+function createCtx(): any {
+    return { logger: createTestLogger(), getService: () => undefined };
+}
+
+describe('decision with overlapping out-edge conditions — status-quo pin (#15429)', () => {
+    let engine: AutomationEngine;
+    /** `enter:<id>` / `exit:<id>` per visited successor — order AND nesting. */
+    let trace: string[];
+
+    beforeEach(() => {
+        warnings.length = 0;
+        trace = [];
+        engine = new AutomationEngine(createTestLogger());
+        registerLogicNodes(engine, createCtx());
+        // A terminal that yields between its two marks, so a fan-out that really
+        // is concurrent interleaves (`enter,enter,exit,exit`) and a sequential
+        // traversal nests (`enter,exit,enter,exit`). The yield is a macrotask,
+        // not a duration: both orderings below are deterministic.
+        engine.registerNodeExecutor({
+            type: 'mark',
+            async execute(node) {
+                trace.push(`enter:${node.id}`);
+                await new Promise(resolve => setTimeout(resolve, 0));
+                trace.push(`exit:${node.id}`);
+                return { success: true };
+            },
+        });
+        // This harness is an embedded host, so it owes the ADR-0018 host half:
+        // the vocabulary it contributes is complete (#4771). Without the seal the
+        // first `execute()` warns about it and the zero-warning assertion below —
+        // which is about branch reporting, not node types — would count that line.
+        engine.sealNodeTypeVocabulary();
+    });
+
+    /**
+     * The hotcrm shape, reduced: one `decision`, two out-edges, no
+     * `config.conditions` on the node. `a` and `b` are the two edge predicates;
+     * an empty string means the edge carries no condition at all.
+     */
+    function gatewayFlow(opts: { a: string; b: string; conditions?: Array<{ label: string; expression: string }> }) {
+        return {
+            name: 'gateway',
+            label: 'Gateway',
+            type: 'autolaunched' as const,
+            variables: [{ name: 'lead', type: 'object', isInput: true }],
+            nodes: [
+                { id: 'start', type: 'start' as const, label: 'Start' },
+                {
+                    id: 'check', type: 'decision' as const, label: 'Check',
+                    ...(opts.conditions ? { config: { conditions: opts.conditions } } : {}),
+                },
+                { id: 'refuse', type: 'mark' as const, label: 'Refuse' },
+                { id: 'convert', type: 'mark' as const, label: 'Convert' },
+            ],
+            edges: [
+                { id: 'e1', source: 'start', target: 'check' },
+                { id: 'e_refuse', source: 'check', target: 'refuse', label: 'Refuse', ...(opts.a ? { condition: opts.a } : {}) },
+                { id: 'e_convert', source: 'check', target: 'convert', label: 'Convert', ...(opts.b ? { condition: opts.b } : {}) },
+            ],
+        };
+    }
+
+    const run = (lead: Record<string, unknown>) => engine.execute('gateway', { params: { lead } } as any);
+
+    const stepsOfLastRun = async () => {
+        const [log] = await engine.listRuns('gateway');
+        return (log?.steps ?? []).map(s => ({ nodeId: s.nodeId, status: s.status, edgeId: s.skippedBy?.edgeId ?? null }));
+    };
+
+    // ── The instrument, before any reading taken with it ──────────────────
+
+    it('CONTROL — disjoint edge conditions take exactly one successor', async () => {
+        // Same node, same two edges, same record: only the predicates differ.
+        // If this read "both" the counting method would prove nothing below.
+        engine.registerFlow('gateway', gatewayFlow({
+            a: "lead.status == 'suspected'",
+            b: "lead.status == 'confirmed'",
+        }));
+
+        await run({ status: 'confirmed' });
+
+        expect(trace).toEqual(['enter:convert', 'exit:convert']);
+        // …and the branch not taken leaves a trace: a closed gate records a
+        // `skipped` step naming the edge that closed it (#4354).
+        expect(await stepsOfLastRun()).toContainEqual({ nodeId: 'refuse', status: 'skipped', edgeId: 'e_refuse' });
+    });
+
+    // ── The reading ───────────────────────────────────────────────────────
+
+    it('takes EVERY out-edge whose condition holds — the reported hazard, confirmed', async () => {
+        // The hotcrm pair verbatim in shape: a `Clean` guard spelled as a
+        // negation, and a later `== confirmed` branch added beside it. For a
+        // confirmed record both predicates are true, and the author's reading of
+        // the node — "one of these" — is nowhere written down.
+        engine.registerFlow('gateway', gatewayFlow({
+            a: "lead.status != 'suspected'",
+            b: "lead.status == 'confirmed'",
+        }));
+
+        const result = await run({ status: 'confirmed' });
+
+        // Both successors run. The refusal screen renders AND the conversion
+        // runs, in one execution — pinned as today's behaviour, ⛔ not endorsed.
+        expect(trace.filter(t => t.startsWith('enter:'))).toEqual(['enter:refuse', 'enter:convert']);
+        expect(result.success).toBe(true);
+    });
+
+    it('takes them one at a time, NOT in parallel — the card says parallel; the engine does not', async () => {
+        engine.registerFlow('gateway', gatewayFlow({
+            a: "lead.status != 'suspected'",
+            b: "lead.status == 'confirmed'",
+        }));
+
+        await run({ status: 'confirmed' });
+
+        // Nested, not interleaved: `refuse` finishes before `convert` starts.
+        expect(trace).toEqual(['enter:refuse', 'exit:refuse', 'enter:convert', 'exit:convert']);
+    });
+
+    it('POSITIVE CONTROL — the same instrument reads interleaving on the unconditional fan-out', async () => {
+        // Drop both conditions and the identical pair of edges lands in the
+        // unconditional bucket, which really is `Promise.all`. This is what
+        // proves the previous test measured sequencing rather than an instrument
+        // that cannot see concurrency at all.
+        engine.registerFlow('gateway', gatewayFlow({ a: '', b: '' }));
+
+        await run({ status: 'confirmed' });
+
+        expect(trace).toEqual(['enter:refuse', 'enter:convert', 'exit:refuse', 'exit:convert']);
+    });
+
+    it('reports the multi-take NOWHERE — no warning, and no `skipped` step to notice it by', async () => {
+        engine.registerFlow('gateway', gatewayFlow({
+            a: "lead.status != 'suspected'",
+            b: "lead.status == 'confirmed'",
+        }));
+
+        await run({ status: 'confirmed' });
+
+        // Both edges opened, so neither records the `skipped` step that makes a
+        // closed gate visible in the CONTROL above: the run log of a
+        // two-branch execution is indistinguishable from a flow that was
+        // *authored* to run both.
+        const steps = await stepsOfLastRun();
+        expect(steps.filter(s => s.status === 'skipped')).toEqual([]);
+        expect(steps.filter(s => s.status === 'success').map(s => s.nodeId)).toEqual(['start', 'check', 'refuse', 'convert']);
+        expect(warnings).toEqual([]);
+    });
+
+    // ── The other half of the question: is undeclared a distinct mode? ────
+
+    it('declared `config.conditions` is a DIFFERENT mode — first match wins, even when two match', async () => {
+        // The same two overlapping predicates, moved onto the node. The executor
+        // returns on the first match (`logic-nodes.ts`), traversal narrows to the
+        // edge carrying that label, and the second branch is never reached.
+        engine.registerFlow('gateway', gatewayFlow({
+            a: '', b: '',
+            conditions: [
+                { label: 'Refuse', expression: "lead.status != 'suspected'" },
+                { label: 'Convert', expression: "lead.status == 'confirmed'" },
+            ],
+        }));
+
+        await run({ status: 'confirmed' });
+
+        expect(trace).toEqual(['enter:refuse', 'exit:refuse']);
+        // Narrowed away, not gated: the losing edge leaves no step at all — not
+        // even the `skipped` one a closed gate writes. The two modes differ in
+        // what they record as well as in what they run.
+        const steps = await stepsOfLastRun();
+        expect(steps.map(s => s.nodeId)).toEqual(['start', 'check', 'refuse']);
+        expect(warnings).toEqual([]);
+    });
+});


### PR DESCRIPTION
Part of #15429

A **status-quo pin only**. No engine, spec or lint change: the card rules that changing evaluation semantics on a shipped node type is a behaviour change with its own ruling, and this PR is the step that ruling needs first — a measured baseline that cannot drift while it is pending.

One file added: `packages/services/service-automation/src/builtin/decision-overlapping-edge-conditions.pin.test.ts`.

## The three questions, and what was measured

**1. Is "no `config.conditions`" a distinct mode?** Yes, and deliberately so. `builtin/logic-nodes.ts` returns `{ success: true }` with **no** `branchLabel` when the node declares no conditions; with conditions declared it returns on the **first** matching entry's label and `traverseNext` narrows the edge set to the edge carrying it. The split is documented in that executor as the #4414 repair. Both halves are measured here, not just read: with the same two overlapping predicates moved onto the node, only the first branch runs — and the losing edge leaves no step at all, not even the `skipped` one a closed gate writes.

**2. How many successors does the engine take when several conditions hold?** **Every** one of them — the reported hazard, confirmed by driving. Two out-edges spelled as in the reproduction (`status != 'suspected'` and `status == 'confirmed'`), one confirmed record: both successors execute in one run.

⚠️ **But not in parallel, and the card says parallel.** Matching conditional edges are traversed one at a time; each successor completes before the next edge is evaluated. Only the *unconditional* bucket fans out through `Promise.all`. The pin keeps that fan-out as a positive control, so the interleaving instrument is shown to detect concurrency where concurrency exists (`enter,enter,exit,exit`) and to report nesting where it does not (`enter,exit,enter,exit`). The hazard is multi-branch execution, not a race — a distinction the ruling starts from, since two branches writing the same record do so in a defined order.

**3. Intended or incidental?** ⛔ **No record of a decision.** The take-every-match loop predates the buckets it lives in: before `cc8484224` (2026-02-21) traversal was one loop that `continue`d past a closed gate and executed everything else. That commit split conditional from unconditional edges, recorded a decision about the unconditional half in its own message ("parallel branch execution (Promise.all for unconditional edges)"), and carried the conditional half over unchanged under a new comment reading `// Conditional edges: evaluate sequentially (mutually exclusive)`. That comment is the only written trace, and it is an assumption: nothing in the engine, the schema or the linter makes sibling conditions exclusive. Searched `git log -S` over `engine.ts` for the loop's symbols (`conditionalEdges`, `anyConditionMet`, the comment text) on a non-shallow clone, and `content/docs/automation/flows.mdx` describes the mode as a "BPMN exclusive gateway" without ever saying what happens when two conditions hold at once.

Also measured: the multi-take is reported **nowhere**. No warning, and no `skipped` step, so the run log of a two-branch execution is indistinguishable from a flow authored to run both.

## The instrument was proven to discriminate first

- **Control** — the same node, the same two edges, the same record, disjoint predicates: reads exactly one successor, and records the `skipped` step for the closed gate.
- **Positive control** — the same async instrument on the known-parallel unconditional fan-out: reads interleaving.
- **Ablation** — a first-match `break` inserted into `traverseNext`, mutation confirmed on disk (marker count 0 before / 1 after, blob hash `f7a18c3c` to `43429b93`), turns the three take-every-match assertions red and leaves both controls and the declared-conditions test green. Restored via `git checkout HEAD -- (absolute path)` under a trap; restoration proven by an empty `git diff HEAD`, a clean `git status`, a blob hash equal to the HEAD blob, and a marker count back to 0. No rebuild leg was owed: the test imports `../engine.js` inside its own package, which vitest resolves to `src`, so no `dist` sits between the mutation and the reading.

## Adjacent work, not duplicated

`flow-decision-unconditional-branch` (landed via #16382) reports the *fully inert* decision — no edge gated, no `conditions[]` declared. This pin is about the opposite shape: gates that are present and **overlap**. Neither rule is touched or extended here. #14945 is an expressiveness gap and stays separate; it is not addressed by this PR.

## Verification

Everything below ran on the final head `74ff87419`, exit codes captured immediately after a single redirect, never through a pipe.

- Gate family derived mechanically on that head: `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack --commands` — 46 commands, **all 46 exit 0**. Two first returned exit 3 `PREREQUISITE NOT MET` (`check:dual-build-cjs-loads`, `check:type-check-debt`) — neither green nor red; the closure was built (`turbo run build`, 71/71 tasks) and both re-run to a real green, the debt gate under an 8192 MB heap.
- `pnpm --filter @objectstack/service-automation exec vitest run` — 124 files, 1443 tests, all passing.
- `pnpm --filter @objectstack/service-automation typecheck` — clean, and the new file is genuinely in that program: `tsc --listFiles -p tsconfig.test.json` names it among 578 files (a `typecheck` that excluded tests would have been a green over nothing).
- `pnpm lint` (repo-wide `eslint . --no-inline-config`) — exit 0. Run in full, so no narrowing is claimed.

## Changeset

`skip-changeset`, and the reason rather than the habit: the only file added is a `*.pin.test.ts` under `packages/services/service-automation/src`, and that package publishes `files: ["dist", "README.md", "CHANGELOG.md"]` from a `src/index.ts` entry. Nothing in this PR reaches any published artifact, and no behaviour changes, so there is no release surface for a changeset to describe.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XpTx2tbq3pZRYAdoGt6E6Y

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpTx2tbq3pZRYAdoGt6E6Y)_