### PR TITLE
ci: the merge queue's Test Core runs the affected package set; selection moves into a script with a self-test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -350,15 +350,17 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      # PRs: only test packages affected by the diff against the PR base.
-      # spec sits at the root of the dependency graph, so spec-touching PRs
-      # still run (close to) everything — but the many PRs that don't touch
-      # spec skip the bulk of the 75-package matrix. Push to main and
-      # merge-queue builds partition the FULL package list instead: the queue
-      # result IS the next main, so it gets main's validation, not the PR's
-      # affected-only subset. (Spec's suite runs here plain / uninstrumented;
-      # the coverage-instrumented pass lives in the nightly coverage-nightly
-      # workflow.)
+      # PRs and merge-queue builds: only test packages affected by the diff —
+      # against the PR base on pull_request, against the group's own
+      # `base_sha` on merge_group (#16453). spec sits at the root of the
+      # dependency graph, so spec-touching diffs still run (close to)
+      # everything — but the many that don't touch spec skip the bulk of the
+      # 75-package matrix, and at ~120 queue merges a day that is the bulk of
+      # the queue's test compute. Push to main partitions the FULL package
+      # list: it gates nobody, and its full run is the ground truth the
+      # shard-timings refresh reads. (Spec's suite runs here plain /
+      # uninstrumented; the coverage-instrumented pass lives in the nightly
+      # coverage-nightly workflow.)
       #
       # !@objectstack/dogfood: the ~7½-minute dogfood suite is the dedicated
       # Dogfood job's whole purpose, and both jobs run under the same `core`
@@ -415,127 +417,26 @@ jobs:
       #     `turbo ls`'s internal choice of dot-ness — undocumented, and
       #     `turbo ls` is experimental (see above). Resolving to a commit here
       #     leaves turbo no choice to make.
+      # The selection itself lives in scripts/ci/select-shard-packages.sh:
+      # environment in, `$RUNNER_TEMP/turbo-ls.json` out. This step only
+      # exports the event's fields, so the same script -- every branch of
+      # it -- runs locally and under its self-test (#16453). Per event:
+      #   pull_request  affected set against merge-base(origin/<base>, HEAD)
+      #   merge_group   affected set against the group's `base_sha`, unioned
+      #                 with the same cross-package scans. An EMPTY set is a
+      #                 legitimate docs-only group: it reaches the "No packages
+      #                 on this shard" exit below, every shard still attests,
+      #                 and Test Core is an honest green. It is NOT the #10057
+      #                 case, which is pull_request-only (the script says why).
+      #   push          unchanged: the FULL list.
       - name: Compute this shard's package set
         env:
-          BASE_REF: ${{ github.event.pull_request.base.ref }}
-          PINNED_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          OS_SHARD_EVENT_NAME: ${{ github.event_name }}
+          OS_SHARD_PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          OS_SHARD_PR_PINNED_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          OS_SHARD_MERGE_GROUP_BASE_SHA: ${{ github.event.merge_group.base_sha }}
         run: |
-          SCM_BASE=''
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            if [ -z "$BASE_REF" ]; then
-              echo "::warning::This pull_request event carries no base branch, so the affected-set diff base cannot be computed."
-            else
-              # `fetch-depth: 0` above already makes this resolve — the fetch is
-              # the guard for the day that changes, not the normal path.
-              #
-              # `git cat-file -e` rather than the more idiomatic strict
-              # `git rev-parse --verify` spelling. That is history rather than
-              # style, and it is written down because it used to be a live
-              # hazard: the pre-#6589 check-shard-attestation.mjs classified a
-              # job as an aggregate GATE when the script's basename and its
-              # `--verify` flag merely CO-OCCURRED as substrings anywhere in
-              # the job's joined `run:` text. This job always carries the
-              # basename (its `--emit` step at the bottom), so spelling
-              # `--verify` anywhere in this step — comments included, since
-              # they were part of `run:` — silently reclassified the shard job
-              # as a gate.
-              #
-              # #6589 closed that by construction. Classification is now by
-              # INVOCATION: within one command the flag must follow the
-              # script's own name as an argument, the test is applied per STEP
-              # and never over the job's joined text, and the lexer drops shell
-              # comments — all three pinned by that script's `--self-test`,
-              # which is why this comment can now name the flag at all. Either
-              # spelling is safe here; `git cat-file -e` stays because
-              # churning it would buy nothing.
-              if ! git cat-file -e "refs/remotes/origin/$BASE_REF^{commit}" 2>/dev/null; then
-                git fetch --no-tags --quiet origin "+refs/heads/$BASE_REF:refs/remotes/origin/$BASE_REF" \
-                  || echo "::warning::Could not fetch origin/$BASE_REF; the merge-base resolution below will decide."
-              fi
-              # `if !` rather than a bare assignment on purpose: these steps run
-              # under `bash -e`, where a failing command substitution kills the
-              # step with no message at all.
-              if ! SCM_BASE=$(git merge-base "refs/remotes/origin/$BASE_REF" HEAD); then
-                SCM_BASE=''
-              fi
-            fi
-          fi
-          if [ -n "$SCM_BASE" ]; then
-            # The drift is printed, not just corrected: nothing in this log ever
-            # said which commit the affected diff started from, which is why the
-            # decay was invisible.
-            DRIFT=$(git rev-list --count "$PINNED_BASE_SHA..$SCM_BASE" 2>/dev/null || echo '?')
-            echo "Affected-set diff base: $SCM_BASE  (merge-base of origin/$BASE_REF and HEAD)"
-            echo "Frozen payload base.sha: $PINNED_BASE_SHA  -- $BASE_REF has moved $DRIFT commit(s) since it was frozen, and that drift is exactly what this step used to charge to this PR."
-            TURBO_SCM_BASE="$SCM_BASE" pnpm exec turbo ls --affected --output=json > "$RUNNER_TEMP/turbo-ls.json"
-            # `turbo ls --affected` answers "which packages does the dependency
-            # GRAPH reach from this diff" — and some suites read files the graph
-            # does not connect them to. spec's api-methods-batch-conformance scan
-            # walks every `*.object.ts` in the monorepo while spec declares no
-            # dependency on the packages it judges (nor should it: the scan reads
-            # source text precisely to avoid inverting the spec -> * direction).
-            # A platform-objects-only diff therefore left it unrun, and #7769
-            # landed a violation on `main` that only PRs touching `spec` ever saw.
-            # Measured on turbo 2.10.7: 51 packages affected by that diff, spec
-            # not among them.
-            #
-            # So packages that declare a cross-package input radius are unioned
-            # back in when the diff touches it. The declarations, and the static
-            # detector that refuses to let a new cross-package scan go
-            # undeclared, live in the script (`pnpm check:cross-package-test-inputs`).
-            #
-            # Failure here falls back to the FULL package list, never to the
-            # affected-only set: same posture as the merge-base fallback below
-            # (#6195), and the same reason — the full list is a strict superset,
-            # so doubt costs minutes rather than coverage. This is the FILTER
-            # CONTRACT's half 1 applied one layer down.
-            if ! git diff --name-only "$SCM_BASE" HEAD > "$RUNNER_TEMP/changed-files.txt" \
-              || ! node scripts/check-cross-package-test-inputs.mjs \
-                   --union-into "$RUNNER_TEMP/turbo-ls.json" \
-                   --changed "$RUNNER_TEMP/changed-files.txt"; then
-              echo "::warning::Could not union cross-package scans into the affected set; falling back to the full package list for this shard."
-              pnpm exec turbo ls --output=json > "$RUNNER_TEMP/turbo-ls.json"
-            # A fourth signal the failure branches do not cover: a producer that
-            # exits 0 with a wrong, plausible, EMPTY answer. Only that `git
-            # diff`'s exit STATUS was checked, never its emptiness, so a
-            # merge-base resolving to something wrong-but-valid gave an empty
-            # changed-file list -> zero affected packages -> a green shard that
-            # tested nothing, with every log line reading like a normal quiet PR
-            # (#10057). The shard attestation (#6082) does not cover it: it
-            # attests "shard N ran and every step passed", which is exactly what
-            # a shard that tested nothing does.
-            #
-            # Empty is decidable as BROKEN here, and only here: a pull_request
-            # always differs from its merge-base. At the partitioner zero is
-            # frequently the CORRECT answer (a docs-only PR genuinely affects no
-            # package, and with 6 shards a small change legitimately leaves
-            # shards empty), so a blanket "red on empty" belongs there least of
-            # all -- this is the one place selection-failed and nothing-selected
-            # can be told apart.
-            #
-            # Scoping this to pull_request needs no `github.event_name` test:
-            # SCM_BASE is assigned only inside the `pull_request` guard above, so
-            # this whole `[ -n "$SCM_BASE" ]` branch is unreachable on push and
-            # merge_group. Those keep taking the full-list path in the `else`
-            # below, by design.
-            elif [ ! -s "$RUNNER_TEMP/changed-files.txt" ]; then
-              echo "::warning::The diff against merge-base $SCM_BASE listed no changed files, which a pull_request cannot legitimately produce; falling back to the full package list for this shard rather than selecting nothing (#10057)."
-              pnpm exec turbo ls --output=json > "$RUNNER_TEMP/turbo-ls.json"
-            fi
-          else
-            # Falling back to the FULL package list, never to the frozen
-            # base.sha. This is not the #4690 silent-skip anti-pattern: that is
-            # about a gate PASSING on input it could not read, and the full list
-            # is a strict superset of the affected one — this shard still runs
-            # everything it would have run and more. Cost is minutes; the
-            # alternative is a red Test Core on a PR with nothing wrong with it.
-            # Push and merge-queue builds take this branch by design (the queue
-            # result IS the next main, so it gets main's validation).
-            if [ "${{ github.event_name }}" = "pull_request" ]; then
-              echo "::warning::Could not resolve merge-base(origin/$BASE_REF, HEAD); falling back to the full package list for this shard rather than diffing from the frozen base.sha (#6195)."
-            fi
-            pnpm exec turbo ls --output=json > "$RUNNER_TEMP/turbo-ls.json"
-          fi
+          bash scripts/ci/select-shard-packages.sh
           node scripts/partition-test-shards.mjs "$RUNNER_TEMP/turbo-ls.json" \
             --shard ${{ matrix.shard }}/6 --exclude @objectstack/dogfood \
             > "$RUNNER_TEMP/shard-packages.txt"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3235,6 +3235,20 @@ jobs:
       - name: Shard attestation gate
         run: pnpm check:shard-attestation
 
