### PR TITLE
fix(spec): `KnowledgeRefreshPolicy.cron` no longer attributes the syntax verdict to a cron engine that never sees it

### DIFF
--- a/.changeset/knowledge-refresh-cron-attribution.md
+++ b/.changeset/knowledge-refresh-cron-attribution.md
@@ -1,0 +1,7 @@
+---
+"@objectstack/spec": patch
+---
+
+`KnowledgeRefreshPolicy.cron` no longer tells authors that the `cron` dialect engine judges their syntax "when the expression is evaluated". Both halves of that sentence were false: nothing evaluates `refresh.cron` — `service-knowledge` reads `refresh.onRecordChange` and never `refresh.cron` — and `@objectstack/formula`'s registered `cron` engine has no caller outside that package, so it was never going to issue that verdict either. The claim shipped to authors through the generated reference page (`content/docs/references/ai/knowledge-source.mdx`), naming both an engine that never sees the value and an event that never happens.
+
+The docblock, the `.describe()` and the slot's two pin-test comments now say what is true today, matching the wording of the already-corrected Expression Protocol dialect table: cron syntax is not checked at parse time and no engine evaluates this slot — `croner` judges a cron pattern only where a schedule is wired (`CronSchedule.expression`, a different slot) — so the verdict belongs to whatever external scheduler the author hands the value to. Documentation only: no exported symbol, no authorable key and no accept-set movement; the parse behaviour is byte-for-byte unchanged, and the pin that proves `'not a cron'` still normalizes is untouched.

--- a/content/docs/references/ai/knowledge-source.mdx
+++ b/content/docs/references/ai/knowledge-source.mdx
@@ -65,7 +65,7 @@ const result = FileKnowledgeSourceSchema.parse(data);
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | **onRecordChange** | `boolean` | optional (default: `true`) |  |
-| **cron** | `string \| { dialect: 'cron'; source?: string; ast?: any; meta?: object }` | optional | Cron-dialect expression for a periodic full reindex. A bare string is shorthand for `{ dialect: 'cron', source }`; the parse enforces a non-empty string or an expression envelope and normalizes to the envelope — cron syntax (5- or 6-field, or an `@` alias) is the `cron` dialect engine's verdict when the expression is evaluated, not checked here. `service-knowledge` does not schedule it: the value is surfaced so an automation flow / external scheduler can trigger `reindexSource`. |
+| **cron** | `string \| { dialect: 'cron'; source?: string; ast?: any; meta?: object }` | optional | Cron-dialect expression for a periodic full reindex. A bare string is shorthand for `{ dialect: 'cron', source }`; the parse enforces a non-empty string or an expression envelope and normalizes to the envelope — cron syntax is not checked here, and no engine evaluates this slot: the verdict belongs to whatever external scheduler you hand the value to. `service-knowledge` does not schedule it: the value is surfaced so an automation flow / external scheduler can trigger `reindexSource`. |
 
 
 ---
@@ -130,7 +130,7 @@ const result = FileKnowledgeSourceSchema.parse(data);
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | **onRecordChange** | `boolean` | optional (default: `true`) |  |
-| **cron** | `string \| { dialect: 'cron'; source?: string; ast?: any; meta?: object }` | optional | Cron-dialect expression for a periodic full reindex. A bare string is shorthand for `{ dialect: 'cron', source }`; the parse enforces a non-empty string or an expression envelope and normalizes to the envelope — cron syntax (5- or 6-field, or an `@` alias) is the `cron` dialect engine's verdict when the expression is evaluated, not checked here. `service-knowledge` does not schedule it: the value is surfaced so an automation flow / external scheduler can trigger `reindexSource`. |
+| **cron** | `string \| { dialect: 'cron'; source?: string; ast?: any; meta?: object }` | optional | Cron-dialect expression for a periodic full reindex. A bare string is shorthand for `{ dialect: 'cron', source }`; the parse enforces a non-empty string or an expression envelope and normalizes to the envelope — cron syntax is not checked here, and no engine evaluates this slot: the verdict belongs to whatever external scheduler you hand the value to. `service-knowledge` does not schedule it: the value is surfaced so an automation flow / external scheduler can trigger `reindexSource`. |
 
 
 ---

