### PR TITLE
fix(lint): the partof gate stops asking for a rewrite it also forbids

### DIFF
--- a/scripts/check-partof-closing-keyword.mjs
+++ b/scripts/check-partof-closing-keyword.mjs
@@ -109,12 +109,48 @@
  * their own, so a branch pushed to the default branch by any other route closes
  * the cards its intermediate commits name.
  *
- * The remedy is the contract this repository already carries, cited rather than
- * restated — the card relation is declared ONCE, in the PR body, and the merger
- * takes the squash message from that body. ⛔ Nothing in this gate's output asks
- * anyone to rewrite history: amend, rebase and force-push are forbidden here,
- * and a red on an already-pushed branch is repaired the way this repo's merges
- * already repair it, in the body and at the merge.
+ * The contract is the one this repository already carries, cited rather than
+ * restated — the card relation is declared ONCE, in the PR body, and no commit
+ * carries a card trailer.
+ *
+ * ## RULE 2 — what the output may ask for, and when it may ask for nothing
+ *
+ * ⛔ Nothing in this gate's output asks anyone to rewrite history: amend, rebase
+ * and force-push are forbidden here. That prohibition is absolute, which makes
+ * the TIMING of a RULE 2 finding the whole story:
+ *
+ *   - BEFORE the branch is pushed the remedy is ordinary work — reword the
+ *     commit messages, state the relation only in the body, push once. Nothing
+ *     published is rewritten and the check goes green.
+ *   - ONCE THE BRANCH IS PUSHED no author action clears the red. This gate reads
+ *     the PR's COMMIT LIST, so a new commit on top JOINS that list and leaves
+ *     the offending message in it; the only thing that would remove it is the
+ *     rewrite forbidden above. The red is PERMANENT for that branch, and saying
+ *     so plainly is the point of this section. An earlier revision instead told
+ *     the author to push reworded commits — which on a pushed branch IS the
+ *     forbidden rewrite — and a seat that read it instructed one; the dev's
+ *     refusal is what stopped it, not the wording.
+ *
+ * ⚠️ That earlier revision also had the merger "take the squash message from
+ * that body". Measured, that is false: on 0a61db1f5, the squash of PR #16646,
+ * the landed message is the branch commit's verbatim and carries its
+ * `Refs #16624`, while the body's `Fixes #16624` appears nowhere in it. The
+ * squash message is assembled from the COMMITS. This does not weaken RULE 2 —
+ * it is RULE 2's premise: a trailer left on a pushed commit really does reach
+ * the default branch's permanent history.
+ *
+ * What that costs depends on the spelling, and the output says so rather than
+ * flattening it: Part-of and Refs land as a reference and move no card, while a
+ * CLOSING keyword lands on the surface GitHub's parser reads. The asymmetry is
+ * why the rule refuses all three at PR time rather than only the contradictory
+ * ones.
+ *
+ * ⛔ Whether a pull request LANDS carrying this red is not this gate's call and
+ * its output must not make it. The check run is advisory at the branch-
+ * protection layer — absent from the required-context registry, and its workflow
+ * subscribes to no `merge_group` event because a queue build carries no body for
+ * it to judge — so that decision belongs to whoever lands the PR, under the
+ * rules that bind them. This gate reports.
  *
  * ## Where the commit messages come from, and why the endpoint and not a walk
  *