+      # Test Core package selection self-test (#16453). ci.yml's "Compute this
+      # shard's package set" step is a thin call into
+      # scripts/ci/select-shard-packages.sh — environment in, turbo-ls.json
+      # out — so that the `merge_group` branch, which by construction cannot
+      # run before a PR is already in the queue, is proved here instead: the
+      # self-test drives every branch of every event (pull_request, merge_group,
+      # push) offline, against a throwaway upstream + clone and a fake `turbo`
+      # on PATH, and pins which `turbo ls` calls were made and with what base,
+      # whether the cross-package union ran, every `::warning::` fallback and
+      # the absence of the ones that must not fire (an empty docs-only merge
+      # group selects nothing WITHOUT the #10057 complaint). Offline; ~2s.
+      - name: Test Core package selection self-test
+        run: pnpm check:select-shard-packages
+
       # Aggregator roster gate (#10490). Three required contexts are aggregate
       # jobs standing in for a set of real jobs — `Test Core` and `Dogfood
       # Regression Gate` in ci.yml, `TypeScript Type Check` in this file — and

--- a/package.json
+++ b/package.json
@@ -132,6 +132,7 @@
     "check:node-version": "node scripts/check-node-version.mjs",
     "check:pnpm-acquisition": "node scripts/check-pnpm-acquisition.mjs --self-test && node scripts/check-pnpm-acquisition.mjs",
     "check:workflow-status-functions": "node scripts/check-workflow-status-functions.mjs --self-test && node scripts/check-workflow-status-functions.mjs",
+    "check:select-shard-packages": "bash scripts/ci/select-shard-packages.selftest.sh",
     "check:shard-attestation": "node scripts/check-shard-attestation.mjs --self-test && node scripts/check-shard-attestation.mjs",
     "check:required-contexts": "node scripts/check-required-contexts.mjs --self-test && node scripts/check-required-contexts.mjs",
     "check:cross-package-test-inputs": "node scripts/check-cross-package-test-inputs.mjs --self-test && node scripts/check-cross-package-test-inputs.mjs",

