### PR TITLE
test(plugin-approvals): reproduce #15358 — a cascade-failed ancestor is reported as the repairable strand it is not

### DIFF
--- a/packages/plugins/plugin-approvals/src/stranded-run-repairability.test.ts
+++ b/packages/plugins/plugin-approvals/src/stranded-run-repairability.test.ts
@@ -1,0 +1,386 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * #15358 — THE REPRODUCTION: `inspectStrandedRequests` labels a repairable
+ * strand and an UNREPAIRABLE cascade-failed ancestor identically.
+ *
+ * The card was filed from a reading of the sources. This file is the drive,
+ * against a real `AutomationEngine` and a real `ApprovalService`, and it
+ * reproduces: one fixture produces both rows, the inspection returns both as
+ * `runState: 'failed'`, and the repair verb an operator would reach for next
+ * answers `restored: true` for one and refuses the other.
+ *
+ * ## The two rows, from one fixture
+ *
+ * `deal_subflow` parks at an `approval`, and its approve edge leads to a
+ * `subflow` node hosting `post_approval`, which parks at a SECOND `approval`
+ * whose approve edge throws.
+ *
+ *  - CHILD run — the #13909 strand: its resume consumed the pause and the
+ *    downstream node threw. The engine journals the consumed suspension, so
+ *    `restoreConsumedSuspension` re-arms it. REPAIRABLE.
+ *  - PARENT run — the cascade-failed ancestor (#15222's shape): it was parked
+ *    at its `subflow` node when the descendant failed, so `failAncestors` ran
+ *    `failSuspendedRun` on it, which consumes the pause and journals NOTHING.
+ *    `restoreConsumedSuspension` refuses it `NO_CONSUMED_SUSPENSION`. The
+ *    engine's own words for a terminal record carrying neither
+ *    `consumedSuspension` nor `consumedSuspensionDropped` (`RunRecord`):
+ *    "a run that reached a terminal state which was NOT a strand (completed,
+ *    cancelled, cascade-failed)". UNREPAIRABLE — and this row's decision did
+ *    advance its flow, which is the half the shared label denies.
+ *
+ * ## What must turn these assertions RED
+ *
+ * ⛔ The `runState` assertions below record what the inspection reports
+ * TODAY. The maintainer ruling on this card (2026-09-04, decision batch #36,
+ * option B) splits `StrandedRunState` into a repairable and an unrepairable
+ * member and reports both, labelled apart — so whatever lands for B MUST turn
+ * the "both come back identical" assertion red on purpose. It is written as a
+ * single `toEqual` over both rows for exactly that reason: a split that
+ * relabels only one of them still fails it.
+ *
+ * ## The measurement that sent the card back to the decision box
+ *
+ * `PIN 3` is the load-bearing one. B's first clause is "`getRun` widens to
+ * carry the discriminator the engine already records". The engine records it
+ * on the DURABLE `RunRecord`, and `AutomationEngine.getRun` answers an
+ * `ExecutionLogEntry`, which carries neither field — deliberately: `recordLog`
+ * says the snapshot is "a parameter rather than a field of
+ * `ExecutionLogEntry`" because that interface "is served verbatim by
+ * `GET /automation/:name/runs/:runId`". So widening the plugin-side
+ * declaration alone cannot separate these two rows: on a real engine the
+ * discriminator is absent for BOTH, and a classifier reading absence as "not a
+ * strand" would answer UNREPAIRABLE for the repairable row — the #15555
+ * false-negative harm, one surface over. Where the discriminator gets
+ * published is a producer-side contract decision, and it is open.
+ *
+ * ## The control that makes the readings trustworthy
+ *
+ * `PIN 4` drives the SAME strand through a different door in the same run.
+ * `decide` throws `RESUME_FAILED` carrying `{ finalized, decision, runId,
+ * repairable: true }` (#13807, batch #37); `recall` reports the same strand as
+ * a plain `resumeError` string with no envelope at all. ⇒ the difference is
+ * the DOOR, not the strand — so a reading taken at one door is not a fact
+ * about strands until the other door is driven too.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { AutomationEngine, InMemorySuspendedRunStore, installBuiltinNodes } from '@objectstack/service-automation';
+// [#4550] The engine double's write verbs route through ObjectQL's OWN dispatch
+// predicates rather than a hand-mirrored copy — a double looser than the engine
+// it stands in for is how #4434 shipped a dead REST route with its suite green.
+import { assertEngineDeleteDispatch, assertEngineUpdateDispatch } from '@objectstack/objectql';
+import { strandedDecisionDetails } from '@objectstack/types';
+import { ApprovalService } from './approval-service.js';
+import { registerApprovalNode } from './approval-node.js';
+
+const SYSTEM_CTX = { isSystem: true, positions: [], permissions: [] } as any;
+const noopLogger: any = {
+  info() {}, warn() {}, error() {}, debug() {}, child() { return noopLogger; },
+};
+
+/** The downstream failure, in the card's own shape. */
+const DOWNSTREAM_FAILURE = 'update_record(crm_leave_request) failed: Record 9SEmlyRfw8D9-J7Z not found';
+
+/** In-memory ObjectQL stand-in for the approvals tables. */
+function makeFakeEngine() {
+  const tables = new Map<string, any[]>();
+  const rows = (o: string) => (tables.get(o) ?? (tables.set(o, []), tables.get(o)!));
+  const matches = (row: any, where: any) => Object.entries(where ?? {}).every(([k, v]) => {
+    if (k.startsWith('$')) throw new Error(`fake engine: unsupported filter operator ${k}`);
+    if (v && typeof v === 'object' && '$in' in (v as any)) return (v as any).$in.includes(row[k]);
+    if (v && typeof v === 'object' && '$ne' in (v as any)) return row[k] !== (v as any).$ne;
+    return row[k] === v;
+  });
+  return {
+    tables,
+    async find(object: string, opts: any = {}) {
+      const where = opts.where ?? opts.filter ?? {};
+      const out = rows(object).filter(r => matches(r, where));
+      // The caller's bound is honoured by PRESENCE, never truthiness: `limit: 0`
+      // is a real bound that must return no rows.
+      const start = opts.offset ?? 0;
+      const page = typeof opts.limit === 'number' ? out.slice(start, start + opts.limit) : out.slice(start);
+      return page.map(r => ({ ...r }));
+    },
+    async insert(object: string, data: any) { rows(object).push({ ...data }); return { ...data }; },
+    async update(object: string, data: any, options?: any) {
+      const dispatch = assertEngineUpdateDispatch(data, options);
+      const table = rows(object);
+      if (dispatch.kind === 'multi') {
+        let n = 0;
+        for (let i = 0; i < table.length; i++) {
+          if (matches(table[i], options?.where)) { table[i] = { ...table[i], ...data }; n++; }
+        }
+        return { updated: n };
+      }
+      const i = table.findIndex(r => r.id === dispatch.id);
+      if (i >= 0) table[i] = { ...table[i], ...data };
+      return i >= 0 ? { ...table[i] } : null;
+    },
+    async delete(object: string, options?: any) {
+      const dispatch = assertEngineDeleteDispatch(options);
+      const table = rows(object);
+      if (dispatch.kind === 'multi') {
+        const survivors = table.filter(r => !matches(r, options?.where));
+        const deleted = table.length - survivors.length;
+        table.splice(0, table.length, ...survivors);
+        return { deleted };
+      }
+      const i = table.findIndex(r => r.id === dispatch.id);
+      if (i >= 0) table.splice(i, 1);
+      return { id: dispatch.id };
+    },
+    registerHook() {}, unregisterHooksByPackage() { return 0; }, async fire() {},
+  };
+}
+
+/** PARENT: approval, then a subflow that hosts a second approval. */
+const DEAL_SUBFLOW = {
+  name: 'deal_subflow',
+  label: 'Deal Approval With Follow-up Subflow',
+  type: 'autolaunched',
+  nodes: [
+    { id: 'start', type: 'start', label: 'Start' },
+    {
+      id: 'approve_step', type: 'approval', label: 'Manager Approval',
+      config: { approvers: [{ type: 'user', value: 'u1' }] },
+    },
+    {
+      id: 'sub', type: 'subflow', label: 'Post-approval subflow',
+      config: { flowName: 'post_approval', outputVariable: 'subOut' },
+    },
+    { id: 'rejected', type: 'mark', label: 'Rejected' },
+    { id: 'end', type: 'end', label: 'End' },
+  ],
+  edges: [
+    { id: 'e1', source: 'start', target: 'approve_step' },
+    { id: 'e2', source: 'approve_step', target: 'sub', label: 'approve' },
+    { id: 'e3', source: 'approve_step', target: 'rejected', label: 'reject' },
+    { id: 'e4', source: 'sub', target: 'end' },
+    { id: 'e5', source: 'rejected', target: 'end' },
+  ],
+};
+
+/** CHILD: a second approval whose approve edge is the node that throws. */
+const POST_APPROVAL = {
+  name: 'post_approval',
+  label: 'Post-approval follow-up',
+  type: 'autolaunched',
+  nodes: [
+    { id: 'cstart', type: 'start', label: 'Start' },
+    {
+      id: 'hold', type: 'approval', label: 'Second Approval',
+      config: { approvers: [{ type: 'user', value: 'u2' }] },
+    },
+    { id: 'boom', type: 'mark', label: 'Follow-up write' },
+    { id: 'child_rejected', type: 'mark', label: 'Child rejected' },
+    { id: 'cend', type: 'end', label: 'End' },
+  ],
+  edges: [
+    { id: 'c1', source: 'cstart', target: 'hold' },
+    { id: 'c2', source: 'hold', target: 'boom', label: 'approve' },
+    { id: 'c3', source: 'hold', target: 'child_rejected', label: 'reject' },
+    { id: 'c4', source: 'boom', target: 'cend' },
+    { id: 'c5', source: 'child_rejected', target: 'cend' },
+  ],
+};
+
+/** A single-approval flow, for the door control. */
+const DEAL_APPROVAL = {
+  name: 'deal_approval',
+  label: 'Deal Approval',
+  type: 'autolaunched',
+  nodes: [
+    { id: 'start', type: 'start', label: 'Start' },
+    {
+      id: 'approve_step', type: 'approval', label: 'Manager Approval',
+      config: { approvers: [{ type: 'user', value: 'u1' }] },
+    },
+    { id: 'on_approved', type: 'mark', label: 'Approved' },
+    { id: 'mark_rejected', type: 'mark', label: 'Rejected' },
+    { id: 'end', type: 'end', label: 'End' },
+  ],
+  edges: [
+    { id: 'e1', source: 'start', target: 'approve_step' },
+    { id: 'e2', source: 'approve_step', target: 'on_approved', label: 'approve' },
+    { id: 'e3', source: 'approve_step', target: 'mark_rejected', label: 'reject' },
+    { id: 'e4', source: 'on_approved', target: 'end' },
+    { id: 'e5', source: 'mark_rejected', target: 'end' },
+  ],
+};
+
+describe('#15358 — a cascade-failed ancestor is reported as the repairable strand it is not', () => {
+  let data: ReturnType<typeof makeFakeEngine>;
+  let service: ApprovalService;
+  /** Node id → the message it throws when reached. */
+  let throwOn: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    throwOn = {};
+    data = makeFakeEngine();
+    service = new ApprovalService({ engine: data as any, logger: noopLogger });
+  });
+
+  /** One live process: real engine, real builtin nodes, real approval node, real service. */
+  function boot() {
+    const automation = new AutomationEngine(noopLogger, new InMemorySuspendedRunStore());
+    installBuiltinNodes(automation, { logger: noopLogger, getService() { throw new Error('none'); } } as any);
+    registerApprovalNode(automation, service, noopLogger);
+    automation.registerNodeExecutor({
+      type: 'mark',
+      async execute(node: any) {
+        const boom = throwOn[node.id];
+        if (boom) throw new Error(boom);
+        return { success: true };
+      },
+    } as never);
+    automation.registerFlow('deal_subflow', DEAL_SUBFLOW as never);
+    automation.registerFlow('post_approval', POST_APPROVAL as never);
+    automation.registerFlow('deal_approval', DEAL_APPROVAL as never);
+    service.attachAutomation(automation);
+    return automation;
+  }
+
+  const pendingRequest = async () =>
+    (await data.find('sys_approval_request', { where: { status: 'pending' } }))[0];
+
+  /**
+   * Drive the composition to its two terminal requests: a CHILD run stranded
+   * mid-continuation, and a PARENT run cascade-failed while parked at its
+   * `subflow` node.
+   */
+  async function driveBothShapes(automation: AutomationEngine) {
+    throwOn.boom = DOWNSTREAM_FAILURE;
+    await automation.execute('deal_subflow', {
+      object: 'crm_deal', record: { id: 'd1', amount: 100 }, userId: 'submitter',
+    } as never);
+
+    const parentReq = await pendingRequest();
+    const parentRunId = parentReq.flow_run_id as string;
+    expect(parentRunId, 'the first request names the parent run').toBeTruthy();
+
+    // The parent's decision SUCCEEDS — it advances the flow into the subflow,
+    // which is the whole reason its later `failed` row must not read as a
+    // decision that never moved.
+    const advanced = await service.decide(
+      parentReq.id, { decision: 'approve', actorId: 'u1' }, SYSTEM_CTX,
+    );
+    expect(advanced.resumed, 'the parent decision DID advance the flow').toBe(true);
+    expect(advanced.resumeError).toBeUndefined();
+    expect(await automation.hasSuspendedRun(parentRunId), 'the parent is now parked at its subflow node').toBe(true);
+
+    const childReq = await pendingRequest();
+    const childRunId = childReq.flow_run_id as string;
+    expect(childRunId, 'the child run hosts the second approval').toBeTruthy();
+    expect(childRunId).not.toBe(parentRunId);
+
+    // The child's decision strands the child AND cascade-fails the parent.
+    const err = await service
+      .decide(childReq.id, { decision: 'approve', actorId: 'u2' }, SYSTEM_CTX)
+      .then(() => null, (e: Error) => e);
+    expect(err?.message, 'the child door throws its stranded refusal').toMatch(/^RESUME_FAILED/);
+
+    return { parentReq, parentRunId, childReq, childRunId, childError: err };
+  }
+
+  it('PIN 1 — the two rows come back with the SAME `runState`, and one of them cannot be repaired', async () => {
+    const automation = boot();
+    const { parentReq, parentRunId, childReq, childRunId } = await driveBothShapes(automation);
+
+    // ⚠️ INSPECT BEFORE RESTORING ANYTHING: `restoreConsumedSuspension` re-arms
+    // the pause, which would move the row out of the inspection's answer.
+    const out = await service.inspectStrandedRequests();
+    expect(out.scanned).toBe(2);
+    expect(out.undetermined).toBe(0);
+
+    const labelled = out.stranded
+      .map(s => [s.requestId === parentReq.id ? 'cascade-failed ancestor' : 'genuine strand', s.runState])
+      .sort((a, b) => a[0].localeCompare(b[0]));
+    // ⛔ THE DEFECT, as one assertion: the label does not distinguish them.
+    // Option B splits `StrandedRunState`, so this MUST go red when B lands.
+    expect(labelled).toEqual([
+      ['cascade-failed ancestor', 'failed'],
+      ['genuine strand', 'failed'],
+    ]);
+
+    // …and both are reported with their decision durable, which is the true
+    // half the report gets right for both rows.
+    expect(out.stranded.map(s => s.status)).toEqual(['approved', 'approved']);
+    expect(new Set(out.stranded.map(s => s.runId))).toEqual(new Set([parentRunId, childRunId]));
+    void childReq;
+  });
+
+  it('PIN 2 — the repair verb DOES tell them apart: one is re-armed, the other refused', async () => {
+    // This is the fact the shared label hides, and the operator-visible cost
+    // named on the card: a reported row the repair verb declines.
+    const automation = boot();
+    const { parentRunId, childRunId } = await driveBothShapes(automation);
+
+    const child = await automation.restoreConsumedSuspension(childRunId);
+    expect(child.restored, 'the genuine strand is repairable').toBe(true);
+
+    const parent = await automation.restoreConsumedSuspension(parentRunId);
+    expect(parent.restored, 'the cascade-failed ancestor is NOT').toBe(false);
+    // The refusal is named, and its name is the engine's own reading of a
+    // terminal record carrying no consumed-suspension snapshot.
+    expect((parent as { refusal?: string }).refusal).toBe('NO_CONSUMED_SUSPENSION');
+  });
+
+  it('PIN 3 — `getRun` carries NEITHER discriminator field, for either run', async () => {
+    // Why B's first clause cannot be executed on the plugin side alone. The
+    // engine records `consumedSuspension` / `consumedSuspensionDropped` on the
+    // durable `RunRecord`; `getRun` answers an `ExecutionLogEntry`, and
+    // `recordLog` keeps the snapshot OFF that interface on purpose because
+    // `GET /automation/:name/runs/:runId` serves it verbatim.
+    const automation = boot();
+    const { parentRunId, childRunId } = await driveBothShapes(automation);
+
+    for (const [what, runId] of [['strand', childRunId], ['cascade', parentRunId]] as const) {
+      const run = await automation.getRun(runId);
+      // Positive control FIRST: this read reached a real terminal record, so
+      // the absences below are absences IN one, not the shape of a null.
+      expect(run, `${what}: the run history answers`).toBeTruthy();
+      expect(run?.status, `${what}: and answers 'failed'`).toBe('failed');
+      expect(typeof run?.error, `${what}: carrying the failure text`).toBe('string');
+      // ⛔ The measurement: the property the inspector would have to read is
+      // not on the object it reads.
+      expect(Object.keys(run as object)).not.toContain('consumedSuspension');
+      expect(Object.keys(run as object)).not.toContain('consumedSuspensionDropped');
+    }
+  });
+
+  it('PIN 4 — CONTROL: the same strand says `repairable: true` at one door and nothing at the other', async () => {
+    // Without this, a reading taken at one door is not a reading about strands.
+    throwOn.mark_rejected = DOWNSTREAM_FAILURE;
+    const automation = boot();
+
+    // Door A — `decide`, which throws the #13807 envelope.
+    await automation.execute('deal_approval', {
+      object: 'crm_deal', record: { id: 'd2', amount: 10 }, userId: 'submitter',
+    } as never);
+    const decided = await pendingRequest();
+    const decidedRunId = decided.flow_run_id as string;
+    const err = await service
+      .decide(decided.id, { decision: 'reject', actorId: 'u1' }, SYSTEM_CTX)
+      .then(() => null, (e: Error) => e);
+    expect(strandedDecisionDetails(err)).toEqual({
+      finalized: true, decision: 'reject', runId: decidedRunId, repairable: true,
+    });
+
+    // Door B — `recall`, same flow, same throwing node, same strand.
+    await automation.execute('deal_approval', {
+      object: 'crm_deal', record: { id: 'd3', amount: 20 }, userId: 'submitter',
+    } as never);
+    const recalled = await pendingRequest();
+    const recalledRunId = recalled.flow_run_id as string;
+    const result = await service.recall(recalled.id, { actorId: 'submitter' }, SYSTEM_CTX);
+
+    expect(result.resumed, 'the recall could not advance the run either').toBe(false);
+    expect(result.resumeError, 'and reports it as a bare string').toContain(DOWNSTREAM_FAILURE);
+    // ⛔ No envelope at this door — `repairable` is not stated at all…
+    expect(strandedDecisionDetails(result as unknown)).toBeUndefined();
+    // …while the strand behind it is every bit as repairable as door A's.
+    expect((await automation.restoreConsumedSuspension(recalledRunId)).restored).toBe(true);
+  });
+});

