### PR TITLE
test(cli): attribute the stdout-purity e2e probes to the serve child

### DIFF
--- a/packages/cli/test/serve-stdio-stdout-purity.e2e.test.ts
+++ b/packages/cli/test/serve-stdio-stdout-purity.e2e.test.ts
@@ -48,6 +48,7 @@ import {
   E2E_SECRET_KEY,
   RUN_JS_RESOLVES_FROM_DIST,
   childEnv,
+  probeThroughChild,
   randomPort,
   requireBuiltCli,
 } from './helpers/serve-process.js';
@@ -357,22 +358,63 @@ describe('#7915: a stdio MCP boot writes nothing but protocol frames to stdout',
     // boot 2 sees the same row (`:memory:` would not survive the restart).
     const first = await boot({ OS_DATABASE_URL: join(dir, 'probe.db') }, /Server is ready/);
     const base = `http://localhost:${port}/api/v1`;
-    const signIn = await fetch(`${base}/auth/sign-in/email`, {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ email: 'admin@objectos.ai', password: 'admin123' }),
+
+    // ⭐ #15898 — the fifth and last file of the family #15653 repaired.
+    // `boot()`'s `child.on('exit')` handler feeds the READINESS promise ONLY — it
+    // returns early once `settled` — so a death AFTER readiness is invisible to
+    // it, and the two requests below used to reach vitest as a bare
+    // `TypeError: fetch failed` with no exit code, no stdout and no stderr: the
+    // unattributable failure #15545 recorded once and could not diagnose.
+    // `probeThroughChild()` is where the child's fate is read instead; its own
+    // section in `helpers/serve-process.ts` carries the measurement, the bound
+    // and the fences (⛔ no skip, no quarantine, no timeout bump).
+    //
+    // Read at THROW time, so a failure carries what the child printed on its way
+    // down rather than the buffer as it stood at ready.
+    const transcript = () =>
+      `\n--- child stdout ---\n${first.stdout()}\n--- child stderr ---\n${first.stderr()}`;
+    const probe = <T>(what: string, request: () => Promise<T>): Promise<T> =>
+      probeThroughChild(
+        {
+          child: first.child,
+          transcript,
+          label: 'serve-stdio-stdout-purity',
+          what: `${what} on port ${port}`,
+        },
+        request,
+      );
+
+    // ⛔ The body read is INSIDE the thunk and cannot throw: a connection torn
+    // down mid-body rejects out of `res.json()` rather than out of `fetch()`, and
+    // the guard reads any throw as a transport failure — so an ASSERTION must
+    // never live in here or a wrong answer would be reported as a dropped socket.
+    const signIn = await probe('the sign-in probe', async () => {
+      const res = await fetch(`${base}/auth/sign-in/email`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        // `serve --dev` seeds this admin on an empty DB.
+        body: JSON.stringify({ email: 'admin@objectos.ai', password: 'admin123' }),
+      });
+      let body: unknown = null;
+      try { body = await res.json(); } catch { /* non-JSON error body */ }
+      return { status: res.status, body };
     });
     expect(signIn.status).toBe(200);
-    const token = ((await signIn.json()) as { token?: string }).token;
+    const token = (signIn.body as { token?: string } | null)?.token;
     expect(token).toBeTruthy();
 
