### PR TITLE
feat(spec): object-kanban props declare `limit`, the row cap objectui already implements

### DIFF
--- a/.changeset/object-kanban-limit-row-cap.md
+++ b/.changeset/object-kanban-limit-row-cap.md
@@ -1,0 +1,17 @@
+---
+"@objectstack/spec": minor
+---
+
+feat(spec): `ComponentPropsMap['object-kanban']` declares `limit`, the row cap four objectui faces already implement (#16503, the spec half of objectui#8172)
+
+`object-kanban` gains one optional authorable key:
+
+```ts
+limit: z.number().int().positive().optional()
+```
+
+Maximum number of records loaded onto the board (row cap), lowered to the top-level `$top` of the board's one query. The renderer default stays 100 and is documented rather than declared, so an unset key remains unset. The component-level `dataSource.limit` wins when both are set, and a bound named view's `pagination.pageSize` fills the key only when the component authored none — the `ElementDataSourceGate` precedence table, unchanged.
+
+Measured at the objectui pin this repo builds against (`.objectui-sha` = `a472b0716`): `plugin-kanban` reads `schema.limit` as the query's `$top` (wired by objectui#4025), `OBJECT_KANBAN_DATA_SOURCE` maps `limit: 'limit'`, `KanbanSchema` declares `limit?: number`, and `content/docs/plugins/plugin-kanban.mdx` teaches it with a typed snippet (`limit: 250`) plus a Properties row. The strict props map refused the key by name, so an author following the published docs wrote a node the save gate rejected with the same `unrecognized_keys` verdict a typo gets. Decision batch #68 (2026-09-07, option A): the contract declares the capability that is already implemented, documented and in use.
+
+Widening a published accept set (Clause-② yes): `safeParse({ objectName: 'x', limit: 250 })` now succeeds; every other undeclared key on the node is refused exactly as before. objectui#8172 publishes the key in the registry declaration on its side.

--- a/content/docs/references/ui/component.mdx
+++ b/content/docs/references/ui/component.mdx
@@ -457,6 +457,7 @@ Sort field and direction pair
 | **groupBy** | `string` | optional | Field whose values become the board columns |
 | **columns** | `any[]` | optional | Swimlane definitions (`{ id, title }` per `groupBy` value, or bare value strings) — NOT a field projection |
 | **filter** | `any` | optional | Base query filter, handed to the wire `$filter` |
+| **limit** | `integer` | optional | Maximum number of records loaded onto the board (row cap); lowered to the query's top-level `$top` (renderer default 100). The component-level `dataSource.limit` wins when both are set; a bound view's `pagination.pageSize` fills it only when unset |
 | **data** | `any[]` | optional | Static inline cards — bypasses the object query |
 | **cardTitle** | `string` | optional | Field rendered as each card title |
 | **titleField** | `string` | optional | Legacy fallback for `cardTitle` (the board reads `cardTitle \|\| titleField`). Prefer `cardTitle` |

--- a/packages/spec/authorable-surface/ui.json
+++ b/packages/spec/authorable-surface/ui.json
@@ -778,6 +778,7 @@
     "ui/ObjectKanbanProps:filter",
     "ui/ObjectKanbanProps:groupBy",
     "ui/ObjectKanbanProps:grouping",
+    "ui/ObjectKanbanProps:limit",
     "ui/ObjectKanbanProps:objectName",
     "ui/ObjectKanbanProps:quickAdd",
     "ui/ObjectKanbanProps:swimlaneField",

--- a/packages/spec/src/ui/component.test.ts
+++ b/packages/spec/src/ui/component.test.ts
@@ -21,6 +21,7 @@ import {
   ElementRecordPickerPropsSchema,
   ElementTextInputPropsSchema,
   ObjectMetricPropsSchema,
+  ObjectKanbanPropsSchema,
 } from './component.zod';
 import { PageComponentSchema, PageSchema, PageComponentType, ElementDataSourceSchema } from './page.zod';
 
@@ -2769,6 +2770,68 @@ describe('#7751 — object-* block props schemas', () => {
     ] as const) {
       expect(ComponentPropsMap[type].safeParse({}).success, type).toBe(true);
     }
+  });
+});
+
+// #16503 — the spec half of objectui#8172 (decision batch #68, 2026-09-07,
+// option A: the contract declares the capability that already ships, is
+// documented and is in use). Measured at the objectui pin this repo builds
+// against (`.objectui-sha` = `a472b0716`): `plugin-kanban/src/ObjectKanban.tsx:264`
+// queries `$top: schema.limit ?? DEFAULT_KANBAN_LIMIT` (100, `:71`),
+// `plugin-kanban/src/index.tsx:395-398` maps `limit: 'limit'` in
+// `OBJECT_KANBAN_DATA_SOURCE`, `plugin-kanban/src/types.ts:134` declares
+// `KanbanSchema.limit?: number`, and `content/docs/plugins/plugin-kanban.mdx`
+// teaches `limit: 250` with a Properties row. The strict map refused the key by
+// name — the same `unrecognized_keys` verdict as the `bogusProp` control — so an
+// author following the published docs wrote a node the save gate rejected.
+describe('ObjectKanbanPropsSchema limit — the row cap four objectui faces already implement (#16503)', () => {
+  const kanban = ComponentPropsMap['object-kanban'];
+
+  it("accepts the documented shape `{ objectName: 'x', limit: 250 }` and carries the value through", () => {
+    const result = kanban.safeParse({ objectName: 'x', limit: 250 });
+    expect(result.success).toBe(true);
+    const parsed = (result.success ? result.data : undefined) as { limit?: number } | undefined;
+    // Carried through to the parsed output, not stripped: what the board
+    // lowers to `$top` is what the author wrote.
+    expect(parsed?.limit).toBe(250);
+  });
+
+  it('still refuses an undeclared sibling on the same node — the accept above is not vacuous', () => {
+    // The card's own control, and the half that proves the object stayed
+    // strict: without it the green above would also be green on a map that
+    // had stopped refusing anything.
+    const result = kanban.safeParse({ objectName: 'x', bogusProp: 250 });
+    expect(result.success).toBe(false);
+    const issue = result.error?.issues.find((i) => i.code === 'unrecognized_keys') as
+      | { keys?: string[] }
+      | undefined;
+    expect(issue?.keys).toEqual(['bogusProp']);
+  });
+
+  it('refuses a cap the query could not lower to `$top` — zero, negative, fractional, or a string — at the VALUE, not the key', () => {
+    // `z.number().int().positive()`: the shape `element:record_picker` and
+    // `record:related_list` declare for the same `$top` read, so the flat row
+    // caps in this map are one contract rather than three dialects. The key is
+    // recognised (no `unrecognized_keys`); the value is what fails.
+    for (const limit of [0, -1, 1.5, '250']) {
+      const result = kanban.safeParse({ objectName: 'x', limit });
+      expect(result.success, JSON.stringify(limit)).toBe(false);
+      const codes = (result.error?.issues ?? []).map((i) => i.code);
+      expect(codes, JSON.stringify(limit)).not.toContain('unrecognized_keys');
+      expect(result.error?.issues[0]?.path, JSON.stringify(limit)).toEqual(['limit']);
+    }
+  });
+
+  it('keeps a `.describe()` that names the `$top` the board lowers it to and the binding that outranks it', () => {
+    // The describe is the artifact an auditor reads instead of hunting across
+    // repos, and the row the generated reference page prints; deleting it is
+    // what re-opens the "is this key live?" question this record answers.
+    const shape = (ObjectKanbanPropsSchema as unknown as {
+      def: { shape: Record<string, { description?: string }> };
+    }).def.shape;
+    expect(shape.limit?.description).toContain('$top');
+    expect(shape.limit?.description).toContain('row cap');
+    expect(shape.limit?.description).toContain('dataSource.limit');
   });
 });
 

