### PR TITLE
fix(rest): lower public-picker filter rules to the grammar the ingress parses

### DIFF
--- a/.changeset/public-picker-filter-lowering.md
+++ b/.changeset/public-picker-filter-lowering.md
@@ -1,0 +1,14 @@
+---
+"@objectstack/rest": patch
+---
+
+`GET /forms/:slug/lookup/:field` answers a search again: the public-form lookup picker no longer refuses every non-empty query with `400 INVALID_FILTER`.
+
+The route composed its filter list out of `ViewFilterRule` objects — the `{ field, operator, value }` dialect `FormFieldPublicPickerSchema.filter` declares in so many words ("Same `{ field, operator, value }` dialect as list-view filters") — and put them straight onto the `findData` filter slot. That slot accepts a `FilterCondition` object or a `FilterArray` (`[field, operator, value]`, a logical node, or a list of those) and refuses anything else. The refusal did not depend on an author declaring `publicPicker.filter`: the route's own `q` predicate is built in the same object shape, so **every** non-empty search was refused and only the degenerate empty-filter call could succeed — on an anonymous surface where a public-form applicant has no way around it.
+
+- **The route lowers; the parser is untouched.** The composed rows are translated to the array grammar the ingress parses, at the one door that speaks both dialects. ⛔ The repair deliberately NOT taken is teaching `findData` a second dialect: that maintains two filter grammars in the data layer permanently and spreads the object shape to every `findData` caller. The declaration already promises the object dialect on the authoring surface, so what changes is the side that failed to honour the promise. A test keeps the control that the object shape fed to the parser directly is still refused, so "the route lowers" cannot be confused with "the parser was loosened".
+- **Both branches.** The declared `publicPicker.filter` rows and the route's own `contains` search row are lowered together and ANDed explicitly; no declared filter still means no filter (`[]`), never an empty logical node the ingress would refuse.
+- **The operator fold is the spec's own.** Lowering reuses `normalizeFilterOperator` from `@objectstack/spec/ui` — the fold `ViewFilterRuleSchema.operator` itself runs — so a stored row carrying a legacy spelling (`notEquals`, `isNotEmpty`, `gt`) folds exactly as the schema folds it. No second alias table.
+- **A rule that cannot be read is forwarded, not dropped.** The request is then refused exactly as before. That direction is deliberate: a picker's static filter is often the only thing keeping an anonymous visitor's search inside the rows a form may expose, and silently skipping a row nobody understood would answer 200 over an unfiltered table.
+
+No authoring surface moves: `FormFieldPublicPickerSchema` already declared this dialect as accepted, and this makes the runtime honour it.