-    const minted = await fetch(`${base}/keys`, {
-      method: 'POST',
-      headers: { 'content-type': 'application/json', authorization: `Bearer ${token}` },
-      body: JSON.stringify({ name: 'mcp-stdout-purity-e2e' }),
+    const minted = await probe('the key-mint probe', async () => {
+      const res = await fetch(`${base}/keys`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', authorization: `Bearer ${token}` },
+        body: JSON.stringify({ name: 'mcp-stdout-purity-e2e' }),
+      });
+      let body: unknown = null;
+      try { body = await res.json(); } catch { /* non-JSON error body */ }
+      return { status: res.status, body };
     });
     expect(minted.status).toBe(201);
-    apiKey = String(((await minted.json()) as { data: { key: string } }).data.key);
+    apiKey = String((minted.body as { data: { key: string } }).data.key);
     expect(apiKey.startsWith('osk_')).toBe(true);
 
     await stop(first.child);


### PR DESCRIPTION
Fixes #15898

`serve-stdio-stdout-purity.e2e.test.ts` was the fifth and last file in the family that fetched a spawned `os serve` with no child-lifecycle attribution. Its `boot()` handler for `child.on('exit')` returns early on `if (settled) return`, so it feeds the READINESS promise only — a death after readiness was invisible to it, and the two `beforeAll` probes reached vitest as a bare `TypeError: fetch failed` with no exit code, no stdout and no stderr. This file runs on `Test Core`, a required shard, so it was the worst place to hold a red nobody could explain.

Both probes now route through the existing `probeThroughChild()` helper, the same shape the four siblings already use. No redesign, no new export, no sixth file.

## Pre-state, measured on this tree rather than inherited

The card's tense was stale (it wrote the helper as "landing"); the helper is on `main` at `packages/cli/test/helpers/serve-process.ts:1117`. Re-measured here before editing:

| measurement | value |
|---|---|
| `probeThroughChild` occurrences in the target file | **0** |
| bare probes against the spawned child | **2** — `:360` `POST auth/sign-in/email`, `:369` `POST keys` |
| `if (settled) return` early-returns feeding only the readiness promise | **3** — `:200` (timeout), `:210` (output), `:239` (exit) |

Matched on `fetch(`, not `await fetch(` — the card's own correction about its recipe's reach. That distinction is between a **blind tool and a wrong conclusion**: the card's reasoning was sound, only its grep under-reached. Here both sites happened to be spelled `await fetch(`, so the wider pattern changed no count in this file — it was used because the narrower one cannot be trusted to, not because it moved the number.

`serve-port-drift-notice.e2e.test.ts` remains untouched: it fetches the neighbour fixture it owns at `neighbour.port`, never the spawned child.

## The repair is demonstrated, not asserted

A conversion nobody demonstrated is a refactor. The prediction below was written to disk **before** either leg ran; both legs kill the child through the handle the file itself owns (never by name pattern — the process table is shared).

The mutation is identical in both legs: `SIGKILL` the child immediately after `const base = ...`, i.e. **after** readiness has settled — precisely the window `if (settled) return` makes invisible.

| | predicted | observed |
|---|---|---|
| **BEFORE** (bare `fetch`) | bare `TypeError: fetch failed`, cause `ECONNREFUSED`, naming no exit code, no signal, no stdout, no stderr | `TypeError: fetch failed` / `Caused by: Error: connect ECONNREFUSED 127.0.0.1:41851`. Grep for exit code, signal or transcript: **0 hits** |
| **AFTER** (`probeThroughChild`) | `os serve DIED while answering the sign-in probe on port N — exit code null, signal SIGKILL`, not retried, transcript attached | verbatim: `os serve DIED while answering the sign-in probe on port 39907 — exit code null, signal SIGKILL. This is the CHILD's failure, not a dropped socket, so it is NOT retried` |
| attempts | exactly 1 (a dead child is never retried) | `attempt 1/3` — one only |
| captured output | child stdout and stderr carried | both markers present; stderr carries the full boot log |

`exit code null` with `signal SIGKILL` is the honest reading of a signalled death — `fateOf()` reports the signal where there is no numeric code; a child that exits on its own reports the number instead. Both are attribution, which is the thing that was missing.

**One place the observation was sharper than the prediction:** the prediction expected the boot banner in the `--- child stdout ---` half. Observed, that half is **empty** and the whole boot log arrives on `--- child stderr ---`. That is not a shortfall — it is this file's own invariant confirmed in passing: `serve-stdio-stdout-purity` exists to pin that a healthy boot puts nothing but protocol frames on stdout.

Ablation hygiene: absolute-path `trap ... EXIT INT TERM`; the mutation was proven on disk by grepping the injected text (never the editor's exit code); each restore was proven by `git hash-object` equal to the `HEAD` blob **and** an empty `git diff HEAD`, and spelled `git checkout HEAD -- path` rather than the bare form, which restores from the index the other leg had polluted. The subject is the test file and a same-tree relative helper import, both read from source by vitest, so no `dist` leg exists to go stale.

## Verification

- **Healthy control** (unmutated, converted): `vitest run test/serve-stdio-stdout-purity.e2e.test.ts` — 1 file, 1 test passed, 10.32s.
- **Helper pin**: `test/serve-probe-child-attribution.test.ts` — 7 passed.
- **Typecheck**: `pnpm --filter @objectstack/cli typecheck` green. The package's `tsconfig.json` includes only `src`, so `tsc --noEmit` says nothing about this file; coverage was proven separately with `--listFiles` on `tsconfig.test.json` (the edited file and the helper both present). Raw diagnostics: 28 across 3 files, all pre-existing and ledgered, **0** attributable to this diff.
- **Gates**: all 44 families from `dispatch-gates.mjs --commands --repo objectstack-ai/objectstack`, each exit code captured before any pipe. 43 measured green. 1 **NOT MEASURED, not a pass**: `check:dual-build-cjs-loads` exits 3 `PREREQUISITE NOT MET` because 11 packages have no `dist/` in this worktree (only the `@objectstack/cli` closure was built). It reads built output of published packages and this diff changes no package source. `check:type-check-debt` first exited 3 on a V8 OOM on the shared box; re-run with a larger heap it is measured and green (5 ledger entries, 55 raw errors, none above its recorded number).
- **Lint**: narrowed to the changed file and the narrowing is measured, not assumed — population from eslint's own config, count from `--format json` (1 file, 0 errors, 0 warnings), and the config enables no type-aware linting anywhere (0 `parserOptions.project`, 0 `projectService`), so this diff cannot move the verdict on any file it did not touch.

## Clause 2 — graded `no`

No newly exported symbol, no new key on any published payload, no `packages/spec/src/**` path. Test-only, through a helper that already exists with an unchanged signature. The label is therefore not hung here.

No changeset: this publishes nothing from any package, so it carries `skip-changeset`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D47qPfEWVPmhguWgBZCi5N

---
_Generated by [Claude Code](https://claude.ai/code/session_01D47qPfEWVPmhguWgBZCi5N)_