### PR TITLE
lint(security-posture): record which intakes can reach `security-owd-alias` — measured, annotated, pinned

### DIFF
--- a/packages/lint/src/authoring-rule-input-tier.test.ts
+++ b/packages/lint/src/authoring-rule-input-tier.test.ts
@@ -32,12 +32,20 @@
 // to see pre-parse evidence".
 
 import { describe, expect, it, vi } from 'vitest';
-import { defineStack, normalizeStackInput } from '@objectstack/spec';
+import {
+  ObjectStackSchema,
+  applyConversionsToStoredItem,
+  defineStack,
+  normalizeStackInput,
+} from '@objectstack/spec';
+import { getMetadataTypeSchema } from '@objectstack/spec/kernel';
 
 import { validateListViewMode } from './validate-list-view-mode.js';
 import { validateViewContainers } from './validate-view-containers.js';
 import { validateVisibilityPredicates } from './validate-visibility-predicates.js';
 import { runAuthoringRules } from './authoring-rules.js';
+import { runRuntimeAuthoringRules } from './runtime-gate.js';
+import { SECURITY_OWD_ALIAS } from './validate-security-posture.js';
 
 type AnyRec = Record<string, unknown>;
 
@@ -372,5 +380,110 @@ describe('what `normalized` DOES buy: findings survive a schema error that stops
     const rules = new Set(findings.map((f) => f.rule));
     expect(rules.has('list-view-filters-in-views-mode')).toBe(true);
     expect(rules.has('view-container-shape')).toBe(true);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// #16109 — `security-owd-alias` reaches the rule ONLY through the unparsed doors.
+//
+// `ObjectSchema.sharingModel` / `externalSharingModel` are closed enums
+// (ADR-0090 D4 / D11): every alias the rule names is refused with
+// `invalid_value` on any door that parses before the registry runs, so on a
+// `defineStack`-authored app the rule is dead by construction — the card's own
+// hotcrm measurement. It is NOT dead: `os lint` never parses, `loadConfig`
+// hands a raw object-literal config on as authored, and the ADR-0087 stored-row
+// conversion for these aliases is `retiredFromLoadPath`, so the alias survives
+// `normalizeStackInput` and the rule is the only diagnostic that door gets.
+// Each leg below is paired with the parsed-door control taken in the same run;
+// the module docblock's "## Intake" table in `validate-security-posture.ts`
+// is the prose form of these pins.
+describe('security-owd-alias reaches the rule only through the unparsed doors (#16109)', () => {
+  const owdObject = (sharingModel: string) => ({
+    name: 'tier_owd',
+    label: 'OWD',
+    sharingModel,
+    fields: { title: { type: 'text', label: 'Title' } },
+  });
+  const rawStack = (sharingModel: string) => ({ manifest, objects: [owdObject(sharingModel)] });
+  const aliasFindings = (findings: readonly { rule: string; path: string }[]) =>
+    findings.filter((f) => f.rule === SECURITY_OWD_ALIAS).map((f) => f.path);
+  /** Every key of the rule's `OWD_ALIAS_FIX` map. */
+  const ALIASES = ['read', 'read_write', 'full', 'public'] as const;
+
+  it.each(ALIASES)('CONTROL — defineStack (strict default) refuses %s at load, before any rule runs', (alias) => {
+    const { error } = quietly(() => defineStack(rawStack(alias) as never));
+    expect(error).toBeDefined();
+    expect(error!.message).toContain('objects.0.sharingModel');
+  });
+
+  it.each(ALIASES)('CONTROL — the os validate / os compile schema step refuses %s on a raw config', (alias) => {
+    const parsed = ObjectStackSchema.safeParse(normalizeStackInput(rawStack(alias)));
+    expect(parsed.success).toBe(false);
+    const issue = parsed.success ? undefined : parsed.error.issues.find((i) => i.path.join('.') === 'objects.0.sharingModel');
+    expect(issue?.code).toBe('invalid_value');
+  });
+
+  it.each(ALIASES)('INTAKE — os lint on a raw object-literal config hands %s to the rule intact, and the rule fires', (alias) => {
+    // Exactly the call `lint.ts` makes: `loadConfig` (no parse) → `normalizeStackInput`
+    // → `runAuthoringRules('lint', { normalized })`. No conversion notice fires:
+    // `owd-legacy-read-aliases` is retired from the load path, and `full` /
+    // `public` never had one.
+    const notices: string[] = [];
+    const normalized = normalizeStackInput(rawStack(alias), {
+      onConversionNotice: (n) => notices.push(n.conversionId),
+    }) as AnyRec;
+    expect((normalized.objects as AnyRec[])[0].sharingModel).toBe(alias);
+    expect(notices).toEqual([]);
+    expect(aliasFindings(runAuthoringRules('lint', { normalized }))).toEqual(['objects[0].sharingModel']);
+  });
+
+  it('INTAKE — defineStack(x, { strict: false }) skips the parse, so the alias reaches os lint too', () => {
+    const loose = quietly(() => defineStack(rawStack('read_write') as never, { strict: false })).value as AnyRec;
+    expect((loose.objects as AnyRec[])[0].sharingModel).toBe('read_write');
+    expect(aliasFindings(runAuthoringRules('lint', { normalized: normalizeStackInput(loose) as AnyRec }))).toEqual([
+      'objects[0].sharingModel',
+    ]);
+  });
+
+  it('CONTROL — the rule is silent on a canonical value through the same unparsed door', () => {
+    const normalized = normalizeStackInput(rawStack('public_read')) as AnyRec;
+    expect(aliasFindings(runAuthoringRules('lint', { normalized }))).toEqual([]);
+  });
+
+  it.each(ALIASES)('CONTROL — the runtime publish door refuses %s with the object schema before the gate runs', (alias) => {
+    // `saveMetaItem` runs `getMetadataTypeSchema('object').safeParse` and 422s
+    // BEFORE `runRuntimeAuthoringRules`; the gate never sees this item.
+    const schema = getMetadataTypeSchema('object');
+    expect(schema).toBeDefined();
+    const parsed = schema!.safeParse(owdObject(alias));
+    expect(parsed.success).toBe(false);
+    expect(parsed.success ? undefined : parsed.error.issues.find((i) => i.path.join('.') === 'sharingModel')?.code).toBe('invalid_value');
+  });
+
+  it('INTAKE — runRuntimeAuthoringRules called directly with an unparsed item fires (the exported API is a door)', () => {
+    const result = runRuntimeAuthoringRules({
+      type: 'object',
+      item: owdObject('full'),
+      context: { objects: [], permissions: [], books: [], datasets: [], pages: [] },
+    });
+    expect(aliasFindings(result.errors)).toEqual(['objects.tier_owd.sharingModel']);
+  });
+
+  it('CONTROL — a pre-D4 stored sibling does not surface: read/read_write fold on rehydration, and the gate diff cancels the rest', () => {
+    // The stored-row chain replays retired conversions, so `read` / `read_write`
+    // come back canonical…
+    expect((applyConversionsToStoredItem('object', owdObject('read')) as AnyRec).sharingModel).toBe('public_read');
+    expect((applyConversionsToStoredItem('object', owdObject('read_write')) as AnyRec).sharingModel).toBe('public_read_write');
+    // …`full` / `public` have no conversion and come back as authored…
+    const storedFull = applyConversionsToStoredItem('object', owdObject('full')) as AnyRec;
+    expect(storedFull.sharingModel).toBe('full');
+    // …and even so, a sibling in the gate's universe produces the finding in
+    // BOTH the baseline and the candidate pass, so it never leaves the gate.
+    const result = runRuntimeAuthoringRules({
+      type: 'object',
+      item: { ...owdObject('private'), name: 'tier_other' },
+      context: { objects: [storedFull], permissions: [], books: [], datasets: [], pages: [] },
+    });
+    expect(aliasFindings(result.errors)).toEqual([]);
   });
 });

--- a/packages/lint/src/authoring-rule-input-tier.test.ts
+++ b/packages/lint/src/authoring-rule-input-tier.test.ts
@@ -407,8 +407,14 @@ describe('security-owd-alias reaches the rule only through the unparsed doors (#
   const rawStack = (sharingModel: string) => ({ manifest, objects: [owdObject(sharingModel)] });
   const aliasFindings = (findings: readonly { rule: string; path: string }[]) =>
     findings.filter((f) => f.rule === SECURITY_OWD_ALIAS).map((f) => f.path);
-  /** Every key of the rule's `OWD_ALIAS_FIX` map. */
-  const ALIASES = ['read', 'read_write', 'full', 'public'] as const;
+  /** Every key of the rule's `OWD_ALIAS_FIX` map, with the canonical value its fix-it names. */
+  const ALIAS_FIX = {
+    read: 'public_read',
+    read_write: 'public_read_write',
+    full: 'public_read_write',
+    public: 'public_read_write',
+  } as const;
+  const ALIASES = Object.keys(ALIAS_FIX) as (keyof typeof ALIAS_FIX)[];
 
   it.each(ALIASES)('CONTROL — defineStack (strict default) refuses %s at load, before any rule runs', (alias) => {
     const { error } = quietly(() => defineStack(rawStack(alias) as never));
@@ -434,7 +440,13 @@ describe('security-owd-alias reaches the rule only through the unparsed doors (#
     }) as AnyRec;
     expect((normalized.objects as AnyRec[])[0].sharingModel).toBe(alias);
     expect(notices).toEqual([]);
-    expect(aliasFindings(runAuthoringRules('lint', { normalized }))).toEqual(['objects[0].sharingModel']);
+    const findings = runAuthoringRules('lint', { normalized }).filter((f) => f.rule === SECURITY_OWD_ALIAS);
+    expect(findings.map((f) => f.path)).toEqual(['objects[0].sharingModel']);
+    // The fix-it is what this door gets that the enum's `invalid_value` does not
+    // — and it is the ALIAS branch's own contribution: the sibling
+    // "not canonical" branch names the same rule id at the same path but no
+    // replacement, so this line is what tells the two apart.
+    expect(findings[0].hint).toContain(`sharingModel: '${ALIAS_FIX[alias]}'`);
   });
 
   it('INTAKE — defineStack(x, { strict: false }) skips the parse, so the alias reaches os lint too', () => {

--- a/packages/lint/src/validate-security-posture.ts
+++ b/packages/lint/src/validate-security-posture.ts
@@ -9,7 +9,7 @@
  * | Rule                                    | Origin                          |
  * |-----------------------------------------|---------------------------------|
  * | security-owd-unset            (error)   | objectui#2348 leave_request 事故 |
- * | security-owd-alias            (error)   | ADR-0090 D4 canonical enum      |
+ * | security-owd-alias            (error)   | ADR-0090 D4 canonical enum — UNPARSED intakes only, see § Intake |
  * | security-external-wider       (error)   | ADR-0090 D11 external ≤ internal|
  * | security-wildcard-vama        (error)   | ADR-0066 superuser wildcard     |
  * | security-anchor-high-privilege(error)   | ADR-0090 D5/D9 anchors — declared `everyone` suggestions (`isDefault: true`) only; a `guest`-bound set is outside a package-time linter's sight and is the bind-time gate's alone (#16110) |
@@ -75,6 +75,44 @@
  * Directive #12). Here it also silently downgraded a NAMED rejection into an
  * inert branch — and an inert branch in a security linter reads, to the next
  * author, as a gate that is watching (#4984, #5009, #5017).
+ *
+ * ## Intake — which doors can reach `security-owd-alias` at all (#16109)
+ *
+ * `sharingModel` and `externalSharingModel` are CLOSED enums on `ObjectSchema`
+ * (ADR-0090 D4 / D11): every value `OWD_ALIAS_FIX` names, and every
+ * non-canonical string, is refused by the schema with `invalid_value`. So on
+ * any door that PARSES before the registry runs, this rule's alias branches
+ * are unreachable by construction — the object never arrives. Measured on
+ * this package's dist (the pins live in `authoring-rule-input-tier.test.ts`,
+ * "security-owd-alias reaches the rule only through the unparsed doors"):
+ *
+ * | door                                                        | alias reaches the rule? |
+ * |-------------------------------------------------------------|-------------------------|
+ * | `defineStack(x)` (strict default) — every TS config that     | no — refused at load    |
+ * |   `os init` scaffolds, hence `os validate`/`os build`/       |                         |
+ * |   `os lint` on such a config                                 |                         |
+ * | `os validate` / `os compile` schema step on a RAW config     | no — stops before rules |
+ * | `saveMetaItem` (Studio / REST `/meta` / MCP) — the runtime   | no — 422 before the gate|
+ * |   publish gate runs AFTER `getMetadataTypeSchema('object')`   |                         |
+ * | a pre-D4 stored `sys_metadata` sibling in the gate's universe | no — cancels in the diff|
+ * | **`os lint` on a RAW object-literal config** (never parses;   | **yes — fires**         |
+ * |   `loadConfig` returns the default export as authored, and   |                         |
+ * |   `owd-legacy-read-aliases` is `retiredFromLoadPath`, so      |                         |
+ * |   `normalizeStackInput` leaves the alias intact)              |                         |
+ * | **`defineStack(x, { strict: false })`**                        | **yes — fires**         |
+ * | **`check:doc-security-posture`** (docs gate: statically        | **yes — fires**; its    |
+ * |   evaluated `ObjectSchema.create({...})` literals, no parse)   | self-test asserts it    |
+ * | **`runRuntimeAuthoringRules` / `validateSecurityPosture`      | **yes — fires**         |
+ * |   called directly with an unparsed item** (exported API)      |                         |
+ *
+ * Read the two alias branches below accordingly: they are NOT a second
+ * opinion on the enum, and they are dead on the parsed doors on purpose. They
+ * exist so the UNPARSED doors — `os lint` first, the docs gate second — name
+ * the canonical replacement instead of letting a retired spelling ride to
+ * `os build`, where the enum's generic `invalid_value` is the only message. A
+ * consumer crediting this rule id as live `error` coverage on a
+ * `defineStack`-authored app is crediting the wrong gate: on that door the
+ * credit belongs to the schema's closed enum.
  */
 
 import { describeAnchorForbiddenBits } from '@objectstack/spec/security';
@@ -346,6 +384,10 @@ export function validateSecurityPosture(stack: AnyRec, opts?: { nowMs?: number }
             `'public_read', 'public_read_write', or 'controlled_by_parent' (master-detail children).`,
         });
       } else if (typeof owd === 'string' && OWD_ALIAS_FIX[owd]) {
+        // Reachable ONLY through the unparsed doors (`os lint` on a raw
+        // config, `strict: false`, the docs gate, a direct call) — the D4 enum
+        // refuses this value on every parsed door before the registry runs.
+        // See "## Intake" in this module's docblock (#16109).
         findings.push({
           severity: 'error',
           rule: SECURITY_OWD_ALIAS,
@@ -462,6 +504,8 @@ export function validateSecurityPosture(stack: AnyRec, opts?: { nowMs?: number }
     // external ≤ internal. controlled_by_parent inherits the master's pair.
     if (typeof external === 'string') {
       if (OWD_ALIAS_FIX[external]) {
+        // Same intake note as the `sharingModel` alias branch above: the D11
+        // enum is closed, so only the unparsed doors can deliver this value.
         findings.push({
           severity: 'error',
           rule: SECURITY_OWD_ALIAS,


### PR DESCRIPTION
Fixes #16109

## What this PR is

The card's primary ask was a **measurement**: which `@objectstack/lint` intakes can hand `validateSecurityPosture` a `sharingModel` that never passed `ObjectSchema.parse`? Triage (comment 5556566227) ordered the branches: no such intake, retire the dead branches; such an intake exists, do NOT retire, annotate the rule with its intake and update the coverage table's wording. **The measurement found intakes, so this PR takes the annotate branch** and changes no behaviour: the rule source diff is comment-only (proved below), plus a pin test that keeps the measurement honest. `packages/spec`'s two enums are untouched.

## Step 1 — the measurement (branch `b8c72ac052`, base `c383352cb7`)

Every leg was taken in one run against the freshly built dist of `spec`, `formula`, `sdui-parser` and `lint` (`pnpm --filter '@objectstack/lint...' build`, exit 0), for each of the four `OWD_ALIAS_FIX` keys (`read`, `read_write`, `full`, `public`). The `os lint` leg was additionally taken end to end with the CLI's real loader: `loadConfig` (bundle-require, no parse) from `packages/cli/src/utils/config.ts` on a raw `objectstack.config.ts`, then exactly the call `lint.ts` makes.

| door | what reaches the rule | `security-owd-alias`? | role |
|:--|:--|:--|:--|
| `defineStack(x)` (strict default) — every `os init` config, hence `os validate` / `os build` / `os lint` on such a config | nothing: `defineStack validation failed … objects.0.sharingModel: Invalid value` at load | no | **positive control** (parses) |
| `os validate` / `os compile` schema step (`ObjectStackSchema.safeParse`) on a RAW config | refused `invalid_value` at `objects.0.sharingModel`; compile stops before any rule | no | positive control |
| `saveMetaItem` (Studio / REST meta / MCP) — the runtime publish gate | refused 422 `invalid_value` at `sharingModel` by `getMetadataTypeSchema('object')`, which runs BEFORE `runRuntimeAuthoringRules` (`protocol.ts`, "Placed immediately after the schema check") | no | positive control |
| a pre-D4 stored `sys_metadata` sibling in the gate's context universe | `read` / `read_write` fold to canonical on rehydration (`applyConversionsToStoredItem`, full chain incl. retired); `full` / `public` come back as authored — and either way the finding is produced in BOTH baseline and candidate passes and cancels in the diff | no | control |
| **`os lint` on a RAW object-literal config** | `loadConfig` returns the default export as authored; `os lint` never parses (`content/docs/deployment/cli.mdx`, `lint.ts`); `owd-legacy-read-aliases` is `retiredFromLoadPath`, so `normalizeStackInput` leaves the alias intact (0 conversion notices) | **yes — `error` at `objects[0].sharingModel`, hint names the canonical value** | **bypassing intake** |
| **`defineStack(x, { strict: false })`** then `os lint` | parse skipped; alias intact | **yes** | bypassing intake |
| **`check:doc-security-posture`** (`packages/lint/scripts/check-doc-security-posture.mjs`, wired in `lint.yml`) | statically evaluated `ObjectSchema.create({...})` literals from docs and skills, never parsed; its own `--self-test` asserts the alias value is flagged — the gate ran green here: "self-test: flags the measured defect (owd-unset) and the alias value at the right page line" | **yes** | bypassing intake, CI-wired |
| **`runRuntimeAuthoringRules` / `validateSecurityPosture` called directly** (both exported) | item handed in unparsed | **yes** (`objects.tier_owd.sharingModel`) | bypassing intake (public API) |

Re-derivation of the card's own hotcrm reading: the first row is it. On a `defineStack`-authored app the alias never arrives, and the sibling `security-owd-unset` branch fires on the byte-adjacent removal — the card was right about that door and wrong that it is the only door.

The four yaml mentions under `packages/lint/src` triage noted are prose (`object-graph.ts`: "a YAML list item left empty is `null`") and three tests; there is no yaml reader in the package. `runRuntimeAuthoringRules`'s only production caller is `metadata-protocol`'s `evaluateRuntimeAuthoringGate`, which sits behind the schema step above.

## Step 3 — what changed

- `packages/lint/src/validate-security-posture.ts` — comment-only: the header table row marks the rule "UNPARSED intakes only", a new `## Intake` section carries the table above, and both alias branches (`sharingModel`, `externalSharingModel`) carry a one-line pointer. Code with comments stripped is byte-identical to `main` (measured: identical, 18166 chars both sides).
- `packages/lint/src/authoring-rule-input-tier.test.ts` — a describe block pinning every leg with its parsed-door control: `defineStack` refuses each alias; the schema step refuses each alias; `os lint`'s call fires with the canonical fix-it in the hint (0 conversion notices); `strict: false` fires; the canonical value stays silent; `getMetadataTypeSchema('object')` refuses each alias; a direct `runRuntimeAuthoringRules` call fires; a stored sibling folds (`read`, `read_write`) or survives (`full`) and cancels in the diff either way.

Why not the retire branch: retiring the branches would also have to delete the `check:doc-security-posture` self-test that asserts the alias verdict, and would take the only fix-it the `os lint` pre-flight gives a raw config carrying a retired spelling.

## Re-route flag for the PM (triage's escalation clause)

Branch 3 taken, so per triage the card becomes "update the coverage table's wording", cross-seat. `objectstack-ai/hotcrm` is outside this session's scope; nothing was opened there. Suggested wording for hotcrm #1586's step-3 table row (the seat that owns it should confirm the row's current text):

> `security-owd-alias` (error) — **applies to unparsed intakes only**: `os lint` on a raw object-literal config, `defineStack(x, { strict: false })`, the `check:doc-security-posture` docs gate, and direct API calls. On a `defineStack`-authored app such as this one the value is refused earlier by `ObjectSchema`'s closed `sharingModel` / `externalSharingModel` enums (`invalid_value` at config load, exit 1; ADR-0090 D4 / D11) — the platform gate to credit for retiring a local alias assertion is **the spec enum, not this rule id**.

## Tests and gates (all on `b8c72ac052`)

- `pnpm --filter @objectstack/lint exec vitest run --maxWorkers=2 src/authoring-rule-input-tier.test.ts src/validate-security-posture.test.ts src/validate-security-posture.runtime-surface.test.ts src/rule-id-barrel-exports.test.ts src/authoring-rule-wiring.test.ts` — `Test Files 5 passed (5)`, `Tests 191 passed (191)`; `os-verify-lock: VERDICT command-exit 0`.
- `pnpm --filter @objectstack/lint typecheck` (tsc plus `check:test-typecheck` over `tsconfig.test.json`, whose `include` is `src/**/*` so the new pins are compiled) — `VERDICT command-exit 0`.
- Ablation, on the committed tree, restore by `git checkout HEAD -- path`, hash equal to the HEAD blob afterwards (`d616b72f…`): green leg 35/35; disabling the `sharingModel` alias branch alone (marker on disk 1, anchor 0) — red, 4 INTAKE pins fail on the missing fix-it; disabling both `sharingModel` alias branches (the retirement shape; marker 2, anchors 0) — red, 6 INTAKE pins fail. A first ablation attempt that disabled only branch 1 while the pins held rule id and path alone stayed green: the sibling "not canonical" branch emits the same id at the same path. That reading is why the pins now hold the fix-it hint.
- `node scripts/pm/dispatch-gates.mjs --commands --repo objectstack-ai/objectstack` derived 45 commands; all 45 ran, `dispatch-gates --ran: 45 derived famil(ies) accounted for — 45 run, 0 NOT-MEASURED` (43 exit 0). Two answered `PREREQUISITE NOT MET` exit 3 because they read a whole-repo build (`check:dual-build-cjs-loads`, `check:type-check-debt`) — NOT MEASURED here, declared to CI. `pnpm check:nul-bytes` OK (8099 files). `pnpm --filter @objectstack/lint run check:doc-security-posture` green.
- **Declared narrowing.** `turbo ls --affected` against the base lists 54 packages (every consumer of `@objectstack/lint`). Only `@objectstack/lint` was tested locally: the runtime source diff is comment-only (stripped-comment source identical to `main`), so no downstream consumer can observe a behaviour change; CI runs the full affected set.
- Changeset: none — comments and tests only, nothing published changes; `skip-changeset` applies.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vbw3RPgdtqesx4azk9SbW8)_