### PR TITLE
fix(tooling): derive check-wildcard-fallthrough's self-test case count from its own ledger

### DIFF
--- a/scripts/check-wildcard-fallthrough.mjs
+++ b/scripts/check-wildcard-fallthrough.mjs
@@ -460,9 +460,11 @@ const SELF_TEST_VERDICT = 'check-wildcard-fallthrough self-test reached its verd
 //
 // "no assertion threw" used to be this self-test's ONLY success condition, so
 // "every case held" and "the cases never ran" printed the same line — and this
-// file's verdict spells a TRANSCRIBED count (`17 cases`), which is evidence, not
-// proof: nothing compared it, so a deleted block shrank the real count while the
-// literal stayed put. Closed the way PR #13487 validated on check-doc-authoring:
+// file's verdict once spelled a TRANSCRIBED count (a literal `17` against a real
+// 18), which is evidence, not proof: nothing compared it, so a deleted block
+// shrank the real count while the literal stayed put. The verdict now derives
+// its number from the ledger this roster floors (#15231). Closed the way PR
+// #13487 validated on check-doc-authoring:
 // what is pinned is the registered NAMES, not a number, and the floor requires
 // the OPENED set to equal the DECLARED set with each battery at or above its own
 // count.
@@ -625,13 +627,16 @@ function selfTest() {
     process.exit(1);
   }
 
-  // ⚠️ MEASURED at 18, not 17: this transcribed literal had already drifted one
-  // below the real count before this floor existed, which is precisely why a
-  // printed number is evidence and not proof. It is left as-is here so this
-  // change stays a pure no-op on output; the correction is filed separately, and
-  // the floor above is what makes the drift harmless — the count can no longer
-  // shrink in silence.
-  console.log('✓ self-test: 17 cases');
+  // The verdict DERIVES its number from `batterySeen` — the very ledger the floor
+  // above just evaluated — so the printed count and the floor can never disagree,
+  // and a block that stops running shrinks the number instead of leaving a
+  // transcribed literal standing (#15231). What it counts is assertions that
+  // actually RAN this run, not `assert(` call sites in the source: those are two
+  // different facts, and only the first one is measured here. Summing the whole
+  // ledger is exact because reaching this line means every battery that
+  // registered is a declared one — the set difference above reds otherwise.
+  const casesRun = [...batterySeen.values()].reduce((total, count) => total + count, 0);
+  console.log(`✓ self-test: ${casesRun} cases`);
 
   return SELF_TEST_VERDICT;
 }


### PR DESCRIPTION
Fixes #15231

The self-test verdict of `scripts/check-wildcard-fallthrough.mjs` printed a
transcribed `17 cases` while the body ran 18 assertions and the battery roster
pinned 18. Nothing derived that number and nothing compared it — the fourth
instance of a class already filed twice (#13963, #13536) and once more in
#16007. Per triage, the route is option 2: derive the count, not correct the
literal.

## Before / after

```
$ node scripts/check-wildcard-fallthrough.mjs --self-test     # origin/main 0a61db1f5d
✓ self-test: 17 cases                                          exit 0

$ node scripts/check-wildcard-fallthrough.mjs --self-test     # this branch
✓ self-test: 18 cases                                          exit 0

$ pnpm check:wildcard-fallthrough                             # this branch
✓ self-test: 18 cases
✓ wildcard fall-through: 8 yielding / 0 ratcheted / 5 exempt (13 namespace-claiming mounts)
                                                               exit 0
```

Re-derived on this branch's base, not taken from the card: the literal was at
`scripts/check-wildcard-fallthrough.mjs:634`, and `grep -c "^\s*assert("` over
that file returns 18.

## Which number is printed, and why that one

The line now prints **assertions that actually RAN this run** — the sum of
`batterySeen`, the same ledger the battery floor immediately above already
evaluates. It does **not** print `assert(` call sites in the source.

Today both facts are 18, so a reader would otherwise assume whichever one was
not meant. The runtime ledger is the honest choice for a line whose words are
"cases": a call site that never executes is not a case that held, and the whole
reason this class exists is that a printed number must be produced by the run
it describes. It also makes the printed number and the floor structurally
incapable of disagreeing, since they read one ledger.

Summing the whole ledger is exact rather than approximate: reaching the verdict
means the set-difference check above found every battery that registered to be
a declared one, so the sum has no unattributed remainder.

No new floor is introduced. `SELF_TEST_BATTERIES` keeps its existing pinned
value of 18 and is untouched — this change does not convert a printed number
into a gate.

## Two comments rewritten, deliberately

Both would have become false on landing, standing next to a derived line:

- the in-place comment above the literal explained that `17` was knowingly
  wrong and "left as-is here so this change stays a pure no-op on output" —
  that sentence was about the PR that added the floor, not this one;
- the roster's rationale block described the verdict, in the present tense, as
  spelling a transcribed count.

Both now describe what the file does.

## Nothing outside the file pinned this stdout

`git grep -n "17 cases"` at the base returns 10 hits: CHANGELOG prose and test
fixtures about unrelated 17-case corpora, plus this file's own two lines. None
is an expectation of this file's output. The instrument was controlled — the
same pattern scoped to the file finds line 634 — so the zero is a real zero.
`docs/audits/2026-09-self-test-shape-census.md` names this script but records
its *failure* line, not the success line. This change deliberately moves output,
so it could not have ridden the byte-identical batch that left the literal wrong.

## Verification

Positive and negative controls, each mutated on disk (blob hash shown to differ
from the HEAD blob), run, then restored under a trap and proven restored by
hash equality plus an empty `git diff HEAD`:

| leg | mutation | printed |
|---|---|---|
| baseline | none | `✓ self-test: 18 cases` (exit 0) |
| positive control | one deliberately added 19th assertion | `✓ self-test: 19 cases` (exit 0) |
| negative control | an assertion's message text edited, case count untouched | `✓ self-test: 18 cases` (exit 0) |
| deletion | one assertion removed | floor reds: `registered 17 case(s), below its pinned floor of 18` (exit 1) |

And the same positive control against the **pre-change** code, to show what the
literal could not do: `origin/main`'s version of the file plus a deliberately
added 19th case still prints `✓ self-test: 17 cases`, exit 0.

Restore proof for every leg: `git checkout HEAD -- path`, then
`git hash-object path` equal to `git rev-parse HEAD:path`
(`bf00750b2d11cb8b0af7c4c0216d9c355fca5e4a`) and `git diff HEAD` empty.

Gates — `node scripts/pm/dispatch-gates.mjs --commands --repo objectstack-ai/objectstack`
derived 31 commands; all 31 were run and all exited 0 (exit code captured before
any pipe), reconciled with `--ran`:
`✓ dispatch-gates --ran: 31 derived famil(ies) accounted for — 31 run, 0 NOT-MEASURED.`

Repo-wide lint at final HEAD `3185352ffc`: `pnpm exec eslint . --no-inline-config
--format json` — 6309 files, 0 errors, 0 warnings, exit 0. No narrowing claimed.
Control-character self-scan over the changed file is clean, and
`pnpm check:nul-bytes` is green.

## Changeset

`skip-changeset` applies and is set on this PR: the diff is one repo-internal
gate script under `scripts/`, which publishes from no package.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Vbw3RPgdtqesx4azk9SbW8)_