@@ -314,7 +350,7 @@ const SELF_TEST_BATTERIES = Object.freeze({
   'Context reading: presence, not truthiness.': 4,
   'The wiring itself. A gate whose workflow step is deleted or whose': 6,
   'The predicate source this gate reuses must still be there to reuse.': 1,
-  'RULE 2 — every card-relation spelling in a commit message is a finding,': 13,
+  'RULE 2 — every card-relation spelling in a commit message is a finding,': 19,
   'The regression fixture: the squash that assembled a contradiction no': 4,
   'RULE 2 delegates to the sweep extractors at the commit-message reading.': 3,
   'The commit list input. An absent, broken or empty list can never read': 8,
@@ -505,10 +541,11 @@ export function commitTrailerFindings(commits) {
         `message that lands on the default branch — a text no one writes and no one reviews, which ` +
         `carries every trailer its inputs carried and can contradict itself where its parts did not. ` +
         `The trailer is also live on its own. ${RELATION_CONTRACT} ` +
-        `Remedy: move this relation into the PR body, where it is stated once, and take the squash ` +
-        `message from that body at merge. ` +
+        `Remedy, while this branch is still UNPUSHED: reword this commit message so the relation is ` +
+        `stated only in the PR body. ` +
         `⛔ Do NOT amend, rebase or force-push to remove it — rewriting pushed history is forbidden ` +
-        `here, and it is not what fixes this.`,
+        `here; on an already-pushed branch nothing removes it, and the summary below is what to do ` +
+        `about that.`,
     );
   }
   return findings;
@@ -658,8 +695,32 @@ export function judge(ctx) {
       );
       for (const finding of commitFindings) lines.push(`  ${finding}`, '');
       lines.push(
-        '  Pushing the reworded commits re-runs this check. ⛔ The repair is NOT a history rewrite:',
-        '  state the relation once in the PR body and take the squash message from that body at merge.',
+        '  ⛔ The repair is NOT a history rewrite. Amend, rebase and force-push are forbidden in this',
+        '  repository and this gate never asks for one. What it does ask for turns on one thing only:',
+        '',
+        '  BRANCH NOT PUSHED YET — reword the commit messages now and push once. Nothing published is',
+        '  rewritten, the relation goes in the PR body where the contract puts it, and this check is green.',
+        '',
+        '  BRANCH ALREADY PUSHED — no author action clears this red, and that is expected rather than a',
+        "  problem to solve. This gate reads the PR's COMMIT LIST, so a new commit on top JOINS that list",
+        '  and leaves the message above in it; the only thing that would remove it is the rewrite forbidden',
+        '  above. Three measured facts, so this red can be READ rather than acted on:',
+        '',
+        '    1. This check run is advisory at the branch-protection layer: it is absent from the',
+        '       required-context registry, and its workflow subscribes to no `merge_group` event because a',
+        '       queue build carries no PR body for it to judge.',
+        '    2. The squash message is assembled from the COMMIT messages, not from the PR body. Measured on',
+        "       0a61db1f5, the squash of PR #16646: the landed message is the branch commit's, verbatim,",
+        "       carrying its `Refs #16624`; the body's `Fixes #16624` is nowhere in it.",
+        '    3. The card relation is safe either way. #16624 closed on that same merge although no commit',
+        "       message named a closing keyword for it — the PR BODY's keyword is what acts. Declaring the",
+        '       relation once in the body is the whole contract, and it already works.',
+        '',
+        '  So the residue of landing this red is the trailer above sitting in the permanent history, and',
+        '  what that costs depends on its spelling: `Part of` and `Refs` land as a reference and move no',
+        "  card, while a CLOSING keyword lands on the surface GitHub's parser reads. ⛔ Weigh that under the",
+        '  landing rules that bind you — this gate found a real contradiction between your commits and your',
+        '  body, and it does not decide whether the pull request merges.',
       );
     }
     return { exit: EXIT_CONTRADICTION, lines: [...lines, ...(unread.length ? ['', ...unread] : [])] };
