### PR TITLE
fix(lint): validateFormLayout resolves a list-bound view's object for its default form

### DIFF
--- a/.changeset/lint-form-layout-list-binding.md
+++ b/.changeset/lint-form-layout-list-binding.md
@@ -1,0 +1,9 @@
+---
+"@objectstack/lint": patch
+---
+
+`validateFormLayout` now resolves the bound object for a view container's default `form` (and its `formViews.*` entries that declare no binding of their own) when that container names its object only on the `list` block (`list.data.object`, `list.object` or `list.objectName`) and nowhere on the container itself.
+
+Before this fix, `containerObject` had no way to see a list-only binding, so `objName` stayed `undefined` for every site under such a container — and `form-field-unknown` / `form-section-group-unknown` never fired there, however wrong the section content was. This is the same fallback rung `validate-translatable-sections.ts` already carries for its own sites; it is now shared by both. `absolute-colspan-discouraged` is unaffected by this change — it was never gated on the object binding (it needs only a field's `colSpan`), so it already fired on a list-bound container's form sections before this fix.
+
+Consequence: a view whose object binding lives only on `list` and whose default `form` (or an unbound `formViews.*` entry) references a nonexistent field or an undeclared `section.group` now gets a `warning` finding it did not get before. A stack with no such dangling reference sees no new output.

--- a/packages/lint/src/validate-form-layout.test.ts
+++ b/packages/lint/src/validate-form-layout.test.ts
@@ -434,3 +434,102 @@ describe('#6251 — reachable on a REAL parsed app stack', () => {
     expect(validateFormLayout(value!)).toEqual([]);
   });
 });
