### PR TITLE
docs(adr): ADR-0135 mirrors the open half of cloud ADR-0024 — identity & access architecture

### DIFF
--- a/docs/adr/0132-identity-and-access-architecture.md
+++ b/docs/adr/0132-identity-and-access-architecture.md
@@ -1,0 +1,272 @@
+# ADR-0132: Identity and access architecture — the open half, mirrored from cloud ADR-0024
+
+**Status**: The DECISION is Accepted — it is `objectstack-ai/cloud` ADR-0024, accepted there on
+2026-06-25, and its mechanism half is implemented in this repository today. ⚠️ This **file** is a
+mirror awaiting the maintainer's hand-merge (`docs/adr/**` is a governed surface, AGENTS.md Prime
+Directive #14), so merging it settles the RECORD, not the decision. ⛔ Nothing below is decided
+here: a clause that cloud ADR-0024 did not decide is not decided by this file either.
+**Decided**: 2026-06-25, by the founder, in `objectstack-ai/cloud`
+`docs/adr/0024-identity-and-access-architecture.md` (Status: Accepted there).
+**Mirrored**: 2026-09-07, under the maintainer's ruling of 2026-09-02 on
+[#14496](https://github.com/objectstack-ai/objectstack/issues/14496) — verbatim and untranslated,
+「ok」 to option 2: mirror the open half, ⛔ do not move files, ⛔ do not renumber. Recorded by
+[#14506](https://github.com/objectstack-ai/objectstack/issues/14506).
+**Shape**: [ADR-0079](./0079-record-display-name.md) — the same cross-repo split, the same
+Provenance-section discipline.
+**Builds on**: [ADR-0068](./0068-unified-user-context-and-built-in-identity-roles.md) (the one
+platform-admin derivation this record's D5 leans on), [ADR-0092](./0092-sys-user-profile-field-delegation.md)
+(the identity write guard that keeps the generic data path out of a better-auth table),
+[ADR-0093](./0093-tenancy-mode-and-membership-lifecycle.md) and
+[ADR-0105](./0105-group-tenancy-posture-and-first-class-org-scope.md) (membership lifecycle and
+org scope), [ADR-0095](./0095-authz-kernel-tenant-layer-and-posture-ladder.md) and
+[ADR-0108](./0108-membership-grade-is-not-a-capability-channel.md) (authorization is derived in
+the environment, and a membership grade is not a capability channel).
+**Consumers**: `@objectstack/plugin-auth` (the whole package), `@objectstack/platform-objects`
+(the `identity/` object set), `@objectstack/core` (`security/resolve-authz-context.ts`).
+
+---
+
+## Provenance — read this before citing this file
+
+**This file records, in this repository, decisions taken in `objectstack-ai/cloud` ADR-0024 on
+2026-06-25.** The cloud record is the original. It is not superseded, not moved and not
+renumbered; it keeps the commercial half of the same decision, and where this file and the cloud
+record differ, **the cloud record is the decision and this file is the bug** — say so in an issue
+and this file gets corrected.
+
+Three facts make that disclosure load-bearing rather than decorative.
+
+1. **Why the record is split at all.** AGENTS.md Prime Directive #13 states the rule this file
+   obeys: *an ADR lives in the repository whose code it governs*; decisions that draw the
+   open/closed or commercial boundary live in `cloud`, and when such a decision's **mechanism
+   half** governs open code here, this repository carries its own ADR with its own number, a
+   Provenance section naming the cloud record and its date, and the commercial half left where it
+   was. That rule was itself adopted by the 2026-09-02 ruling cited above.
+
+2. **This file was written from the cloud record's decision list and from the code that
+   implements it**, by a seat that could not open the `cloud` repository. What is quoted here is
+   quoted from *this* tree; what is attributed to cloud ADR-0024 is attributed at the granularity
+   the ruling's execution card carried (its decision letters and their headings), never at
+   sentence granularity. Every mechanism claim below carries a symbol anchor into this tree, so a
+   reader can check the mechanism half without cloud access. The attribution half is what cloud
+   access would check.
+
+3. **⚠️ A bare `ADR-0024` in this repository's code does NOT resolve to this record — it never
+   did, and this file does not change that.** `docs/adr/0024-mcp-connectors.md` is a real,
+   unrelated record in this registry, and the two numbering series are independent, which is
+   exactly why AGENTS.md forbids the bare form and requires `cloud ADR-NNNN`. The same trap sits
+   one number away: cloud ADR-0071 is the env-side SCIM mechanism, while this registry's `0071`
+   is the dataset semantic-layer depth record. Re-pointing the identity surface's existing bare
+   citations at this record is
+   [#14361](https://github.com/objectstack-ai/objectstack/issues/14361)'s job and ⛔ was
+   deliberately not done in the change that added this file: on the commit that introduced it,
+   `git grep -n -E "ADR-0024" -- packages/plugins/plugin-auth/src packages/platform-objects/src/identity`
+   minus the `cloud ADR-0024` spellings still measured **64** citing lines.
+
+---
+
+## Context
+
+An ObjectStack environment is a running system with its own database, its own metadata and its
+own users. Two questions had to be answered together, and answering either one alone produces an
+architecture that cannot hold: **where does an identity come from**, and **where is the decision
+made about what that identity may do**.
+
+The tempting answer for a multi-environment product is one central directory: users sign in once,
+the platform knows everybody, environments ask it. That answer forecloses the two properties this
+platform is built to keep — an environment that can be self-hosted with no vendor in the loop,
+and a customer whose employees already live in the customer's own identity provider. cloud
+ADR-0024 chose the other direction, and the mechanism half of that choice is what this repository
+implements: authentication runs *in* the environment, federation is something the environment's
+operator configures, and authorization is never delegated at all.
+
+---
+
+## Decision
+
+Each clause below is cloud ADR-0024's, restated in this repository's words, with the code that
+enforces it. The lettering is the cloud record's, kept so that a citation of `cloud ADR-0024 D5.2`
+and a citation of this record's D5.2 name the same clause.
+
+### D1 — Identity is per-environment, and never centralised
+
+Every environment authenticates its own users. The authentication stack runs **inside** the
+environment process; there is no central authentication service that an environment must reach in
+order to sign a user in. An environment cut off from every other ObjectStack deployment still
+works.
+
+The mechanism is better-auth, mounted by the environment's own plugin
+(`packages/plugins/plugin-auth/src/auth-plugin.ts#AuthPlugin`) and built in-process
+(`packages/plugins/plugin-auth/src/auth-manager.ts#AuthManager`). It persists through the
+environment's **own** data engine rather than any remote store: the vendor's model names are
+bridged onto this platform's system objects by
+`packages/plugins/plugin-auth/src/objectql-adapter.ts#AUTH_MODEL_TO_PROTOCOL`, so the directory is
+a set of tables in the environment's database.
+
+### D2 — Two user populations, two sources of truth
+
+The people who reach an environment are not one population. Some identities are **owned by an
+external directory** — an identity provider the operator registered; others are **the
+environment's own**. Each population keeps its own source of truth, and the platform does not
+collapse the two into a single authority: the environment's tables hold a row for both, but for a
+managed identity that row is a mirror, and the directory that owns it remains the authority for
+the facts it owns.
+
+The distinction is a first-class column, not an inference:
+`packages/platform-objects/src/identity/sys-user.object.ts#source` carries exactly two values,
+`idp_provisioned` and `env_native`, and its declaration states the split it exists for —
+federated-SSO JIT provisioning on one side, local signup and app end-users on the other. The
+provider links that justify a value live in
+`packages/platform-objects/src/identity/sys-account.object.ts`.
+
+### D4 — Source-of-truth marking: managed vs env-native
+
+Which side of D2 a row is on must be **marked**, and the marking must be produced by the system
+rather than typed by an operator, because everything downstream gates on it.
+
+Two markings do that work, at two levels:
+
+- **The table** is marked as owned by the auth vendor —
+  `packages/platform-objects/src/identity/sys-user.object.ts#managedBy`,
+  `packages/platform-objects/src/identity/sys-member.object.ts#managedBy`,
+  `packages/platform-objects/src/identity/sys-sso-provider.object.ts#managedBy` all declare
+  `better-auth`. Under [ADR-0092](./0092-sys-user-profile-field-delegation.md) that declaration is
+  what makes the generic data path fail-closed on those tables.
+- **The row** is marked with its provenance — `sys_user.source`, stamped automatically as accounts
+  are linked and never edited by hand. Two writers keep it true, because the two creation paths do
+  not share a seam: better-auth's `account.create.after` hook in
+  `packages/plugins/plugin-auth/src/auth-manager.ts`, and an ObjectQL `afterInsert` hook on
+  `sys_account` in `packages/plugins/plugin-auth/src/auth-plugin.ts` for adapter-level creates
+  that bypass the vendor hook. Both are idempotent, both fail open on the write, and both log
+  loudly when the stamp does not land — a row that silently keeps the wrong `source` is how a
+  managed user is offered the local-password action D5.2 exists to hide.
+
+### D5 — Identity comes from the IdP; authorization is decided in the environment
+
+Authentication may be delegated. **Authorization never is.** What a signed-in principal may do is
+derived from the environment's own grant tables at the moment it is asked, from evidence the
+environment stores — never from a claim the identity provider asserted, and never from a role
+string carried in on a token.
+
+`packages/core/src/security/resolve-authz-context.ts#resolveUserAuthzGrants` is that derivation,
+and `#hasPlatformAdminStanding` is its id-shaped projection: platform standing is an unscoped,
+in-window `sys_user_permission_set` grant of `admin_full_access`, held now — the ADR-0068 D2
+definition, read from this environment's tables. Organization grade is read the same way, from
+`sys_member`, through the one predicate every consumer asks
+(`packages/plugins/plugin-auth/src/invitation-role-cap.ts#isOrgAdminGrade`), and
+`packages/plugins/plugin-auth/src/member-role-canonical.ts#registerMemberRoleCanonicalization`
+normalises the stored spelling before any guard judges it.
+
+### D5.2 — The local user-management surface under SSO, split by population
+
+An environment that has adopted SSO still needs a user-management surface, and that surface is
+**split by the D2/D4 population**, not switched off wholesale:
+
+- **Managed identities hold no local credential**, so the actions that would mint or change one
+  are hidden for them rather than merely failing:
+  `packages/platform-objects/src/identity/sys-user.object.ts#change_my_password` and
+  `#change_my_email` are visible only when the row's `source` is not `idp_provisioned`. The point
+  is not tidiness — a managed user who could self-mint a password would have a route around
+  enforced SSO.
+- **Break-glass keeps a local credential reachable.** An environment-native owner, or an
+  SSO-onboarded user setting an *initial* password, goes through
+  `packages/plugins/plugin-auth/src/set-initial-password.ts#runSetInitialPassword`; the admin-side
+  equivalent is `packages/platform-objects/src/identity/sys-user.object.ts#set_user_password`.
+  Gaining a local credential flips the row back to `env_native` (D4's stamp), so the owner never
+  loses self-service password management.
+- **An environment may never be left with zero administrators who can sign in.**
+  `packages/plugins/plugin-auth/src/last-admin-guard.ts#registerLastAdminGuard` holds that
+  invariant across every write shape that could take the last administrator away — a ban, a row
+  delete, and the revocations that leave the user row untouched — and it refuses for **every**
+  context, `isSystem` included, because the paths that actually lock an organization out are the
+  system ones.
+
+### D6 — SSO per production environment, configured in the environment
+
+A production environment federates login to the customer's own identity provider, and that
+federation is **configured in the environment** by its operator — not provisioned centrally.
+
+`packages/platform-objects/src/identity/sys-sso-provider.object.ts#SysSsoProvider` is the
+registered-provider table, backed by `@better-auth/sso`, env-global and admin-only. Every mutation
+routes through the vendor's own endpoints rather than the generic data layer, so config validation
+and secret handling run: `packages/plugins/plugin-auth/src/register-sso-provider.ts`, with the
+model bridged at the adapter layer (`packages/plugins/plugin-auth/src/auth-schema-config.ts`
+records why the bridge sits there and not on the plugin's `schema` option).
+
+**Domain verification is opt-in** — the clause this repository's code cites as `ADR-0024 ②`. When
+the environment turns it on, `@better-auth/sso` mounts a DNS-TXT proof-of-ownership challenge and
+refuses a login through a provider whose email domain is not proven, which stops an organization
+admin from registering a provider for a domain they do not control. It is off by default, because
+turning it on changes the register-then-login flow. The surface is
+`packages/platform-objects/src/identity/sys-sso-provider.object.ts#request_domain_verification`,
+`#verify_domain` and `#domain_verified`.
+
+⚠️ **The SCIM half of "SSO + SCIM per production environment" is not restated here.** Its
+mechanism record is `cloud ADR-0071`, mirrored into this repository by its own card; this file
+records only that the same environment-side posture applies to it — the SCIM models are bridged
+into the environment's tables by the same adapter map D1 names, and the D5.2 guard judges a SCIM
+deprovision exactly as it judges an admin one.
+
+### D7 — Portability and self-host are preserved
+
+Nothing above requires the vendor's cloud. Every mechanism in D1–D6 is in this repository under
+Apache-2.0, and each optional piece is switched on by an environment variable in a self-hosted
+deployment — `OS_SSO_ENABLED` for the external-IdP relying party,
+`OS_SSO_DOMAIN_VERIFICATION` for D6's opt-in check — resolved in
+`packages/plugins/plugin-auth/src/auth-manager.ts`. A self-hosted environment therefore reaches
+the same identity architecture as a hosted one; what a hosted environment adds is entitlement and
+lifecycle, which is cloud ADR-0024's half.
+
+### D9 — Environment users live in the environment; organization membership goes through better-auth
+
+A user of an environment is a row in that environment's `sys_user`, and their membership of an
+organization is a row in that environment's `sys_member` — backed by better-auth's organization
+plugin (`packages/platform-objects/src/identity/sys-member.object.ts#SysMember`), reached through
+the same adapter bridge as every other identity model
+(`packages/plugins/plugin-auth/src/objectql-adapter.ts#AUTH_MODEL_TO_PROTOCOL`). Membership is
+therefore maintained by the auth stack's own endpoints, and read — never re-spelled — by the
+guards that judge administrative standing.
+
+---
+
+## What stays in `cloud` ADR-0024
+
+These clauses are the same decision's commercial half. They are **not** recorded here, and code in
+this repository that means one of them must keep citing `cloud ADR-0024`:
+
+| Clause | Subject |
+|---|---|
+| D3 | cloud-as-IdP hub |
+| D5.1 | the cloud operator-portal membership gate |
+| D8 | billing |
+| D10 | production/development metering and population lifecycle |
+| V1 | the roadmap and the commercial framing |
+
+⚠️ Consequence for [#14361](https://github.com/objectstack-ai/objectstack/issues/14361): a bare
+`ADR-0024` citation in this tree is **not** mechanically re-pointable at this record. Some of
+today's citations mean a clause above — `packages/plugins/plugin-auth/src/auth-manager.ts` cites
+`ADR-0024 V1` for the SSO default-role provisioning — and those keep the `cloud ADR-0024`
+spelling. The re-pointing is per-site and semantic.
+
+## What this record does NOT settle
+
+- **Anything cloud ADR-0024 did not decide.** This file adds no clause. Where the mechanism in
+  this tree is richer than the decision (the ADR-0092 write guard, the ADR-0095 tenant wall, the
+  ADR-0091 validity window), that richness belongs to those records, and is cited here only as the
+  thing D4 and D5 lean on.
+- **The attribution itself, against the cloud original.** See Provenance point 2: this file was
+  written without cloud access. A difference between it and cloud ADR-0024 is this file's bug.
+- **The SCIM mechanism** — `cloud ADR-0071` and its own mirror record.
+- **Whether any individual bare `ADR-0024` citation should move.** That is #14361's per-site call,
+  and the table above is why it cannot be a search-and-replace.
+
+## Consequences
+
+- A reader who follows an `ADR-0024` citation out of `plugin-auth` or `platform-objects/identity`
+  now has somewhere in *this* registry to land — once #14361 re-points the citations that mean the
+  open half. Until then the citation still resolves to `docs/adr/0024-mcp-connectors.md`, which is
+  the defect this record is a precondition for fixing, not one it fixes by itself.
+- The open half of the identity architecture becomes reviewable by anyone who can read this
+  repository, including a self-hosting customer who has no access to `cloud`.
+- `cloud` ADR-0024 gains a one-line pointer naming this record's number — filed as a `cloud` chore
+  by the seat that accepts this PR, since the number is only knowable once this file merges.

--- a/docs/adr/0135-identity-and-access-architecture.md
+++ b/docs/adr/0135-identity-and-access-architecture.md
@@ -1,4 +1,4 @@
-# ADR-0132: Identity and access architecture — the open half, mirrored from cloud ADR-0024
+# ADR-0135: Identity and access architecture — the open half, mirrored from cloud ADR-0024
 
 **Status**: The DECISION is Accepted — it is `objectstack-ai/cloud` ADR-0024, accepted there on
 2026-06-25, and its mechanism half is implemented in this repository today. ⚠️ This **file** is a


### PR DESCRIPTION
Fixes #14506

⚠️ **RENUMBERED 0132 → 0135 (2026-09-07) — this is deliberate, ⛔ please do not "correct" it back.** `0132` is free on `main`, but claimed on the branch of an open PR: #16215 adds `docs/adr/0132-multi-organization-runtime-is-open-core.md`. The first commit on this branch used 0132 (the number assigned before that scan existed); the second `git mv`s it to 0135 and moves the record's single self-citation with it. History was not rewritten and nothing was force-pushed.

Claim map, measured here by a **full** `git diff --name-only origin/main...<pr-head> -- docs/adr/` over **all 27 open PRs** — a file-list scan, not a title scan:

| number | claimed by | state |
|---|---|---|
| ≤ 0131 | `origin/main` (`1ecee3e53`) | landed |
| 0132 | #16215 | open PR |
| 0133 | #16267 (card #14508, third mirror) | open PR |
| 0134 | #16476 (card #14507, sibling mirror) | open PR |
| **0135** | **this PR** | previously unclaimed |

⛔ **GOVERNED SURFACE — draft PR, human merge.** The diff is one file under `docs/adr/**`. No seat flips this ready, enqueues it, or arms auto-merge (AGENTS.md Prime Directive #14). Verified mechanically rather than recalled, both directions, on the final filename:

| reading | command | exit |
|---|---|---|
| positive (this PR's path) | `node scripts/pm/check-governed-merges.mjs --test docs/adr/0135-identity-and-access-architecture.md` | **3 — GOVERNED** (`docs/adr/** ×1`) |
| negative control | `node scripts/pm/check-governed-merges.mjs --test packages/plugins/plugin-auth/src/auth-manager.ts` | **0 — NOT governed** |

## What this writes

`docs/adr/0135-identity-and-access-architecture.md` — one new file, 272 lines, nothing else touched.

It records **in this repository**, in this repository's own words, the half of `objectstack-ai/cloud` ADR-0024 (Status: Accepted, founder, 2026-06-25) whose mechanism governs open code here. Under the maintainer's ruling of 2026-09-02 on #14496 (verbatim 「ok」 to option 2): mirror the open half, ⛔ do not move files, ⛔ do not renumber *the cloud record*. Shape copied from `docs/adr/0079-record-display-name.md` — a `## Provenance — read this before citing this file` section first, naming the cloud record and its date, declaring that the cloud record is the original and keeps the commercial half, and declaring that this file was written from the cloud record's decision list plus the implementing code by a seat with no cloud access.

The slug is unchanged across the renumber and deliberately reuses the cloud original's slug, on the precedent ADR-0079 states in its own Provenance section ("deliberately reuses the original's slug … so the two are recognisably one record").

## The clauses recorded, and the code anchor each one carries

Every anchor below is a symbol anchor (`path#symbol`), was opened and read before it was written, and resolves under `node scripts/check-adr-symbol-anchors.mjs` — line-number anchors are a hard finding in this corpus with no transition period, so there are none (the gate's own summary line: "0 line anchors survive").

| clause | recorded as | anchors |
|---|---|---|
| **D1** per-environment identity, never centralised | better-auth is mounted and built in the environment's own process and persists through the environment's own data engine | `auth-plugin.ts#AuthPlugin`, `auth-manager.ts#AuthManager`, `objectql-adapter.ts#AUTH_MODEL_TO_PROTOCOL` |
| **D2** two user populations, two sources of truth | externally-owned vs environment-owned identities; the platform does not collapse them into one authority | `sys-user.object.ts#source` (`idp_provisioned` / `env_native`), `sys-account.object.ts` |
| **D4** source-of-truth marking, managed vs env-native | marked at two levels — the table (`managedBy: 'better-auth'`) and the row (`sys_user.source`, stamped by two writers because the two creation paths do not share a seam) | `sys-user.object.ts#managedBy`, `sys-member.object.ts#managedBy`, `sys-sso-provider.object.ts#managedBy`, plus the `account.create.after` stamp in `auth-manager.ts` and the SCIM-safe `afterInsert` stamp in `auth-plugin.ts` |
| **D5** identity from the IdP, authorization in the env | authentication may be delegated; authorization never is — standing is derived from the environment's own grant tables | `resolve-authz-context.ts#resolveUserAuthzGrants`, `#hasPlatformAdminStanding`, `invitation-role-cap.ts#isOrgAdminGrade`, `member-role-canonical.ts#registerMemberRoleCanonicalization` |
| **D5.2** the local user-management surface under SSO | split by population: managed users' credential actions hide; break-glass keeps a local credential reachable; an environment may never be left with zero administrators who can sign in | `sys-user.object.ts#change_my_password`, `#change_my_email`, `#set_user_password`, `set-initial-password.ts#runSetInitialPassword`, `last-admin-guard.ts#registerLastAdminGuard` |
| **D6** SSO per production environment | the registered-provider table, mutations routed through the vendor's own endpoints, and the opt-in DNS domain verification this tree cites as `ADR-0024 ②` | `sys-sso-provider.object.ts#SysSsoProvider`, `#request_domain_verification`, `#verify_domain`, `#domain_verified`, `register-sso-provider.ts`, `auth-schema-config.ts` |
| **D7** portability / self-host preserved | every mechanism above is in this repo under Apache-2.0 and switched on by env var in self-host (`OS_SSO_ENABLED`, `OS_SSO_DOMAIN_VERIFICATION`) | `auth-manager.ts` |
| **D9** env users live in the env; org membership via better-auth | `sys_user` and `sys_member` are rows in the environment's database, maintained by the auth stack's endpoints and only read by the guards | `sys-member.object.ts#SysMember`, `objectql-adapter.ts#AUTH_MODEL_TO_PROTOCOL` |

## What stays in cloud, still cited as `cloud ADR-0024`

D3 cloud-as-IdP hub · D5.1 the cloud operator-portal membership gate · D8 billing · D10 prod/dev metering and population lifecycle · the V1 roadmap and commercial framing. The record carries this as a table, with a consequence stated for #14361: a bare `ADR-0024` in this tree is **not** mechanically re-pointable, because some sites mean a clause that stays in cloud — `auth-manager.ts` cites `ADR-0024 V1` for the SSO default-role provisioning. That re-pointing is #14361's per-site call and is not touched here. The env-side SCIM mechanism is `cloud ADR-0071`'s, mirrored by #16476, and is likewise not restated here.

⛔ No decision is added and none is widened. Anything cloud ADR-0024 did not decide is not decided by this file, and the record says so in its own "What this record does NOT settle" section.

⛔ The record cites no number that does not yet exist under `docs/adr/` — in particular not the sibling mirrors' 0133 / 0134, which `check-adr-anchors` would read as a squat.

## Measurements I took myself

⚠️ Both re-checks the card lists were attempted; one could not be run and is declared, not faked.

**1. `git -C ../cloud show origin/main:docs/adr/0024-...` — SKIPPED, not run.** This seat has no `cloud` checkout and no `cloud` access. Nothing here is derived from the cloud file; the record's Provenance section states that limitation in the document itself, so a future reader is not misled about what was checked.

**2. The bare-citation count — measured here, and it does not reproduce the card's figure.**

```
git grep -n -E "ADR-0024" -- packages/plugins/plugin-auth/src packages/platform-objects/src/identity | grep -v -i "cloud ADR-0024" | wc -l
```

| tree | filtered (the card's command) | unfiltered |
|---|---|---|
| `5a9138703` (this branch's base) | **64** | 76 |
| `00ff228fe` (the commit the card cites) | **59** | 71 |

So the card's `# expect ~71` is the **unfiltered** count at `00ff228fe` — the annotation and the command it is attached to disagree by the `grep -v` line. The record quotes **64** (this branch's own base), and labels it as such. Not a blocker for this card; it does matter to #14361, whose scope figure comes from the same reading.

**3. `docs/adr/PRIORITIZATION.md` — NOT registered, deliberately.** The card says to register the new file there *if that index is maintained by hand*, judged from the file's own header. Its own header says it is not an index:

> ⚠️ **STALE (noted 2026-07-16):** this review predates ADR-0050 onward … Treat it as a historical snapshot, not current state. The `Status:` header of each ADR file … is the authority; this document is retained for its method and its ranked-plan rationale.

It is a dated 2026-06-12 review of "All 49 ADRs in `docs/adr/`", not a registry, and `docs/adr/` holds no other index file. Adding a 2026-09 record to a snapshot of 2026-06 would falsify it. No ADR since `0050` is listed there either.

## Gates — the full table, mechanically derived

Derived, not recalled: `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack --commands` (17 commands), re-derived after the renumber commit and byte-identical to the earlier derivation. The union below was re-run in full **at `3d7762e3e`**, the head of this PR; each exit code was captured immediately after its own redirect, never through a pipe.

| # | command | exit |
|---|---|---|
| 1 | `node scripts/check-adr-links.mjs` | 0 |
| 2 | `node scripts/check-adr-links.mjs --self-test` | 0 |
| 3 | `node scripts/check-adr-symbol-anchors.mjs` | 0 |
| 4 | `node scripts/check-adr-symbol-anchors.mjs --self-test` | 0 |
| 5 | `node scripts/check-ci-filter-parity.mjs` | 0 |
| 6 | `node scripts/check-closing-keyword-parity.mjs` | 0 |
| 7 | `node scripts/check-closing-keyword-parity.mjs --self-test` | 0 |
| 8 | `node scripts/check-comment-mask-corpus.mjs` | 0 |
| 9 | `pnpm --filter @objectstack/lint run check:doc-formula-expressions` | 0 |
| 10 | `pnpm check:adr-anchors` | 0 |
| 11 | `pnpm check:cross-package-test-inputs` | 0 |
| 12 | `pnpm check:doc-authoring` | 0 |
| 13 | `pnpm check:driver-memory-census` | 0 |
| 14 | `pnpm check:nul-bytes` | 0 |
| 15 | `pnpm check:pm-governed-merges` | 0 |
| 16 | `pnpm check:refd-timer-probe` | 0 |
| 17 | `pnpm check:watch-hint-literal` | 0 |

⚠️ **On a fresh worktree #9 is an exit 3, and an exit 3 is NOT a green.** `check-doc-formula-expressions` refuses with `PREREQUISITE NOT MET — the workspace package @objectstack/formula is not built` and measures nothing. Cleared both times by building the two declared prerequisites (`turbo run build --filter=@objectstack/formula --filter=@objectstack/lint`, run under `scripts/pm/os-verify-lock.sh`) and re-running, which is the 0 in the table.

Three further families the derivation names as **NOT MEASURED** here, quoted rather than silently omitted: `check-cross-package-test-inputs --union-into …`, `check-shard-attestation --emit …` and `check-test-completeness …` each take a value from the workflow that has none outside a CI run. The derivation also reports 10 families whose declared population is too wide to place and 41 artifact-roster families scored `silent` for every card in the tree — ⛔ neither group is a clearance, and none of their rosters sits in a directory this PR's single path is in.

## Changeset

None, and `skip-changeset` applied — this diff publishes nothing from any package. Not from memory: the three most recent ADR-only landings in this repo did exactly this — #14976 (ADR-0131), #14151 (ADR-0130) and #12519 (ADR-0127) each landed with **no** `.changeset/` file and the `skip-changeset` label, read back off the PRs themselves. The one recent counter-example proves the rule: #13067 (ADR-0129) carried a changeset because it also changed `packages/spec` and `plugin-auth` code.

## Not in scope, filed separately

A stale filename found while verifying anchors: `last-admin-ban-guard.ts` has not existed since the guard was renamed to `last-admin-guard.ts`, yet five comments still point at it (`invitation-role-cap.ts`, `objectql-adapter.ts`, `break-glass-local-credential.test.ts` ×2, and `objectql-adapter.test.ts` pointing at a `last-admin-ban-guard.test.ts` that does not exist). Filed as #16477 (label `finding`, unassigned); ⛔ not fixed here — this PR touches `docs/adr/**` only. #16477 remains open.