--- a/scripts/ci/select-shard-packages.selftest.sh
+++ b/scripts/ci/select-shard-packages.selftest.sh
@@ -1,0 +1,447 @@
+#!/usr/bin/env bash
+#
+# Self-test for scripts/ci/select-shard-packages.sh (#16453).
+#
+# The script decides the Test Core package set from the event, and every one
+# of its fallbacks is a `::warning::` plus the FULL list -- so the property
+# under test is not "does it exit 0" (it nearly always does) but WHICH branch
+# it took: which `turbo ls` calls it made and with what `TURBO_SCM_BASE`,
+# whether the cross-package union ran and over which changed-file list, which
+# warnings it printed, and what landed in `turbo-ls.json`. Every case pins all
+# of those, and pins the ABSENCE of the warnings it must not print (the
+# #10057 guard on a merge group is the one that matters most: an empty
+# docs-only group has to select nothing without complaint).
+#
+# Hermetic and offline: a throwaway upstream + clone (+ a shallow clone) under
+# $TMPDIR, a fake `pnpm`/`turbo` pair on PATH that answers from control files
+# and records every call, and a stub `check-cross-package-test-inputs.mjs`
+# inside the fixture that records its argv and appends what it is told to.
+# The REAL union script has its own self-test (`check:cross-package-test-
+# inputs`); what is pinned here is that the selection script hands it the
+# right files and ships its answer. Needs git, node and bash; ~2s.
+#
+# Run: bash scripts/ci/select-shard-packages.selftest.sh
+set -uo pipefail
+cd "$(git rev-parse --show-toplevel)" || exit 1
+
+SCRIPT="$PWD/scripts/ci/select-shard-packages.sh"
+FIX=$(mktemp -d "${TMPDIR:-/tmp}/os-select-shard-selftest.XXXXXX") || exit 1
+trap 'rm -rf "$FIX"' EXIT INT TERM
+
+fail=0
+cases=0
+checks=0
+
+git_q() {
+  git -c user.name=selftest -c user.email=selftest@example.invalid -c commit.gpgsign=false "$@"
+}
+
+# ── The fakes ───────────────────────────────────────────────────────────────
+mkdir -p "$FIX/bin"
+cat > "$FIX/bin/pnpm" <<EOF
+#!/usr/bin/env bash
+# fake pnpm: the script only ever spells \`pnpm exec turbo ...\`.
+if [ "\${1:-}" != exec ] || [ "\${2:-}" != turbo ]; then
+  echo "fake pnpm: unexpected argv: \$*" >&2
+  exit 97
+fi
+shift 2
+exec "$FIX/bin/turbo" "\$@"
+EOF
+cat > "$FIX/bin/turbo" <<EOF
+#!/usr/bin/env bash
+# fake turbo: records the call (argv and TURBO_SCM_BASE), answers from the
+# control files, exits as told.
+case " \$* " in
+  *" --affected "*)
+    printf 'affected argv=[%s] TURBO_SCM_BASE=%s\n' "\$*" "\${TURBO_SCM_BASE:-unset}" >> "$FIX/turbo-calls.log"
+    cat "$FIX/affected.json"
+    exit "\$(cat "$FIX/affected-exit")"
+    ;;
+  *)
+    printf 'full argv=[%s] TURBO_SCM_BASE=%s\n' "\$*" "\${TURBO_SCM_BASE:-unset}" >> "$FIX/turbo-calls.log"
+    cat "$FIX/full.json"
+    exit 0
+    ;;
+esac
+EOF
+chmod +x "$FIX/bin/pnpm" "$FIX/bin/turbo"
+
+# The stub union script, committed into the fixture upstream's scripts/ dir.
+write_union_stub() {
+  mkdir -p "$1/scripts"
+  cat > "$1/scripts/check-cross-package-test-inputs.mjs" <<EOF
+import { readFileSync, writeFileSync, appendFileSync } from 'node:fs';
+const FIX = '$FIX';
+const argv = process.argv.slice(2);
+appendFileSync(FIX + '/union.log', 'argv ' + argv.join(' ') + '\n');
+const list = argv[argv.indexOf('--union-into') + 1];
+const changed = argv[argv.indexOf('--changed') + 1];
+const files = readFileSync(changed, 'utf8').split('\n').filter(Boolean);
+appendFileSync(FIX + '/union.log', 'changed ' + (files.join(',') || '(none)') + '\n');
+const doc = JSON.parse(readFileSync(list, 'utf8'));
+const add = readFileSync(FIX + '/union-add', 'utf8').trim();
+if (add) {
+  doc.packages.items.push({ name: add, path: 'packages/' + add });
+  doc.packages.count = doc.packages.items.length;
+}
+writeFileSync(list, JSON.stringify(doc));
+process.exit(Number(readFileSync(FIX + '/union-exit', 'utf8').trim() || 0));
+EOF
+}
+
+# ── Control files ───────────────────────────────────────────────────────────
+full_json='{"packageManager":"pnpm@10.0.0","packages":{"count":3,"items":[{"name":"a","path":"packages/a"},{"name":"b","path":"packages/b"},{"name":"c","path":"packages/c"}]}}'
+printf '%s\n' "$full_json" > "$FIX/full.json"
+
+# set_affected <name>...  -- what the fake `turbo ls --affected` answers
+set_affected() {
+  local items='' name
+  for name in "$@"; do
+    [ -n "$items" ] && items="$items,"
+    items="$items{\"name\":\"$name\",\"path\":\"packages/$name\"}"
+  done
+  printf '{"packageManager":"pnpm@10.0.0","packages":{"count":%d,"items":[%s]}}\n' "$#" "$items" > "$FIX/affected.json"
+}
+reset_controls() {
+  set_affected a
+  printf '0' > "$FIX/affected-exit"
+  : > "$FIX/union-add"
+  printf '0' > "$FIX/union-exit"
+}
+
+# ── Fixture repositories ────────────────────────────────────────────────────
+UP="$FIX/upstream"
+mkdir -p "$UP"
+git_q -C "$UP" init -q
+git_q -C "$UP" symbolic-ref HEAD refs/heads/main
+mkdir -p "$UP/packages/a" "$UP/docs"
+printf '{"name":"fixture","private":true}\n' > "$UP/package.json"
+printf 'export const a = 1;\n' > "$UP/packages/a/index.ts"
+printf '# guide\n' > "$UP/docs/guide.md"
+# The stub union script is part of C0, so every commit carries it unchanged
+# and no changed-file list below ever names it.
+write_union_stub "$UP"
+git_q -C "$UP" add -A
+git_q -C "$UP" commit -q -m 'C0: root'
+C0=$(git_q -C "$UP" rev-parse HEAD)
+printf 'export const a = 2;\n' > "$UP/packages/a/index.ts"
+git_q -C "$UP" commit -q -am 'C1: a moves'
+C1=$(git_q -C "$UP" rev-parse HEAD)
+# A merge group's base is fetched BY SHA; a local upstream has to be told to
+# serve one (GitHub does so for every reachable commit -- actions/checkout
+# itself fetches the merge ref by sha).
+git_q -C "$UP" config uploadpack.allowReachableSHA1InWant true
+git_q -C "$UP" config uploadpack.allowAnySHA1InWant true
+
+REPO="$FIX/repo"
+git_q clone -q "$UP" "$REPO"
+git_q -C "$REPO" checkout -q -b feature
+printf 'export const leaf = 1;\n' > "$REPO/packages/a/leaf.ts"
+git_q -C "$REPO" add -A
+git_q -C "$REPO" commit -q -m 'F1: leaf change on the feature branch'
+F1=$(git_q -C "$REPO" rev-parse HEAD)
+# The queue's HEAD: this entry merged onto its base.
+git_q -C "$REPO" checkout -q --detach "$C1"
+git_q -C "$REPO" merge -q --no-ff -m 'M: feature merged onto C1' feature
+M=$(git_q -C "$REPO" rev-parse HEAD)
+# A docs-only entry on top of that.
+printf '# guide, revised\n' > "$REPO/docs/guide.md"
+git_q -C "$REPO" commit -q -am 'D: docs only'
+D=$(git_q -C "$REPO" rev-parse HEAD)
+# Created AFTER the clone, so the clone has no refs/remotes/origin/release:
+# the pull_request fetch path has something to fetch.
+git_q -C "$UP" branch release "$C1"
+
+SHALLOW="$FIX/shallow"
+git_q clone -q --depth 1 "file://$UP" "$SHALLOW" 2>/dev/null
+
+ZEROS=0000000000000000000000000000000000000000
+
+# ── The runner and the assertions ───────────────────────────────────────────
+at() { git_q -C "$REPO" checkout -q --detach "$1"; }
+
+RT=''
+rc=0
+# run_case <label> <cwd> <event> <pr base ref> <pr pinned sha> <merge-group base sha>
+run_case() {
+  label=$1
+  cases=$((cases + 1))
+  RT="$FIX/rt-$cases"
+  mkdir -p "$RT"
+  : > "$FIX/turbo-calls.log"
+  : > "$FIX/union.log"
+  (
+    cd "$2" && PATH="$FIX/bin:$PATH" RUNNER_TEMP="$RT" \
+      OS_SHARD_EVENT_NAME="$3" OS_SHARD_PR_BASE_REF="$4" \
+      OS_SHARD_PR_PINNED_BASE_SHA="$5" OS_SHARD_MERGE_GROUP_BASE_SHA="$6" \
+      bash "$SCRIPT"
+  ) > "$RT/out.txt" 2>&1
+  rc=$?
+  echo "case: $label"
+}
+
+# Captured script output is echoed INDENTED: the Actions runner parses a
+# `::warning::` at line start into a real annotation, and the failing case
+# must not mint one on the lint job's behalf.
+show_output() {
+  echo "        -- output --"
+  sed 's/^/        | /' "$RT/out.txt"
+}
+
+ok() { checks=$((checks + 1)); printf '  ok    %s\n' "$1"; }
+bad() {
+  checks=$((checks + 1))
+  fail=1
+  printf '  FAIL  %s\n' "$1"
+  shift
+  while [ $# -gt 0 ]; do printf '        %s\n' "$1"; shift; done
+  show_output
+}
+
+expect_rc() {
+  if [ "$rc" -eq "$1" ]; then ok "exit $1"; else bad "exit $1" "got exit $rc"; fi
+}
+
+# expect_file_is <label> <file> <expected content, newline-separated>
+expect_file_is() {
+  printf '%s' "$3" > "$RT/want.txt"
+  if [ -n "$3" ]; then printf '\n' >> "$RT/want.txt"; fi
+  if diff -u "$RT/want.txt" "$2" > "$RT/diff.txt"; then
+    ok "$1"
+  else
+    bad "$1" "$(sed 's/^/diff: /' "$RT/diff.txt" | tr '\n' ' ')"
+  fi
+}
+
+expect_warnings() {
+  grep '^::warning::' "$RT/out.txt" > "$RT/warnings.txt"
+  expect_file_is "warnings: ${1:-none}" "$RT/warnings.txt" "$2"
+}
+expect_turbo() { expect_file_is "turbo calls: $1" "$FIX/turbo-calls.log" "$2"; }
+expect_union() { expect_file_is "union: $1" "$FIX/union.log" "$2"; }
+
+# The package set that landed in turbo-ls.json, as `count:name,name`.
+expect_packages() {
+  local got
+  got=$(node -e '
+    const j = JSON.parse(require("fs").readFileSync(process.argv[1], "utf8"));
+    process.stdout.write(j.packages.count + ":" + j.packages.items.map((i) => i.name).sort().join(","));
+  ' "$RT/turbo-ls.json" 2>&1)
+  if [ "$got" = "$1" ]; then ok "turbo-ls.json = $1"; else bad "turbo-ls.json = $1" "got: $got"; fi
+}
+expect_line() {
+  if grep -qF -- "$1" "$RT/out.txt"; then ok "prints: $1"; else bad "prints: $1"; fi
+}
+expect_no_line() {
+  if grep -qF -- "$1" "$RT/out.txt"; then bad "does not print: $1"; else ok "does not print: $1"; fi
+}
+
+W_UNION='::warning::Could not union cross-package scans into the affected set; falling back to the full package list for this shard.'
+affected_call() { echo "affected argv=[ls --affected --output=json] TURBO_SCM_BASE=$1"; }
+full_call='full argv=[ls --output=json] TURBO_SCM_BASE=unset'
+union_lines() { printf 'argv --union-into %s/turbo-ls.json --changed %s/changed-files.txt\nchanged %s' "$RT" "$RT" "$1"; }
+
+echo "select-shard-packages selftest  (fixture: C0=${C0:0:7} C1=${C1:0:7} F1=${F1:0:7} M=${M:0:7} D=${D:0:7})"
+
+# ── usage ───────────────────────────────────────────────────────────────────
+reset_controls
+cases=$((cases + 1)); RT="$FIX/rt-$cases"; mkdir -p "$RT"
+(cd "$REPO" && env -u RUNNER_TEMP PATH="$FIX/bin:$PATH" OS_SHARD_EVENT_NAME=push bash "$SCRIPT") > "$RT/out.txt" 2>&1
+rc=$?
+echo "case: usage: no RUNNER_TEMP is a usage error, not a selection"
+expect_rc 2
+expect_line 'usage: RUNNER_TEMP='
+
+# ── push ────────────────────────────────────────────────────────────────────
+reset_controls; at "$M"
+run_case 'push: the FULL list, one turbo call, no warnings' "$REPO" push '' '' ''
+expect_rc 0
+expect_warnings '' ''
+expect_turbo 'full only' "$full_call"
+expect_union 'not invoked' ''
+expect_packages '3:a,b,c'
+
+reset_controls; at "$M"
+run_case 'push: the event decides, not the variables that happen to be set' "$REPO" push main "$C0" "$C1"
+expect_rc 0
+expect_warnings '' ''
+expect_turbo 'full only' "$full_call"
+expect_packages '3:a,b,c'
+
+reset_controls; at "$M"
+run_case 'an event that is neither: the FULL list' "$REPO" workflow_dispatch '' '' ''
+expect_rc 0
+expect_warnings '' ''
+expect_turbo 'full only' "$full_call"
+expect_packages '3:a,b,c'
+
+# ── pull_request ────────────────────────────────────────────────────────────
+reset_controls; at "$F1"
+run_case 'pull_request: affected against merge-base(origin/main, HEAD), unioned' "$REPO" pull_request main "$C0" ''
+expect_rc 0
+expect_warnings '' ''
+expect_turbo 'affected only, base = merge-base' "$(affected_call "$C1")"
+expect_union 'the diff base..HEAD' "$(union_lines packages/a/leaf.ts)"
+expect_packages '1:a'
+expect_line "Affected-set diff base: $C1  (merge-base of origin/main and HEAD)"
+expect_line "Frozen payload base.sha: $C0  -- main has moved 1 commit(s) since it was frozen"
+
+reset_controls; at "$F1"; printf 'spec' > "$FIX/union-add"
+run_case 'pull_request: the union adds a declaring package and the set ships it' "$REPO" pull_request main "$C0" ''
+expect_rc 0
+expect_warnings '' ''
+expect_packages '2:a,spec'
+
+reset_controls; at "$F1"; printf '1' > "$FIX/union-exit"
+run_case 'pull_request: a failed union falls back to the FULL list, loudly' "$REPO" pull_request main "$C0" ''
+expect_rc 0
+expect_warnings 'union fallback' "$W_UNION"
+expect_turbo 'affected, then full' "$(affected_call "$C1")
+$full_call"
+expect_packages '3:a,b,c'
+
+reset_controls; at "$C1"; set_affected
+run_case 'pull_request: an EMPTY diff is #10057 -- the FULL list, never an empty set' "$REPO" pull_request main "$C0" ''
+expect_rc 0
+expect_warnings '#10057' "::warning::The diff against merge-base $C1 listed no changed files, which a pull_request cannot legitimately produce; falling back to the full package list for this shard rather than selecting nothing (#10057)."
+expect_turbo 'affected, then full' "$(affected_call "$C1")
+$full_call"
+expect_union 'ran over an empty list' "$(union_lines '(none)')"
+expect_packages '3:a,b,c'
+
+reset_controls; at "$F1"
+run_case 'pull_request: no base branch in the payload' "$REPO" pull_request '' "$C0" ''
+expect_rc 0
+expect_warnings 'no base + #6195' '::warning::This pull_request event carries no base branch, so the affected-set diff base cannot be computed.
+::warning::Could not resolve merge-base(origin/, HEAD); falling back to the full package list for this shard rather than diffing from the frozen base.sha (#6195).'
+expect_turbo 'full only' "$full_call"
+expect_union 'not invoked' ''
+expect_packages '3:a,b,c'
+
+reset_controls; at "$F1"
+if git_q -C "$REPO" rev-parse -q --verify refs/remotes/origin/release > /dev/null; then
+  bad 'precondition: origin/release is absent before the fetch case'
+else
+  ok 'precondition: origin/release is absent before the fetch case'
+fi
+run_case 'pull_request: a base ref absent locally is fetched, then diffed' "$REPO" pull_request release "$C1" ''
+expect_rc 0
+expect_warnings '' ''
+if git_q -C "$REPO" rev-parse -q --verify refs/remotes/origin/release > /dev/null; then
+  ok 'origin/release exists after the run (the fetch happened)'
+else
+  bad 'origin/release exists after the run (the fetch happened)'
+fi
+expect_turbo 'affected only' "$(affected_call "$C1")"
+expect_packages '1:a'
+expect_line "Frozen payload base.sha: $C1  -- release has moved 0 commit(s) since it was frozen"
+
+reset_controls; at "$F1"
+run_case 'pull_request: an unfetchable base ref warns twice and falls back' "$REPO" pull_request nope "$C0" ''
+expect_rc 0
+expect_warnings 'fetch + #6195' '::warning::Could not fetch origin/nope; the merge-base resolution below will decide.
+::warning::Could not resolve merge-base(origin/nope, HEAD); falling back to the full package list for this shard rather than diffing from the frozen base.sha (#6195).'
+expect_turbo 'full only' "$full_call"
+expect_packages '3:a,b,c'
+
+reset_controls; at "$F1"; printf '1' > "$FIX/affected-exit"
+run_case 'pull_request: a failing `turbo ls --affected` reds the step (bash -e parity), no fallback' "$REPO" pull_request main "$C0" ''
+expect_rc 1
+expect_turbo 'affected only' "$(affected_call "$C1")"
+expect_union 'not reached' ''
+
+# ── merge_group ─────────────────────────────────────────────────────────────
+reset_controls; at "$M"
+run_case 'merge_group: affected against the group base_sha, unioned' "$REPO" merge_group '' '' "$C1"
+expect_rc 0
+expect_warnings '' ''
+expect_turbo 'affected only, base = base_sha' "$(affected_call "$C1")"
+expect_union 'the diff base_sha..HEAD' "$(union_lines packages/a/leaf.ts)"
+expect_packages '1:a'
+expect_line "Affected-set diff base: $C1  (the merge group's base_sha)"
+expect_no_line 'Frozen payload base.sha'
+
+reset_controls; at "$D"; set_affected
+run_case 'merge_group: a docs-only group selects NOTHING and warns about nothing' "$REPO" merge_group '' '' "$M"
+expect_rc 0
+expect_warnings '' ''
+expect_turbo 'affected only -- no fallback to full' "$(affected_call "$M")"
+expect_union 'the docs file' "$(union_lines docs/guide.md)"
+expect_packages '0:'
+
+reset_controls; at "$C1"; set_affected
+run_case 'merge_group: an EMPTY diff is NOT #10057 -- nothing selected, no warning' "$REPO" merge_group '' '' "$C1"
+expect_rc 0
+expect_warnings '' ''
+expect_no_line '#10057'
+expect_turbo 'affected only' "$(affected_call "$C1")"
+expect_union 'ran over an empty list' "$(union_lines '(none)')"
+expect_packages '0:'
+
+reset_controls; at "$M"; printf 'spec' > "$FIX/union-add"
+run_case 'merge_group: the union adds a declaring package and the set ships it' "$REPO" merge_group '' '' "$C1"
+expect_rc 0
+expect_warnings '' ''
+expect_packages '2:a,spec'
+
+reset_controls; at "$M"; printf '1' > "$FIX/union-exit"
+run_case 'merge_group: a failed union falls back to the FULL list, loudly' "$REPO" merge_group '' '' "$C1"
+expect_rc 0
+expect_warnings 'union fallback' "$W_UNION"
+expect_turbo 'affected, then full' "$(affected_call "$C1")
+$full_call"
+expect_packages '3:a,b,c'
+
+reset_controls
+if git_q -C "$SHALLOW" cat-file -e "$C0^{commit}" 2>/dev/null; then
+  bad 'precondition: the shallow clone lacks C0 before the fetch case'
+else
+  ok 'precondition: the shallow clone lacks C0 before the fetch case'
+fi
+run_case 'merge_group: a base_sha absent from a shallow checkout is fetched BY SHA' "$SHALLOW" merge_group '' '' "$C0"
+expect_rc 0
+expect_warnings '' ''
+if git_q -C "$SHALLOW" cat-file -e "$C0^{commit}" 2>/dev/null; then
+  ok 'C0 is present after the run (the fetch happened)'
+else
+  bad 'C0 is present after the run (the fetch happened)'
+fi
+expect_turbo 'affected only, base = base_sha' "$(affected_call "$C0")"
+expect_union 'the diff C0..C1' "$(union_lines packages/a/index.ts)"
+expect_packages '1:a'
+
+reset_controls; at "$M"
+run_case 'merge_group: an unfetchable base_sha warns twice and falls back' "$REPO" merge_group '' '' "$ZEROS"
+expect_rc 0
+expect_warnings 'fetch + resolve' "::warning::Could not fetch the merge group's base $ZEROS; the resolution below will decide.
+::warning::Could not resolve the merge group's base '$ZEROS' in this checkout; falling back to the full package list for this shard rather than selecting nothing (#16453)."
+expect_turbo 'full only' "$full_call"
+expect_union 'not invoked' ''
+expect_packages '3:a,b,c'
+
+reset_controls; at "$M"
+run_case 'merge_group: no base_sha in the payload' "$REPO" merge_group '' '' ''
+expect_rc 0
+expect_warnings 'no base + resolve' "::warning::This merge_group event carries no base_sha, so the affected-set diff base cannot be computed.
+::warning::Could not resolve the merge group's base '' in this checkout; falling back to the full package list for this shard rather than selecting nothing (#16453)."
+expect_turbo 'full only' "$full_call"
+expect_packages '3:a,b,c'
+
+reset_controls; at "$M"; printf '1' > "$FIX/affected-exit"
+run_case 'merge_group: a failing `turbo ls --affected` reds the step, exactly as on pull_request' "$REPO" merge_group '' '' "$C1"
+expect_rc 1
+expect_turbo 'affected only' "$(affected_call "$C1")"
+expect_union 'not reached' ''
+
+# ── Verdict ─────────────────────────────────────────────────────────────────
+# #4690: a battery that ran nothing is a failure, never a pass.
+if [ "$cases" -lt 20 ] || [ "$checks" -lt 80 ]; then
+  echo "SELFTEST FAILED: only $cases case(s) / $checks check(s) ran -- the battery is short"
+  exit 1
+fi
+if [ "$fail" -ne 0 ]; then
+  echo "SELFTEST FAILED ($cases cases, $checks checks)"
+  exit 1
+fi
+echo "all $cases cases passed ($checks checks)"

--- a/scripts/ci/select-shard-packages.selftest.sh
+++ b/scripts/ci/select-shard-packages.selftest.sh
@@ -24,7 +24,15 @@
 set -uo pipefail
 cd "$(git rev-parse --show-toplevel)" || exit 1
 
-SCRIPT="$PWD/scripts/ci/select-shard-packages.sh"
+# The one repo path this self-test reads, spelled as a quoted repo-relative
+# literal on purpose: the dispatch derivation (scripts/pm/dispatch-gates.mjs)
+# reads a gate's quoted path literals as the population it watches, so a card
+# touching the script schedules this family. Every other path below is a
+# throwaway fixture under $TMPDIR, and none is spelled as a repo path -- a
+# quoted literal with a slash in it would read as a declared population that reaches
+# nothing (check:declared-population-live refuses exactly that).
+SCRIPT_REL='scripts/ci/select-shard-packages.sh'
+SCRIPT="$PWD/$SCRIPT_REL"
 FIX=$(mktemp -d "${TMPDIR:-/tmp}/os-select-shard-selftest.XXXXXX") || exit 1
 trap 'rm -rf "$FIX"' EXIT INT TERM
 
@@ -82,7 +90,7 @@ appendFileSync(FIX + '/union.log', 'changed ' + (files.join(',') || '(none)') + 
 const doc = JSON.parse(readFileSync(list, 'utf8'));
 const add = readFileSync(FIX + '/union-add', 'utf8').trim();
 if (add) {
-  doc.packages.items.push({ name: add, path: 'packages/' + add });
+  doc.packages.items.push({ name: add, path: add });
   doc.packages.count = doc.packages.items.length;
 }
 writeFileSync(list, JSON.stringify(doc));
@@ -91,7 +99,9 @@ EOF
 }
 
 # ── Control files ───────────────────────────────────────────────────────────
-full_json='{"packageManager":"pnpm@10.0.0","packages":{"count":3,"items":[{"name":"a","path":"packages/a"},{"name":"b","path":"packages/b"},{"name":"c","path":"packages/c"}]}}'
+# The `path` of a fake package is its bare name: the script under test never
+# reads it, and a slash here would spell a repo-path literal (see SCRIPT_REL).
+full_json='{"packageManager":"pnpm@10.0.0","packages":{"count":3,"items":[{"name":"a","path":"a"},{"name":"b","path":"b"},{"name":"c","path":"c"}]}}'
 printf '%s\n' "$full_json" > "$FIX/full.json"
 
 # set_affected <name>...  -- what the fake `turbo ls --affected` answers
@@ -99,7 +109,7 @@ set_affected() {
   local items='' name
   for name in "$@"; do
     [ -n "$items" ] && items="$items,"
-    items="$items{\"name\":\"$name\",\"path\":\"packages/$name\"}"
+    items="$items{\"name\":\"$name\",\"path\":\"$name\"}"
   done
   printf '{"packageManager":"pnpm@10.0.0","packages":{"count":%d,"items":[%s]}}\n' "$#" "$items" > "$FIX/affected.json"
 }

--- a/scripts/ci/select-shard-packages.sh
+++ b/scripts/ci/select-shard-packages.sh
@@ -1,0 +1,230 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+#
+# select-shard-packages -- the Test Core package set, decided from the event.
+#
+#   OS_SHARD_EVENT_NAME=pull_request OS_SHARD_PR_BASE_REF=main \
+#   OS_SHARD_PR_PINNED_BASE_SHA=<sha> RUNNER_TEMP=/tmp/rt \
+#     bash scripts/ci/select-shard-packages.sh
+#   OS_SHARD_EVENT_NAME=merge_group OS_SHARD_MERGE_GROUP_BASE_SHA=<sha> \
+#   RUNNER_TEMP=/tmp/rt bash scripts/ci/select-shard-packages.sh
+#   bash scripts/ci/select-shard-packages.selftest.sh   # every branch, offline
+#
+# Environment in, `$RUNNER_TEMP/turbo-ls.json` out (a `turbo ls --output=json`
+# payload, ready for partition-test-shards.mjs), `::warning::` lines out for
+# every fallback. Exit 0 on every decided outcome -- a fallback to the full
+# list is a decision, not a failure; exit 2 on a usage error; and a failing
+# `turbo ls` exits with turbo's own status, exactly as it did under `bash -e`
+# when this text lived inline in ci.yml (see below).
+#
+# ## What decides the set, per event (#16453)
+#
+#   pull_request  affected set against merge-base(origin/<base ref>, HEAD),
+#                 unioned with the cross-package scans the diff touches.
+#   merge_group   affected set against the group's own base --
+#                 `github.event.merge_group.base_sha` -- with the same union.
+#                 The queue builds each entry as merged onto the current main
+#                 (or onto the entry ahead of it) and NAMES that base, so there
+#                 is no merge-base to compute and no frozen sha to drift from.
+#   push          the FULL list, unchanged: a push to main gates nobody, and
+#                 it is the ground truth the shard-timings refresh reads.
+#
+# An EMPTY affected set on merge_group is legitimate -- a docs-only group has
+# nothing to test -- and flows into ci.yml's existing "No packages on this
+# shard -- nothing to test" path, where every shard still attests and the
+# `Test Core` gate counts six credentials over zero packages: an honest green.
+# It is NOT the #10057 case; that guard is pull_request-only, and the comment
+# beside it below says why the two cannot be told apart anywhere else.
+#
+# ## Why this is a script and not the step's `run:` block
+#
+# The selection used to be ~120 lines of inline shell with `${{ }}` expressions
+# in it, which cannot be run anywhere but on a runner -- so a `merge_group`
+# branch, which by construction cannot run until the PR is already in the
+# queue, could not be proved before it landed. Reading plain environment
+# variables instead lets the selftest drive every branch offline with a fake
+# `turbo` on PATH, and lets a reviewer run the four event shapes locally.
+# The pull_request branch was moved here VERBATIM: its comments, warnings and
+# fallbacks (#6195, #10057) are the lines of the original step, and the only
+# edits are the variable plumbing at the top and the merge_group additions.
+#
+# ## The interface
+#
+#   OS_SHARD_EVENT_NAME             `github.event_name`
+#   OS_SHARD_PR_BASE_REF            `github.event.pull_request.base.ref`
+#   OS_SHARD_PR_PINNED_BASE_SHA     `github.event.pull_request.base.sha` -- the
+#                                   payload's FROZEN base, printed for the drift
+#                                   reading and never diffed from (#6195)
+#   OS_SHARD_MERGE_GROUP_BASE_SHA   `github.event.merge_group.base_sha`
+#   RUNNER_TEMP                     the runner's temp dir; the outputs land here
+#
+# Variables absent from the event are empty strings, which is what the runner
+# hands over for an expression that does not apply to the event -- so a local
+# run sets only the ones its event carries.
+set -euo pipefail
+
+if [ -z "${RUNNER_TEMP:-}" ]; then
+  echo "usage: RUNNER_TEMP=<dir> OS_SHARD_EVENT_NAME=<event> [OS_SHARD_PR_BASE_REF=… OS_SHARD_PR_PINNED_BASE_SHA=… OS_SHARD_MERGE_GROUP_BASE_SHA=…] bash scripts/ci/select-shard-packages.sh" >&2
+  exit 2
+fi
+
+# Every path below is repo-relative (`scripts/...`, `pnpm exec`), so stand on
+# the repository root whatever directory the caller stood on.
+cd "$(git rev-parse --show-toplevel)"
+
+EVENT_NAME="${OS_SHARD_EVENT_NAME:-}"
+BASE_REF="${OS_SHARD_PR_BASE_REF:-}"
+PINNED_BASE_SHA="${OS_SHARD_PR_PINNED_BASE_SHA:-}"
+MERGE_GROUP_BASE_SHA="${OS_SHARD_MERGE_GROUP_BASE_SHA:-}"
+
+SCM_BASE=''
+if [ "$EVENT_NAME" = "pull_request" ]; then
+  if [ -z "$BASE_REF" ]; then
+    echo "::warning::This pull_request event carries no base branch, so the affected-set diff base cannot be computed."
+  else
+    # `fetch-depth: 0` above already makes this resolve — the fetch is
+    # the guard for the day that changes, not the normal path.
+    #
+    # `git cat-file -e` rather than the more idiomatic strict
+    # `git rev-parse --verify` spelling. That is history rather than
+    # style, and it is written down because it used to be a live
+    # hazard: the pre-#6589 check-shard-attestation.mjs classified a
+    # job as an aggregate GATE when the script's basename and its
+    # `--verify` flag merely CO-OCCURRED as substrings anywhere in
+    # the job's joined `run:` text. This job always carries the
+    # basename (its `--emit` step at the bottom), so spelling
+    # `--verify` anywhere in this step — comments included, since
+    # they were part of `run:` — silently reclassified the shard job
+    # as a gate.
+    #
+    # #6589 closed that by construction. Classification is now by
+    # INVOCATION: within one command the flag must follow the
+    # script's own name as an argument, the test is applied per STEP
+    # and never over the job's joined text, and the lexer drops shell
+    # comments — all three pinned by that script's `--self-test`,
+    # which is why this comment can now name the flag at all. Either
+    # spelling is safe here; `git cat-file -e` stays because
+    # churning it would buy nothing.
+    if ! git cat-file -e "refs/remotes/origin/$BASE_REF^{commit}" 2>/dev/null; then
+      git fetch --no-tags --quiet origin "+refs/heads/$BASE_REF:refs/remotes/origin/$BASE_REF" \
+        || echo "::warning::Could not fetch origin/$BASE_REF; the merge-base resolution below will decide."
+    fi
+    # `if !` rather than a bare assignment on purpose: these steps run
+    # under `bash -e`, where a failing command substitution kills the
+    # step with no message at all.
+    if ! SCM_BASE=$(git merge-base "refs/remotes/origin/$BASE_REF" HEAD); then
+      SCM_BASE=''
+    fi
+  fi
+fi
+# merge_group (#16453): the payload names the base outright, so there is no
+# merge-base to compute and no frozen sha to drift from. `base_sha` is an
+# ancestor of HEAD -- the queue built HEAD by merging this entry onto it --
+# and `git diff base_sha HEAD` is exactly what this entry adds. Every failure
+# shape mirrors the pull_request branch above: an absent field, a sha the
+# checkout cannot resolve even after a fetch, and further down a failed scan
+# all fall back to the FULL list with a `::warning::` naming the reason,
+# never to a silent narrower set.
+if [ "$EVENT_NAME" = "merge_group" ]; then
+  if [ -z "$MERGE_GROUP_BASE_SHA" ]; then
+    echo "::warning::This merge_group event carries no base_sha, so the affected-set diff base cannot be computed."
+  else
+    # The checkout's `fetch-depth: 0` already makes this resolve -- the fetch
+    # is the guard for the day that changes, exactly as it is above. Fetched
+    # by sha, not by ref: a merge group's base is a commit, and the queue
+    # branch it sits on is transient.
+    if ! git cat-file -e "$MERGE_GROUP_BASE_SHA^{commit}" 2>/dev/null; then
+      git fetch --no-tags --quiet origin "$MERGE_GROUP_BASE_SHA" \
+        || echo "::warning::Could not fetch the merge group's base $MERGE_GROUP_BASE_SHA; the resolution below will decide."
+    fi
+    if git cat-file -e "$MERGE_GROUP_BASE_SHA^{commit}" 2>/dev/null; then
+      SCM_BASE="$MERGE_GROUP_BASE_SHA"
+    fi
+  fi
+fi
+if [ -n "$SCM_BASE" ]; then
+  if [ "$EVENT_NAME" = "pull_request" ]; then
+    # The drift is printed, not just corrected: nothing in this log ever
+    # said which commit the affected diff started from, which is why the
+    # decay was invisible.
+    DRIFT=$(git rev-list --count "$PINNED_BASE_SHA..$SCM_BASE" 2>/dev/null || echo '?')
+    echo "Affected-set diff base: $SCM_BASE  (merge-base of origin/$BASE_REF and HEAD)"
+    echo "Frozen payload base.sha: $PINNED_BASE_SHA  -- $BASE_REF has moved $DRIFT commit(s) since it was frozen, and that drift is exactly what this step used to charge to this PR."
+  else
+    echo "Affected-set diff base: $SCM_BASE  (the merge group's base_sha)"
+  fi
+  TURBO_SCM_BASE="$SCM_BASE" pnpm exec turbo ls --affected --output=json > "$RUNNER_TEMP/turbo-ls.json"
+  # `turbo ls --affected` answers "which packages does the dependency
+  # GRAPH reach from this diff" — and some suites read files the graph
+  # does not connect them to. spec's api-methods-batch-conformance scan
+  # walks every `*.object.ts` in the monorepo while spec declares no
+  # dependency on the packages it judges (nor should it: the scan reads
+  # source text precisely to avoid inverting the spec -> * direction).
+  # A platform-objects-only diff therefore left it unrun, and #7769
+  # landed a violation on `main` that only PRs touching `spec` ever saw.
+  # Measured on turbo 2.10.7: 51 packages affected by that diff, spec
+  # not among them.
+  #
+  # So packages that declare a cross-package input radius are unioned
+  # back in when the diff touches it. The declarations, and the static
+  # detector that refuses to let a new cross-package scan go
+  # undeclared, live in the script (`pnpm check:cross-package-test-inputs`).
+  #
+  # Failure here falls back to the FULL package list, never to the
+  # affected-only set: same posture as the merge-base fallback below
+  # (#6195), and the same reason — the full list is a strict superset,
+  # so doubt costs minutes rather than coverage. This is the FILTER
+  # CONTRACT's half 1 applied one layer down.
+  if ! git diff --name-only "$SCM_BASE" HEAD > "$RUNNER_TEMP/changed-files.txt" \
+    || ! node scripts/check-cross-package-test-inputs.mjs \
+         --union-into "$RUNNER_TEMP/turbo-ls.json" \
+         --changed "$RUNNER_TEMP/changed-files.txt"; then
+    echo "::warning::Could not union cross-package scans into the affected set; falling back to the full package list for this shard."
+    pnpm exec turbo ls --output=json > "$RUNNER_TEMP/turbo-ls.json"
+  # A fourth signal the failure branches do not cover: a producer that
+  # exits 0 with a wrong, plausible, EMPTY answer. Only that `git
+  # diff`'s exit STATUS was checked, never its emptiness, so a
+  # merge-base resolving to something wrong-but-valid gave an empty
+  # changed-file list -> zero affected packages -> a green shard that
+  # tested nothing, with every log line reading like a normal quiet PR
+  # (#10057). The shard attestation (#6082) does not cover it: it
+  # attests "shard N ran and every step passed", which is exactly what
+  # a shard that tested nothing does.
+  #
+  # Empty is decidable as BROKEN here, and only here: a pull_request
+  # always differs from its merge-base. At the partitioner zero is
+  # frequently the CORRECT answer (a docs-only PR genuinely affects no
+  # package, and with 6 shards a small change legitimately leaves
+  # shards empty), so a blanket "red on empty" belongs there least of
+  # all -- this is the one place selection-failed and nothing-selected
+  # can be told apart.
+  #
+  # Scoping this to pull_request is an explicit test now that merge_group
+  # reaches this branch too (#16453): a merge group whose diff against its
+  # base lists nothing is a group whose tree IS its base's tree -- already
+  # validated as main, nothing new to test -- so selecting nothing there is
+  # the honest answer, not the #10057 shape. push never reaches this branch:
+  # SCM_BASE is assigned only under the two event guards above.
+  elif [ "$EVENT_NAME" = "pull_request" ] && [ ! -s "$RUNNER_TEMP/changed-files.txt" ]; then
+    echo "::warning::The diff against merge-base $SCM_BASE listed no changed files, which a pull_request cannot legitimately produce; falling back to the full package list for this shard rather than selecting nothing (#10057)."
+    pnpm exec turbo ls --output=json > "$RUNNER_TEMP/turbo-ls.json"
+  fi
+else
+  # Falling back to the FULL package list, never to the frozen
+  # base.sha. This is not the #4690 silent-skip anti-pattern: that is
+  # about a gate PASSING on input it could not read, and the full list
+  # is a strict superset of the affected one — this shard still runs
+  # everything it would have run and more. Cost is minutes; the
+  # alternative is a red Test Core on a PR with nothing wrong with it.
+  # Push builds take this branch by design: a push to main gates nobody, and
+  # its full run is the ground truth the shard-timings refresh reads. Merge
+  # groups used to take it too; since #16453 they land here only when the
+  # group's base could not be resolved, and say so just below.
+  if [ "$EVENT_NAME" = "pull_request" ]; then
+    echo "::warning::Could not resolve merge-base(origin/$BASE_REF, HEAD); falling back to the full package list for this shard rather than diffing from the frozen base.sha (#6195)."
+  fi
+  if [ "$EVENT_NAME" = "merge_group" ]; then
+    echo "::warning::Could not resolve the merge group's base '$MERGE_GROUP_BASE_SHA' in this checkout; falling back to the full package list for this shard rather than selecting nothing (#16453)."
+  fi
+  pnpm exec turbo ls --output=json > "$RUNNER_TEMP/turbo-ls.json"
+fi

--- a/scripts/pm/dispatch-gates.mjs
+++ b/scripts/pm/dispatch-gates.mjs
@@ -13438,10 +13438,19 @@ function selfTest() {
       `the live tree really carries ${valueBearing.length} value-bearing invocation(s) across ${new Set(valueBearing.map((i) => i.script)).size} script(s), so the cases above judge a live class`,
       valueBearing.length > 0,
     );
+    // Five of the card's six named specimens. The sixth,
+    // `scripts/check-cross-package-test-inputs.mjs`, classified as VARIABLE
+    // through ci.yml's inline package-selection step (`--union-into
+    // "$RUNNER_TEMP/turbo-ls.json" --changed …`) until #16453 moved that step's
+    // shell into scripts/ci/select-shard-packages.sh, which no workflow-text
+    // scan reaches; its only workflow invocation is now the all-literal
+    // `pnpm check:cross-package-test-inputs`, so it belongs to the LITERAL
+    // class below and no longer to this roster — the rot the block comment
+    // above predicts for a typed list, and the reason the count is read.
     t(
       '⭐ the card\'s named specimens all classify as VARIABLE from the workflow text — no per-script table was needed',
       ['scripts/check-empty-changeset.mjs', 'scripts/check-test-completeness.mjs', 'scripts/check-shard-attestation.mjs',
-        'scripts/check-cross-package-test-inputs.mjs', 'scripts/check-adr-0087-registration.mjs', 'scripts/check-changeset-no-major.mjs']
+        'scripts/check-adr-0087-registration.mjs', 'scripts/check-changeset-no-major.mjs']
         .every((script) => valueBearing.some((i) => i.script === script)),
     );
     t(


### PR DESCRIPTION
Fixes #16453

The merge queue's `Test Core` runs the affected package set instead of the full list. The "Compute this shard's package set" step in `ci.yml` becomes a thin call into a new script that reads plain environment variables, so every branch of every event runs locally and under a self-test — which is how the `merge_group` branch, which cannot run before a PR is already in the queue, is proved here before it lands. `push` on `main` is unchanged: the full list.

Maintainer-directed (part A of the test-cost programme; the authority is quoted on the card). Not a governed surface: `check-governed-merges --test` on this PR's six paths printed `governed-surface predicate: 0 of 6 path(s) hit the register (5 surfaces, repo-agnostic). NOT governed — ordinary queue landing applies to a PR with exactly this file list.` (exit 0).

## What changed

| file | change |
|---|---|
| `scripts/ci/select-shard-packages.sh` (new) | the selection: environment in (`OS_SHARD_EVENT_NAME`, `OS_SHARD_PR_BASE_REF`, `OS_SHARD_PR_PINNED_BASE_SHA`, `OS_SHARD_MERGE_GROUP_BASE_SHA`, `RUNNER_TEMP`), `$RUNNER_TEMP/turbo-ls.json` out; exit 0 on every decided outcome, 2 on a usage error, turbo's own status when `turbo ls` fails (the `bash -e` behaviour the inline step had) |
| `scripts/ci/select-shard-packages.selftest.sh` (new) | 21 cases / 97 checks, hermetic and offline: a throwaway upstream + clone + shallow clone, a fake `pnpm`/`turbo` pair on PATH that records every call, a stub union script that records its argv; pins which `turbo ls` calls were made and with what `TURBO_SCM_BASE`, the union's changed-file list, every `::warning::` fallback text, and the ABSENCE of the ones that must not fire |
| `.github/workflows/ci.yml` | the step exports the four event fields and calls the script; the partition call stays in the step verbatim (`partition-test-shards.mjs` pins its spelling); the header comment states the per-event posture and the empty-set rule |
| `.github/workflows/lint.yml` | one step, `Test Core package selection self-test`, runs `pnpm check:select-shard-packages` (wiring the self-test into CI is what `check:self-test-wired` exists for) |
| `package.json` | `check:select-shard-packages` |
| `scripts/pm/dispatch-gates.mjs` | one self-test roster entry removed, reason recorded beside it: the case `the card's named specimens all classify as VARIABLE from the workflow text` listed `scripts/check-cross-package-test-inputs.mjs`, whose only value-bearing invocation was the inline step's `--union-into … --changed …` line that this PR moved into the script; with it gone from the workflow text `check:pm-dispatch-gates` failed `1 of 1534` on this branch (the rot its own block comment predicts for a typed list). Measured before the edit with the tool's exported `extractCheckInvocations` over the live workflows: the other five specimens still classify VARIABLE, `check-cross-package-test-inputs.mjs` no longer does anywhere. After the edit: `✓ dispatch-gates self-test: 1534 cases pass.` |

File-surface increment against the claim: `lint.yml` and `package.json` carry the self-test wiring only (one step, one script line); `scripts/pm/dispatch-gates.mjs` is the one-entry repair above, a red this PR itself causes. Flight X (#16455) edits a different `ci.yml` step and none of these files; `git merge-tree --write-tree HEAD d2fab7ab77` against its pushed head exits 0 both plain and with `-c merge.os-regen.driver=false` (final head: both write tree `4c84c99cf3`).

## Per event

- `pull_request` — moved VERBATIM: the affected set against merge-base(origin/BASE_REF, HEAD), unioned with the cross-package scans; fallbacks #6195 and #10057 with their exact warning texts.
- `merge_group` — `SCM_BASE` is `github.event.merge_group.base_sha`; if the checkout cannot resolve it the script fetches it by sha (mirroring the PR branch's fetch of `origin/BASE_REF`), then `TURBO_SCM_BASE=base_sha pnpm exec turbo ls --affected --output=json` and the union over `git diff --name-only base_sha HEAD`, through the same code path the PR branch runs. Any failure to resolve the base, to fetch it, or to run the scans falls back to the FULL list with a `::warning::` naming the reason. An EMPTY selection is legitimate (a docs-only group) and is not the #10057 case: that guard is now an explicit `pull_request` test, and the comment beside it says why the two cannot be told apart anywhere else.
- `push` — unchanged, the full list (the step comment says so in one line).

## Byte-for-byte equivalence of the `pull_request` branch

The old `run:` block (121 lines at `6eba38f5a3`, extracted and dedented; the round-trip re-indents to the identical bytes) was spliced into the script by line range, never retyped. `diff -b old-inline new-script-body` removes exactly 15 lines and adds 45; the 15 removed are, in full:

```text
- if [ "${{ github.event_name }}" = "pull_request" ]; then        (plumbing, becomes "$EVENT_NAME", 2 sites)
-   # Scoping this to pull_request needs no `github.event_name` test:
-   # SCM_BASE is assigned only inside the `pull_request` guard above, so
-   # this whole `[ -n "$SCM_BASE" ]` branch is unreachable on push and
-   # merge_group. Those keep taking the full-list path in the `else`
-   # below, by design.                                              (comment rewritten: no longer true)
-   elif [ ! -s "$RUNNER_TEMP/changed-files.txt" ]; then           (gains `[ "$EVENT_NAME" = "pull_request" ] &&`)
-   # Push and merge-queue builds take this branch by design (the queue
-   # result IS the next main, so it gets main's validation).        (comment rewritten: push only)
-   if [ "${{ github.event_name }}" = "pull_request" ]; then        (plumbing)
- node scripts/partition-test-shards.mjs ...  (5 lines)             (the partition tail stays in the step)
```

Every other old line survives verbatim: 106 of 121 are present byte-for-byte in the script (indentation aside — the six drift/echo lines sit one level deeper under the new `pull_request` guard, with a `merge_group` `else` printing `Affected-set diff base: SHA  (the merge group's base_sha)`). The added lines are the merge_group resolution block, the two event guards, the merge_group fallback warning, and the plumbing header.

Behavioural proof — the OLD step's `run:` block (with `${{ github.event_name }}` = `pull_request`, `${{ matrix.shard }}` = 1) and the NEW step's `run:` block were both executed under `bash -e` in a scratch clone against the same tree and the same event variables, real turbo, real union script, real partitioner:

| pull_request shape | old vs new stdout+stderr | turbo-ls.json | shard-packages.txt | selected |
|---|---|---|---|---|
| (a) leaf change, base ref resolves | IDENTICAL (18 lines) | IDENTICAL `86f09bcdd964` | IDENTICAL | 53 |
| (a2) empty base ref | IDENTICAL (17 lines, both #6195 warnings) | IDENTICAL `e1ac2440598f` | IDENTICAL | 79 (full) |
| (a3) unresolvable base ref `nope` | IDENTICAL (19 lines, fetch + #6195 warnings) | IDENTICAL | IDENTICAL | 79 (full) |
| (a4) HEAD == merge-base (#10057) | IDENTICAL (20 lines, the #10057 warning) | IDENTICAL | IDENTICAL | 79 (full) |

And live: this PR's own `pull_request` run of the new step on a runner — `Test Core (1/6)` … `(6/6)` and the aggregate `Test Core` all `success` on `05cb57b43c`.

## The four scenario runs (real commits in a scratch clone, `git diff` against the synthetic base T = `e6fe28e94e`; never pushed)

`raw` is `turbo ls --affected` alone at the same HEAD; `selected` is what the step wrote after the union.

| scenario | changed file | raw turbo | union adds | selected | shards 1..6 |
|---|---|---|---|---|---|
| (a) `pull_request`, leaf (`packages/drivers/driver-sql/src/index.ts`) | 1 | 50 | spec, core, types | **53** (== old inline, see above) | — |
| (b) `merge_group`, same leaf change | 1 | 50 | spec, core, types | **53** | 9 / 10 / 9 / 8 / 9 / 8 |
| (b2) `merge_group`, TRUE leaf, `.ts` (`packages/plugins/knowledge-ragflow/src/index.ts`; zero dependents) | 1 | 1 | spec, core, types, objectql, runtime | **6** | — |
| (b3) `merge_group`, TRUE leaf, `.md` only (`packages/plugins/knowledge-ragflow/CHANGELOG.md`) | 1 | 1 | spec | **2** | — |
| (c) `merge_group`, `packages/spec/src/index.ts` | 1 | 75 | none | **75** | 16 / 13 / 13 / 11 / 11 / 11 |
| (d) `merge_group`, docs-only (`.claude/agents/os-dev.md`, the 01:18Z shape) | 1 | 0 | none | **0** | 0 / 0 / 0 / 0 / 0 / 0 |
| (d2) `merge_group`, docs-only (root `README.md`) | 1 | 0 | none | **0** | — |
| (d3) `merge_group`, docs-only under `content/**` (`content/docs/concepts/north-star.mdx`) | 1 | 0 | spec, rest, create-objectstack | **3** | 1 / 1 / 1 / 0 / 0 / 0 |

(d): no warning, exit 0, `shard-packages.txt` is 0 bytes on every shard, so each shard takes the existing `No packages on this shard — nothing to test` exit. Every merge_group run printed zero `::warning::` lines. The (d) reading is the docs-only group the card measured at 15–20 minutes of shard time; it now costs six ~1-minute shards.

## Seat addendum — does `turbo ls --affected` read the `$TURBO_ROOT$` inputs?

No. Measured on turbo 2.10.10: `--affected` reads package directories plus the dependency graph only; the `$TURBO_ROOT$` inputs on the heavy test tasks feed the task hash and never widen the affected verdict. What pulls those packages into the queue run is the cross-package union (`check-cross-package-test-inputs.mjs --union-into`), by declared glob.

| change | turbo.json `$TURBO_ROOT$` inputs that match it | raw `turbo ls --affected` | pulled in by the union (declared glob) |
|---|---|---|---|
| leaf `.ts` (b2) | `spec#test`, `core#test`, `types#test`, `runtime#test`, `objectql#test` all list `packages/**/*.ts` | knowledge-ragflow only (1) | spec, core, types, objectql, runtime (`packages/**/*.ts`) |
| leaf `.md` (b3) | `spec#test` (`packages/**/*.md`) | knowledge-ragflow only (1) | spec (`packages/**/*.md`) |
| docs under `content/**` (d3) | `spec#test`, `rest#test`, `create-objectstack#test` list `content/**` | none (0) | spec, rest, create-objectstack (`content/**`) |
| `.claude/agents/*.md` / root `README.md` (d, d2) | none | none (0) | none |

So the floor for a leaf `.ts` merge is six packages — the leaf plus the five whose declared radius is every `.ts` under `packages/`; spec's suite (~500s) dominates that shard. That radius is a declaration in `scripts/cross-package-test-inputs.mjs`, not a turbo.json input, and nothing here moves it (no turbo.json input was changed).

## The attestation reading (empty roster on every shard)

`check-shard-attestation.mjs --emit` carries no package field at all (payload: attestation, job, shard, total, run_id, run_attempt, sha, workflow_job, attested_at); the emit step has no `if:`, and on an empty shard the test step exits 0 before creating a log while the completeness guard exits 0 on `No test log`. Dry run: six `--emit` calls over six empty `shard-packages.txt` files, then `--verify --gate 'Test Core' --dir ... --filter-result success --leg test/6:success`:

```text
    attested 6 / 6 declared shard(s)
Test Core: satisfied — all 6 declared shard(s) published a positive attestation.   (exit 0)
```

Control, one credential removed: `- test-4-of-6  MISSING` / `::error::Test Core: 1 of 6 declared shard(s) of test published no positive attestation (test-4-of-6)` (exit 1). Its `--self-test`: `144 assertions` green. Nothing in that script needed to change.

## Gates (final head `05cb57b43c`, every exit captured before any pipe)

- `node scripts/pm/dispatch-gates.mjs --commands --repo objectstack-ai/objectstack` (path-less, derived from the merge base): 58 commands (the three `scripts/pm/` families joined at the last commit: `check-declaration-mirrors`, its self-test, `check:ratchet-remedy-authority`, all exit 0). 55 ran to exit 0, including `check:select-shard-packages` (`all 21 cases passed (97 checks)`), `check:pm-dispatch-gates` (`✓ dispatch-gates self-test: 1534 cases pass.`, run detached as its header requires), `check:shard-attestation`, `check:cross-package-test-inputs`, `check:workflow-status-functions`, `check:required-contexts`, `check:aggregator-roster`, `check:ci-filter-parity`, `check:self-test-wired`, `check:self-test-workflow-commands`, `check:step-collectors`, `check:declared-population-live` (`224 of 270 famil(ies) declare a path population, and every one of them reaches this tree's 8087 tracked file(s)`), `check:entry-guard`, `check:parse-guard`, `check:scripts-symbol-anchors`, `check:bash32-floor` (`29 tracked shell file(s) ... name no bash 4+ construct`), `check:nul-bytes` (`OK (scanned 8080 text file(s) ...)`).
- 3 NOT MEASURED, each a `PREREQUISITE NOT MET` exit 3 on an unbuilt closure: `check:dts-closure`, `check:dual-build-cjs-loads`, `check:type-check-debt`. Declared narrowing: this diff touches no package source, tsconfig or build input (workflows, two shell scripts, one root script line, one self-test roster entry), so none of the three properties can move; CI ran them on a built closure (`Type Check · debt ledger`, `TypeScript Type Check`: success).
- `--ran` reconciliation: `✓ dispatch-gates --ran: 58 derived famil(ies) accounted for — 55 run, 3 NOT-MEASURED.` (exit 0; the three carry their stated reason).
- Whole-repo `pnpm lint` through `scripts/pm/os-verify-lock.sh` (slot `issue-16453`): `VERDICT command-exit 0 · held the lock 138s (2m18s) · waited 0s`.
- `check-governed-merges --test` on the six paths: exit 0, NOT governed (quoted above).
- CI on `05cb57b43c`: 33 check runs completed, 31 `success`, 2 `skipped` (`Check Changeset` under `skip-changeset`; `Packed-tarball smoke (opt-in)`), 0 failures — `Lint & Repo Gates`, `TypeScript Type Check`, `Test Core`, `Dogfood Regression Gate`, `Build Core`, `Temporal Conformance (live PG + MySQL)` all `success`.

`skip-changeset`: nothing here publishes from any package.

Noted, not filed (below the #16351 threshold): two prose readings are now stale for `merge_group` — the header of `scripts/check-cross-package-test-inputs.mjs` ("the merge-queue and push builds ... partition the FULL package list") and AGENTS.md multi-agent §7 ("the queue runs the full suite; the PR ran affected-only"); the second is a governed surface and both are outside this card's file surface.

Authored in Claude Code session `session_019RfFHiRCSs3JXLK4cwcfox` (os-steve).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019RfFHiRCSs3JXLK4cwcfox