+
+// ───────────────────────────────────────────────────────────────────────────
+// #16168 — a container that binds its object only through `list.data.object`
+// (HotCRM's own shape, 14/14 views) had NO `object` / `objectName` /
+// `data.object` of its own, so `containerObject` — and every site under it,
+// including the container's own default `form` — resolved to `undefined` and
+// `form-field-unknown` / `form-section-group-unknown` never fired there.
+// Fix: fall back to `viewObjectName(view.list)`, the same third rung
+// `validate-translatable-sections.ts:178-179` already carries for its sites.
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('#16168 — falls back to the container list binding', () => {
+  /** A container that binds ONLY through `list.data.object` — no `object` / `objectName` at the container root. */
+  const listBoundContainer = (form: AnyRec) => ({
+    name: 'contract_views',
+    list: { label: 'Contracts', type: 'grid', data: { provider: 'object', object: 'contract' }, columns: [{ field: 'name' }] },
+    form,
+  });
+
+  it('P1 — flags a dangling field in the default `form` of a list-bound container', () => {
+    const findings = validateFormLayout({
+      objects,
+      views: [listBoundContainer({ sections: [{ columns: 2, fields: ['name', 'ghost_field'] }] })],
+    });
+    expect(findings.map((f) => `${f.rule}@${f.path}`)).toEqual([
+      `${FORM_FIELD_UNKNOWN}@views[0].form.sections[0].fields[1]`,
+    ]);
+    expect(findings[0].message).toContain('"contract"');
+  });
+
+  it('P2 — flags an undeclared `group` in the default `form` of a list-bound container', () => {
+    const findings = validateFormLayout({
+      objects: groupedObjects,
+      views: [listBoundContainer({ sections: [{ group: 'contact_info' }] })],
+    });
+    expect(findings.map((f) => `${f.rule}@${f.path}`)).toEqual([
+      `${FORM_SECTION_GROUP_UNKNOWN}@views[0].form.sections[0].group`,
+    ]);
+  });
+
+  it('N1 — positive control: the same defects with `object` also on the container produce the SAME findings (byte-identical where/path)', () => {
+    const withObject = (view: AnyRec) => ({ ...view, object: 'contract' });
+    const p1 = validateFormLayout({
+      objects,
+      views: [withObject(listBoundContainer({ sections: [{ columns: 2, fields: ['name', 'ghost_field'] }] }))],
+    });
+    expect(p1.map((f) => ({ rule: f.rule, where: f.where, path: f.path }))).toEqual([
+      { rule: FORM_FIELD_UNKNOWN, where: 'view "contract_views" · form', path: 'views[0].form.sections[0].fields[1]' },
+    ]);
+    const p2 = validateFormLayout({
+      objects: groupedObjects,
+      views: [withObject(listBoundContainer({ sections: [{ group: 'contact_info' }] }))],
+    });
+    expect(p2.map((f) => ({ rule: f.rule, where: f.where, path: f.path }))).toEqual([
+      { rule: FORM_SECTION_GROUP_UNKNOWN, where: 'view "contract_views" · form', path: 'views[0].form.sections[0].group' },
+    ]);
+  });
+
+  it('N2 — a list-bound container whose form references only real fields is clean', () => {
+    expect(validateFormLayout({
+      objects,
+      views: [listBoundContainer({ sections: [{ columns: 2, fields: ['name', 'amount'] }] })],
+    })).toEqual([]);
+  });
+
+  it('N3 — a `formViews[]` entry with its own `objectName` resolves as today, independent of the container', () => {
+    const findings = validateFormLayout({
+      objects,
+      views: [{
+        name: 'contract_views',
+        list: { data: { object: 'contract' } },
+        formViews: { edit: { objectName: 'contract', sections: [{ fields: ['ghost_via_own_binding'] }] } },
+      }],
+    });
+    expect(findings.map((f) => `${f.rule}@${f.path}`)).toEqual([
+      `${FORM_FIELD_UNKNOWN}@views[0].formViews.edit.sections[0].fields[0]`,
+    ]);
+  });
+
+  it('N4 — a view with neither a container nor a list binding stays silent (unchanged: the rule cannot check what it cannot resolve)', () => {
+    expect(validateFormLayout({
+      objects,
+      views: [{ name: 'orphan_views', form: { sections: [{ fields: ['whatever'] }] } }],
+    })).toEqual([]);
+  });
+
+  it('the colSpan rule is unconditional on the object binding — it already fired on a list-bound container before this fix', () => {
+    // Measured for the changeset: `absolute-colspan-discouraged` sits OUTSIDE
+    // the `known`-gated block (validate-form-layout.ts, the `(b)` comment) —
+    // it needs only `entry.colSpan != null`, never `objName` / `known`. So it
+    // was never actually dead on HotCRM's list-bound views; #16168 only fixes
+    // `form-field-unknown` and `form-section-group-unknown`.
+    const findings = validateFormLayout({
+      objects,
+      views: [listBoundContainer({ sections: [{ columns: 2, fields: [{ field: 'name', colSpan: 2 }] }] })],
+    });
+    expect(findings.map((f) => f.rule)).toEqual([FORM_COLSPAN_ABSOLUTE]);
+  });
+});

