### PR TITLE
fix(spec): stop GetMetaItemsRequestSchema.organizationId promising it is always consulted

### DIFF
--- a/.changeset/getmetaitems-organization-id-describe-precision.md
+++ b/.changeset/getmetaitems-organization-id-describe-precision.md
@@ -1,0 +1,13 @@
+---
+"@objectstack/spec": patch
+---
+
+`GetMetaItemsRequestSchema.organizationId` no longer documents itself as always consulted.
+
+The published `describe()` opened with "Selects the org partition in the ADR-0005 overlay read order" and closed with "Absent = environment-wide read: only env-level overlays apply and no org partition is consulted." Stating only the absent case invites the converse, and an integrator reading it completes it as *present ⇒ consulted* — so a caller who supplies an organization believes it has scoped a read that can in fact be environment-wide. A supplied organization is not consulted on every `getMetaItems` read.
+
+The corrected text qualifies the promise instead of implying its converse: the parameter selects the org partition **when an org partition applies**, and supplying a value "does not by itself guarantee an org partition is consulted; where none applies, and whenever it is absent, the read is environment-wide and only env-level overlays apply."
+
+Prose only. No key is added, removed or renamed, no export moves, no accept set changes and no runtime behaviour changes — the schema's shape and validation are byte-for-byte what they were. What ships is the JSON-Schema `description` for the existing `organizationId` key and the matching row in the generated API reference, which is why this is user-visible enough to owe an entry and narrow enough to be a patch.
+
+The three sibling `organizationId` describes on `GetMetaItemRequestSchema`, `GetMetaItemLayeredRequestSchema` and `GetMetaItemCachedRequestSchema` are deliberately left alone.

--- a/content/docs/references/api/protocol.mdx
+++ b/content/docs/references/api/protocol.mdx
@@ -1317,7 +1317,7 @@ Enable package response
 | :--- | :--- | :--- | :--- |
 | **type** | `string` | ✅ | Metadata type name (e.g., "object", "plugin") |
 | **packageId** | `string` | optional | Optional package ID to filter items by |
-| **organizationId** | `string` | optional | Organization (tenant) scope for the read. Selects the org partition in the ADR-0005 overlay read order — org overlay wins over env-wide overlay wins over packaged artifact — so it decides which tenant's customization rows are merged into the list. Absent = environment-wide read: only env-level overlays apply and no org partition is consulted. |
+| **organizationId** | `string` | optional | Organization (tenant) scope for the read. When an org partition applies, this selects it in the ADR-0005 overlay read order — org overlay wins over env-wide overlay wins over packaged artifact — so it decides which tenant's customization rows are merged into the list. Supplying a value does not by itself guarantee an org partition is consulted; where none applies, and whenever it is absent, the read is environment-wide and only env-level overlays apply. |
 | **previewDrafts** | `boolean` | optional | Draft-visibility switch (ADR-0033 draft-overlay preview): when true, pending `state='draft'` rows are overlaid on the active list — draft wins on name collision, draft-only items appear, and each overlaid item is tagged `_draft: true` so UIs can badge the preview. Absent/false = published world only. Declaration ≠ authorization: this member only switches which rows are read, and ADR-0106 masking is unaffected — callers without draft-preview authorization are refused upstream (admin-gated), not by this schema. |
 
 