--- a/scripts/engine-double-contract.pinned.json
+++ b/scripts/engine-double-contract.pinned.json
@@ -2222,6 +2222,16 @@
       "pinned": 1
     },
     {
+      "file": "packages/plugins/plugin-approvals/src/stranded-run-repairability.test.ts",
+      "verb": "delete",
+      "pinned": 1
+    },
+    {
+      "file": "packages/plugins/plugin-approvals/src/stranded-run-repairability.test.ts",
+      "verb": "update",
+      "pinned": 1
+    },
+    {
       "file": "packages/plugins/plugin-approvals/src/subflow-hosted-approval-strand.test.ts",
       "verb": "delete",
       "pinned": 1


### PR DESCRIPTION
Part of #15358

⛔ **This PR does NOT implement the ruled option B.** It lands the measurement that option B was ruled on, and it reports one premise that the drive falsified. The card stays open; see "The fork" below.

## What is here

One new pin file, `packages/plugins/plugin-approvals/src/stranded-run-repairability.test.ts`, driving a **real `AutomationEngine` and a real `ApprovalService`** (approvals tables on an in-memory ObjectQL double whose write verbs route through ObjectQL's own dispatch predicates), plus the ledger row `check:engine-double-contract` asks for that double.

One fixture produces **both** shapes at once. `deal_subflow` parks at an `approval`; its approve edge leads to a `subflow` node hosting `post_approval`, which parks at a second `approval` whose approve edge throws.

| run | how it ended | `restoreConsumedSuspension` | reported `runState` today |
| --- | --- | --- | --- |
| child | resume consumed the pause, downstream node threw — a strand | `restored: true` | `failed` |
| parent | parked at its `subflow` node, cascade-failed by `failAncestors` | refused `NO_CONSUMED_SUSPENSION` | `failed` |

The parent's own decision **succeeded** — the pin asserts `resumed: true` on it before the cascade — so its later `failed` row is not a decision that never moved. That is the over-report the card is about, now measured rather than read off the sources.

PIN 1 asserts both labels in a single `toEqual`, deliberately: whatever lands for option B must turn it red, and a split that relabels only one of the two rows still fails it.

## The fork — why option B's first clause could not be executed here

The ruling's clause 1 is "`getRun` widens to carry the discriminator the engine already records". The engine records `consumedSuspension` / `consumedSuspensionDropped` on the durable `RunRecord`. `AutomationEngine.getRun` answers an `ExecutionLogEntry`, and **PIN 3 measures that this object carries neither field, for either run** — with a positive control in the same assertion block so the absences are absences in a real terminal record, not the shape of a null.

That is deliberate on the producer's side, not an oversight: `recordLog` states the snapshot is "a parameter rather than a field of `ExecutionLogEntry`" because that interface "is served verbatim by `GET /automation/:name/runs/:runId`" — and the runtime route does serve it verbatim, with no schema strip.

⇒ Widening only the plugin-side declaration cannot separate these two rows. On a real engine the discriminator is absent for **both**, so a classifier reading absence as "not a strand" answers UNREPAIRABLE for the repairable row — telling an operator not to attempt a repair that succeeds, which is the #15555 harm shape one surface over. So the ruled split needs a producer-side decision first, and there are two readings of where the discriminator gets published:

- **Publish it on the run-detail surface** — a field on the engine's `ExecutionLogEntry` plus its spec declaration, after which the plugin reads it through `getRun` exactly as ruled. Cost: a new key on a published HTTP response, for every automation API consumer.
- **Keep the wire surface untouched** — a dedicated read-only engine member the plugin declares on `ApprovalResumeSurface` the way `listSuspendedRunsDurable` already is. Cost: the ruling's "`getRun` widens" becomes "the surface widens", and there is one more optional member whose absence has to be handled.

Those differ in what the platform promises to every automation API caller, so this seat did not pick one. ⛔ No public type in `plugin-approvals` is touched by this PR.

## Also measured (the door control)

PIN 4 drives the same strand through two doors in one run: `decide` throws `RESUME_FAILED` carrying `{ finalized, decision, runId, repairable: true }` (#13807), while `recall` reports the same strand as a bare `resumeError` string with no envelope at all — `strandedDecisionDetails` on the recall result is `undefined`. The difference is the door, not the strand.

## Verification

Final head `9f4e3ed55`.

- `pnpm --filter @objectstack/plugin-approvals test` — 42 files, 694 tests, all passing.
- `pnpm --filter @objectstack/plugin-approvals typecheck` — green; its third leg (`check:test-typecheck`, `tsconfig.test.json`) is the one that covers the new file, because the package's own `tsconfig.json` excludes `**/*.test.ts`.
- Ablation, to show PIN 1 reads the classifier rather than the harness: `classifyStrandedRunState`'s `case 'failed'` arm mutated to return `undefined`, proven on disk by the injected marker count and a changed blob hash (`141b6300` becomes `6975962a`); the run went red on **PIN 1 only** (1 failed, 3 passed), which is the expected direction — PINs 2 to 4 read the engine, not the classifier. Restored with `git checkout HEAD -- ABSOLUTE_PATH`, proven by `git diff HEAD` empty, the blob hash back at `141b6300`, and the marker gone. The plugin's own source resolves from `src` here (relative import), so no rebuild sits between the mutation and the reading; the engine resolves through `exports` to `dist`, which was built before every run.
- Gate family derived mechanically on the final head with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack --commands` and run in full — 56 commands, every one exit 0, each exit code captured immediately after its own single redirection. `check:engine-double-contract` was genuinely red first (the new double was unledgered) and is green after the `--write` regeneration committed here. Three families answered exit 3 `PREREQUISITE NOT MET` (`check:dual-build-cjs-loads`, `check:i18n`, `check:type-check-debt`); the workspace build was run and all three re-run to real green readings — `check:type-check-debt` needs an 8192 MB heap in this container.

## No changeset

Test file plus a gate ledger — nothing any package publishes changes. Same shape as the most recent test-only landing in this tree (`d5df8168f`, one new pin file, no changeset). `skip-changeset` applied.

## 验收备注

- **`recall`'s stranded exit carries no machine-readable repairability signal.** Measured in PIN 4: the same strand that makes `decide` throw an envelope with `repairable: true` leaves `recall` returning `resumed: false` plus a bare `resumeError` string, and `strandedDecisionDetails` on that result is `undefined`. ⛔ Noted, NOT filed: `recall` deliberately tolerates a run it cannot resume (its own doc says the withdrawal and the record-lock release are the point), and no declared contract promises the envelope at this door — so this is a characterisation, outside the three filing classes. It is pinned in PIN 4 so it cannot drift unnoticed, and it is the door half of the #13807 family if anyone widens that ruling.
- **The card's own instance card, re-read as triage asked.** #15222 is open and is the same shape this PR reproduces — its cascade-failed ancestor answers `NO_CONSUMED_SUSPENSION`, exactly as PIN 2 measures. ⛔ Nothing about it is folded into this PR.
- The dispatch expected `strandedDecisionDetails` on the recall result to be `null`; the measured value is `undefined`. Reported rather than smoothed over.