--- a/packages/lint/src/validate-form-layout.ts
+++ b/packages/lint/src/validate-form-layout.ts
@@ -130,16 +130,25 @@ export function validateFormLayout(stack: AnyRec): FormLayoutFinding[] {
     // artifact-emitted one may carry neither, so the path is the last resort.
     const viewName = strName(view.name) ?? strName(view.object) ?? viewPath;
     const containerObject = viewObjectName(view);
+    // [#16168] A container whose object lives on the LIST block
+    // (`list.data.object`, `list.object` or `list.objectName` — any anchor
+    // `viewObjectName` reads) has no `object` / `objectName` / `data.object` of
+    // its own, so `containerObject` above is `undefined` and every site under it
+    // — including the container's own default `form` — was unreferenceable.
+    // Same third rung `validate-translatable-sections.ts:178-179` already
+    // carries for its own sites.
+    const listBinding = isRec(view.list) ? viewObjectName(view.list) ?? containerObject : undefined;
 
     for (const site of formViewSites(view, viewPath)) {
       // A sub-container declares its own binding (`form.data.object`) and
-      // otherwise inherits the container's — the resolution order every other
+      // otherwise inherits the container's, then the container's list-bound
+      // object as a last resort (#16168) — the resolution order every other
       // view-walking rule in this package uses. The base rung is the shared
       // `viewObjectName` (#6662); this FALLBACK is deliberately NOT folded into
       // the shared walker, because the consumers compose it differently (see
       // `view-walk.ts`) and a refactor that changes a verdict is a failed
       // refactor.
-      const objName = viewObjectName(site.view) ?? containerObject;
+      const objName = viewObjectName(site.view) ?? containerObject ?? listBinding;
       // Only reference-check when the bound object resolves; otherwise we can't.
       const known = objName ? objectFields.get(objName) : undefined;
       const where = site.surface ? `view "${viewName}" · ${site.surface}` : `view "${viewName}"`;


### PR DESCRIPTION
Fixes #16168

## What

`validateFormLayout` now falls back to the container's `list` binding (`list.data.object` / `list.object` / `list.objectName`, via the shared `viewObjectName`) when resolving the bound object for a form site, whenever the container itself carries no `object` / `objectName` / `data.object` of its own. This is the same third rung `validate-translatable-sections.ts:178-179` already carries for its own sites (`recordObject` / `listBinding`) — carried, not duplicated, into `validate-form-layout.ts:132/142`.

Before: a view container that binds its object only through the `list` block (HotCRM's own shape, all 14 of its views) had `containerObject === undefined`, so every site under it — including its own default `form` — could never resolve an object, and `form-field-unknown` / `form-section-group-unknown` never fired there, however wrong the section content was.

`packages/lint/src/validate-form-layout.ts` — the fix (2 new lines + 1 changed line + comments).
`packages/lint/src/validate-form-layout.test.ts` — new describe block ("falls back to the container list binding"): P1/P2 (red-first on unmodified code, confirmed), N1 positive control (byte-identical `where`/`path` with `object` also on the container), N2 clean list-bound container, N3 a `formViews[]` entry with its own binding (unchanged), N4 no binding anywhere stays silent (unchanged), plus a pin proving `absolute-colspan-discouraged` was never gated on the object binding (see "colspan" below).
`.changeset/lint-form-layout-list-binding.md` — `@objectstack/lint` patch.

## Why

Filed by the hotcrm epic's rule-survey seat (hotcrm card 1637): on hotcrm at `db5fe702`, 49 of 49 authored form sections across 14/14 views were unreachable by this validator because every one of those views binds its object only via `list.data.object`. Triaged (comment 5556877712) against `origin/main`: the diagnosis holds on the platform source, and the fix shape already exists one validator over — this PR carries that same ladder into `validate-form-layout.ts`, and only there (the package's other two ladder lengths are a separate convergence card per that triage, out of scope here).

## Colspan — measured, not assumed

The filing seat's own scope correction (comment 5556746408) flagged `absolute-colspan-discouraged` as **unmeasured** on the "never fires" claim. Measured here: the colspan check (`validate-form-layout.ts`'s `(b)` block) sits **outside** the `known`-gated block — it needs only `entry.colSpan != null`, never `objName` / `known`. So it was never actually dead on a list-bound container; it already fired regardless of whether the object resolved. This PR's fix therefore changes only `form-field-unknown` and `form-section-group-unknown`.

## Risk & cost (rollback)

Advisory-only (`severity: 'warning'`) — nothing is blocked. A stack whose list-bound container's default `form` (or an unbound `formViews.*` entry) references a real dangling field/group now surfaces a warning it did not surface before; a clean stack of the same shape produces no new output (N2/N4 pin this). Patch-level change to `@objectstack/lint`, single-file source diff, revert is a straight `git revert`.

## Open questions for the maintainer

See report JSON `open_questions` (posted as a comment on this issue) — notably what the `groups` legacy-bucket alias (card 6926) now surfaces once this binding resolves, per the triage seat's ask; reported there for information, not acted on here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vbw3RPgdtqesx4azk9SbW8