### PR TITLE
fix(spec): stop gen:docs warning about the one schema directory declared absent

### DIFF
--- a/packages/spec/scripts/build-docs.ts
+++ b/packages/spec/scripts/build-docs.ts
@@ -47,6 +47,12 @@ import {
 } from './lib/root-index';
 import { rootCategoryDirs } from './lib/root-meta';
 import {
+  formatSchemaClosureExemptionCoverage,
+  schemaClosureAbsenceIsDeclared,
+  schemaClosureExemptionCoverage,
+  schemaClosureExemptionsAreClean,
+} from './lib/schema-closure';
+import {
   buildSchemaIndex,
   formatConflicts,
   resolveSchemaPage,
@@ -313,13 +319,24 @@ function schemaHrefFrom(fromCategory: string): (name: string) => string | null {
  */
 function groupSchemasByPage(): Map<string, Map<string, Array<{ name: string; content: any }>>> {
   const byCategory = new Map<string, Map<string, Array<{ name: string; content: any }>>>();
+  /** Fed to the exemption coverage check below — never a second walk of the tree. */
+  const categoriesWithSchemaDir: string[] = [];
 
   for (const category of Object.keys(CATEGORIES)) {
     const categorySchemaDir = path.join(SCHEMA_DIR, category);
     if (!fs.existsSync(categorySchemaDir)) {
-      console.log(`Warning: Schema directory ${categorySchemaDir} does not exist`);
+      // Absent AND undeclared is the reading this warning exists to deliver, so
+      // it still prints. Absent and declared is `CATEGORIES_WITHOUT_SCHEMA_CLOSURE`
+      // — the exemption is a hand-signed claim about design carrying its
+      // citation, not "the Protocol map in build-schemas.ts happens to omit it",
+      // which would make a category dropped from that map by accident exempt
+      // itself from the very check that would have caught it (#15870).
+      if (!schemaClosureAbsenceIsDeclared(category)) {
+        console.log(`Warning: Schema directory ${categorySchemaDir} does not exist`);
+      }
       continue;
     }
+    categoriesWithSchemaDir.push(category);
 
     const pages = new Map<string, Array<{ name: string; content: any }>>();
     for (const file of fs.readdirSync(categorySchemaDir).filter(f => f.endsWith('.json'))) {
@@ -337,6 +354,18 @@ function groupSchemasByPage(): Map<string, Map<string, Array<{ name: string; con
     }
 
     byCategory.set(category, pages);
+  }
+
+  // Held in both directions, from the walk that just ran rather than from a
+  // second one: an exemption may not outlive the condition it declares, or the
+  // module it names. Loud and fatal, like `resolveCategoryTitles` above — the
+  // freshness guard at the top of this file has already proved `json-schema/`
+  // is newer than `src/`, so a mismatch here is the declaration being wrong and
+  // never a half-built tree.
+  const exemptions = schemaClosureExemptionCoverage(Object.keys(CATEGORIES), categoriesWithSchemaDir);
+  if (!schemaClosureExemptionsAreClean(exemptions)) {
+    console.error(`\n\u2717 ${formatSchemaClosureExemptionCoverage(exemptions)}`);
+    process.exit(1);
   }
 
   return byCategory;

--- a/packages/spec/scripts/lib/schema-closure.ts
+++ b/packages/spec/scripts/lib/schema-closure.ts
@@ -1,0 +1,173 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * The `packages/spec/src/` module directories DECLARED to publish no JSON
+ * Schema — and the coverage check that stops the declaration from outliving
+ * the condition it declares (#15870).
+ *
+ * ## The condition
+ *
+ * `build-docs.ts` walks every module directory under `packages/spec/src/`
+ * (`CATEGORY_TITLES` holds that list total in both directions) and looks for
+ * `json-schema/<category>/`. That tree is written by `gen:schema`, which
+ * iterates the hard-coded `Protocol` namespace map in `build-schemas.ts` and
+ * `ensureDir`s one directory per entry. Measured on this tree: 18 module
+ * directories, 15 `Protocol` entries, so three categories have no directory at
+ * all and `groupSchemasByPage` warned about each of them on EVERY run.
+ *
+ * `contracts` is the shape that does not warn and is worth stating, because it
+ * is the one people reach for as the counter-example: it IS on the `Protocol`
+ * map, so it gets `json-schema/contracts/` — empty, because its service
+ * interfaces are plain TypeScript rather than Zod. Present-and-empty and
+ * absent-entirely are different states and only the second one warns.
+ *
+ * ## Why an unconditional warning is worth removing
+ *
+ * A warning that fires for an intended condition on every run is a warning
+ * readers learn to skim, which is how a real one later gets skimmed too. The
+ * channel is only worth having if a line in it means something happened.
+ *
+ * ## Why a DECLARED list and not "absent from the Protocol map"
+ *
+ * Reading the exemption off `build-schemas.ts`'s map would make the warning
+ * unfalsifiable: a category dropped from that map by accident would be
+ * self-exempting, which is precisely the case the warning exists to catch. So
+ * the exemption is declared here, by hand, one entry at a time, each carrying
+ * the citation that declares it — the same idiom `CATEGORY_TITLES`,
+ * `FOREIGN_JSON_SCHEMA_ARTIFACTS` and `browser-reachable-entries.json` already
+ * use one datum over: a promotion into this map is a judgement someone makes
+ * and signs, never something a generator can grant itself.
+ *
+ * A category that is genuinely, unintentionally missing is not in this map, so
+ * it still warns — pinned by `schema-closure.test.ts`, both directions.
+ */
+
+/**
+ * Category directory -> the citation in this repo that declares it ships no
+ * schema closure.
+ *
+ * ⛔ An entry here is a claim about DESIGN, so it is added only when the tree
+ * already says so somewhere a reader can check. Do not add one because a
+ * directory happens to be missing today — that is the state the warning
+ * reports, and silencing it without a citation converts a report into a guess.
+ *
+ * ⛔ And never satisfy the warning by creating an empty `json-schema/<cat>/`:
+ * an empty directory claims a closure it does not have, which is worse than
+ * the noise it removes.
+ *
+ * ## What is deliberately NOT here (measured on this tree, #15870)
+ *
+ * `conversions` and `migrations` are the other two categories with no schema
+ * directory, and **neither carries an equivalent declaration**. A repo-wide
+ * search for the declaration phrasings (`schema closure`, `schema-free`,
+ * `no JSON Schema`, `without the schema machinery`) returns the `meta-spelling`
+ * citations below and nothing for either of them; the only text that mentions
+ * their missing directory at all is a comment in `build-docs.ts` §2 recording
+ * it as an asymmetry that comment's guard deliberately does NOT act on. Both
+ * are titled `... Protocol` in `CATEGORY_TITLES` — the same word every
+ * category WITH a schema closure is titled with — where `meta-spelling` is
+ * titled `Meta-Spelling Vocabulary` for exactly this reason.
+ *
+ * `migrations` is the further one from an exemption, not the nearer: its
+ * `spec-changes.ts` exports five real Zod schemas, so "no schema closure" is
+ * not even factually true of it. What is true is that it is not on the
+ * `Protocol` map — which is a fact about a generator's input list, not a
+ * declaration about the module.
+ *
+ * So their warnings still fire, and that is the deliberate outcome: whether
+ * either is intentional is an open question this fix does not answer, and a
+ * silenced warning would close it by default in the wrong direction.
+ */
+export const CATEGORIES_WITHOUT_SCHEMA_CLOSURE: Readonly<Record<string, string>> = {
+  'meta-spelling':
+    'scripts/build-meta-url-spelling.ts — "`/meta-spelling` entry ships vocabulary with no schema closure." ' +
+    'Also src/meta-spelling/manifest-collection-spelling.ts ("no schema closure on the vocabulary path"), ' +
+    'scripts/lib/category-title.ts (titled "Vocabulary", not "Protocol", because the entry "folds without ' +
+    'the schema machinery every Protocol category links"), and browser-reachable-entries.json, which ' +
+    'declares `./meta-spelling` browser-reachable under the standing schema-free principle.',
+};
+
+/**
+ * Is this category's missing `json-schema/<category>/` a DECLARED state?
+ *
+ * The one predicate `build-docs.ts` branches its warning on, exported so both
+ * of its answers can be pinned directly. A unit test over it is not sufficient
+ * on its own — the caller could stop asking — so `build-docs.ts` calling it is
+ * pinned end-to-end as well; neither half replaces the other.
+ */
+export function schemaClosureAbsenceIsDeclared(
+  category: string,
+  exempt: Readonly<Record<string, string>> = CATEGORIES_WITHOUT_SCHEMA_CLOSURE,
+): boolean {
+  return Object.hasOwn(exempt, category);
+}
+
+/** Directories whose exemption no longer describes the tree. */
+export interface SchemaClosureExemptionCoverage {
+  /**
+   * Declared exempt, and `json-schema/<category>/` is now there. The
+   * declaration outlived the condition: either the category grew a schema
+   * closure, or the citation was never true.
+   */
+  stale: string[];
+  /**
+   * Declared exempt, and no such module directory exists. The declaration
+   * outlived the module — the `src/hub` failure `categoryTitleCoverage`
+   * guards against, one datum over.
+   */
+  orphaned: string[];
+}
+
+/**
+ * Place the declared exemptions against the tree, in BOTH directions.
+ *
+ * Pure over its inputs so the self-test drives every branch offline. The
+ * direction that is NOT reported here is the interesting one: a category that
+ * is absent and undeclared is not an error, it is the warning's whole job, and
+ * `build-docs.ts` prints it rather than failing.
+ */
+export function schemaClosureExemptionCoverage(
+  allCategories: readonly string[],
+  categoriesWithSchemaDir: readonly string[],
+  exempt: Readonly<Record<string, string>> = CATEGORIES_WITHOUT_SCHEMA_CLOSURE,
+): SchemaClosureExemptionCoverage {
+  const onDisk = new Set(allCategories);
+  const withSchemaDir = new Set(categoriesWithSchemaDir);
+  const declared = Object.keys(exempt).sort();
+
+  return {
+    stale: declared.filter((c) => withSchemaDir.has(c)),
+    orphaned: declared.filter((c) => !onDisk.has(c)),
+  };
+}
+
+/** True when {@link schemaClosureExemptionCoverage} found nothing to report. */
+export function schemaClosureExemptionsAreClean(coverage: SchemaClosureExemptionCoverage): boolean {
+  return coverage.stale.length === 0 && coverage.orphaned.length === 0;
+}
+
+/**
+ * The build-stopping message for {@link schemaClosureExemptionCoverage}.
+ *
+ * Names the entry, the file holding it, and what to do — a message that only
+ * said "exemption mismatch" would leave the reader to work out which of the
+ * two directions fired and which way to edit.
+ */
+export function formatSchemaClosureExemptionCoverage(coverage: SchemaClosureExemptionCoverage): string {
+  return (
+    `CATEGORIES_WITHOUT_SCHEMA_CLOSURE in scripts/lib/schema-closure.ts no longer describes this tree:\n\n` +
+    [
+      ...coverage.stale.map(
+        (c) =>
+          `    - ${c} (declared to ship no schema closure, but json-schema/${c}/ now exists — ` +
+          `delete the entry so the category is checked like every other one)`,
+      ),
+      ...coverage.orphaned.map(
+        (c) => `    - ${c} (declared, but packages/spec/src/${c}/ is gone — delete the entry)`,
+      ),
+    ].join('\n') +
+    `\n\nThe map exists so that a category with no json-schema/ directory stops warning ONLY when the\n` +
+    `tree says its absence is intended. An entry that no longer matches the tree silences a reading\n` +
+    `nobody decided to silence, which is the failure this map was added to remove rather than move.\n`
+  );
+}

--- a/packages/spec/scripts/schema-closure.test.ts
+++ b/packages/spec/scripts/schema-closure.test.ts
@@ -1,0 +1,174 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+//
+// Unit pins for the schema-closure exemption (#15870): `gen:docs` stops warning
+// about `json-schema/<category>/` ONLY where the tree declares the absence is
+// intended, and keeps warning everywhere else.
+//
+// These run in milliseconds over pure functions and over source text. The last
+// describe block is the CALLER half, and it is here for the reason
+// `json-schema-out-dir.test.ts` states about its own pair: a unit test over an
+// extracted helper stays green forever if the caller stops calling it.
+//
+// ⚠️ That caller half is a SOURCE-TEXT pin, and what it cannot see is stated
+// rather than left to be discovered: it proves the warning's only emission site
+// is behind the predicate, NOT that a run of the generator behaves that way. A
+// spawned end-to-end run was weighed and rejected — `build-docs.ts` resolves
+// `json-schema/`, `api-surface/` and the repo's `content/docs/references/` from
+// its own `__dirname`, so driving it takes the whole sandbox
+// `build-schemas-check-mode.test.ts` builds, for one console line. The
+// behavioural reading was taken once, by hand, at the change: with
+// `json-schema/data/` moved aside, `gen:docs` printed the warning for `data`
+// and still printed nothing for `meta-spelling`.
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import {
+  CATEGORIES_WITHOUT_SCHEMA_CLOSURE,
+  formatSchemaClosureExemptionCoverage,
+  schemaClosureAbsenceIsDeclared,
+  schemaClosureExemptionCoverage,
+  schemaClosureExemptionsAreClean,
+} from './lib/schema-closure';
+import { CATEGORY_TITLES } from './lib/category-title';
+
+/** This package's root — every read below stays inside it. */
+const PKG_DIR = path.resolve(__dirname, '..');
+const read = (rel: string) => fs.readFileSync(path.join(PKG_DIR, rel), 'utf-8');
+
+describe('CATEGORIES_WITHOUT_SCHEMA_CLOSURE — the declared list', () => {
+  it('declares meta-spelling, and nothing else', () => {
+    // The boundary is the finding, not an implementation detail: `conversions`
+    // and `migrations` are the OTHER two categories with no json-schema
+    // directory, and a search of this tree turns up no equivalent declaration
+    // for either. Pinned so that adding one is a decision someone writes down
+    // rather than a line that slips in beside a refactor.
+    expect(Object.keys(CATEGORIES_WITHOUT_SCHEMA_CLOSURE)).toEqual(['meta-spelling']);
+  });
+
+  it('leaves conversions and migrations warning — the un-silenced half', () => {
+    expect(schemaClosureAbsenceIsDeclared('conversions')).toBe(false);
+    expect(schemaClosureAbsenceIsDeclared('migrations')).toBe(false);
+    expect(schemaClosureAbsenceIsDeclared('meta-spelling')).toBe(true);
+  });
+
+  it('says no for a category nobody has heard of', () => {
+    // The default answer for anything unlisted, which is what makes a category
+    // that goes missing by accident visible instead of self-exempting.
+    expect(schemaClosureAbsenceIsDeclared('iam')).toBe(false);
+    expect(schemaClosureAbsenceIsDeclared('constructor')).toBe(false);
+    expect(schemaClosureAbsenceIsDeclared('toString')).toBe(false);
+  });
+
+  it('names a real citation for every entry, and the cited file really says it', () => {
+    // A citation nobody checked is the shape this map exists to replace. The
+    // control that makes each assertion a reading rather than a tautology: the
+    // phrase is grepped out of the cited file, so deleting the declaration
+    // upstream turns this red instead of leaving a dangling reference.
+    expect(CATEGORIES_WITHOUT_SCHEMA_CLOSURE['meta-spelling']).toContain(
+      'scripts/build-meta-url-spelling.ts',
+    );
+    expect(read('scripts/build-meta-url-spelling.ts')).toContain(
+      '`/meta-spelling` entry ships vocabulary with no schema closure.',
+    );
+    expect(read('src/meta-spelling/manifest-collection-spelling.ts')).toContain(
+      'no schema closure on the vocabulary path',
+    );
+    expect(JSON.parse(read('browser-reachable-entries.json')).browserReachable).toHaveProperty(
+      './meta-spelling',
+    );
+  });
+
+  it('is corroborated by the declared TITLES — Vocabulary, not Protocol', () => {
+    // `CATEGORY_TITLES` is an independent, hand-declared surface, and it draws
+    // the same boundary: the schema-free entry is titled "Vocabulary" while the
+    // two undeclared ones carry the same word every category WITH a schema
+    // closure carries. That agreement is why one entry is defensible and the
+    // other two are not.
+    expect(CATEGORY_TITLES['meta-spelling']).toBe('Meta-Spelling Vocabulary');
+    expect(CATEGORY_TITLES['meta-spelling']).not.toContain('Protocol');
+    expect(CATEGORY_TITLES.conversions).toContain('Protocol');
+    expect(CATEGORY_TITLES.migrations).toContain('Protocol');
+  });
+});
+
+describe('schemaClosureExemptionCoverage — an exemption may not outlive its condition', () => {
+  const declared = { 'meta-spelling': 'because the tree says so' };
+  const categories = ['data', 'meta-spelling', 'ui'];
+
+  it('is clean when the declared category is on disk with no schema directory', () => {
+    const coverage = schemaClosureExemptionCoverage(categories, ['data', 'ui'], declared);
+
+    expect(coverage).toEqual({ stale: [], orphaned: [] });
+    expect(schemaClosureExemptionsAreClean(coverage)).toBe(true);
+  });
+
+  it('reports an exemption whose json-schema directory has appeared', () => {
+    // The category grew a closure, or the citation was never true. Either way
+    // the exemption now hides a real reading, so it has to go.
+    const coverage = schemaClosureExemptionCoverage(categories, ['data', 'meta-spelling', 'ui'], declared);
+
+    expect(coverage.stale).toEqual(['meta-spelling']);
+    expect(coverage.orphaned).toEqual([]);
+    expect(schemaClosureExemptionsAreClean(coverage)).toBe(false);
+  });
+
+  it('reports an exemption whose module directory is gone', () => {
+    const coverage = schemaClosureExemptionCoverage(['data', 'ui'], ['data', 'ui'], declared);
+
+    expect(coverage.stale).toEqual([]);
+    expect(coverage.orphaned).toEqual(['meta-spelling']);
+    expect(schemaClosureExemptionsAreClean(coverage)).toBe(false);
+  });
+
+  it('does NOT report an absent, undeclared category — that is the warning, not an error', () => {
+    // The direction deliberately left out. `conversions` here is absent from
+    // the schema-dir list and absent from `declared`, and the coverage check
+    // stays silent so `build-docs.ts` can print its warning instead of exiting.
+    const coverage = schemaClosureExemptionCoverage(
+      ['conversions', 'data', 'meta-spelling'],
+      ['data'],
+      declared,
+    );
+
+    expect(coverage).toEqual({ stale: [], orphaned: [] });
+    expect(schemaClosureExemptionsAreClean(coverage)).toBe(true);
+  });
+
+  it('names the entry, the file to edit, and which direction fired', () => {
+    const stale = formatSchemaClosureExemptionCoverage({ stale: ['meta-spelling'], orphaned: [] });
+    expect(stale).toContain('meta-spelling');
+    expect(stale).toContain('scripts/lib/schema-closure.ts');
+    expect(stale).toContain('json-schema/meta-spelling/ now exists');
+
+    const orphaned = formatSchemaClosureExemptionCoverage({ stale: [], orphaned: ['hub'] });
+    expect(orphaned).toContain('packages/spec/src/hub/ is gone');
+  });
+});
+
+describe('the caller — build-docs.ts, where the predicate has to be asked', () => {
+  const BUILD_DOCS = read('scripts/build-docs.ts');
+
+  it('emits the warning from exactly one place', () => {
+    // Everything below is a claim about THAT site. A second emission would make
+    // the pin describe half the behaviour while reading fully green.
+    const sites = BUILD_DOCS.match(/Warning: Schema directory/g) ?? [];
+    expect(sites).toHaveLength(1);
+  });
+
+  it('guards it with the predicate, so an undeclared absence still warns', () => {
+    expect(BUILD_DOCS).toContain("from './lib/schema-closure'");
+    expect(BUILD_DOCS).toMatch(
+      /if \(!schemaClosureAbsenceIsDeclared\(category\)\) \{\s*\n\s*console\.log\(`Warning: Schema directory/,
+    );
+  });
+
+  it('runs the both-directions coverage check on the same walk', () => {
+    // The exemption is only safe because it expires: without this call a
+    // declaration would outlive its condition silently, which is the failure
+    // the map replaces rather than the one it introduces.
+    expect(BUILD_DOCS).toContain('schemaClosureExemptionCoverage(Object.keys(CATEGORIES), categoriesWithSchemaDir)');
+    expect(BUILD_DOCS).toContain('schemaClosureExemptionsAreClean(exemptions)');
+  });
+});


### PR DESCRIPTION
Fixes #15870

`pnpm --filter @objectstack/spec gen:docs` printed three
`Warning: Schema directory ... does not exist` lines on every run. This silences
**one** of the three — the only one the tree declares — and deliberately leaves
the other two firing.

## The first step, verbatim (the card's explanation was on trial, not its observation)

The card argued the condition is "permanent and pre-existing" from *all three
directories hold 0 tracked files*. Triage corrected that: `packages/spec/json-schema/`
is entirely gitignored (`.gitignore:63`) because it is a build artifact, so "0 tracked
files" is true of every directory under it and distinguishes nothing. The mandated
first step was to measure the **built** tree instead. All three readings, verbatim:

```
$ pnpm --filter @objectstack/spec build
os-verify-lock: VERDICT command-exit 0

$ ls -d packages/spec/json-schema/conversions \
        packages/spec/json-schema/meta-spelling \
        packages/spec/json-schema/migrations 2>&1
ls: cannot access 'packages/spec/json-schema/conversions': No such file or directory
ls: cannot access 'packages/spec/json-schema/meta-spelling': No such file or directory
ls: cannot access 'packages/spec/json-schema/migrations': No such file or directory

$ pnpm --filter @objectstack/spec gen:docs 2>&1 | grep -n "does not exist"
15:Warning: Schema directory .../packages/spec/json-schema/conversions does not exist
16:Warning: Schema directory .../packages/spec/json-schema/meta-spelling does not exist
17:Warning: Schema directory .../packages/spec/json-schema/migrations does not exist
```

Positive control that `ls` was reading a populated tree and not an empty one: the same
build leaves **15** other category directories in place holding **1576** files. All three
absent after a build, so the card's conclusion stands.

## The mechanism, which nothing had written down

`build-docs.ts` walks the **18** module directories under `packages/spec/src/`
(`CATEGORY_TITLES` holds that list total in both directions). `gen:schema` creates one
`json-schema/CATEGORY/` per entry of the hard-coded **15**-entry `Protocol` namespace map
in `build-schemas.ts`. 18 minus 15 is exactly the three that warn.

`contracts` is the counter-example worth stating, because it is the one people reach for:
it **is** on the `Protocol` map, so it gets `json-schema/contracts/` — empty, 0 files,
because its service interfaces are plain TypeScript rather than Zod. Present-and-empty and
absent-entirely are different states and only the second warns.

## Per-directory declaration search — and its lit control

Searched for a statement that the category ships no schema closure by design, over the
whole repo excluding `dist/` and `CHANGELOG.md`:

```
git grep -n "schema closure"
git grep -n -i -E "schema[- ]free|schemaless|no schema closure|no JSON Schema|without the schema machinery|not a Protocol" -- packages/spec
```

**Control that the searches could return a hit:** the second returns ~100 lines, the first
returns 8, and both include `packages/spec/scripts/build-meta-url-spelling.ts:20`. A zero
below is a reading, not a broken probe.

| directory | declared? | what the search found |
|:--|:--|:--|
| `meta-spelling` | **yes** | `scripts/build-meta-url-spelling.ts:20` — "`/meta-spelling` entry ships vocabulary with no schema closure." Corroborated three more times: `src/meta-spelling/manifest-collection-spelling.ts:21` ("no schema closure on the vocabulary path"); `scripts/lib/category-title.ts:81` titles it **"Meta-Spelling Vocabulary"**, not "Protocol", because the entry "folds without the schema machinery every Protocol category links"; and `browser-reachable-entries.json` declares `./meta-spelling` browser-reachable under the standing schema-free principle. |
| `conversions` | **no** | Zero hits. The only text that mentions its missing directory at all is a comment in `build-docs.ts` section 2, which records it as an asymmetry that comment's guard **deliberately does not act on**. `CATEGORY_TITLES` calls it "Conversions Protocol" — the same word every category **with** a schema closure carries. |
| `migrations` | **no** | Zero hits, and it is the further one from an exemption, not the nearer: `src/migrations/spec-changes.ts` exports five real Zod schemas (`SpecChangesSchema`, `SpecConvertedSchema`, `SpecMigratedSchema`, `SpecSurfaceAddSchema`, `SpecSurfaceRemoveSchema`), so "no schema closure" is not even factually true of it. What is true is that it is not on the `Protocol` map — a fact about a generator's input list, not a declaration about the module. |

So this PR silences `meta-spelling` only. `conversions` and `migrations` keep warning,
which is the deliberate outcome: whether either is intentional is an open question this
change does not answer, and a silenced warning would close it by default in the wrong
direction.

## What changed

- **`packages/spec/scripts/lib/schema-closure.ts`** (new) — `CATEGORIES_WITHOUT_SCHEMA_CLOSURE`,
  a hand-signed map of one entry carrying its citation, plus a both-directions coverage
  check. The exemption is deliberately **not** read off the `Protocol` map: a category
  dropped from that map by accident would exempt itself from the very check that would
  have caught it.
- **`packages/spec/scripts/build-docs.ts`** — the warning is guarded by
  `schemaClosureAbsenceIsDeclared(category)`; the coverage check runs on the same walk and
  stops the build if a declared exemption grows a `json-schema/` directory or loses its
  module directory.
- **`packages/spec/scripts/schema-closure.test.ts`** (new) — 13 pins: the declared list and
  its boundary, the citations grepped out of the files they cite, the coverage in both
  directions plus the direction it deliberately does not report, and the caller wiring.

No empty directory was created to silence anything — the card forbids it and triage
doubled down; an empty directory claims a closure it does not have.

## Ablation — the warning still works for a genuinely missing directory

Each leg proves its mutation landed on disk before reading any result, and each restore is
proven by observing state, never by an exit code.

**Leg A — a directory that should exist, undeclared.** `json-schema/data/` (166 files,
sha256 digest `6df3c80c...`) moved aside; mutation proof: the path is gone and the stashed
copy still holds 166 files. `pnpm check:docs` then printed:

```
Warning: Schema directory .../json-schema/conversions does not exist
Warning: Schema directory .../json-schema/data does not exist      (still fires)
Warning: Schema directory .../json-schema/migrations does not exist
```

Restored; digest and file count both match the baseline exactly.

**Leg B — the exemption expires.** An empty `json-schema/meta-spelling/` created (mutation
proof: the path exists), so the declared exemption no longer describes the tree:

```
check:docs EXIT=1
CATEGORIES_WITHOUT_SCHEMA_CLOSURE in scripts/lib/schema-closure.ts no longer describes this tree:
    - meta-spelling (declared to ship no schema closure, but json-schema/meta-spelling/ now exists — delete the entry so the category is checked like every other one)
```

Removed; the path is gone again.

**Control — unmutated tree, same command:** `check:docs` **EXIT=0**, and only `conversions`
and `migrations` warn. `meta-spelling` is silent.

**Reverse verification of the caller pin.** Predicted direction: red. With the guard
deleted from `build-docs.ts` (anchor count 1 to 0, blob `010cdaea` to `f6f4b003`),
`schema-closure.test.ts` went `1 failed | 12 passed`, failing exactly the pin that claims
the guard is there. Restored with `git checkout HEAD --`, blob back to `010cdaea` and
`git diff HEAD` empty for the path; control run 13 passed.

## Verification

Every verdict below is the command's own printed line with its exit code captured before
any pipe. Head at the time of the runs: `d70a3c0929`.

| what | verdict |
|:--|:--|
| `pnpm --filter @objectstack/spec test` | **exit 0** — `Test Files 483 passed (483)`, `Tests 13115 passed (13115)` |
| `pnpm --filter @objectstack/spec typecheck` | **exit 0** — `tsc --noEmit`, `check:scripts-typecheck`, `check:test-typecheck` all green |
| coverage of the new files | measured, not assumed: `tsc -p tsconfig.scripts.json --listFiles` lists **both** new files, and that is the project `check:scripts-typecheck` runs |
| derived gate families (`node scripts/pm/dispatch-gates.mjs --commands`) | **56 derived, 56 run**; `--ran` reconciliation printed `56 derived famil(ies) accounted for` |
| of those 56 | **54 exit 0**. 2 exit **3 = `PREREQUISITE NOT MET`** (`check:dual-build-cjs-loads`, `check:type-check-debt`) — both need the whole workspace built and both say in their own words "this is NOT a pass: nothing was measured". Reported as NOT MEASURED, left to CI, not as failures. |
| `pnpm --filter @objectstack/spec check:docs` | **exit 0** — the generated docs are byte-identical; this change alters console output only |
| `pnpm lint` (`eslint . --no-inline-config`, whole repo, not narrowed) | **exit 0** |
| `pnpm check:nul-bytes` plus a hand scan with the control-byte grep over the three touched files | **exit 0** / no hits |

One note for the reviewer: `dispatch-gates` flagged that `scripts/engine-double-contract.pinned.json`
moved on `origin/main` after this branch was cut. This diff does not touch it and
`check:engine-double-contract` is green here; CI will run the newer roster.

## Changeset: none owed

`skip-changeset` applies, and the reasoning is mechanical rather than a judgement call:
the whole diff is under `packages/spec/scripts/`, which is **not** in the package's
`files[]`, is **not** an `exports` subpath, and is **not** a `tsup` entry — nothing in it
reaches a published artifact. `check:docs` exits 0 on the unmutated tree, so the generated
`content/docs/references/` output is unchanged too. No consumer can observe this release,
so it releases nothing.

## `enhancement`, not `bug` — the type the measurement supports

The build does not drop directories: `gen:schema` emits exactly the 15 categories its
`Protocol` map names, `gen:docs` exits 0, and the reference docs are byte-identical before
and after. Nothing is broken, so this is not a repair. What it removes is an
unconditionally-true line in a diagnostic channel — in the card's own words, *a warning
that fires unconditionally for an intended condition is a warning readers learn to skim,
which is how a real one later gets skimmed too*. That is an `enhancement`.

## Clause 2: no

Confirmed mechanically, not recalled. Path limb: `node scripts/pm/dispatch-gates.mjs --tier`
prints *"no path-derived mandate: the surface hits none of the 3 declared glob(s)"* —
`SUSPECT_TIER_GLOBS` is `packages/spec/src/**` and this diff is entirely under
`packages/spec/scripts/**`. Content limb: no published schema surface (not in `files[]`,
no `exports` subpath, no `tsup` entry, and nothing outside `packages/spec/scripts/`
imports the new module), and no accept-set movement — `check:docs` exit 0 means no
generated byte moved.

---
_Generated by [Claude Code](https://claude.ai/code/session_01T6HeZvT9wdSJD1ZxJb5Eno)_