--- a/packages/spec/src/ai/knowledge-source.test.ts
+++ b/packages/spec/src/ai/knowledge-source.test.ts
@@ -17,10 +17,13 @@
 //   slot's own path whose message names the fix — the shared dialect fixed its
 //   envelope arm and learned to trim at #15028 / #15035; the sentences are
 //   `TYPED_EXPRESSION_SOURCE_REQUIRED.cron` / `TYPED_EXPRESSION_DIALECT_ONLY.cron`;
-// - cron SYNTAX is not judged at parse time. `'not a cron'` normalizes like
-//   any other string: the syntax verdict belongs to the `cron` dialect engine
-//   (`@objectstack/formula` cron-engine — 5- or 6-field, or an `@` alias) when
-//   the expression is evaluated. That pin is deliberate: it is what keeps the
+// - cron SYNTAX is not judged at parse time, and no engine judges it later
+//   either. `'not a cron'` normalizes like any other string, and this slot is
+//   parsed and reaches no engine: `croner` judges a cron pattern only where a
+//   schedule is wired (`CronSchedule.expression`, a different slot), and
+//   `@objectstack/formula`'s registered `cron` engine has no caller outside
+//   that package. The syntax verdict belongs to whatever external scheduler
+//   the author hands the value to. That pin is deliberate: it is what keeps the
 //   schema's describe honest. If the shared dialect ever gains parse-time
 //   syntax validation, this pin flips, and the describe on the slot must be
 //   rewritten in the same commit.
