### PR TITLE
docs(adr): point ADR-0041's References at where the trigger packages live

### DIFF
--- a/docs/adr/0041-flow-trigger-family.md
+++ b/docs/adr/0041-flow-trigger-family.md
@@ -191,8 +191,8 @@ other contract-ahead-of-runtime surfaces.
 
 - Engine seam: `packages/services/service-automation/src/engine.ts`
   (`FlowTrigger`, `registerTrigger`, `activateFlowTrigger`)
-- Shipped triggers: `packages/plugins/plugin-trigger-record-change`,
-  `packages/plugins/plugin-trigger-schedule`
+- Shipped triggers: `packages/triggers/trigger-record-change`,
+  `packages/triggers/trigger-schedule`
 - Reserved surface: `FlowSchema.type` enum (`packages/spec/src/automation/flow.zod.ts`)
 - Auto-wiring: `packages/cli/src/commands/serve.ts` (trigger `nameMatch` table)
 - Related: ADR-0018 (descriptor pattern this extends), ADR-0030 (outbox),


### PR DESCRIPTION
Refs #15478. Carved out of PR #15993 — this is that PR's fourth file, on a branch of its own.

## What

ADR-0041's `## References` section names the two shipped trigger packages by source path. Both packages moved on 2026-06-12 and the pointer did not, so it names a directory that does not exist:

```
- - Shipped triggers: `packages/plugins/plugin-trigger-record-change`,
-   `packages/plugins/plugin-trigger-schedule`
+ - Shipped triggers: `packages/triggers/trigger-record-change`,
+   `packages/triggers/trigger-schedule`
```

Two lines, one file, `+2/-2`. The bytes are identical to what PR #15993 carried — the file's blob is `9016f38ff` on both branches, so nothing was re-authored on the way over.

## Why this is its own PR

`docs/adr/**` is a governed surface, so under Prime Directive #14 a diff that touches one is landed by the maintainer by hand and never through the merge queue. One path hit governs the whole PR — 「混合 diff 一条命中即整 PR 分叉」 — so this single line made PR #15993 ineligible as a whole, alongside two published-manifest corrections that are ordinary queue work.

That is measured, not predicted. On **every** `added_to_merge_queue` for PR #15993 (20:09Z, 21:49Z, 22:22Z, 01:57Z) the merge-group run's `Governed Surface Queue Guard` failed at the step *"Governed surfaces may not enter the merge queue unreviewed"* and `github-merge-queue[bot]` removed the PR. Four ejections. The PR-level check of the same name stayed green throughout, because that guard bites in the `merge_group` event — which is why 34 green PR checks never predicted any of them.

With this file carved out, PR #15993 is three paths with zero governed hits. Read from the register rather than recalled, and with its control fired in the opposite direction so the reading is a measurement and not an empty pass:

```
node scripts/pm/check-governed-merges.mjs --test  (the three remaining paths)
  EXIT=0   0 of 3 path(s) hit the register (5 surfaces, repo-agnostic)
           NOT governed — ordinary queue landing applies

node scripts/pm/check-governed-merges.mjs --test docs/adr/0041-flow-trigger-family.md
  EXIT=3   1 of 1 path(s) hit the register
           GOVERNED — docs/adr/** ×1
```

## Landing

⛔ **This PR waits for a maintainer's merge.** It stays draft; no seat flips it ready, enqueues it, or arms auto-merge on it. That is where a `docs/adr/**` touch was always going to end up — the carve-out changes which PR waits, not whether one does.

## Deliberately left as written

The same record's rename table and narrative at lines 46, 48 and 97-100. Those name the old identifiers as the decision's own history, and the table's left column is a **package name**, not a path — not a pointer by construction. The anchored replacement could not have reached them in any case, since they carry no `packages/plugins/` prefix; the distinction is the point. A References pointer is live; a decision record's account of what it renamed is not.

## No changeset

This publishes nothing from any package, so `skip-changeset` applies and is set on this PR.

## Verification

Gate family derived mechanically on head `c18ae4060` — `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack --commands`, which reads the change set from the merge base itself (1 path), never hand-built. Every exit code captured immediately after a single redirected command, never through a pipe.

All **17** derived commands **EXIT=0**: `check-adr-links` (and its self-test), `check-adr-symbol-anchors` (and its self-test), `check-ci-filter-parity`, `check-closing-keyword-parity` (and its self-test), `check-comment-mask-corpus`, `check:doc-formula-expressions`, `check:adr-anchors`, `check:cross-package-test-inputs`, `check:doc-authoring`, `check:driver-memory-census`, `check:nul-bytes`, `check:pm-governed-merges`, `check:refd-timer-probe`, `check:watch-hint-literal`.

⚠️ One of those needed its prerequisite met first and is **not** reported as a first-pass pass: `pnpm --filter @objectstack/lint run check:doc-formula-expressions` answered **3 = PREREQUISITE NOT MET** (unbuilt `@objectstack/formula` and `@objectstack/lint`) — neither green nor red, nothing measured. After `turbo run build --filter=@objectstack/formula --filter=@objectstack/lint` (4/4 tasks) it re-ran **EXIT=0**.

⚠️ `pnpm check:pm-governed-merges` runs the checker's own `--self-test` (274 assertions), so it grades the checker and not this diff. The verdict on this diff is the `--test` pair quoted above.

⛔ Nothing here is a claim about CI. Working tree clean at `c18ae4060`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XpTx2tbq3pZRYAdoGt6E6Y

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpTx2tbq3pZRYAdoGt6E6Y)_