### PR TITLE
docs(cli): state the measured platform-id width at four citation sites

### DIFF
--- a/packages/cli/src/commands/generate-field-type-vocabulary.pin.test.ts
+++ b/packages/cli/src/commands/generate-field-type-vocabulary.pin.test.ts
@@ -512,8 +512,10 @@ describe('#14828 — the SQL answers are the platform’s, not this file’s inv
       expect(
         tsColumn(type),
         `os generate migration (typescript) gave a ${type} column something other than a string ` +
-        'column. A platform id is 26 characters (driver-sql spells one out in its lookup arm), ' +
-        'so a `uuid` column refuses it outright on Postgres with 22P02.',
+        'column. A platform id is not a uuid, and its width is not a fixed number (driver-sql\'s ' +
+        'lookup arm states both: it mints a 16-character nanoid, and stores a supplied id at ' +
+        'whatever width the caller chose), so a `uuid` column refuses it outright on Postgres ' +
+        'with 22P02.',
       ).toBe(`table.string('f_${type}')`);
     }
     // The width is knex's default for a bare `table.string(name)`, which is the

--- a/packages/cli/src/commands/generate-multiple-json-column.pin.test.ts
+++ b/packages/cli/src/commands/generate-multiple-json-column.pin.test.ts
@@ -273,7 +273,9 @@ describe('#14829 — `multiple: true` is one answer across all three surfaces', 
   it('#14828 discharged — the five disputed SCALAR answers are the platform’s', () => {
     // A reference column holds the target's `id`: `table.string(name)`, knex's
     // varchar(255). `table.uuid` was the one HARD failure of the five — a
-    // platform id is 26 characters and Postgres refuses one in a `uuid` column.
+    // platform id is not a uuid, and its width is not a fixed number (driver-sql
+    // mints a 16-character nanoid, and stores a supplied id at whatever width
+    // the caller chose), so Postgres refuses one in a `uuid` column.
     expect(sqlColumn('single_lookup')).toBe('VARCHAR(255)');
     expect(tsColumn('single_lookup')).toBe("table.string('single_lookup')");
 

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -992,9 +992,12 @@ async function runClientGeneration(configPath: string | undefined, flags: { outp
  *   `lookup` /    VARCHAR(36) → VARCHAR(255), with the migration switch's
  *   `master_detail`             `table.uuid` corrected in the same breath. The
  *                 `uuid` half is the only HARD failure of the five: a platform
- *                 id is 26 characters (`createColumn`'s lookup arm says so and
- *                 spells one out — `01JQ8XKZ9M4N7P2R5T6V8W0Y3B`), and Postgres
- *                 refuses one in a `uuid` column with `22P02`. The width half
+ *                 id is NOT a uuid, and its width is not a fixed number at all
+ *                 (`createColumn`'s lookup arm states both): the driver mints a
+ *                 16-character nanoid when the caller supplies none, and stores
+ *                 a SUPPLIED id verbatim at whatever width the caller chose.
+ *                 Postgres refuses either in a `uuid` column with `22P02`. The
+ *                 width half
  *                 is the same rule for the whole REFERENCE_VALUE_TYPES class:
  *                 `user` and `tree` moved with them, because a reference column
  *                 holds the TARGET's `id` — which the driver itself emits as
@@ -1886,10 +1889,12 @@ export function generateMigrationTs(config: Record<string, unknown>): string {
         // answer: `createColumn`'s `case 'lookup': case 'user':` is
         // `table.string(name)`, and `master_detail` reaches the same call
         // through its catch-all. `table.uuid` was the one HARD failure among
-        // this card's five rows — a platform id is 26 characters
-        // (`01JQ8XKZ9M4N7P2R5T6V8W0Y3B`, spelled out in that same driver arm),
-        // and Postgres refuses one in a `uuid` column with `22P02 invalid
-        // input syntax for type uuid` on the very first insert.
+        // this card's five rows — a platform id is NOT a uuid, and its width
+        // is not a fixed number at all: that same driver arm mints a
+        // 16-character nanoid when the caller supplies no id, and stores a
+        // SUPPLIED one verbatim at whatever width the caller chose. Postgres
+        // refuses either in a `uuid` column with `22P02 invalid input syntax
+        // for type uuid` on the very first insert.
         case 'lookup': case 'master_detail':
         case 'user': case 'tree':
         case 'image': case 'file': case 'avatar': case 'video': case 'audio':

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -997,8 +997,8 @@ async function runClientGeneration(configPath: string | undefined, flags: { outp
  *                 16-character nanoid when the caller supplies none, and stores
  *                 a SUPPLIED id verbatim at whatever width the caller chose.
  *                 Postgres refuses either in a `uuid` column with `22P02`. The
- *                 width half
- *                 is the same rule for the whole REFERENCE_VALUE_TYPES class:
+ *                 width half is the same rule for the whole
+ *                 REFERENCE_VALUE_TYPES class:
  *                 `user` and `tree` moved with them, because a reference column
  *                 holds the TARGET's `id` — which the driver itself emits as
  *                 `table.string('id').primary()`, i.e. `varchar(255)` — and


### PR DESCRIPTION
Fixes #16114

Four `packages/cli` sites cited driver-sql's `case 'lookup': case 'user':` arm **by name** for the sentence *"a platform id is 26 characters"*, two of them spelling out a ULID literal. #15522 corrected that origin sentence, so the citation chain pointed at text that no longer exists — the arm today carries an explicit guard, *"⛔ Do not restore the number this sentence used to carry"*, which names these four surviving copies and hands them to this card.

This PR makes the four citations true. It changes **comment and failure-message text only** — no behaviour, no asserted value, no minted width.

## The card's premise was re-derived here, not inherited

The dispatch was explicit that the count and the numbers were the card's and unverified by the dispatching seat. Both were re-measured on this branch.

**The premise holds.** Every claim reproduced.

### What the platform actually does — driven, not read

The oracle enters the chain at the top: a real `SqlDriver` against SQLite, through `create()` and `find()`, rather than reading `DEFAULT_ID_LENGTH` or calling `nanoid()` directly.

| measured | result |
|---|---|
| width of an id the driver MINTS (caller supplies none) | **16** — 12 samples, exactly one distinct width. Samples: `m3rD4WR6sc6XqF-O`, `cevYV0RMKDHMMTbk`, `F6uD2Cz19oQO167i` |
| is that shape a ULID? | **no** — the alphabet carries `-` and lowercase; a Crockford-base32 check over the samples returns `false` |
| a SUPPLIED id, at widths 10 / 17 / 18 / 26 / 40 / 200 | **all six stored verbatim and read back unaltered** |
| non-vacuity control on that read | a query for an id never written returned **0 rows** while the table held **6** ⇒ the filter really filters |
| ULID minted anywhere in the repo | **no** — `ulid` case-insensitive over tracked source matches exactly **1** file, and that file is driver-sql's own "do not restore" guard naming the removed literal |
| positive control on the same instrument | `nanoid` matches **26** files ⇒ the instrument fires, so the 1 is a real reading |
| is width a platform constant? | **no, it is driver-owned** — driver-sql / driver-mongodb / driver-turso each spell `DEFAULT_ID_LENGTH = 16`; `driver-memory` mints `objectName-timestamp-counter`, a variable-width shape |

⚠️ The first attempt at the supplied-id leg was a **no-op that read as a pass**: the filter shape was wrong, so every read-back returned row 1 and all six comparisons "agreed" at width 10. It is reported rather than quietly swapped out, and the control above is what now makes the leg falsifiable.

### The repair therefore does not swap 26 for 16

An id's width is not a fixed number at all. Naming a new fixed number would re-arm the same trap, so each site now says **which half it states** — what the driver MINTS versus what a supplied id is stored at.

Every site's **conclusion is unchanged**, which is why this is `documentation` and not a defect: a reference column takes `table.string(...)` / `VARCHAR(255)` rather than `table.uuid`, because Postgres refuses a platform id in a `uuid` column with `22P02` — it refuses a 16-character nanoid exactly as it refused a ULID.

## The population was swept, and four was a floor

The dispatch asked for the real number rather than the card's. Sweeping `26 char` / `26-character` variants, the ULID literal, `platform id`, `DEFAULT_ID_LENGTH` and id-width phrasings across code, comments, docblocks, tests and docs:

**Four in `packages/cli` — all corrected here** (located by text; the triage anchors had rotted, one by 491 lines):

- `packages/cli/src/commands/generate.ts` — doc comment, `id is 26 characters (...says so and`
- `packages/cli/src/commands/generate.ts` — inline comment, `this card's five rows — a platform id is 26 characters`
- `packages/cli/src/commands/generate-field-type-vocabulary.pin.test.ts` — `expect(value, message)` failure string
- `packages/cli/src/commands/generate-multiple-json-column.pin.test.ts` — plain comment

**A fifth live-source site, outside the card's population — filed as #16410, not edited here:** `packages/platform-objects/src/audit/sys-import-job.object.ts` carries *"a minted platform id is 26 characters"* — the strongest form, since "minted" is the one reading measurement flatly contradicts. The card listed the `platform-objects` **CHANGELOG** copy but not the live source it records. It is filed rather than ridden along on this card's own stated precedent — *"deliberately not fixed there — a different package, so a different verification surface"* — which measurement confirms: adding that file took the derived gate set from 48 to **49** families, pulling in `check:i18n-stale-fill` and `packages/platform-objects`' i18n extractor.

**Correctly excluded, verified individually:** the two CHANGELOG copies (historical records); driver-sql's arm at `sql-driver.ts` (it is the **correction**, and says the opposite); `like-pattern.ts`, `text-match-sql.ts` and `sql-driver.ts:2761,2767` (the 26 letters of `A-Z`); `validate-rule-schema-formats.ts` (format names ≤ 26 chars); `notification-keyed-text-bounds.test.ts` (uses 255, the physical column width).

⛔ `packages/rest/src/rest-server.ts` is a reserved single-writer path and was **not** edited. The sweep found no stale citation in it.

## Verification

Everything below was run on the final commit, `e58829a2563`, with the workspace built.

Two commits, and the second corrects the first: `f933d1e3c7d` made the four corrections, and `e58829a2563` reflows one line that commit left orphaned (`width half` stranded on a line of its own), quoting the three lines it corrects and naming the commit. Nothing is added there and no line is bought — the same words occupy one line fewer.

**Suites**

- `pnpm --filter @objectstack/cli test` — **272 test files passed (272); 3263 passed, 6 expected fail**.
- `pnpm --filter @objectstack/cli typecheck` — exit 0. ⭐ Not taken on trust: `tsc --noEmit --listFiles` was checked to actually contain all three edited files, including the two `.test.ts`, so "typecheck is clean" is a statement *about this diff* rather than about a program that excluded it.
- Targeted re-run on the final commit — the two edited pin tests plus the seven files described below: **9 files, 76 tests, all pass**.

⚠️ **A first full-suite run reported 7 failed files, and that reading was wrong — reported rather than buried.** The dependency closure had been built but not `@objectstack/cli` itself, and those seven `test/` files assert against the package's own `dist/`. Each failure said so in its own words (*"packages/cli is not built... CI declares the build (turbo: `@objectstack/cli#test` dependsOn build); a direct vitest run does not"*). After `pnpm build`, all seven pass. No diagnosis was assumed: the tests named the cause and the rebuild confirmed it.

**Gates** — derived, not recalled. `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` attests the answer comes from this repo at `e58829a2563`; the plain form's `Reconciliation — 48 famil(ies)` and the 48 lines of `--commands` agree, so the union is reconciled across both spellings.

- **The 48-family union: 47 green, 1 NOT MEASURED.** The exception is `check:type-check-debt`, whose `--re-measure` half exhausted tsc's heap at the 4 GB ceiling this shared box runs under, and which then *refused to record a number* rather than report one ("refusing to record 0"; its own text: *"⛔ This is NOT a pass and NOT a finding"*). Its coverage half printed `OK — 75/79 workspace packages type-checked`. That is a resource limit, not a verdict on this diff.
- **The `Declared WIDE population` block — all 10 run, all green.** These sit outside the 48 and no derivation can say whether they bite, so their absence from the matched block is not a clearance. They walk every non-test source under `packages/`, which is exactly what this diff edits, so they were run rather than read as silence.
- **The `Artifact roster` block — all run, one NOT MEASURED.** `check:react-declaration-parity` needs an SDUI manifest that only a browser build of objectui produces and that this repo's build deliberately does not; unrelated to this diff, which touches no spec or React surface.
- **Two gates are NOT WIRED locally and judge this PR in CI:** `check:partof-closing-keyword` and `check:single-claim-paths` both refuse without `PR_NUMBER`/`PR_BODY` (*"a wiring or usage failure, NOT a verdict"*). The first is the one that reads this body's closing keyword. This body carries exactly one, on its opening line, and it names this card alone; every other card referenced here is mentioned with no keyword standing before it — checked mechanically over the body and over both commit messages.

⭐ **The four gates that needed the build were measured, not waved through.** `check:i18n`, `check:i18n-coverage`, `check:i18n-walk-parity` and `check:dual-build-cjs-loads` all reported `PREREQUISITE NOT MET` on an unbuilt tree — which reads as neither pass nor fail. `check:i18n` is genuinely implicated here, because it re-extracts translation bundles from `packages/cli/src`, which this diff edits. After the build all four are green on their own verdict lines, `check:i18n` reporting `OK (9 package(s) — all bundles in sync, no undeclared authoring keys)`.

⭐ **No ablation leg, stated rather than invented.** The diff changes comment and message text only, so there is nothing whose removal could turn a test red — a mutation here could not fire, and a leg that cannot fire proves nothing.

⭐ **No mirror pair.** Nothing here mirrors a second declaration, so there is no "mutate the side you mirror" leg to run.

⛔ **No changeset**, and `skip-changeset` applied: this publishes nothing from any released package. Comments and one test failure-message string are the entire diff.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D47qPfEWVPmhguWgBZCi5N

---
_Generated by [Claude Code](https://claude.ai/code/session_01D47qPfEWVPmhguWgBZCi5N)_