@@ -103,9 +106,11 @@ describe('KnowledgeRefreshPolicySchema.cron — the typed cron slot (#14825)', (
   });
 
   it('does NOT judge cron syntax at parse time — measured, and the describe promises no more (declared = enforced)', () => {
-    // The syntax verdict is the `cron` dialect engine's at evaluate time:
-    // `@objectstack/formula` cron-engine accepts 5- or 6-field expressions and
-    // the `@yearly`…`@reboot` aliases. The parse only normalizes. If this case
+    // Nothing evaluates this slot, so no engine ever issues a syntax verdict on
+    // it: `croner` judges `CronSchedule.expression`, a different slot, and
+    // `@objectstack/formula`'s registered `cron` engine has no caller outside
+    // that package. The verdict belongs to whatever external scheduler the
+    // author hands the value to. The parse only normalizes. If this case
     // ever goes red because the shared dialect learned to refuse syntax, update
     // the slot's describe in the same commit — do not weaken this pin.
     for (const source of ['not a cron', '0 0 3 * * *', '@daily']) {

--- a/packages/spec/src/ai/knowledge-source.zod.ts
+++ b/packages/spec/src/ai/knowledge-source.zod.ts
@@ -33,10 +33,13 @@ export const KnowledgeRefreshPolicySchema = lazySchema(() => z.object({
    * `integration/connector.zod.ts`). A bare string is shorthand for
    * `{ dialect: 'cron', source }`; the parse enforces a non-empty string or an
    * expression envelope and normalizes to the envelope. It does NOT judge cron
-   * syntax: that verdict is the `cron` dialect engine's (`@objectstack/formula`
-   * cron-engine — 5- or 6-field, or an `@yearly`…`@reboot` alias) when the
-   * expression is evaluated, so the describe below promises exactly what the
-   * parse enforces (ADR-0049 declared = enforced; #14825).
+   * syntax, and neither does anything downstream: this slot is parsed and
+   * reaches no engine. `croner` judges a cron pattern only where a schedule is
+   * wired (`CronSchedule.expression`, a different slot), and
+   * `@objectstack/formula`'s registered `cron` engine has no caller outside
+   * that package — so the syntax verdict belongs to whatever external
+   * scheduler the author hands this value to, and the describe below promises
+   * exactly what the parse enforces (ADR-0049 declared = enforced; #14825).
    *
    * `service-knowledge` does not schedule the cron itself — it merely
    * surfaces the value so an automation flow / external scheduler can
@@ -45,8 +48,8 @@ export const KnowledgeRefreshPolicySchema = lazySchema(() => z.object({
   cron: CronExpressionInputSchema.optional().describe(
     'Cron-dialect expression for a periodic full reindex. A bare string is shorthand for '
     + '`{ dialect: \'cron\', source }`; the parse enforces a non-empty string or an expression '
-    + 'envelope and normalizes to the envelope — cron syntax (5- or 6-field, or an `@` alias) is '
-    + 'the `cron` dialect engine\'s verdict when the expression is evaluated, not checked here. '
+    + 'envelope and normalizes to the envelope — cron syntax is not checked here, and no engine '
+    + 'evaluates this slot: the verdict belongs to whatever external scheduler you hand the value to. '
     + '`service-knowledge` does not schedule it: the value is surfaced so an automation flow / '
     + 'external scheduler can trigger `reindexSource`.',
   ),


### PR DESCRIPTION
Fixes #15867

`Clause-②: no` — no exported symbol moves, no authorable key moves, no accept-set moves. Parse behaviour is byte-for-byte unchanged. Both surface gates were confirmed at exit 0 **and** ablated to prove they can go red (below), so the green is a measurement rather than a bare reading.

## What was false on `main`

`packages/spec/src/ai/knowledge-source.zod.ts` told authors that cron syntax on `KnowledgeRefreshPolicy.cron` "is the `cron` dialect engine's verdict when the expression is evaluated". Both halves were false, and the sentence is customer-facing — it is the `cron` row of the generated `content/docs/references/ai/knowledge-source.mdx` (lines 68 and 133).

Re-measured on this branch's base `a5eccf9257`, not inherited:

| claim | measurement |
| :--- | :--- |
| "when the expression is evaluated" names an event that happens | `git grep -n -E 'refresh\?\.\s*cron\|refresh\.cron'` outside `packages/spec` returns **one hit, and it is a ledger note**. `service-knowledge`'s only `refresh` reads are `source.refresh?.onRecordChange` (`knowledge-service.ts:396`). Nothing evaluates this slot. |
| the named evaluator is the right one | `git grep -n -E 'cronEngine\|cron-engine'` outside `packages/formula` returns **prose only** — a CHANGELOG line, the D7 conformance ledger, and the three sites this PR fixes. Positive control: the same pattern **inside** `packages/formula` returns the definition (`cron-engine.ts:63`), the tests and the import sites. |

The one evaluator any spec cron slot actually meets is `croner`, on `CronSchedule.expression` — a different slot.

## The four sites, re-located by phrase and not by line number

The card's line numbers had already drifted once, so every site was re-found with the single-line-safe anchor `dialect engine` (the fuller phrase wraps across comment lines and matches on no single line).

| site | card said | found on base `a5eccf9257` |
| :--- | :--- | :--- |
| docblock | `:35-38` | **`:36`** |
| `.describe()` | `:45-49` | **`:49`** |
| test comment 1 | `:17-20` | **`:21`** |
| test comment 2 | `:96-98` | **`:106`** |

A deliberate multi-line scan (comment markers stripped, whitespace collapsed, whole tree) confirms the population is exactly these four source sites plus the two generated `.mdx` rows. `packages/spec/CHANGELOG.md` also carries the old wording and is deliberately left alone — it is a record of what shipped.

## What they say now

All four now match the wording of the already-landed sibling correction in `packages/spec/src/shared/expression.zod.ts:25-30`: cron syntax is not judged at parse time and **no engine evaluates this slot** — `croner` judges a cron pattern only where a schedule is wired (`CronSchedule.expression`, a different slot), and `@objectstack/formula`'s registered `cron` engine has no caller outside that package — so the verdict belongs to whatever external scheduler the author hands the value to.

Three boundaries held deliberately:

1. **The describe's first half is accurate and untouched.** "The parse enforces a non-empty string or an expression envelope and normalizes to the envelope", and "not checked here", both survive verbatim.
2. **The pin test's behaviour is untouched.** The parse does not refuse `'not a cron'` and does not start to; only the two comments were wrong.
3. **The comment block at `:21` is corrected, not deleted.** It ends with a self-maintaining rule — that the pin is what keeps the describe honest, and that if the shared dialect ever gains parse-time syntax validation the pin flips and the describe must be rewritten in the same commit. That rule is true and is preserved verbatim; only the attribution half of the block changed.

This correction is safe to write now rather than obsolete on arrival: re-confirmed on base that `expression.zod.ts:25` and `:267` both still read `No cron syntax is judged at parse time`, so no parse-time verdict has landed. The parent card #15035 is no longer open, and the PR that resolved it fixed the envelope arm and blank-string refusal — not a syntax verdict.

## Generated artifacts this change moves — measured, not estimated

Measured by generating from the base source, snapshotting, restoring to this branch's source (restore proven by blob hash equal to the `HEAD` blob **and** an empty `git diff HEAD` for that path), and generating again:

- **Tracked (1):** `content/docs/references/ai/knowledge-source.mdx` — the only artifact `check:generated` proved stale; regenerated with `check:generated --fix`, never hand-edited.
- **Gitignored (3), all under `packages/spec/json-schema/`:** `ai/KnowledgeRefreshPolicy.json`, `ai/KnowledgeSource.json`, `objectstack.json`.

Population of that gitignored tree is unchanged at 1576 files — three contents move, nothing is added or removed.

## Verification

All readings below are from the final commit `f7a9b0f901`; exit codes were captured before any pipe.

**Tests and types**

- `pnpm --filter @objectstack/spec test` → **483 test files, 13136 tests, all passed**, `VERDICT command-exit 0` from the shared verify lock.
- `pnpm --filter @objectstack/spec typecheck` → exit 0. Its `check:test-typecheck` leg confirms the test layer really compiles (`54 file(s) / 261 error(s) / 145 pinned signature(s)` held in the shrink-only debt ledger), so the edited test file is genuinely type-checked and not silently excluded.

**Clause-② gates, with ablations**

| gate | on this branch | ablated | restored |
| :--- | :--- | :--- | :--- |
| `check:api-surface` | exit 0 | removed one export line from `api-surface/ai.json` → **exit 1**, "0 breaking (removed/narrowed), 1 added." | exit 0 |
| `check:authorable-surface` | exit 0 | removed `ai/KnowledgeRefreshPolicy:cron` from `authorable-surface/ai.json` → **exit 1**, `+ ai/KnowledgeRefreshPolicy:cron` | exit 0 |

Each ablation ran under a restore trap with absolute paths; each mutation was proven on disk (line count and blob hash both moved) and each restore proven by blob hash equal to the `HEAD` blob and an empty `git diff HEAD`.

**Gate families**

Derived mechanically with `node scripts/pm/dispatch-gates.mjs --commands --repo objectstack-ai/objectstack` (change set taken from the merge base, three-dot), then re-derived after the changeset existed, which added six more. **All 97 runnable derived commands were run: 95 exit 0, 2 not measured** (named below). The 95 include `check:generated` (15 artifacts), `check:nul-bytes`, `check:api-surface`, `check:authorable-surface`, `check:docs`, `check:type-check-coverage`, `check:cross-package-test-inputs`, `check:test-source-alias`, `check:skill-examples` (all three prose surfaces, after building `@objectstack/client-react` so its verdict is not a false green) and the four changeset families. Two roster-block gates were run on top: `check-changeset-fixed.mjs` and `check-skills-token-ratchet.mjs`, both exit 0.

`pnpm lint` (`eslint . --no-inline-config`) ran repo-wide rather than narrowed: **6273 files linted, 0 errors, 0 warnings**, exit 0.

**Not measured** (never read as a pass and never as a finding): `check:dual-build-cjs-loads` exits 3, `PREREQUISITE NOT MET — this gate reads built output, and some package has no dist/`; `check:type-check-debt` is a whole-farm aggregate that did not finish inside the foreground budget. Both belong to CI, which builds everything. `check:react-declaration-parity` cannot run here at all — its right-hand side is objectui's `sdui.manifest.json`.

**Byte discipline**: `grep -naP` over the edited files for control characters returns no hits, and `check:nul-bytes` is green.

_Generated by [Claude Code](https://claude.ai/code/session_01T6HeZvT9wdSJD1ZxJb5Eno)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01T6HeZvT9wdSJD1ZxJb5Eno)_