### PR TITLE
fix(lint): nav-object-ungranted stops prescribing a gate it cannot honour

### DIFF
--- a/.changeset/nav-object-ungranted-hint-drops-gating.md
+++ b/.changeset/nav-object-ungranted-hint-drops-gating.md
@@ -1,0 +1,5 @@
+---
+"@objectstack/lint": patch
+---
+
+`nav-object-ungranted`'s hint no longer tells you to gate the nav entry with `requiredPermissions`/`visible` — that never cleared the finding, because the rule never reads either key. Gating restricts who can see the entry; it doesn't grant the object read, so a holder who clears the gate could still hit permission-denied, and the warning kept firing anyway. The hint (and the module doc-block) now name the two remedies that actually clear it: grant read on the object in a permission set (`allowRead: true` or `viewAllRecords`), or drop the nav entry. No behavior change — the rule fires and stays silent on exactly the same inputs as before; only the wording of the hint moved.

--- a/packages/lint/src/validate-nav-access.test.ts
+++ b/packages/lint/src/validate-nav-access.test.ts
@@ -190,3 +190,61 @@ describe('validateNavAccess — exemptions (false-positive floor)', () => {
     expect(findings).toEqual([]);
   });
 });
+
+// #16065: the hint used to prescribe a third remedy — "gate the entry with
+// requiredPermissions/visible" — that this rule cannot honour: neither key is
+// read anywhere in this file, so a gated-but-ungranted entry kept warning
+// forever. The fix corrects the hint (and the doc-block) to the two remedies
+// the rule can actually prove; it does NOT make the rule start reading those
+// keys. These controls pin that: gating must not silence a genuinely
+// ungranted object, and must not spuriously flag a genuinely granted one.
+describe('validateNavAccess — gating keys are not read (#16065)', () => {
+  it('hint prescribes only the two remedies it can prove, not gating', () => {
+    const findings = validateNavAccess({
+      objects,
+      apps: navApp([objectNav('nav_forecast', 'crm_forecast')]),
+      permissions: [{ name: 'p', label: 'P', objects: { crm_lead: { allowRead: true } } }],
+    });
+    expect(findings).toHaveLength(1);
+    const { hint } = findings[0];
+    // The two remedies the rule can prove.
+    expect(hint).toContain('allowRead: true');
+    expect(hint).toContain('viewAllRecords');
+    // The retired third remedy must not return.
+    expect(hint).not.toContain('gate the entry');
+    expect(hint).not.toMatch(/requiredPermissions.*if it is meant for admins only/);
+  });
+
+  it('a requiredPermissions-gated but ungranted object still fires (gating is not a remedy)', () => {
+    const findings = validateNavAccess({
+      objects,
+      apps: navApp([
+        { ...objectNav('nav_forecast', 'crm_forecast'), requiredPermissions: ['view_forecast'] },
+      ]),
+      permissions: [{ name: 'p', label: 'P', objects: { crm_lead: { allowRead: true } } }],
+    });
+    expect(findings).toHaveLength(1);
+    expect(findings[0].rule).toBe(NAV_OBJECT_UNGRANTED);
+  });
+
+  it('a visible:false but ungranted object still fires (gating is not a remedy)', () => {
+    const findings = validateNavAccess({
+      objects,
+      apps: navApp([{ ...objectNav('nav_forecast', 'crm_forecast'), visible: false }]),
+      permissions: [{ name: 'p', label: 'P', objects: { crm_lead: { allowRead: true } } }],
+    });
+    expect(findings).toHaveLength(1);
+    expect(findings[0].rule).toBe(NAV_OBJECT_UNGRANTED);
+  });
+
+  it('a gated AND granted object stays silent — gating causes no false positive either', () => {
+    const findings = validateNavAccess({
+      objects,
+      apps: navApp([
+        { ...objectNav('nav_forecast', 'crm_forecast'), requiredPermissions: ['view_forecast'] },
+      ]),
+      permissions: [{ name: 'p', label: 'P', objects: { crm_forecast: { allowRead: true } } }],
+    });
+    expect(findings).toEqual([]);
+  });
+});

