### PR TITLE
docs(rest): drop the hand-written translatable-type list from meta-plural-i18n's header

### DIFF
--- a/packages/rest/src/meta-plural-i18n.test.ts
+++ b/packages/rest/src/meta-plural-i18n.test.ts
@@ -7,10 +7,9 @@
  * `translateMetaItem` / `translateMetaItems` decide "does this type translate"
  * by asking `isTranslatableMetaType`, which reads
  * `TRANSLATABLE_METADATA_TYPES` — a set DERIVED (#3786) from
- * `METADATA_DOCUMENT_TRANSLATORS`' keys, and those keys are singular-only:
- * `view` / `action` / `object` / `app` / `dashboard` / `page`. The `/meta`
- * handlers were handing those helpers the RAW `:type` path segment, while
- * Prime Directive #3 makes PLURAL the canonical REST spelling
+ * `METADATA_DOCUMENT_TRANSLATORS`' keys, and those keys are singular-only. The
+ * `/meta` handlers were handing those helpers the RAW `:type` path segment,
+ * while Prime Directive #3 makes PLURAL the canonical REST spelling
  * (`/api/v1/meta/apps`). So the documented spelling missed the set, the
  * predicate answered `false`, and the entire localization was skipped: the
  * same route, the same document, the same `Accept-Language`, two answers.


### PR DESCRIPTION
Fixes #15860

The header of `packages/rest/src/meta-plural-i18n.test.ts` restated
`METADATA_DOCUMENT_TRANSLATORS`' keys by hand as `view` / `action` / `object` /
`app` / `dashboard` / `page` — six, where the table has had seven since
`translateDataset` registered (#14253). It is the header of the test that pins
the translatable-type predicate, so it is the first thing a reader consults
before touching that predicate, and it understated the set.

**The enumeration is deleted, not corrected.** A corrected restatement rots
again on the next registration, which is the whole finding. The sentence's point
is that the keys are SINGULAR, which needs no list to make, and the two clauses
immediately above already name both `TRANSLATABLE_METADATA_TYPES` and
`METADATA_DOCUMENT_TRANSLATORS` — where a reader should be sent. The dispatch
table's own doc comment states the rule this violated: "Derived from the
dispatch table — never restate it." Same disposition #15863 took on the
identical defect class in `rest-server.ts`.

Comment-only: every changed line is inside the file's leading block comment, so
the token stream is unchanged. 3 insertions, 4 deletions, one file.

## Re-derived, not inherited

**The dispatch table's keys**, read out of
`packages/spec/src/system/i18n-resolver.ts` with the TypeScript AST rather than
by eye (`ts.createSourceFile`, then the object-literal property names of the
`METADATA_DOCUMENT_TRANSLATORS` declaration):

```
count=7 ["view","action","object","app","dashboard","dataset","page"]
```

*Positive control for the extractor* — the same extractor, run against a
scratch copy of that file with the `dataset:` row deleted, reports
`count=6 ["view","action","object","app","dashboard","page"]`. So the 7 is a
reading that can come out otherwise, not a constant printed back.

**Population scan** for hand-written restatements of this set, over all 8085
tracked paths (8078 text files read, 7 binary skipped). Two readings, both
scripted:

- *broad* — a 3-line window naming 4 or more distinct members of the set, with
  `translat|i18n|localiz|TRANSLATABLE` within 6 lines: **101** windows;
- *tight* — the window's distinct member set IS the live 7 or the stale 6:
  **14** sites before this change, **13** after.

*Positive control for the scan*: both known carriers fire in the tight reading
before the change — `packages/rest/src/meta-plural-i18n.test.ts:9` and
`packages/spec/src/conversions/registry.ts:3037`, each with the stale 6-member
signature. The differential control is the delta: the tight reading moves 14 to
13, and the one row that leaves is the file this PR edits. `rest-server.ts` does
NOT fire, which is what #15863 having landed looks like from here.

Triaged from those readings, and none of it touched here:

| site | verdict |
| --- | --- |
| `packages/rest/src/meta-plural-i18n.test.ts:11` | **this PR** |
| `packages/spec/src/conversions/registry.ts:3039` | fenced by two prior triages — the recorded rationale for the 17.0.0 `book.translations` retirement, describing the set as it stood at that removal. Untouched. |
| `packages/spec/src/system/book.zod.ts:63-64` | **a fourth carrier neither triage named** — the schema-side twin of that same retirement rationale, same stale 6-member enumeration, same "as it stood at that removal" character. Falls under the identical fence, so untouched and deliberately not filed. |
| `content/docs/ui/translations.mdx:84-85` | a live hand-written restatement of the same set that is currently COMPLETE (all 7). Not stale today, so nothing on `main` is false — but it is the same rot shape on a different carrier. Filed separately rather than folded in. |
| `packages/spec/src/kernel/metadata-plugin.test.ts:18`, `packages/spec/scripts/liveness/check-liveness.mts:236`, `packages/spec/src/security/permission.zod.ts:639`, the docs tables, the three CHANGELOG hits | different sets, or generated release history. Not this set. |
| `packages/rest/src/rest-api-plugin.ts:441`, `packages/runtime/src/app-plugin.ts:1767` | illustrative partial mentions ("used to localize view / action / object metadata"), not exhaustive claims. Not restatements. |

The lint gate the card considered and rejected is NOT built here; its rejection
argument stands unrelitigated.

## Verification

Union re-run at final head `1fa2dc55974`, with the workspace closure built
first (`pnpm exec turbo run build --filter='./packages/*' --filter='./packages/*/*'`,
71/71 tasks).

- **45 of 45** derived gate commands from
  `node scripts/pm/dispatch-gates.mjs --commands --repo objectstack-ai/objectstack`
  — all exit 0. Each exit code captured before any pipe.
  - `check:dts-closure`, `check:dual-build-cjs-loads` and `check:type-check-debt`
    each answered `exit 3 PREREQUISITE NOT MET` on an unbuilt tree and were
    re-run after the closure build; `check:type-check-debt` additionally needs
    the CI-shaped `NODE_OPTIONS=--max-old-space-size=6144` that `lint.yml` sets
    on that step (at 4096 its re-measure tsc OOMs). Verdict lines:
    `71 built package(s) swept - 163/163 declared declaration file(s) present`,
    `103 published require entry point(s) across 66 package(s) load`, and
    `5 ledger entr(ies) re-measured in 82.2s, 55 raw tsc error(s) total, none
    above its recorded number`.
- **3 roster gates** the derivation flagged as keeping their roster under
  `packages/`, where silence is evidence in neither direction — `check:authz-resolver`,
  `check:error-code-casing`, `check:filter-alias-parity` — all exit 0.
- `pnpm --filter @objectstack/rest exec vitest run --maxWorkers=2 src/meta-plural-i18n.test.ts`
  — 1 file, **10/10** tests pass.
- `pnpm --filter @objectstack/rest exec vitest run --maxWorkers=2` — **187 files,
  3179/3179** tests pass.
- `pnpm --filter @objectstack/rest typecheck` (`tsc --noEmit` plus
  `check:test-typecheck`) — exit 0; the test layer compiles under
  `tsconfig.test.json` with 0 files / 0 errors in `test-typecheck-debt.json`.
  The edited file is measured, not merely adjacent: `tsc --listFiles -p
  tsconfig.test.json` puts 736 files in that program and this file is one of them.
- Whole-repo ESLint, the always-runs step `pnpm lint` spells
  (`eslint . --no-inline-config`) — **6248 files, 0 errors, 0 warnings**, exit 0,
  and the edited file is in that population.

Heavy runs went through `scripts/pm/os-verify-lock.sh`; the wall-clock figures
above are shared-box readings, as that entry point states on every hold.

## Contract review

Graded **no**. The diff adds no exported symbol, adds no key to any published
payload, and touches no `packages/spec/src/**` path — it deletes half a sentence
from a block comment in one test file.


---
_Generated by [Claude Code](https://claude.ai/code/session_01D47qPfEWVPmhguWgBZCi5N)_