### PR TITLE
docs(lint): security-anchor-high-privilege states its scope — declared everyone suggestions, not guest bindings

### DIFF
--- a/packages/lint/src/validate-security-posture.ts
+++ b/packages/lint/src/validate-security-posture.ts
@@ -12,7 +12,7 @@
  * | security-owd-alias            (error)   | ADR-0090 D4 canonical enum      |
  * | security-external-wider       (error)   | ADR-0090 D11 external ≤ internal|
  * | security-wildcard-vama        (error)   | ADR-0066 superuser wildcard     |
- * | security-anchor-high-privilege(error)   | ADR-0090 D5/D9 anchors          |
+ * | security-anchor-high-privilege(error)   | ADR-0090 D5/D9 anchors — declared `everyone` suggestions (`isDefault: true`) only; a `guest`-bound set is outside a package-time linter's sight and is the bind-time gate's alone (#16110) |
  * | security-role-word            (error)   | ADR-0090 D3 vocabulary freeze — own function/registry entry since #8310 |
  * | security-book-audience-unknown-set(warn)| ADR-0046 §6.7 { permissionSet } |
  * | security-private-no-readscope (info)    | admin-intent mismatch class     |
@@ -26,6 +26,14 @@
  * BUT ONE mirrors a runtime enforcement point (D1 fail-closed OWD default, D4
  * zod enum + fail-closed evaluator, D5/D9 anchor binding gate, D3 rename wave)
  * — the lint moves the failure from runtime-deny to author-time fix-it.
+ * `security-anchor-high-privilege` mirrors that gate for the one suggestion a
+ * package can actually declare (`isDefault: true` → the `everyone` anchor,
+ * `suggested-audience-bindings.ts`'s "the only declarable suggestion"); a set
+ * an operator binds to `guest` at install time is a decision ADR-0090 D9
+ * ("a package may suggest bindings … the admin confirms each individually")
+ * puts past authoring, so this rule is not — and cannot be — coverage for an
+ * app-authored anchor set bound to `guest` (#16110). That binding is held by
+ * the runtime's own `describeAnchorForbiddenBits(set, 'guest')` gate instead.
  *
  * The exception INVERTS that argument rather than weakening it.
  * `security-cbp-ambiguous-relation` has no runtime refusal to mirror precisely
@@ -531,6 +539,10 @@ export function validateSecurityPosture(stack: AnyRec, opts?: { nowMs?: number }
     // D5: an isDefault set is a SUGGESTED binding to the `everyone` anchor —
     // hold it to the anchor tier at author time (the runtime gate enforces the
     // same predicate at bind time; this moves the failure to the author).
+    // Scope: `isDefault: true` is the only declarable suggestion today — a set
+    // an operator binds to `guest` at install carries no author-time flag for
+    // this rule to key off, so that binding is outside what a package-time
+    // linter can see and is judged by the bind-time gate alone (#16110).
     if (ps.isDefault === true) {
       const offending = describeAnchorForbiddenBits(ps, 'everyone');
       if (offending) {


### PR DESCRIPTION
Fixes #16110

## What

`security-anchor-high-privilege`'s docblock and rule-catalogue entry did not state its own scope. The rule judges a declared `isDefault: true` (an `everyone`-suggested set) at author time — the same predicate the bind-time gate (`describeAnchorForbiddenBits(set, 'everyone' | 'guest')`) enforces at bind time. It does not, and cannot, see a set an operator binds to `guest` at install: that decision happens after authoring, and `isDefault: true` is the only suggestion a package can declare today (`suggested-audience-bindings.ts`'s "the only declarable suggestion" line; ADR-0090 D9 — "a package may suggest bindings to `everyone` or `guest`; the admin confirms each individually"). Without a stated scope, the rule id read as coverage it did not have for an app-authored anchor set bound to `guest`.

Three sites now say so explicitly:
- the module-header catalogue table row for this rule
- one paragraph added to the header's "every `error` rule mirrors a runtime enforcement point" discussion
- the rule-site comment immediately above the `isDefault === true` check

## Why not a behaviour change

Per the maintainer's ruling on the card (comment 5557093062, adopting recommendation 2): a package-declarable `guest` suggestion key is refused as a rider here — "adding a package-declarable `guest` suggestion key is a feature on the manual floor." This PR states the existing scope; it adds no schema key, no new rule, no new finding branch. The retirement-ledger consequence (hotcrm's local assertion for a `guest`-bound anchor set stays; this rule's row may not be counted as live coverage for it) is already on the card — nothing to do here in another repo.

## Diff

Docblock/comment-only — no `message`/`hint` string moved, no behaviour changed. **`skip-changeset`** (no user-read string moved; the PM applies the label).

## Tests

- `pnpm --filter @objectstack/lint exec vitest run --maxWorkers=2 src/validate-security-posture.test.ts` — 109 passed (existing suite is the regression control; no new finding, none needed).
- `pnpm --filter @objectstack/lint test` (through the shared verify lock) — 100 files / 3444 passed, 5 skipped.
- `pnpm --filter @objectstack/lint typecheck` (through the shared verify lock) — clean.
- All 39 dispatch-derived gate commands for this diff — exit 0 (two needed a build prerequisite first: `pnpm --filter '@objectstack/lint...' build` for `check:docs-transcript-drift`, and a full `pnpm build` — 72/72 tasks — for `check:dual-build-cjs-loads`; both re-ran green afterward).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vbw3RPgdtqesx4azk9SbW8

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vbw3RPgdtqesx4azk9SbW8)_