### PR TITLE
test(rest): pin the `/meta/mapping` item shape on three producer paths

### DIFF
--- a/packages/rest/src/import-integration.test.ts
+++ b/packages/rest/src/import-integration.test.ts
@@ -26,6 +26,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { ObjectQL } from '@objectstack/objectql';
 import { SqlDriver } from '@objectstack/driver-sql';
 import { ObjectStackProtocolImplementation } from '@objectstack/metadata-protocol';
+import { MetadataManager } from '@objectstack/metadata';
 import { RestServer } from './rest-server';
 import { loadExcelJs } from './xlsx-module.js';
 
@@ -130,7 +131,15 @@ function makeRes() {
   return res;
 }
 
-async function boot() {
+/**
+ * @param services [#15907] the kernel's service registry, when the test needs
+ * one installed. Only the `metadata` service producer path uses it — a
+ * {@link MetadataManager} reaches `GET /meta/:type` through
+ * `getServicesRegistry()`, so it cannot be attached after the protocol is
+ * constructed. Omitted ⇒ no registry at all, which is what every other suite
+ * in this file boots and what it booted before that path was pinned.
+ */
+async function boot(services?: Map<string, any>) {
   const engine = new ObjectQL();
   liveEngines.push(engine);
   engine.registerDriver(makeSqliteDriver(), true);
@@ -144,7 +153,10 @@ async function boot() {
   await engine.insert('user', { id: 'u1', name: '张三', email: 'zhang@x.com' });
   await engine.insert('user', { id: 'u2', name: '李四', email: 'li@x.com' });
 
-  const protocol = new ObjectStackProtocolImplementation(engine as any);
+  const protocol = new ObjectStackProtocolImplementation(
+    engine as any,
+    services ? () => services : undefined,
+  );
   const rest = new RestServer(createMockServer() as any, protocol as any, { api: { requireAuth: false } } as any);
   (rest as any).resolveExecCtx = async () => ({ userId: 'test-user' });
   rest.registerRoutes();
@@ -674,5 +686,140 @@ describe('import + create routes — number `scale` enforcement (#7501)', () => 
     } as any, ok);
     expect(ok._status ?? 200).toBeLessThan(400);
     expect((await engine.findOne('member', { where: { id: 'w5' } }))?.work_hours).toBe(8);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #15907 — the PRODUCER-side pin on `GET /api/v1/meta/mapping`'s per-item shape.
+//
+// The console's import wizard FEATURE-DETECTS its saved-mapping selector:
+// `@object-ui/data-objectstack`'s `listImportMappings` keeps the items whose
+// TOP-LEVEL `targetObject` names the object being imported, and degrades every
+// failure — a throw, a refusal, a body it cannot read — to an EMPTY LIST. So a
+// producer that started serving the `MetadataManager` publish envelope
+// (`name` / `packageId` / `state` / `metadata`) instead of the document itself
+// would fail NOWHERE: the selector would simply stop appearing, on every
+// deployment, and a released feature would read downstream as a hardcoded
+// client — which is exactly how #14026 was raised.
+//
+// Nothing else covers it. `GetMetaItemsResponseSchema` declares `items` as
+// `unknown[]`, so the spec states nothing about the per-item shape; the
+// consumer-side pin (objectui#7738) carries a COPIED FIXTURE of today's body
+// and by construction moves right or wrong TOGETHER with this producer; and the
+// named-mapping suite above reads its artifact through `getMetaItem`, never
+// through the list door. A consumer that degrades to empty + a schema that
+// declares nothing + no producer pin = a reading that cannot fail. This block
+// is the producer's half of it.
+//
+// ⭐ THREE producer paths, and the third is the reason this is not one test.
+// A pin over `registerApp` alone would be green forever precisely because
+// `registerApp` is not the producer anyone would change. `MetadataManager`
+// — installed as the `metadata` service, the registrar the file-based artifact
+// loader uses — is the one whose envelope could realistically start reaching
+// the wire, so it is pinned here explicitly rather than assumed to travel with
+// the others. Measured: the three paths agree on the document but NOT on the
+// decorations — `registerApp` stamps `_packageId` + `_provenance` (it knows the
+// owning package), the other two carry `_diagnostics` alone — so "they all look
+// the same" is not a premise this block is entitled to.
+//
+// ⚠️ Scope: this asserts the two facts the consumer actually reads — a
+// TOP-LEVEL `targetObject`, and NO nested `metadata` member. Whether
+// `GetMetaItemsResponseSchema.items` should be narrowed from `unknown` is a
+// SPEC decision (narrowing a published declaration carries a manual floor) and
+// is deliberately not taken here.
+// ---------------------------------------------------------------------------
+describe('GET /meta/mapping — items are raw documents, not publish envelopes (#15907)', () => {
+  const MAPPING_TEMPLATE = {
+    name: 'saved_task_feed',
+    label: 'Saved task feed',
+    sourceFormat: 'csv',
+    targetObject: 'task',
+    fieldMapping: [
+      { source: 'ID', target: 'id', transform: 'none' },
+      { source: 'Task Title', target: 'title', transform: 'none' },
+    ],
+    mode: 'upsert',
+    upsertKey: ['id'],
+  };
+
+  // Every producer path DECORATES the document it was handed, IN PLACE, so each
+  // registration gets its own copy. A shared literal carries one path's
+  // `_packageId` into the next path's reading — measured while writing this
+  // block, and it makes the weaker paths look like the stronger one.
+  const mappingDoc = () => JSON.parse(JSON.stringify(MAPPING_TEMPLATE));
+
+  /**
+   * The consumer's own predicate, replicated on this side of the wire:
+   * `listImportMappings` keeps the items whose TOP-LEVEL `targetObject` names
+   * the object. Spelled as a filter rather than an index lookup because the
+   * filter is what makes a shape change SILENT downstream — it answers `[]`,
+   * not an error — and therefore what has to be made loud here.
+   */
+  const asConsumerSees = (items: unknown[], object: string) =>
+    (items ?? []).filter((it: any) => it?.targetObject === object);
+
+  const listMapping = async (rest: any) => {
+    const route = rest.getRoutes().find(
+      (r: any) => r.method === 'GET' && r.path === '/api/v1/meta/:type',
+    );
+    expect(route).toBeDefined();
+    const res = makeRes();
+    // `headers` is not dressing — the conditional-GET branch reads
+    // `req.headers['if-none-match']`.
+    await route.handler(
+      { method: 'GET', params: { type: 'mapping' }, query: {}, body: {}, headers: {} } as any,
+      res,
+    );
+    return res;
+  };
+
+  /** The whole claim, applied identically to every producer path below. */
+  const expectRawDocumentShape = (res: any) => {
+    expect(res._status ?? 200).toBeLessThan(400);
+    expect(res._json).toMatchObject({ type: 'mapping' });
+    expect(Array.isArray(res._json.items)).toBe(true);
+
+    // What the console actually sees. A publish envelope has no top-level
+    // `targetObject`, so this filter answers `[]` — the silent failure, made
+    // into a red one.
+    const visible = asConsumerSees(res._json.items, 'task');
+    expect(visible.map((m: any) => m.name)).toEqual(['saved_task_feed']);
+
+    const item: any = visible[0];
+    // `targetObject` is TOP-LEVEL — not `item.metadata.targetObject`.
+    expect(item.targetObject).toBe('task');
+    // …and there is no nested `metadata` member it could have moved into. The
+    // envelope this refuses is `{ name, packageId, state, metadata }`.
+    expect(Object.prototype.hasOwnProperty.call(item, 'metadata')).toBe(false);
+    // The rest of the document is served at the top level as well, so a
+    // half-move (identity kept, body nested) cannot pass either.
+    expect(item.sourceFormat).toBe('csv');
+    expect(Array.isArray(item.fieldMapping)).toBe(true);
+    expect(item.fieldMapping[0]).toMatchObject({ source: 'ID', target: 'id' });
+  };
+
+  it('path 1 — a manifest `mappings:` entry installed through `registerApp`', async () => {
+    const { engine, rest } = await boot();
+    engine.registerApp({ id: 'feed_pkg', name: 'feed_pkg', mappings: [mappingDoc()] });
+    expectRawDocumentShape(await listMapping(rest));
+  });
+
+  it('path 2 — a direct `registry.registerItem`', async () => {
+    const { engine, rest } = await boot();
+    engine.registry.registerItem('mapping', mappingDoc() as any, 'name');
+    expectRawDocumentShape(await listMapping(rest));
+  });
+
+  it('path 3 — `MetadataManager.register`, installed as the `metadata` service', async () => {
+    // The registrar the file-based artifact loader uses. It holds the document
+    // under `(type, name)` and `list()` hands the document back; the publish
+    // envelope this test refuses is the shape it would serve if that ever
+    // became the thing it returns.
+    const services = new Map<string, any>();
+    const metadata = new MetadataManager({ formats: ['json'], loaders: [] });
+    await metadata.register('mapping', MAPPING_TEMPLATE.name, mappingDoc());
+    services.set('metadata', metadata);
+    const { rest } = await boot(services);
+    expectRawDocumentShape(await listMapping(rest));
   });
 });


### PR DESCRIPTION
Fixes #15907

`GET /api/v1/meta/mapping` serves each item as the raw spec document with
`targetObject` at the **top level**, decorated and wrapped in a `{ type, items }`
envelope. The console's import wizard depends on that silently:
`@object-ui/data-objectstack`'s `listImportMappings` filters items by a top-level
`targetObject` and **degrades every failure to an empty list**.

`GetMetaItemsResponseSchema` declares `items` as `unknown[]`, so the spec states
nothing about the per-item shape. The consumer-side pin (objectui#7738) carries a
copied fixture of today's body, so by construction it moves right or wrong
*together with* this producer. And `packages/rest` had no test that lists
`/meta/mapping` at all — the named-mapping suite in this same file reads its
artifact through `getMetaItem`, never through the list door.

A consumer that degrades to empty, a schema that declares nothing, and no
producer-side pin add up to **a reading that cannot fail**: if the producer began
serving the `MetadataManager` publish envelope (`name` / `packageId` / `state` /
`metadata`), the selector would simply stop appearing, on every deployment, and a
released feature would read downstream as a hardcoded client. This PR adds the
producer's half.

## What it pins

In the existing real-stack harness — real `RestServer` route table over a real
`ObjectStackProtocolImplementation` on a real `ObjectQL` plus sqlite `:memory:` —
`GET /api/v1/meta/mapping` answers items whose `targetObject` is **top-level** and
whose `metadata` member is **absent**. The consumer's own predicate is replicated
on this side of the wire (a filter, not an index lookup), because the filter is
what makes a shape change silent downstream: it answers `[]`, not an error.

## Three producer paths, because one is not enough

A pin over `registerApp` alone would be green forever precisely because
`registerApp` is not the producer anyone would change. The three paths covered:

| # | producer path | why |
|---|---|---|
| 1 | manifest `mappings:` via `registerApp` | the packaged install door |
| 2 | direct `registry.registerItem` | the direct registration door |
| 3 | `MetadataManager.register` installed as the `metadata` service | the registrar the file-based artifact loader uses, and the one whose publish envelope could realistically start reaching the wire |

`boot()` gains an optional service-registry argument: a `metadata` service is read
through `getServicesRegistry()` and cannot be attached after the protocol is
constructed. Omitted, it is byte-for-byte the previous boot.

## The pin was ablated per path — prediction written first, then observed

Each leg mutated one producer to serve the publish envelope, rebuilt the mutated
package's `dist/` (these specifiers resolve through `exports` to `dist/`, with no
vitest alias back to source, so an unrebuilt ablation would have been a false
green), proved the mutation was live in the artifact with
`scripts/ablation-dist-preflight.mjs`, then restored under an absolute-path
`trap ... EXIT INT TERM` and proved the restore by blob equality against `HEAD`,
an empty `git diff HEAD`, and a `--absent` preflight.

| leg | mutation site | predicted | observed |
|---|---|---|---|
| 1 | `engine.ts`, the manifest-collection registration | path 1 RED, paths 2+3 GREEN | **1 failed, 2 passed** — exactly that |
| 2 | `metadata-manager.ts`, `MetadataManager.list()` | path 3 RED, paths 1+2 GREEN | **1 failed, 2 passed** — exactly that |
| 3 | `registry.ts`, `SchemaRegistry.registerItem` | paths 1+2 RED, path 3 GREEN | **2 failed, 1 passed** — exactly that |

Legs 1 and 2 are complements: one producer path moves while the others do not, and
the pin notices the one that moved. That is the property a single-path pin cannot
have. Leg 3 was predicted to red paths 1 and 2 **together** and did: `registerApp`
reaches the registry *through* `registerItem`, so there is no cut below that call
which path 2 reaches and path 1 does not. Paths 1 and 2 are therefore not
separable producers below `registerItem` — leg 1, which cuts above it in the
manifest loop, is what separates them.

## Re-derivation, and one place the card's positive claim was too strong

The item shape was re-derived here rather than inherited. Measured through the
list door on all three paths: the raw document, `targetObject` top-level, no
nested `metadata` member — the card holds.

One refinement: the card describes every item as decorated with `_packageId` /
`_provenance` / `_diagnostics`. Measured at this commit, the three paths agree on
the document but **not** on the decorations — `registerApp` stamps `_packageId`
and `_provenance` (it knows the owning package); the direct `registerItem` and
`MetadataManager` paths carry `_diagnostics` alone. So "they all look the same" is
not a premise this pin is entitled to, and it does not assert the decorations.

## Deliberately not done

- `GetMetaItemsResponseSchema.items` is **not** narrowed from `unknown`. That is a
  spec decision with a separate card and a manual floor for narrowing a published
  declaration.
- Nothing in `objectui` is touched.
- `rest-server.ts` is not touched.

## Verification

- All 45 derived gate families run, each exit code captured before any pipe: 45
  green. Two first returned `exit 3 PREREQUISITE NOT MET` (`check:dual-build-cjs-loads`,
  `check:type-check-debt`) — recorded as NOT MEASURED, then the package closure was
  built as `lint.yml` does and both re-run green.
- `pnpm --filter @objectstack/rest typecheck`: green — and the edited file was
  confirmed present in the tsc program via `--listFiles` (1 hit), so this is
  coverage, not adjacency.
- `pnpm --filter @objectstack/rest exec vitest run`: 187 files, 3182 tests, all pass.
- Lint was narrowed to the changed file and the narrowing is declared: 1 file from
  eslint's own `--format json` output, 0 errors, 0 warnings; the repo's single
  `eslint.config.mjs` enables type-aware linting for no file at all, so this diff
  cannot move the verdict on any untouched file.
- Gates, tests and lint were all run at `b11efe3d951`, this branch's head.

Test-only change, publishing nothing from any package: no changeset, `skip-changeset`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D47qPfEWVPmhguWgBZCi5N

---
_Generated by [Claude Code](https://claude.ai/code/session_01D47qPfEWVPmhguWgBZCi5N)_