--- a/packages/rest/src/public-form-lookup-filter-lowering.test.ts
+++ b/packages/rest/src/public-form-lookup-filter-lowering.test.ts
@@ -209,7 +209,12 @@ function dataEngine(): DataEngine {
         find: async (object: string, options: Record<string, any>) => {
             seen = options;
             if (object !== 'ats_job') return [];
-            return JOBS.filter((r) => matchesCondition(r, options?.where));
+            const rows = JOBS.filter((r) => matchesCondition(r, options?.where));
+            // Hold the caller's bound, AFTER the filter and by PRESENCE — a
+            // limit-blind double reports a page size the engine never granted
+            // (`check:objectql-double-limit`). The picker sends
+            // `limit: maxResults`, so this is also the shape it really meets.
+            return typeof options?.limit === 'number' ? rows.slice(0, options.limit) : rows;
         },
         aggregate: async () => [],
         count: async () => 0,

--- a/packages/rest/src/public-form-lookup-filter-lowering.test.ts
+++ b/packages/rest/src/public-form-lookup-filter-lowering.test.ts
@@ -183,6 +183,8 @@ function matchesCondition(row: Record<string, unknown>, cond: unknown): boolean 
             for (const [op, operand] of Object.entries(expected as Record<string, unknown>)) {
                 if (op === '$eq') {
                     if (row[key] !== operand) return false;
+                } else if (op === '$ne') {
+                    if (row[key] === operand) return false;
                 } else if (op === '$contains') {
                     if (!String(row[key] ?? '').includes(String(operand))) return false;
                 } else {
@@ -405,8 +407,65 @@ describe('[#16581] §3 CONTROL: the parser was NOT loosened — the object shape
         // The other half of the card's control: same server, same object, same
         // anonymity, only the filter's shape differs. That is what rules out
         // permissions, anonymity and every other part of the route as the cause.
+        //
+        // `records` is the key `findData` returns — this route hands its result
+        // through untouched, which is also how the picker's own `data`/`items`
+        // read was measured to match nothing (repaired in the same card).
         const { status, body } = await dataApi('[["status","=","published"]]');
         expect(status).toBe(200);
-        expect(body.data.map((r: any) => r.id)).toEqual(['job_1', 'job_3', 'job_4']);
+        expect(body.records.map((r: any) => r.id)).toEqual(['job_1', 'job_3', 'job_4']);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// §4 the response the route READS back — the second half of "the right rows"
+// ---------------------------------------------------------------------------
+
+/**
+ * The picker read `result.data ?? result.items` and never `result.records`,
+ * which is the key `findData` returns (`{ object, records, total, hasMore }`)
+ * and the order the file's three other read sites already use. So with the
+ * filter lowered the route answered `200 {"data":[]}` — an empty picker for
+ * every search, the same user-visible outcome as the 400 by a different route.
+ *
+ * It was invisible twice over: unreachable while every non-empty search 400'd,
+ * and unreachable in `public-form-lookup-picker.test.ts`, whose `findData`
+ * double answers `{ data: rows }` — a shape the real protocol does not produce.
+ * A double that invents its subject's response shape cannot report that the
+ * consumer reads the wrong key.
+ */
+describe('[#16581] §4 the projection reads `records`, the key `findData` actually returns', () => {
+    it('rows survive the real response envelope — not 200 with an empty list', async () => {
+        const stored = await persistedBody(applyForm(PICKER_WITH_FILTER));
+        const { status, body } = await lookup(stored, 'engineer');
+
+        expect(status).toBe(200);
+        expect(body.total).toBe(2);
+        expect(body.data.length).toBe(2);
+    });
+
+    it('the legacy `data` envelope a protocol double may answer with still works', async () => {
+        // The aliases are kept, so the sibling suite's double and any alternate
+        // protocol keep being read. Driven here rather than assumed.
+        const stored = await persistedBody(applyForm(PICKER_NO_FILTER));
+        const rest = new RestServer(mockServer() as any, {
+            getDiscovery: vi.fn().mockResolvedValue({ version: 'v0', routes: { data: '', metadata: '' } }),
+            getMetaTypes: vi.fn().mockResolvedValue([]),
+            getMetaItem: vi.fn().mockResolvedValue(undefined),
+            getMetaItems: vi.fn(async ({ type }: { type: string }) => {
+                if (type === 'view') return [stored];
+                if (type === 'object') return [jobObject, applicationObject];
+                return [];
+            }),
+            findData: vi.fn().mockResolvedValue({ data: [{ id: 'job_9', title: 'Legacy envelope', city: 'Oslo' }] }),
+        } as any, { api: { requireAuth: false } } as any);
+        (rest as any).resolveExecCtx = async () => ({ userId: 'test-user' });
+        rest.registerRoutes();
+        const route = rest.getRoutes().find((r: any) => r.method === 'GET' && r.path.endsWith('/forms/:slug/lookup/:field'))!;
+        const res = mockRes();
+        await (route as any).handler({ params: { slug: 'apply', field: 'job' }, query: {} } as any, res);
+
+        expect(res.statusCode).toBe(200);
+        expect(res.body.data).toEqual([{ id: 'job_9', title: 'Legacy envelope', city: 'Oslo' }]);
     });
 });

--- a/packages/rest/src/public-form-lookup-filter-lowering.test.ts
+++ b/packages/rest/src/public-form-lookup-filter-lowering.test.ts
@@ -1,0 +1,412 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * [#16581] `GET /forms/:slug/lookup/:field` answers a SEARCH, not a 400.
+ *
+ * ## The defect
+ *
+ * The route composed its filter list out of `ViewFilterRule` objects — the
+ * `{ field, operator, value }` dialect `FormFieldPublicPickerSchema.filter`
+ * declares in so many words ("Same `{ field, operator, value }` dialect as
+ * list-view filters") — and put them on the `findData` filter slot, which
+ * accepts a `FilterCondition` object or a `FilterArray` and refuses everything
+ * else with `400 INVALID_FILTER`. ⭐ The `q` branch builds the SAME object shape
+ * itself, so the refusal did not depend on an author declaring
+ * `publicPicker.filter`: every non-empty search 400'd, and only the degenerate
+ * empty-filter call could succeed. That is the endpoint's entire purpose, on an
+ * anonymous surface an applicant has no way around.
+ *
+ * ## Why this file exists next to `public-form-lookup-picker.test.ts`
+ *
+ * That suite stubs `findData` and pins the route's request COMPOSITION, so it
+ * could never have met the ingress's verdict on the value it composed — which
+ * is exactly how a route shipped for this long building a filter nothing would
+ * parse. Here the protocol's `findData` is the REAL
+ * `ObjectStackProtocolImplementation`, so the request crosses the same
+ * normalizer a served deployment uses and the assertions are on the ANSWER
+ * (status and rows), not on the source this card wrote.
+ *
+ * ## ⭐ §3 is the discriminating control and is not optional
+ *
+ * "The route lowers correctly" and "the parser was loosened" produce the same
+ * green in §1 and §2 and have opposite consequences. §3 keeps the card's own
+ * control pair — the object shape and the triple shape, fed to the ingress
+ * DIRECTLY through `GET /data/:object`'s `$filter` — and asserts the object
+ * shape is still refused. ⛔ Never delete or "repair" §3 to make a change pass:
+ * a green §1/§2 means nothing without it. (`rest-server-canonical-query-ast.ts`'s
+ * §3 CONTROL pins the same fact from its own frozen literal; two independent
+ * pins, deliberately.)
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+// The engine-double contract (#4434 / #5619): a fake engine's update/delete
+// must be exactly as strict as ObjectQL's dispatch, or a dead route ships with
+// its suite green. Both predicates live in metadata-core.
+import {
+    assertEngineDeleteDispatch,
+    assertEngineUpdateDispatch,
+    assertEngineFindOnePredicate,
+    type EngineFindOneQueryInput,
+} from '@objectstack/metadata-core';
+import { ObjectStackProtocolImplementation } from '@objectstack/metadata-protocol';
+import { RestServer } from './rest-server.js';
+
+// ─── the fixture: the card's own shape (an anonymous job-application form) ───
+
+const JOBS = [
+    { id: 'job_1', title: 'Senior software engineer', city: 'Berlin', status: 'published' },
+    { id: 'job_2', title: 'Lead engineer', city: 'Lisbon', status: 'draft' },
+    { id: 'job_3', title: 'Product designer', city: 'Berlin', status: 'published' },
+    { id: 'job_4', title: 'Staff engineer', city: 'Remote', status: 'published' },
+];
+
+const jobObject = {
+    name: 'ats_job',
+    label: 'Job',
+    nameField: 'title',
+    fields: {
+        id: { name: 'id', type: 'text' },
+        title: { name: 'title', type: 'text', label: 'Title' },
+        city: { name: 'city', type: 'text', label: 'City' },
+        status: { name: 'status', type: 'text', label: 'Status' },
+    },
+};
+
+const applicationObject = {
+    name: 'ats_application',
+    label: 'Application',
+    fields: {
+        id: { name: 'id', type: 'text' },
+        job: { name: 'job', type: 'lookup', reference: 'ats_job', label: 'Job' },
+    },
+};
+
+/** The picker the card declares, verbatim. */
+const PICKER_WITH_FILTER = {
+    displayFields: ['title', 'city'],
+    filter: [{ field: 'status', operator: 'equals', value: 'published' }],
+};
+
+/** The same picker with NO declared filter — the case that 400'd anyway. */
+const PICKER_NO_FILTER = { displayFields: ['title', 'city'] };
+
+const applyForm = (picker: unknown) => ({
+    name: 'ats_application.apply',
+    object: 'ats_application',
+    viewKind: 'form',
+    label: 'Apply',
+    config: {
+        type: 'simple',
+        data: { provider: 'object', object: 'ats_application' },
+        sharing: { allowAnonymous: true, publicLink: '/forms/apply' },
+        sections: [{ label: 'Your application', fields: [{ field: 'job', publicPicker: picker }] }],
+    },
+});
+
+// ─── the real save path, so the fixture is a form the spec ACCEPTS ──────────
+
+/** The slice of the engine the `sys_metadata` write path touches. */
+function metadataEngine() {
+    const rows: Array<Record<string, any>> = [];
+    let nextId = 0;
+    return {
+        rows,
+        engine: {
+            async findOne(object: string, query?: EngineFindOneQueryInput) {
+                assertEngineFindOnePredicate(object, query); return null;
+            },
+            async find() { return rows.slice(); },
+            async insert(table: string, data: Record<string, any>) {
+                if (table === 'sys_metadata_audit') return { id: 'audit_skip' };
+                nextId += 1;
+                rows.push({ id: `r_${nextId}`, ...data });
+                return { id: `r_${nextId}` };
+            },
+            async update(_t: string, data: Record<string, unknown>, opts: { where: Record<string, unknown> }) {
+                assertEngineUpdateDispatch(data, opts);
+                return { id: null };
+            },
+            async delete(_t: string, opts: { where: Record<string, unknown> }) {
+                assertEngineDeleteDispatch(opts);
+                return { deleted: 0 };
+            },
+            registry: { registerItem: () => {}, registerObject: () => {}, listItems: () => [] },
+        } as any,
+    };
+}
+
+/**
+ * Persist a view through the REAL `saveMetaItem` and return the stored body.
+ * A 422 here would mean the picker fixture is not spec-valid, which would make
+ * every route assertion below a statement about an unauthorable form.
+ */
+async function persistedBody(item: unknown): Promise<any> {
+    const { engine, rows } = metadataEngine();
+    const protocol = new ObjectStackProtocolImplementation(engine, () => new Map()) as any;
+    const result = await protocol.saveMetaItem({ type: 'view', name: 'ats_application.apply', item });
+    expect(result.success, JSON.stringify(result)).toBe(true);
+    const row = rows.find((r) => r.type === 'view');
+    expect(row, 'the save persisted no view row').toBeDefined();
+    return JSON.parse(row!.metadata);
+}
+
+// ─── the data engine: rows filtered by the condition that REALLY arrives ────
+
+/**
+ * Evaluate a lowered `FilterCondition` against a row.
+ *
+ * ⚠️ Deliberately tiny and deliberately LOUD. It implements exactly the two
+ * comparisons this card's filters lower to and throws on anything else,
+ * including an array — a filter still in the authoring dialect reaching a
+ * driver is the defect itself, and a matcher that shrugged at it would let a
+ * half-lowered filter pass as "the right rows". Case-sensitive `$contains`
+ * follows the spec's split (`icontains` is the insensitive twin); which of the
+ * two the route composes is #16581's business, not this matcher's.
+ */
+function matchesCondition(row: Record<string, unknown>, cond: unknown): boolean {
+    if (cond === undefined || cond === null) return true;
+    if (Array.isArray(cond)) {
+        if (cond.length === 0) return true; // `[]` — "no filter", every path reads it so
+        throw new Error(`an UNLOWERED filter reached the driver: ${JSON.stringify(cond)}`);
+    }
+    if (typeof cond !== 'object') throw new Error(`unexpected filter: ${JSON.stringify(cond)}`);
+    for (const [key, expected] of Object.entries(cond as Record<string, unknown>)) {
+        if (key === '$and') {
+            if (!(expected as unknown[]).every((c) => matchesCondition(row, c))) return false;
+            continue;
+        }
+        if (key === '$or') {
+            if (!(expected as unknown[]).some((c) => matchesCondition(row, c))) return false;
+            continue;
+        }
+        if (expected && typeof expected === 'object' && !Array.isArray(expected)) {
+            for (const [op, operand] of Object.entries(expected as Record<string, unknown>)) {
+                if (op === '$eq') {
+                    if (row[key] !== operand) return false;
+                } else if (op === '$contains') {
+                    if (!String(row[key] ?? '').includes(String(operand))) return false;
+                } else {
+                    throw new Error(`this suite's matcher does not implement "${op}"`);
+                }
+            }
+            continue;
+        }
+        if (row[key] !== expected) return false; // implicit-equality form
+    }
+    return true;
+}
+
+/** The option bag `engine.find` last received, for the receipt assertions. */
+type DataEngine = { engine: any; seen: () => Record<string, any> | undefined };
+
+function dataEngine(): DataEngine {
+    let seen: Record<string, any> | undefined;
+    const objects: Record<string, unknown> = { ats_job: jobObject, ats_application: applicationObject };
+    const engine = {
+        registry: { getObject: (n: string) => objects[n] },
+        find: async (object: string, options: Record<string, any>) => {
+            seen = options;
+            if (object !== 'ats_job') return [];
+            return JOBS.filter((r) => matchesCondition(r, options?.where));
+        },
+        aggregate: async () => [],
+        count: async () => 0,
+    };
+    return { engine, seen: () => seen };
+}
+
+// ─── the real routes over a REAL `findData` ─────────────────────────────────
+
+function mockServer() {
+    return {
+        get: vi.fn(), post: vi.fn(), put: vi.fn(), delete: vi.fn(), patch: vi.fn(),
+        use: vi.fn(), listen: vi.fn().mockResolvedValue(undefined), close: vi.fn().mockResolvedValue(undefined),
+    };
+}
+
+function mockRes() {
+    const res: any = { statusCode: 200, body: undefined };
+    res.status = vi.fn((c: number) => { res.statusCode = c; return res; });
+    res.json = vi.fn((b: any) => { res.body = b; return res; });
+    res.header = vi.fn(() => res);
+    res.end = vi.fn(() => res);
+    return res;
+}
+
+/**
+ * Mount the real routes. `getMetaItems` is stubbed (it serves the stored form
+ * and the object definitions); `findData` is the REAL protocol's, bound to the
+ * data engine above — so the filter this route composes crosses the real
+ * ingress and the real lowering before any row is matched.
+ */
+function routesOver(storedView: any) {
+    const { engine, seen } = dataEngine();
+    const real = new ObjectStackProtocolImplementation(engine as never) as any;
+    const protocol: any = {
+        getDiscovery: vi.fn().mockResolvedValue({ version: 'v0', routes: { data: '', metadata: '' } }),
+        getMetaTypes: vi.fn().mockResolvedValue([]),
+        getMetaItem: vi.fn().mockResolvedValue(undefined),
+        getMetaItems: vi.fn(async ({ type }: { type: string }) => {
+            if (type === 'view') return [storedView];
+            if (type === 'object') return [jobObject, applicationObject];
+            return [];
+        }),
+        findData: (request: unknown) => real.findData(request),
+    };
+    const rest = new RestServer(mockServer() as any, protocol, { api: { requireAuth: false } } as any);
+    (rest as any).resolveExecCtx = async () => ({ userId: 'test-user' });
+    rest.registerRoutes();
+    const route = (method: string, suffix: string) => {
+        const found = rest.getRoutes().find((r: any) => r.method === method && r.path.endsWith(suffix));
+        if (!found) throw new Error(`route ${method} …${suffix} is not mounted`);
+        return found as any;
+    };
+    return { seen, lookup: route('GET', '/forms/:slug/lookup/:field'), list: route('GET', '/data/:object') };
+}
+
+/** Drive the anonymous picker exactly as a browser does: no cookie, one `q`. */
+async function lookup(storedView: any, q?: string) {
+    const { lookup: route, seen } = routesOver(storedView);
+    const res = mockRes();
+    await route.handler({ params: { slug: 'apply', field: 'job' }, query: q === undefined ? {} : { q } } as any, res);
+    return { status: res.statusCode, body: res.body, where: seen()?.where };
+}
+
+// ---------------------------------------------------------------------------
+// §1 the `q` branch — the half that 400'd with NO declared filter at all
+// ---------------------------------------------------------------------------
+
+describe('[#16581] §1 the route lowers the search predicate it builds itself', () => {
+    it('q=engineer answers 200 with the matching rows, not 400 INVALID_FILTER', async () => {
+        // The card's headline call. Before the fix this was
+        // `400 {"code":"INVALID_FILTER"}` — the route's own `{ field, operator:
+        // 'contains', value: q }` row is the object dialect too, so no author
+        // had to declare anything for the endpoint to be unusable.
+        const stored = await persistedBody(applyForm(PICKER_NO_FILTER));
+        const { status, body, where } = await lookup(stored, 'engineer');
+
+        expect(status).toBe(200);
+        expect(body.data).toEqual([
+            { id: 'job_1', title: 'Senior software engineer', city: 'Berlin' },
+            { id: 'job_2', title: 'Lead engineer', city: 'Lisbon' },
+            { id: 'job_4', title: 'Staff engineer', city: 'Remote' },
+        ]);
+        // The receipt: what the ENGINE received is a lowered `FilterCondition`,
+        // which is the only way the rows above could have been produced.
+        expect(where).toEqual({ title: { $contains: 'engineer' } });
+    });
+
+    it('the degenerate empty search still answers 200 — the one call that always worked', async () => {
+        // A guard, not a new capability: `filters: []` was the single shape the
+        // ingress accepted before, and the lowering must not turn "no filter"
+        // into `['and']`, a logical node with nothing to join that the ingress
+        // refuses outright.
+        const stored = await persistedBody(applyForm(PICKER_NO_FILTER));
+        const { status, body, where } = await lookup(stored);
+
+        expect(status).toBe(200);
+        expect(body.data.map((r: any) => r.id)).toEqual(['job_1', 'job_2', 'job_3', 'job_4']);
+        expect(where).toEqual([]);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// §2 the declared `publicPicker.filter` branch, and the two composed
+// ---------------------------------------------------------------------------
+
+describe('[#16581] §2 the declared filter is lowered too, and ANDed ahead of the search', () => {
+    it('the declared filter alone answers 200 and really restricts the rows', async () => {
+        const stored = await persistedBody(applyForm(PICKER_WITH_FILTER));
+        const { status, body, where } = await lookup(stored);
+
+        expect(status).toBe(200);
+        // `job_2` is `draft`: the declared pre-filter is APPLIED, not merely
+        // accepted. On this surface that distinction is the security property —
+        // the filter is what keeps an anonymous visitor inside the rows the form
+        // is allowed to expose.
+        expect(body.data.map((r: any) => r.id)).toEqual(['job_1', 'job_3', 'job_4']);
+        expect(where).toEqual({ status: 'published' });
+    });
+
+    it('the declared filter AND the visitor search compose — the card\'s full combination', async () => {
+        const stored = await persistedBody(applyForm(PICKER_WITH_FILTER));
+        const { status, body, where } = await lookup(stored, 'engineer');
+
+        expect(status).toBe(200);
+        // `job_3` fails the search, `job_2` fails the declared filter: only rows
+        // passing BOTH survive, which is what proves both branches lowered.
+        expect(body.data).toEqual([
+            { id: 'job_1', title: 'Senior software engineer', city: 'Berlin' },
+            { id: 'job_4', title: 'Staff engineer', city: 'Remote' },
+        ]);
+        expect(where).toEqual({ $and: [{ status: 'published' }, { title: { $contains: 'engineer' } }] });
+    });
+
+    it('a legacy operator spelling in a STORED row folds through the spec\'s own normalizer', async () => {
+        // `notEquals` is a `VIEW_FILTER_OPERATOR_ALIASES` row: authored today the
+        // schema folds it on parse, but a row stored before that fold — and this
+        // route reads STORED bodies, never re-parsed ones — still carries it.
+        // The lowering reuses `normalizeFilterOperator`, the schema's own
+        // preprocess, so the canonical spelling is what reaches the parser. ⛔ A
+        // second alias table here is what that reuse exists to prevent.
+        const stored = await persistedBody(applyForm(PICKER_NO_FILTER));
+        stored.config.sections[0].fields[0].publicPicker.filter = [
+            { field: 'status', operator: 'notEquals', value: 'draft' },
+        ];
+        const { status, body, where } = await lookup(stored);
+
+        expect(status).toBe(200);
+        expect(body.data.map((r: any) => r.id)).toEqual(['job_1', 'job_3', 'job_4']);
+        expect(where).toEqual({ status: { $ne: 'draft' } });
+    });
+
+    it('an unreadable stored rule is FORWARDED, so the request is still refused — never served unfiltered', async () => {
+        // The fail-closed direction, stated as a test because the tempting
+        // repair is the opposite one. A row the lowering cannot read as a rule
+        // is passed through and the ingress refuses the whole request; dropping
+        // it would answer 200 over an UNFILTERED table on an anonymous surface —
+        // a widening delivered silently by the code repairing a refusal.
+        const stored = await persistedBody(applyForm(PICKER_NO_FILTER));
+        stored.config.sections[0].fields[0].publicPicker.filter = [{ nonsense: true }];
+        const { status, body } = await lookup(stored, 'engineer');
+
+        expect(status).toBe(400);
+        expect(body.code).toBe('INVALID_FILTER');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// ⭐ §3 THE DISCRIMINATING CONTROL — the card's own control pair
+// ---------------------------------------------------------------------------
+
+describe('[#16581] §3 CONTROL: the parser was NOT loosened — the object shape still answers 400', () => {
+    /** `GET /data/:object?$filter=…` on the same server, same ingress. */
+    async function dataApi($filter: string) {
+        const stored = await persistedBody(applyForm(PICKER_NO_FILTER));
+        const { list } = routesOver(stored);
+        const res = mockRes();
+        await list.handler({ params: { object: 'ats_job' }, query: { $filter } } as any, res);
+        return { status: res.statusCode, body: res.body };
+    }
+
+    it('the OBJECT shape fed straight to the parser is refused — 400 INVALID_FILTER', async () => {
+        // ⭐ Without this assertion a green §1/§2 cannot be told apart from "the
+        // parser was loosened to accept `ViewFilterRule` objects", which is the
+        // repair the ruling excludes: it would maintain two filter grammars in
+        // the data layer forever and spread the shape to every `findData`
+        // caller. ⛔ Do not delete, weaken or "repair" this expectation.
+        const { status, body } = await dataApi('[{"field":"status","operator":"equals","value":"published"}]');
+        expect(status).toBe(400);
+        expect(body.code).toBe('INVALID_FILTER');
+        expect(body.error).toContain('is not a recognised filter shape');
+    });
+
+    it('…and the TRIPLE shape on the same call answers 200 — the pair attributes the failure to SHAPE', async () => {
+        // The other half of the card's control: same server, same object, same
+        // anonymity, only the filter's shape differs. That is what rules out
+        // permissions, anonymity and every other part of the route as the cause.
+        const { status, body } = await dataApi('[["status","=","published"]]');
+        expect(status).toBe(200);
+        expect(body.data.map((r: any) => r.id)).toEqual(['job_1', 'job_3', 'job_4']);
+    });
+});

--- a/packages/rest/src/public-form-lookup-filter-lowering.test.ts
+++ b/packages/rest/src/public-form-lookup-filter-lowering.test.ts
@@ -155,7 +155,7 @@ async function persistedBody(item: unknown): Promise<any> {
 /**
  * Evaluate a lowered `FilterCondition` against a row.
  *
- * ⚠️ Deliberately tiny and deliberately LOUD. It implements exactly the two
+ * ⚠️ Deliberately tiny and deliberately LOUD. It implements exactly the three
  * comparisons this card's filters lower to and throws on anything else,
  * including an array — a filter still in the authoring dialect reaching a
  * driver is the defect itself, and a matcher that shrugged at it would let a

--- a/packages/rest/src/public-form-lookup-picker.test.ts
+++ b/packages/rest/src/public-form-lookup-picker.test.ts
@@ -206,14 +206,19 @@ describe('#7467 a spec-valid stored form carrying a publicPicker reaches the loo
         //
         // [#16337] The KEYS are the canonical QueryAST ones (`where` / `fields`
         // / `orderBy`); until then the route spelled them `filters` / `select` /
-        // `sort`, wire aliases the normalizer folds onto exactly these. The
-        // VALUES are byte-identical across that rewrite, which is the point —
-        // and note what `where` carries: `ViewFilterRule` rows, the dialect
-        // `FormFieldPublicPickerSchema.filter` declares, NOT a
-        // `FilterCondition`. `findData` is stubbed in this suite, so it never
-        // meets the ingress's verdict on that value; the real normalizer
-        // refuses it (#16581) — ⛔ do not "repair" it by editing this
-        // expectation.
+        // `sort`, wire aliases the normalizer folds onto exactly these.
+        //
+        // [#16581] The VALUE on `where` is the part that moved. It used to be
+        // the `ViewFilterRule` rows verbatim — the dialect
+        // `FormFieldPublicPickerSchema.filter` declares — which the ingress
+        // refuses with `400 INVALID_FILTER`, so this endpoint answered 400 for
+        // every non-empty search. The route now LOWERS them to the
+        // `FilterArray` grammar the parser reads, and the declared conjunction
+        // is written down rather than left to the list form's implicit AND.
+        // ⚠️ `findData` is stubbed in this suite, so this remains a COMPOSITION
+        // pin and cannot say the value is served: that is measured against the
+        // real normalizer in `public-form-lookup-filter-lowering.test.ts`,
+        // whose §3 keeps the control that the parser itself was NOT loosened.
         expect(findData).toHaveBeenCalledTimes(1);
         const call = findData.mock.calls[0][0];
         expect(call.object).toBe('sys_user');
@@ -224,8 +229,9 @@ describe('#7467 a spec-valid stored form carrying a publicPicker reaches the loo
         // ascending. The route's `picker.sort ??` read is retired.
         expect(call.query.orderBy).toEqual([{ field: 'name', order: 'asc' }]);
         expect(call.query.where).toEqual([
-            { field: 'is_active', operator: 'equals', value: true },
-            { field: 'name', operator: 'contains', value: 'ad' },
+            'and',
+            ['is_active', 'equals', true],
+            ['name', 'contains', 'ad'],
         ]);
         expect(call.context.anonymous).toBe(true);
     });

--- a/packages/rest/src/rest-server-canonical-query-ast.test.ts
+++ b/packages/rest/src/rest-server-canonical-query-ast.test.ts
@@ -41,7 +41,15 @@
  * pair is asserted equal by both REFUSING — its `where` carries
  * `ViewFilterRule` rows, which the ingress declines with `400 INVALID_FILTER`
  * before and after this card alike. Equality is the assertion; the verdict on
- * either side is the ingress's, and repairing it is #16581.
+ * either side is the ingress's.
+ *
+ * [#16581] The ROUTE no longer builds that literal — it lowers the rule rows to
+ * the `FilterArray` grammar before dispatch — but the pair stays exactly as
+ * frozen here, and its CONTROL becomes load-bearing in a second way: it is one
+ * of the two independent pins that the object dialect is still REFUSED, i.e.
+ * that #16581 lowered the route rather than loosening the parser. ⛔ Never
+ * "update" the picker pair to the lowered shape: a frozen BEFORE that is
+ * rewritten to match the after measures nothing.
  */
 
 import { describe, it, expect, vi } from 'vitest';
@@ -330,6 +338,13 @@ describe('[#16337] §3 the rewrite moves nothing — driven through the real nor
         // Stated rather than left implicit: this pair's equality is not evidence
         // that the picker query is served. Both sides carry `ViewFilterRule`
         // rows on the filter slot, which is not a `FilterCondition`.
+        //
+        // [#16581] ⭐ And this is now the discriminating control for that card:
+        // the route lowers those rows before dispatch, so it no longer sends
+        // this literal — while the literal itself must still be REFUSED. A
+        // green picker search plus a green line here means "the route lowers";
+        // a green picker search with this line flipped would have meant "the
+        // parser was loosened", the repair the ruling excludes.
         const outcome = await normalized(PAIRS[3].canonical) as { refused?: { code?: string; status?: number } };
         expect(outcome.refused).toEqual({ code: 'INVALID_FILTER', status: 400 });
     });

--- a/packages/rest/src/rest-server.ts
+++ b/packages/rest/src/rest-server.ts
@@ -10599,7 +10599,23 @@ export class RestServer {
 
                     // Project the response server-side too — never trust
                     // that the driver respected `select`.
-                    const rows: any[] = Array.isArray(result?.data) ? result.data : Array.isArray(result?.items) ? result.items : [];
+                    //
+                    // [#16581] `records` FIRST, which is the key `findData`
+                    // actually returns (`{ object, records, total, hasMore }`)
+                    // and the order the other three read sites in this file
+                    // already use. This one read `data` / `items` and NOT
+                    // `records`, so against the real protocol it matched
+                    // nothing and the picker answered `200 {"data":[]}` — an
+                    // empty list for every search. Invisible until the filter
+                    // above stopped 400ing, and invisible to the sibling suite
+                    // because its `findData` double answers `{ data }`, a shape
+                    // the protocol does not produce. The legacy aliases stay so
+                    // those doubles and alternate protocols keep working.
+                    const rows: any[] = Array.isArray(result?.records) ? result.records
+                        : Array.isArray(result?.data) ? result.data
+                            : Array.isArray(result?.items) ? result.items
+                                : Array.isArray(result?.rows) ? result.rows
+                                    : Array.isArray(result) ? result : [];
                     const projected = rows.slice(0, maxResults).map((row: any) => {
                         const out: any = { id: row?.id };
                         for (const f of displayFields) {

--- a/packages/rest/src/rest-server.ts
+++ b/packages/rest/src/rest-server.ts
@@ -300,6 +300,8 @@ import {
     type ExportFieldMeta,
 } from './export-format.js';
 import { runImport } from './import-runner.js';
+// [#16581] The public picker's authoring-dialect → parser-grammar lowering.
+import { lowerViewFilterRules } from './view-filter-rule-lowering.js';
 import { prepareImportRequest } from './import-prepare.js';
 import { loadExcelJs, type Worksheet } from './xlsx-module.js';
 import { enrichOpenApiWithEndpoints } from './openapi-endpoints.js';
@@ -10530,9 +10532,25 @@ export class RestServer {
                     // then the search predicate over displayFields. The
                     // search predicate uses `contains` on the first
                     // display field so non-indexed columns still work.
-                    const filters: any[] = [];
-                    if (Array.isArray(picker.filter)) filters.push(...picker.filter);
-                    if (q) filters.push({ field: displayFields[0], operator: 'contains', value: q });
+                    //
+                    // [#16581] …and then LOWER the composed rows to the filter
+                    // grammar the ingress parses. BOTH halves are the authoring
+                    // dialect `FormFieldPublicPickerSchema.filter` declares
+                    // (`{field, operator, value}`) — the declared rows because
+                    // an author wrote them, the search row because this route
+                    // built it in the same shape — and the normalizer refuses
+                    // that shape with `400 INVALID_FILTER`. So the endpoint
+                    // answered 400 for EVERY non-empty search, with or without a
+                    // declared `publicPicker.filter`; only the degenerate
+                    // no-filter call could succeed. `lowerViewFilterRules` is
+                    // the one-way translation (authoring dialect →
+                    // `FilterArray`) and lives at this door because this is the
+                    // door that speaks both; ⛔ the repair the ruling excludes
+                    // is teaching `findData` a second dialect.
+                    const rules: any[] = [];
+                    if (Array.isArray(picker.filter)) rules.push(...picker.filter);
+                    if (q) rules.push({ field: displayFields[0], operator: 'contains', value: q });
+                    const filters = lowerViewFilterRules(rules);
 
                     const context: any = {
                         permissions: ['guest_portal'],
@@ -10547,16 +10565,16 @@ export class RestServer {
                         // moves the value verbatim, so this is a spelling change
                         // and nothing else.
                         //
-                        // ⚠️ The VALUE on `where` is unchanged and is NOT a
-                        // `FilterCondition`: `filters` carries `ViewFilterRule`
-                        // rows (`{field, operator, value}` objects, the dialect
-                        // `FormFieldPublicPickerSchema.filter` declares) composed
-                        // with the route's own search row, and the ingress refuses
-                        // a non-empty one with `400 INVALID_FILTER` — measured, and
-                        // filed as #16581. ⛔ Not repaired here: this card retypes
-                        // the SPELLING of these literals and moves no behaviour.
-                        // `FilterCondition`'s `[key: string]: any` index signature
-                        // is why the array still compiles against the slot.
+                        // ⚠️ The VALUE on `where` is a `FilterArray`, not a
+                        // `FilterCondition`. #16337 left `ViewFilterRule` OBJECTS
+                        // here — the dialect `FormFieldPublicPickerSchema.filter`
+                        // declares — which the ingress refuses with
+                        // `400 INVALID_FILTER`; #16581 lowers them above, so what
+                        // arrives is the declared array grammar the normalizer
+                        // parses. `FilterCondition`'s `[key: string]: any` index
+                        // signature is why an array compiles against the slot at
+                        // all; that the value is now a filter the ingress ACCEPTS
+                        // is measured end-to-end, not asserted by the type.
                         query: {
                             object: referenceTo,
                             limit: maxResults,

--- a/packages/rest/src/view-filter-rule-lowering.ts
+++ b/packages/rest/src/view-filter-rule-lowering.ts
@@ -1,0 +1,90 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * [#16581] Lower `ViewFilterRule` rows to the filter grammar the data ingress
+ * actually parses.
+ *
+ * ## The gap this closes
+ *
+ * `FormFieldPublicPickerSchema.filter` declares the object dialect in so many
+ * words — *"Same `{ field, operator, value }` dialect as list-view filters"* —
+ * and `GET /forms/:slug/lookup/:field` put those rows straight onto the
+ * `findData` filter slot. That slot is read by
+ * `@objectstack/metadata-protocol`'s normalizer, which accepts a
+ * `FilterCondition` object or a `FilterArray` (`[field, operator, value]`, a
+ * logical node, or a list of those) and refuses anything else with
+ * `400 INVALID_FILTER`. An array of `{field, operator, value}` OBJECTS is none
+ * of those, so the route answered 400 for **every** non-empty search — the
+ * declared pre-filter and the route's own `q` predicate alike, since the `q`
+ * branch builds the same object shape. Only the degenerate empty-filter call
+ * could succeed.
+ *
+ * ⛔ The repair is NOT a second dialect on `findData`. Two filter grammars in
+ * the data layer would be maintained forever and would spread the object shape
+ * to every `findData` caller; the declaring side already promises the object
+ * dialect on the AUTHORING surface, so what has to change is the side that
+ * failed to honour it. This module is that side: authoring dialect in,
+ * parser grammar out, at the one door that speaks both.
+ *
+ * ## The operator fold is the spec's own, not a second table
+ *
+ * {@link normalizeFilterOperator} (`@objectstack/spec/ui`) is the fold
+ * `ViewFilterRuleSchema.operator` itself runs as its `z.preprocess`, exported
+ * precisely so "producers and renderers can normalize stored metadata against
+ * the SAME canonical map the schema uses, instead of inventing a second
+ * dialect". ⛔ Never hand-write an alias table here: a stored row predating a
+ * spelling's canonicalisation (`notEquals`, `isNotEmpty`, `gt`) must fold the
+ * way the schema folds it, and `AST_OPERATOR_MAP`'s coverage of that vocabulary
+ * is what `filter-view-operator-parity.test.ts` holds.
+ *
+ * ## An unlowerable row is FORWARDED, never dropped
+ *
+ * A row this function cannot read as a rule passes through verbatim, so the
+ * ingress refuses the whole request exactly as it did before. That direction is
+ * deliberate and it is the fail-CLOSED one: a picker's static filter is often
+ * the only thing keeping an anonymous visitor's search inside the rows a form
+ * is allowed to expose (`filter: [{ field: 'status', … 'published' }]`).
+ * Skipping a row we did not understand would turn a loud 400 into a 200 over an
+ * UNFILTERED table on an unauthenticated surface — a widening, delivered
+ * silently, by the code that was supposed to be repairing a refusal.
+ */
+
+import { normalizeFilterOperator } from '@objectstack/spec/ui';
+
+/**
+ * One rule → one `FilterArray` comparison node, or the input verbatim when it
+ * is not a readable `{ field, operator, value }` row (see the module header:
+ * that is the fail-closed path, not a fallback).
+ *
+ * `value: undefined` emits the two-element form the grammar declares
+ * (`[field, operator]`) rather than a triple with an `undefined` in comparand
+ * position. That is the shape a unary rule authors as — `ViewFilterRuleSchema`
+ * documents `is_empty` / `is_not_empty` / `is_null` / `is_not_null` as taking
+ * their direction from the operator NAME and ignoring `value` — and it needs no
+ * local list of which operators are unary, which would be a third copy of a
+ * vocabulary the spec already owns.
+ */
+function lowerViewFilterRule(rule: unknown): unknown {
+    if (!rule || typeof rule !== 'object' || Array.isArray(rule)) return rule;
+    const { field, operator, value } = rule as { field?: unknown; operator?: unknown; value?: unknown };
+    if (typeof field !== 'string' || field.length === 0) return rule;
+    if (typeof operator !== 'string') return rule;
+    const op = normalizeFilterOperator(operator);
+    return value === undefined ? [field, op] : [field, op, value];
+}
+
+/**
+ * Lower a list of `ViewFilterRule` rows to the value the filter slot takes.
+ *
+ * - no rows → `[]`, which every path already reads as "no filter". ⛔ Not
+ *   `['and']`: a logical node with nothing to join is itself refused (the one
+ *   shape that used to return every row silently), and "the author declared no
+ *   pre-filter" must not become a rejected request.
+ * - one or more rows → an explicit `['and', …]` node. The route ANDs its
+ *   static rows with the visitor's search predicate, so the conjunction is
+ *   written down rather than left to the list form's implicit AND.
+ */
+export function lowerViewFilterRules(rules: readonly unknown[]): unknown[] {
+    if (rules.length === 0) return [];
+    return ['and', ...rules.map(lowerViewFilterRule)];
+}

--- a/scripts/engine-double-contract.pinned.json
+++ b/scripts/engine-double-contract.pinned.json
@@ -3147,6 +3147,21 @@
       "pinned": 1
     },
     {
+      "file": "packages/rest/src/public-form-lookup-filter-lowering.test.ts",
+      "verb": "delete",
+      "pinned": 1
+    },
+    {
+      "file": "packages/rest/src/public-form-lookup-filter-lowering.test.ts",
+      "verb": "findOne",
+      "pinned": 1
+    },
+    {
+      "file": "packages/rest/src/public-form-lookup-filter-lowering.test.ts",
+      "verb": "update",
+      "pinned": 1
+    },
+    {
       "file": "packages/rest/src/public-form-lookup-picker.test.ts",
       "verb": "delete",
       "pinned": 1


### PR DESCRIPTION
Fixes #16581

`GET /forms/:slug/lookup/:field` answered `400 INVALID_FILTER` for every non-empty search. The route composed its filter list out of `ViewFilterRule` objects — the `{ field, operator, value }` dialect `FormFieldPublicPickerSchema.filter` declares in so many words ("Same `{ field, operator, value }` dialect as list-view filters") — and put them on the `findData` filter slot, which accepts a `FilterCondition` object or a `FilterArray` and refuses everything else. The route's own `q` predicate is built in the same object shape, so the refusal never depended on an author declaring `publicPicker.filter`: only the degenerate empty-filter call could succeed. On an anonymous application form the picker is the only sensible way to choose a job, and there is no application-side workaround.

## The direction

The ROUTE lowers `ViewFilterRule` objects to the parser's grammar. The declaring side already promises the object dialect on the authoring surface, so what changes is the side that failed to honour the promise.

- ⛔ `findData` was NOT taught a second dialect. That would maintain two filter grammars in the data layer permanently and spread the object shape to every `findData` caller.
- The operator fold reuses **`normalizeFilterOperator`** from `@objectstack/spec/ui` (`packages/spec/src/ui/view.zod.ts`) — the fold `ViewFilterRuleSchema.operator` itself runs as its `z.preprocess`, exported precisely so producers "normalize stored metadata against the SAME canonical map the schema uses, instead of inventing a second dialect". No second alias table was written. This route reads STORED bodies, never re-parsed ones, so a row carrying a legacy spelling (`notEquals`, `isNotEmpty`, `gt`) folds exactly as the schema folds it — driven by a test.
- **Nothing under `packages/spec/src/` is edited.** The schema is imported, not changed.

## Both branches are lowered

`picker.filter` (the declared rows) **and** `q` (the row the route builds itself) are composed and lowered together, ANDed explicitly. No rules still means no filter (`[]`), never an empty logical node the ingress would refuse — that degenerate call is pinned so the one shape that always worked keeps working.

A row the lowering cannot read as a rule is **forwarded verbatim**, so the ingress refuses the request exactly as before. That direction is deliberate and fail-CLOSED: a picker's static filter is often the only thing bounding what an anonymous visitor can search, and silently skipping a row nobody understood would answer 200 over an unfiltered table.

## ⭐ The discriminating control

"The route lowers correctly" and "the parser was loosened" produce identical greens and have opposite consequences, so an assertion that the object shape fed **directly to the parser** still answers 400 is kept, in two independent places:

- `public-form-lookup-filter-lowering.test.ts` §3 drives the card's own control pair through `GET /data/:object`, same server, same object, same anonymity, only the filter's shape differing — object shape → `400 INVALID_FILTER`; triple shape → `200` with the right rows. That pair is what attributes the failure to SHAPE rather than to permissions, anonymity or another part of the route.
- `rest-server-canonical-query-ast.test.ts` §3's CONTROL keeps its frozen picker literal and asserts the ingress still refuses it. The literal is a historical record, so it is deliberately left as it was rather than "updated" to the lowered shape.

Both ablation legs below leave §3 green, which is what makes it a control rather than a restatement.

## A second defect, fixed in place

Once the 400 was gone the route answered `200 {"data":[]}` — an empty picker for every search. The handler read `result.data ?? result.items` and never `result.records`, which is the key `findData` returns (`{ object, records, total, hasMore }`) and the order this file's three other read sites already use. Bounded in-place repair: same handler, same defect class (the route speaking a shape the protocol layer does not), and the acceptance for this card is "200 with the RIGHT ROWS", which is unreachable without it. The legacy `data` / `items` / `rows` / bare-array aliases stay, and a test drives one.

It was invisible twice over: unreachable while every non-empty search 400'd, and unreachable in `public-form-lookup-picker.test.ts`, whose `findData` double answers `{ data: rows }` — a shape the real protocol does not produce.

## Verification

Implementation committed FIRST, then mutated; every mutation proven on disk by marker counts and blob hash, restored under an `EXIT/INT/TERM` trap with an absolute path, and the restore proven by a whole-tree `git status --porcelain` plus blob-hash equality against HEAD. `ablation-dist-preflight` run on both legs of both ablations.

| leg | mutation | measured |
|---|---|---|
| A | the lowering removed (`filters = rules`) | 5 red — every row/status assertion of §1, §2, §4; the refusal observed is `INVALID_FILTER`. §3 stays GREEN |
| A restore | rebuilt | preflight `--absent`: marker absent from all 6 built files; tree clean |
| B | the `records` read removed | 6 red with a DIFFERENT signature — `expected [] to deeply equal [...]`, i.e. 200 with an empty list, zero `INVALID_FILTER`. §3 stays GREEN |
| B restore | rebuilt | preflight `--absent`: marker absent from all 6 built files; tree clean |

All readings below are taken on `eecc4b0` — this branch with current `origin/main` merged in, so nothing here is measured on a tree nobody is on (the derivation warned STALE TREE before the merge and the warning is gone after it).

- `pnpm --filter @objectstack/rest test` — **190 files / 3228 tests passed**.
- `pnpm --filter @objectstack/rest typecheck` — green, including `check:test-typecheck` (0 files / 0 errors / 0 pinned debt).
- Gate union, `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack --commands`, re-derived on the merged head and reconciled with `--ran`: **65 derived, 65 run, 0 NOT-MEASURED, 0 UNRUN**. Two of them (`check:dual-build-cjs-loads`, `check:type-check-debt`) first reported exit **3 — PREREQUISITE NOT MET** on a partially built tree; a full `turbo run build` across the workspace was run so both became real readings rather than a non-measurement.
- Two gates named this PR's new suite and were satisfied rather than silenced: `check:engine-double-contract` (three additive rows regenerated with `--write`, no losses) and `check:objectql-double-limit` (the data double now holds the caller's bound, after the filter and by presence).

Changeset: `patch` on `@objectstack/rest` — a user-visible runtime repair on a published route, with no package graduating or breaking.

## Clause ② — re-derived from the delivered diff: `no`

An external caller does observe 400 → 200 on a published route, but **no declared face moves**. `FormFieldPublicPickerSchema.filter` already declares the object dialect as accepted and its describe text already promises it; this makes the runtime honour what the declaration says. The diff touches `packages/rest` and one generated ledger under `scripts/`, and nothing under `packages/spec/src/`. Repairing a route that refuses what its own contract promises is a defect fix, not a contract change.

## 验收备注

Observed while working here, deliberately NOT changed and NOT filed:

- `packages/rest`'s picker suites build their `findData` doubles from response shapes the real protocol does not produce (`{ data }`, `{ items }`). That is what hid the `records` read for as long as it hid it. A repo-wide "protocol double answers the protocol's own envelope" sweep is a class-closing job, not a rider on this card.
- The lowering helper lives in `packages/rest/src/view-filter-rule-lowering.ts` because the ruling put the translation at the door that speaks both dialects. If a second consumer ever needs it, promoting it is its own card — it is not needed by anything today.
- `rest-server.ts` emits an unused-import warning for `zodIssuesToFields` during `tsup`'s ESM pass on `main` as well as here; pre-existing, unrelated to this diff, and not a build failure.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YFY46JydE1gMxQG1TqBcMZ)_