@@ -879,6 +940,43 @@ function selfTest() {
   t(
     'the finding CITES the contract rather than restating it in its own words',
     named.includes(RELATION_CONTRACT),
+    true,
+  );
+  // The guidance text itself, pinned. This gate once told the author to push
+  // reworded commits while also forbidding a rewrite — unsatisfiable on a
+  // pushed branch, and a seat that read it instructed an amend and force-push.
+  // These six hold the repaired shape: the forbidden action stays forbidden,
+  // the reachable remedy is scoped to an UNPUSHED branch, the pushed case is
+  // named as permanent, the measured squash fact replaces the false one, and
+  // the gate still refuses to decide the merge.
+  t(
+    'the guidance still forbids amend, rebase and force-push',
+    /⛔ Do NOT amend, rebase or force-push/.test(named),
+    true,
+  );
+  t(
+    'the reachable remedy is scoped to a branch that is NOT pushed yet',
+    named.includes('UNPUSHED') && named.includes('BRANCH NOT PUSHED YET'),
+    true,
+  );
+  t(
+    'the already-pushed case is named, and named as clearing for nobody',
+    named.includes('BRANCH ALREADY PUSHED') && named.includes('no author action clears this red'),
+    true,
+  );
+  t(
+    'the guidance no longer claims the squash message comes from the PR body',
+    /squash message from that body/.test(named),
+    false,
+  );
+  t(
+    'the guidance states the MEASURED squash fact instead',
+    named.includes('assembled from the COMMIT messages, not from the PR body') && named.includes('0a61db1f5'),
+    true,
+  );
+  t(
+    'the guidance leaves the landing decision to the lander rather than ordering a merge',
+    named.includes('does not decide whether the pull request merges'),
     true,
   );
   t(


### PR DESCRIPTION
Fixes #16653

`check-partof-closing-keyword`'s RULE 2 guidance told the author to push reworded commits while forbidding amend, rebase and force-push in the same breath. On an already-pushed branch those are the same act, so the red was permanent for that branch however the author responded — and a PM seat that read the text concluded an amend was wanted and instructed one. The dev's refusal is what stopped it, not the wording.

⭐ Keeping the card's own most accurate sentence, because it is what this PR does **not** change: **the gate did its job — it caught a real contradiction between a commit and a PR body; only its advice about what to do next was unreachable.**

## What changed

Guidance text and its pins in `scripts/check-partof-closing-keyword.mjs`. ⛔ No verdict logic, no exit code, no `REQUIRED_CONTEXTS` change, and remedy 3 from the card (skipping a trailer that matches the body's keyword) is deliberately absent — that is gate logic and needs a census.

The guidance now splits on **timing**, which is what dissolves the contradiction:

- **Branch not pushed yet** — reword the commit messages and push once. Nothing published is rewritten and the check goes green. This was always the reachable remedy; it was never scoped to the case where it applies.
- **Branch already pushed** — no author action clears the red, stated plainly, with the reason (the gate reads the PR's commit list, so a commit on top *joins* that list) and three measured facts that let a reader stop working on it.

## The measured facts the text now carries

**1. The squash message is assembled from the COMMITS, not from the PR body.** The old text had the merger "take the squash message from that body". Measured on `0a61db1f5`, the squash of PR #16646:

```
$ git log -1 --format=%B 0a61db1f5 | sed -n '1p;35p'
fix(tooling): isolate git children from ambient GIT_* and make a shared core.bare flip loud (#16646)
Refs #16624
```

The landed message is the branch commit's verbatim, carrying its `Refs` trailer; the body's closing keyword appears nowhere in it. This confirms the filer's addendum (`5573612912`) independently. ⚠️ It does not weaken RULE 2 — it is RULE 2's premise: a trailer left on a pushed commit really does reach permanent history.

**2. The check run is advisory at the branch-protection layer.** It is absent from the six entries of `REQUIRED_CONTEXTS` (`scripts/check-required-contexts.mjs`), and its own workflow states the mechanism: it subscribes to no `merge_group` event because a queue build carries no PR body to judge (`.github/workflows/partof-closing-keyword-guard.yml`).

**3. The card closes from the PR body's keyword.** #16624 closed on that merge although no commit message named a closing keyword for it.

## One place this PR departs from the dispatched wording, on measurement

The suggested line was that a landed trailer is *cosmetic*. Measured, that holds for `Part of` and `Refs` — they land as a reference and move no card — but **not** for a closing keyword, which lands on the surface GitHub's parser reads. Writing "cosmetic" flatly would have replaced one factually wrong remedy with another, so the text states the cost **by spelling** instead. That asymmetry is also the argument for why the rule refuses all three at PR time.

⛔ The text does not tell anyone to merge. It hands the landing decision to whoever lands the PR, under the rules that bind them — a seat whose queue-entry rule requires every check green is not overruled by a gate's own output.

## Acceptance — the verdict is unchanged

The card's acceptance is that on PR #16646's shape the verdict does not move. Reproduced from the real commit message and a body whose first line is that PR's closing keyword:

| leg | commit message | before | after |
|:---|:---|:---|:---|
| A | as landed (carries `Refs #16624`) | exit 1, names `0a61db1f5` | **exit 1, names `0a61db1f5`** |
| B | same message, that one line removed | exit 0 | **exit 0** |

The `::error::` annotation, the `✗` headline and the commit-naming opener are **byte-identical** before and after; leg B's entire output is byte-identical. Only guidance prose moved.

## Reverse verification

The six new pins are proven able to fail: restoring the old two-line tail block turns 5 of them red (`exit 1`, `5 of 89 case(s) failed`), naming the unpushed scoping, the pushed-permanence sentence, the removed false squash claim, the measured replacement and the no-merge-order clause. The sixth guards the amend/rebase/force-push prohibition in the per-commit sentence, which that ablation does not touch — correctly green.

The mutation was proven on disk before the run (printed-only anchor 1 → 0, old sentence 0 → 1, blob `d5167f42` ≠ `e4689d98`) and the restore leg proven byte-identical to `HEAD` (`e4689d98`, `git diff HEAD` empty, self-test green again). ⚠️ The first ablation attempt anchored on a phrase the new pin also spells, so its count fell 2 → 1 instead of to 0 and the on-disk guard refused the reading; the mutation had landed and the expectation was wrong. Re-anchored on a printed-only phrase and re-run — recorded because a silent retry is the same defect one layer up.

## Verification

- `pnpm check:partof-closing-keyword` (this script's `--self-test`): **89 cases pass**, exit 0.
- **All 31 derived gates run, all exit 0.** Derived in-worktree with `node scripts/pm/dispatch-gates.mjs --commands --repo objectstack-ai/objectstack` (1 path vs merge base `1ea349f0e`, three-dot), and reconciled: `✓ dispatch-gates --ran: 31 derived famil(ies) accounted for — 31 run, 0 NOT-MEASURED.`
- `eslint . --no-inline-config` (the whole `pnpm lint` set, not a narrowing): exit 0 over **6346 files**, 0 errors / 0 warnings, at `1cbd8d45`.
- No package build or package test is owed: repo-root `scripts/` is inside no workspace package, and no `*.test.*` in the tree names this script — its suite is its `--self-test`.
- Mergeability read against `origin/main` `1ea349f0` from a driver-free bare probe: clean, no conflicting paths.

## `skip-changeset`

Nothing publishes. The root package is `private`, and across all 70 published packages every `files[]` glob is package-local — none escapes its own directory, so repo-root `scripts/` cannot ship. Positive control: 70 of 70 published packages declare a non-empty `files[]` (sample `["dist","README.md","CHANGELOG.md"]`), so the scan read what it claims to have read.

## Acceptance notes

- **filed as #16747** — `RELATION_CONTRACT` presents as a verbatim citation of `.claude/agents/os-dev.md` but carries a second sentence that file does not have; the sentence exists nowhere else in the tree. Not repaired here: one candidate fix edits a governed surface and the choice between "trim the quote" and "amend the ruling" is a decision, not a mechanical correction.
- **⚠️ Overlap for the PM to route, not for this PR:** #16516 is not addressed here, and its title names this same gate ("must stop telling agents to force-push") beside a pm-dispatch queue-entry rule change. #16502 remains open and asks which rule yields when a commit-trailer red is unclearable — a decision card. This PR changes only the gate's text and answers neither; whether either is now partly overtaken by it is triage's read.
- noted, not filed: the header still opens by calling this a "BLOCKING guard" while the same header's branch-protection section explains it decides no branch protection. Both readings are defensible (blocking *by intent*, advisory *by settings*) and the section that matters is accurate, so this is a wording observation, not a defect. Successor: whoever next edits that header.

---
_Generated by [Claude Code](https://claude.ai/code/session_01P58euzUXCVJNwmhuPC9DXY)_