--- a/packages/spec/src/api/protocol.zod.ts
+++ b/packages/spec/src/api/protocol.zod.ts
@@ -233,11 +233,13 @@ export const GetMetaItemsRequestSchema = lazySchema(() => z.object({
   type: z.string().describe('Metadata type name (e.g., "object", "plugin")'),
   packageId: z.string().optional().describe('Optional package ID to filter items by'),
   organizationId: z.string().optional().describe(
-    'Organization (tenant) scope for the read. Selects the org partition in the '
-    + 'ADR-0005 overlay read order — org overlay wins over env-wide overlay wins '
-    + 'over packaged artifact — so it decides which tenant\'s customization rows '
-    + 'are merged into the list. Absent = environment-wide read: only env-level '
-    + 'overlays apply and no org partition is consulted.',
+    'Organization (tenant) scope for the read. When an org partition applies, '
+    + 'this selects it in the ADR-0005 overlay read order — org overlay wins '
+    + 'over env-wide overlay wins over packaged artifact — so it decides which '
+    + 'tenant\'s customization rows are merged into the list. Supplying a value '
+    + 'does not by itself guarantee an org partition is consulted; where none '
+    + 'applies, and whenever it is absent, the read is environment-wide and '
+    + 'only env-level overlays apply.',
   ),
   previewDrafts: z.boolean().optional().describe(
     'Draft-visibility switch (ADR-0033 draft-overlay preview): when true, '


### PR DESCRIPTION
Fixes #14772

`Clause-②: no` — no exported symbol, no payload key, no accept-set movement. Confirmed mechanically, not asserted: see *Clause ② confirmation* below.

## What changed

One `describe()` string, on `GetMetaItemsRequestSchema.organizationId` in `packages/spec/src/api/protocol.zod.ts`, plus the generated reference row it compiles into and the owed changeset. No key added, removed or renamed; no export moved; no runtime behaviour touched.

The old text opened with an unconditional *"Selects the org partition in the ADR-0005 overlay read order"* and closed with *"Absent = environment-wide read: only env-level overlays apply and no org partition is consulted."* Stating only the absent case invites the converse, and a reader completes it as **present ⇒ consulted**. A supplied organization is not consulted on every `getMetaItems` read, so that completion is false.

The correction qualifies the promise instead of implying its converse — the parameter selects the org partition **when an org partition applies**, and *"Supplying a value does not by itself guarantee an org partition is consulted; where none applies, and whenever it is absent, the read is environment-wide and only env-level overlays apply."*

Per the maintainer cap on the card (comment 5536474187): **no registry clause**, the flag is not named, and no new `packages/spec` key is added. ADR-0131 D6/D7 retires the per-organization partition wholesale, so teaching vocabulary for a mechanism with about one release to live would cost a changeset going in and another coming out. The escape hatch the maintainer offered was not needed: a true, useful sentence exists without naming the mechanism.

## Scope: one row of four, deliberately

The four sibling sites share a byte-exact opening. Relocated **by symbol**, not by line number:

| schema | line found | card's line | drift |
|---|---|---|---|
| `GetMetaItemsRequestSchema` | `:236` | `:236` | none — **fixed here** |
| `GetMetaItemRequestSchema` | `:271` | `:271` | none — left alone |
| `GetMetaItemLayeredRequestSchema` | `:441` | `:441` | none — left alone |
| `GetMetaItemCachedRequestSchema` | `:1815` | `:1815` | none — left alone |

Population grepped on the **opening** phrase = 4. The *closing* phrase returns 2, reproducing the near-miss triage recorded. Control: `organizationId` occurs 11 times in the file, matching the card's prediction.

The other three rows are **not** touched. My reading agrees with the PM's that `:271` and `:441` are now imprecise in the same way, and the downstream trace is in the report on the card — but widening is the maintainer's call under the ADR-0131 clock, and triage wrote the standing instruction for exactly this case: report it, do not act on it. Out of scope here: #14770 remains open, and the ETag question named on the card is untouched.

## Clause ② confirmation (mechanical, two-direction)

Both gates green on this diff — and both proven able to say otherwise, on the very schema this PR edits, rather than read as a bare green.

| gate | on this diff | under mutation | restored |
|---|---|---|---|
| `check:api-surface` | exit 0 | **exit 1** — *"0 breaking (removed/narrowed), 1 added"* | exit 0 |
| `check:authorable-surface` | exit 0 | **exit 1** — names `+ api/GetMetaItemsRequest:ablationProbeKey` | exit 0 |

The mutation added a public export and a payload key to `GetMetaItemsRequestSchema`; each leg proved the edit reached disk (blob hash vs the HEAD blob) and, for the dist-resolved gate, reached `dist/` via `scripts/ablation-dist-preflight.mjs` (`--absent` on the restore leg). Restore is proven by an empty `git diff HEAD` and the source blob hash returning to HEAD's, not by an exit code.

One confound found and corrected rather than reported as a pass: `pnpm --filter @objectstack/spec build` **regenerates** `authorable-surface/api.json`, so the first attempt at that gate's red leg was masked by its own baseline moving with the mutation. The un-confounded run mutates the source and runs the gate with no rebuild in between.

Independently, neither artifact records `describe()` text at all, while `GetMetaItemsRequest` *is* present in `authorable-surface/api.json` — so these greens mean "the gate looked at this schema and no key moved", not "the gate never looked".

## Verification

- Regenerated with the repo's own tooling only — `check:generated` proved `content/docs/references/**` the single stale artifact and `--fix` regenerated exactly that one. No generated artifact was hand-edited.
- **Measured regeneration footprint: 3 files** — 1 tracked (`content/docs/references/api/protocol.mdx`, one table row) and **2 gitignored** (`packages/spec/json-schema/api/GetMetaItemsRequest.json`, `packages/spec/json-schema/objectstack.json`). The gitignored half is counted, not omitted. Four further gitignored `packages/spec/dist/api/*` files carry the string as build output.
- `check:generated` exit 0 afterwards — all 15 artifacts up to date.
- Derived the gate families mechanically from the change set (`scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack`): **89 of 90 ran green**, reconciled with `--ran`. The one unrun is `check:dual-build-cjs-loads`, which refused with `PREREQUISITE NOT MET` (exit 3, explicitly not a pass) because 33 packages have no `dist/`; it needs a whole-repo build and is declared to CI.
- `@objectstack/spec`: typecheck exit 0; tests **483 files / 13129 passed**.
- Three gates that first returned exit 3 / a build-prerequisite refusal were re-run after building `@objectstack/lint`, `@objectstack/formula` and `@objectstack/client-react`; all three then genuinely measured and passed. None was recorded as a pass while unmeasured.
- Every proof is anchored to the literal sha `c383352cb752245899b6ca7e2dc7d233405113ee`. `origin/main` moved under this container mid-run (to `a5eccf9257`); the anchor did not.

Draft on purpose: not flipped ready and not enqueued — that is the PM's call.

---
_Generated by [Claude Code](https://claude.ai/code/session_01T6HeZvT9wdSJD1ZxJb5Eno)_