--- a/packages/lint/src/validate-nav-access.ts
+++ b/packages/lint/src/validate-nav-access.ts
@@ -25,6 +25,13 @@
  * entry — it is only *suspicious*, and the ceiling for a static check is a
  * warning (the same posture `validate-capability-references` takes).
  *
+ * The only remedies that clear this finding are granting read (a permission set's
+ * `objects` entry with `allowRead: true` or `viewAllRecords`) or dropping the nav
+ * entry. Gating the item with `requiredPermissions` or `visible` does not: those
+ * gate on capabilities/visibility, not the object grant, so a holder who clears
+ * the gate can still lack read and hit permission-denied — honouring either key
+ * here would silence the rule on an object that is genuinely reachable.
+ *
  * Two exemptions keep it quiet:
  *   - **Platform-provided objects** (`sys_user`, `sys_approval_request`, …) are
  *     skipped: the packages that register them ship their own permission sets,
@@ -170,9 +177,10 @@ export function validateNavAccess(stack: AnyRec): NavAccessFinding[] {
         `and breaks for the users the app ships permission sets for.`,
       hint:
         `Add "${objectName}" to a permission set's \`objects\` with \`allowRead: true\` ` +
-        `(or \`viewAllRecords\`), gate the entry with \`requiredPermissions\`/\`visible\` ` +
-        `if it is meant for admins only, or drop it. Ignore this if a permission set ` +
-        `from another installed package grants it.`,
+        `(or \`viewAllRecords\`), or drop the entry. Gating it with \`requiredPermissions\`/` +
+        `\`visible\` does not clear this: those gate visibility, not the object grant, so a ` +
+        `holder can still open the entry and hit permission-denied. Ignore this if a ` +
+        `permission set from another installed package grants it.`,
     });
   }
 


### PR DESCRIPTION
Fixes #16065

Ruling (director seat, decision batch #59; maintainer verbatim 「16063 c, 其他同意」 — this card adopted as recommended, option B):

> `nav-object-ungranted` keeps asserting exactly what it can prove: an object reachable from navigation must be granted, or the entry dropped. The hint and the module doc-block lose the "gate the entry with `requiredPermissions`/`visible`" clause. The rule does **not** start honouring those keys: `requiredPermissions` gates on capabilities, not object grants, so a holder can still lack read on the object, and `visible` is inert at runtime (card 15135) — honouring either would silence the rule on a genuinely reachable ungranted object.

## What changed

- `packages/lint/src/validate-nav-access.ts`: the `nav-object-ungranted` hint no longer prescribes gating the entry with `requiredPermissions`/`visible` — that never cleared the finding, because the rule never reads either key (grep confirmed each word appeared exactly once in the whole file, both inside the old hint string; the module doc-block did not separately restate the three-remedy prose). The hint now names only the two remedies the rule can prove — grant read on the object in a permission set (`allowRead: true` or `viewAllRecords`), or drop the nav entry — plus one sentence on why gating doesn't count. The doc-block gained the same statement.
- `validateNavAccess` itself is unchanged: identical findings on identical inputs before and after this PR (proven by re-running the full existing suite unmodified, and by a red-first check that reverted only the source file and confirmed the new pin test fails against it while every other test still passes).
- `packages/lint/src/validate-nav-access.test.ts`: added a pin for the hint text (the retired "gate the entry" clause must not return, the two live remedies must be present) plus three regression controls — a `requiredPermissions`-gated ungranted object still fires, a `visible: false` ungranted object still fires, and a gated-AND-granted object stays silent (gating causes neither a false negative nor a false positive).
- `.changeset/nav-object-ungranted-hint-drops-gating.md` — `@objectstack/lint` patch.

## Why

Card 16065: an author following the hint's third remedy (gate the entry) got no change in the rule's output — the warning kept firing — after spending an edit that also narrowed what the app actually serves to a real user. `requiredPermissions`/`visible` gate visibility, not the object grant, so a holder who clears the gate can still open the entry and hit permission-denied on the object itself.

## Related, not touched here

- card 14453 — where the defect was first measured against a real audit.
- card 15135 — `visible` is inert at runtime; unrelated defect, not addressed by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vbw3RPgdtqesx4azk9SbW8

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vbw3RPgdtqesx4azk9SbW8)_