--- a/packages/spec/src/ui/component.zod.ts
+++ b/packages/spec/src/ui/component.zod.ts
@@ -2644,6 +2644,9 @@ export type ObjectMetricProps = z.input<typeof ObjectMetricPropsSchema>;
  * forwarded schema `quickAdd`/`coverImageField`/`conditionalFormatting`
  * (`KanbanRenderer`, index.tsx). `groupField` is the DESIGNER's spelling with
  * zero read points (#7973 class) — aliased to the `groupBy` the board reads.
+ * `limit` (#16503) was measured later, at the pin this repo builds against
+ * (`.objectui-sha` = `a472b0716`): `ObjectKanban.tsx:264`, the `$top` of the
+ * board's one query — its docblock below carries the four-face record.
  */
 export const ObjectKanbanPropsSchema = lazySchema(() => strictObject({
   surface: 'this `object-kanban`',
@@ -2662,6 +2665,40 @@ export const ObjectKanbanPropsSchema = lazySchema(() => strictObject({
   columns: z.array(z.unknown()).optional()
     .describe('Swimlane definitions ({ id, title } per `groupBy` value, or bare value strings) — NOT a field projection'),
   filter: z.unknown().optional().describe('Base query filter, handed to the wire `$filter`'),
+  /**
+   * Row cap (#16503 — the spec half of objectui#8172; decision batch #68,
+   * 2026-09-07, option A: the contract declares the capability that already
+   * ships, is documented and is in use). Measured at the objectui pin this
+   * repo builds against (`.objectui-sha` = `a472b0716`), four faces agreed
+   * while this map refused the key by name: the board's one query is
+   * `dataSource.find(objectName, { $filter: schema.filter, $top: schema.limit
+   * ?? DEFAULT_KANBAN_LIMIT })` (`plugin-kanban/src/ObjectKanban.tsx:262-266`,
+   * the default `100` at `:71` — a REAL top-level `$top` since objectui#4025;
+   * before that the cap sat under a `options` key no adapter read),
+   * `OBJECT_KANBAN_DATA_SOURCE` maps `limit: 'limit'`
+   * (`plugin-kanban/src/index.tsx:395-398`), `KanbanSchema` — the type
+   * `ObjectKanban.tsx:143` reads `schema` through — declares `limit?: number`
+   * (`plugin-kanban/src/types.ts:134`), and `content/docs/plugins/plugin-kanban.mdx`
+   * teaches it with a typed snippet (`limit: 250`) plus a Properties row. So
+   * an author following the published docs wrote a node the save gate
+   * refused, with the same `unrecognized_keys` verdict a typo gets.
+   *
+   * Why the carrier is `limit` and not the bound view's `pagination.pageSize`
+   * (the alternative the card opened): precedence is the `ElementDataSourceGate`
+   * table, not this key's. The component-level `dataSource.limit` overrides
+   * this key, and a bound named view's `pagination.pageSize` is LOWERED INTO
+   * it through the `limit: 'limit'` mapping only when the component authored
+   * none (`react/src/element-data-source/ElementDataSourceGate.tsx:236-241`,
+   * `readLimit`/`writeLimit` keyed by `ElementDataSourceLimitKey`). The board
+   * has no `pagination` read point, so declaring that spelling here would name
+   * a key the renderer ignores — the accepted-and-dropped defect this section
+   * exists to remove. Same shape as the `element:record_picker` and
+   * `record:related_list` row caps (one `$top` contract, not a third dialect),
+   * and like them the renderer's 100 is documented rather than declared:
+   * a schema default would materialize `limit: 100` on every parsed board.
+   */
+  limit: z.number().int().positive().optional()
+    .describe("Maximum number of records loaded onto the board (row cap); lowered to the query's top-level `$top` (renderer default 100). The component-level `dataSource.limit` wins when both are set; a bound view's `pagination.pageSize` fills it only when unset"),
   data: z.array(z.unknown()).optional().describe('Static inline cards — bypasses the object query'),
   cardTitle: z.string().optional().describe('Field rendered as each card title'),
   titleField: z.string().optional().describe('Legacy fallback for `cardTitle` (the board reads `cardTitle || titleField`). Prefer `cardTitle`'),


### PR DESCRIPTION
Fixes #16503

Clause-②: yes

## What

`ComponentPropsMap['object-kanban']` (`packages/spec/src/ui/component.zod.ts`) gains one optional authorable key:

```ts
limit: z.number().int().positive().optional()
```

describe: *Maximum number of records loaded onto the board (row cap); lowered to the query's top-level `$top` (renderer default 100). The component-level `dataSource.limit` wins when both are set; a bound view's `pagination.pageSize` fills it only when unset* — the card's sentence, plus the precedence the renderer applies (the sibling `limit` describes in this map, `element:record_picker` and `record:related_list`, name their renderer default and binding precedence the same way).

Widening a published accept set: Clause-② yes, `@objectstack/spec` **minor** changeset (`.changeset/object-kanban-limit-row-cap.md`), `needs:contract-review` on this PR and on #16503. The PR stays **draft**; the ready flip, auto-merge and queueing are the PM's after the at-tier review.

## Premise, re-measured at the objectui pin

Readings pinned to this repo's `.objectui-sha` = `a472b07167a39e55491109e864bb5a54027dcfbd` (never objectui's moving branch):

- `packages/plugin-kanban/src/ObjectKanban.tsx:262-266` — the board's one query is `dataSource.find(objectName, { $filter: schema.filter, $top: schema.limit ?? DEFAULT_KANBAN_LIMIT })`; `DEFAULT_KANBAN_LIMIT = 100` at `:71`; a real top-level `$top` since objectui#4025.
- `packages/plugin-kanban/src/index.tsx:395-398` — `OBJECT_KANBAN_DATA_SOURCE = { filter: true, limit: 'limit' }`.
- `packages/plugin-kanban/src/types.ts:134` — `KanbanSchema.limit?: number`, the type `ObjectKanban.tsx:143` reads `schema` through. **One correction to the card's spelling:** at the pin, `@object-ui/types`' `ObjectKanbanSchema` (zod mirror `types/src/zod/objectql.zod.ts:875-889`, interface `types/src/objectql.ts:2693`) carries no `limit`; the declaring face is `KanbanSchema` in the plugin package. Four faces still agree; the ruling's substance is unchanged.
- `content/docs/plugins/plugin-kanban.mdx:108, 153-172` — the Properties row, the `limit: 250` snippet (default 100), and the note separating the board's `limit` from a column's WIP `limit`.
- Before this PR, at BASE `f48f3f1b21fe207c39d94e49609ac49e19635e3b`: `safeParse({ objectName: 'x', limit: 250 })` yields `unrecognized_keys: ['limit']` — the same verdict as `bogusProp`. Leg B below reproduces it.

## The judgement the card opened: `limit`, not `pagination.pageSize`

Decided for the default and **not** proposed as a change, because at the pin the alternative is not a competing spelling but an upstream source lowered *into* `limit`: `packages/react/src/element-data-source/ElementDataSourceGate.tsx:229-241` (`readLimit` / `writeLimit`, keyed by `ElementDataSourceLimitKey`, whose members are `limit`, `pageSize` and `pagination.pageSize`) writes the binding's `dataSource.limit` — or, only when the component authored none, the bound view's `pagination.pageSize` — onto the key the block's mapping names, and kanban's mapping names `limit`. The board has no `pagination` read point, so declaring `pagination.pageSize` on `object-kanban` would name a key the renderer ignores — the accepted-and-dropped defect the card's ruling exists to remove. The docblock on the key records this.

## Generated footprint (tracked vs gitignored)

- **Tracked: 2 files moved** — `packages/spec/authorable-surface/ui.json` (+1 row, `ui/ObjectKanbanProps:limit`) and `content/docs/references/ui/component.mdx` (+1 table row). **No `api-surface/` shard moves** (`check:api-surface`: "public API surface + factory signatures unchanged"), so no collision with PR #15919's repair; nothing touches the files PR #16531 holds.
- **Gitignored:** `packages/spec/json-schema/` — 1576 files rewritten by the build, 2 of them carrying the new key (`ui/ObjectKanbanProps.json`, `objectstack.json`). The tracked generated corpus counts 317 files (`git ls-files` over authorable-surface, authorable-defaults, json-schema.manifest, api-surface, export-origins, declaration-map and content/docs/references).
- `check:generated` after the build named exactly one stale artifact (`content/docs/references/**`); `gen:docs` regenerated it; `check:docs` reports "228 generated files in sync".

## Verification — all on `fb654377e2`, the final commit; the tree did not change afterwards

**Pins** (`packages/spec/src/ui/component.test.ts`, 4 new cases): accept `{ objectName: 'x', limit: 250 }` and carry the value through; refuse `bogusProp` with `unrecognized_keys: ['bogusProp']` (the half that proves the object stayed strict); refuse `0` / `-1` / `1.5` / `'250'` at the *value* (issue path `['limit']`, no `unrecognized_keys`); the describe names `$top`, `row cap` and `dataSource.limit`.

- `vitest run src/ui/component.test.ts`: 251 passed; with `--reporter=verbose -t 16503`: 4 of 4 passed.
- **Reverse verification (leg B):** `component.zod.ts` reverted to BASE (blob `a549b824…`, equal to the BASE blob, not equal to HEAD `3d939c5e…`), same test file: **3 failed, 1 passed, 247 skipped** — the accept pin, the value pins and the describe pin red; the `bogusProp` control green, as designed. Restored with `git checkout HEAD --`; blob back to `3d939c5e…`, `git diff HEAD` empty, `git status --porcelain` empty.
- **Ablation of the checked-in baseline (leg A, no rebuild** — a rebuild regenerates `authorable-surface/` and would come back falsely green): the `ui/ObjectKanbanProps:limit` row deleted from `authorable-surface/ui.json` (anchor count 1 to 0; blob `eb3c99d7…` not equal to HEAD `1b290888…`), then `check:authorable-surface`: **exit 1**, "authorable-surface/ is out of date (1 key(s) not recorded). + ui/ObjectKanbanProps:limit". Restored with `git checkout HEAD --`; blob back to `1b290888…`, anchor count 1.
- **Package checks:** `pnpm --filter @objectstack/spec typecheck` exit 0 (`check:test-typecheck` included). `vitest run` over the 11 spec test files (of 425) that name the props map, `object-kanban`, `component.zod` or a snapshot: 11 files, 732 tests passed. `pnpm --filter @objectstack/lint test`: 100 files, 3486 tests passed — lint is the in-repo consumer of `ComponentPropsMap` (`validate-component-props.ts`, `validate-react-page-props`).
- **Gates:** `node scripts/pm/dispatch-gates.mjs --ran`: **98 derived, 97 run, 1 unrun** — `check:react-declaration-parity`, which cannot run in this repo (its right-hand side is objectui's `sdui.manifest.json`; NOT MEASURED, not a pass). Green, verdict lines read from each gate's own output: `check:generated` (15 artifacts current after `gen:docs`), `check:api-surface`, `check:authorable-surface`, `check:docs`, `check:objectui-pin-citations` (12 asserting citations match `a472b0716`), `check:duration-unit-keys`, `check:skill-examples` (257 blocks across 3 surfaces, after building `@objectstack/client-react`), `check:nul-bytes`, `check:cross-package-test-inputs`, `check:test-source-alias`, `check:docs-transcript-drift`, the changeset gates (`check-adr-0087-registration`: no declared-breaking changeset; `check-empty-changeset`; `check-changeset-no-major`), `check:liveness`, `check:strictness-ledger`, `check:yaml-examples` (18 component nodes judged against their props schema), and the rest of the derived list. **NOT MEASURED** (exit 3, prerequisite — they need the full `pnpm build` closure): `check:type-check-debt`, `check:dual-build-cjs-loads` — CI's.
- **Declared narrowing:** `turbo ls --affected` lists every package downstream of `@objectstack/spec`. Locally: the spec test files that name the props map, `object-kanban`, `component.zod` or a snapshot, plus the whole `@objectstack/lint` suite. The remaining downstream suites are CI's. The showcase consumer test `examples/app-showcase/test/my-work-visibility.test.ts` queued out twice on the shared verify lock (exit 99, NOT MEASURED); it names `ComponentPropsMap` only in a comment, and no test in the repo asserts that `limit` is refused on `object-kanban`.

## What this PR does not do

- objectui#8172 stays open: the registry declaration that publishes the key on objectui's side is that card's; this PR notifies it.
- No `api-surface` shard, no error-code ledger, no conversion entry — a widened accept set is non-breaking and needs no ADR-0087 disposition.

---
_Generated by [Claude Code](https://claude.ai/code/session_01T6HeZvT9wdSJD1ZxJb5Eno)_