### PR TITLE
docs(skills): platform skill's Complete Working Example prints the scaffolder's TypeScript range

### DIFF
--- a/skills/objectstack-platform/SKILL.md
+++ b/skills/objectstack-platform/SKILL.md
@@ -605,7 +605,7 @@ A minimal but complete project from scratch:
   },
   "devDependencies": {
     "@objectstack/cli": "^17.0.0",
-    "typescript": "^6.0.0"
+    "typescript": "^5.3.0"
   }
 }
 ```


### PR DESCRIPTION
Fixes #16655

Draft, and it stays draft: `skills/**` is a governed surface, so a human merge is
the review record. No seat flips it ready, enqueues it, or arms auto-merge.

## What changed

One value, on one line. `skills/objectstack-platform/SKILL.md:608`, inside the
"Complete Working Example" `package.json` block, taught `typescript: "^6.0.0"` —
the range the scaffold emission policy retired in #16485. It now prints the range
all three scaffolders actually emit.

The value was **read at flight time**, never copied from the card or a comment:

- `packages/cli/src/commands/init.ts:312` — `export const SCAFFOLD_TYPESCRIPT_RANGE = '^5.3.0';`
- corroborated independently by `check:scaffold-emission-policy`, whose own verdict
  line prints `SCAFFOLD_TYPESCRIPT_RANGE=^5.3.0`.

The block stays complete and no other value in it moves. The four `@objectstack/*`
ranges beside it were re-checked and are current — `spec`, `runtime`,
`driver-memory`, `plugin-hono-server` and `cli` are all at `17.3.0`, which `^17.0.0`
admits. Nothing to file there.

## What is deliberately not here

The dispatched shape was triage's compromise: print the value **and** add one
adjacent sentence naming `SCAFFOLD_TYPESCRIPT_RANGE` as the authority. That
sentence is deliberately **not** in this PR, by a seat disposition recorded on the
card. Two things decided it, and the value half is the whole of the card.

**It does not fit, and that ceiling is a human floor.** The published-skills token
ratchet holds this file at 12980 tokens against a ceiling of 12984 — headroom 4
tokens, 18 bytes. The shortest wording that names the constant and the file it
lives in,

    `SCAFFOLD_TYPESCRIPT_RANGE` in `packages/cli/src/commands/init.ts` is the authority.

is 85 bytes and lands the file at 13001 tokens, **17 over**. No wording naming a
25-character constant plus a 33-character path fits in 18 bytes. Raising a ceiling
is not something a seat requests against a human floor, and deleting content to pay
for a sentence that should not land is not a trade worth making.

**It is the wrong instrument anyway**, on all four axes:

- *Real business need.* What a customer agent reading this example needs is the
  correct value, and that is what landed.
- *Long-term soundness.* Prose pointing at a constant is itself a restatement, and
  restatements rot — which is the entire lesson this card is about. The shape that
  does not rot is a gate reading the fence.
- *Structurally harder for an AI to get wrong.* A pin catches the next drift; a
  sentence catches nothing.
- *Startup-stage focus.* The reader of that sentence is a skills maintainer, not a
  customer, yet every session that loads this skill would pay its 17 tokens forever.
  That is a token tax levied on the wrong audience.

The mechanical pin — extending `check:scaffold-emission-policy` to read this fence —
is tracked separately as #16767. Triage's starred option 2 (stop printing the range
at all) stays declined on its own stated reason: the block is titled "Complete
Working Example" and would stop being complete.

## Verification

**Gate families.** Derived in-worktree with `node scripts/pm/dispatch-gates.mjs
--commands` (no paths passed; the tool takes its own change set from the merge base)
and reconciled with `--ran` plus `--repo objectstack-ai/objectstack`:

```
✓ dispatch-gates --ran: 21 derived famil(ies) accounted for — 21 run, 0 NOT-MEASURED.
```

All 21 exited 0. The ones that speak to this diff:

| Gate | Exit | Its own verdict line |
|:---|---:|:---|
| `node scripts/check-skills-token-ratchet.mjs` | 0 | `✓ check-skills-token-ratchet: 36 authored bundle file(s) within their ceilings; 10 generator-owned file(s) measured, not ratcheted.` |
| `pnpm --filter @objectstack/spec run check:skill-docs` | 0 | `✓ content/docs/ai/skills-reference.mdx` |
| `pnpm check:skill-identifier-liveness` | 0 | `check-skill-identifier-liveness OK — Leg 1: 465 citation(s) over 46 published file(s) … Leg 2: 8 registered exhaustive section(s), 0 ledgered gap(s).` |
| `pnpm check:skill-compatibility` | 0 | `✓ check-skill-compatibility-version: 11 SKILL.md file(s) reconciled against 80 workspace packages` |
| `pnpm check:corpus-claim-drift` | 0 | `OK` (published-skills claim sweep) |
| `pnpm check:nul-bytes` | 0 | `✓ check-nul-bytes --self-test: 75 assertions over a temp git repo (real scan() path)` |
| `pnpm check:doc-authoring` | 0 | `✓ doc authoring guard: … 829 pinned site(s) across 231 file(s), no growth` |

One gate needed a build before it measured anything: `pnpm --filter
@objectstack/lint run check:doc-formula-expressions` first exited **3 —
`PREREQUISITE NOT MET`**, which is the gate's own code for *nothing was measured*,
not a finding. After `turbo run build --filter=@objectstack/formula
--filter=@objectstack/lint` it exited 0 with three green verdict lines. Both runs are
recorded rather than only the second, since an exit 3 is a real NOT-MEASURED state
and hiding it would make the sweep read as one clean pass.

**Governed classification**, asserted rather than assumed:

```
$ node scripts/pm/check-governed-merges.mjs --test skills/objectstack-platform/SKILL.md
EXIT=3
  ⛔  GOVERNED — a human merge is the review record for this PR (#9495 regime).
      skills/** ×1 — the published skills catalog
```

**Merge cleanliness.** `git merge-tree --write-tree origin/main HEAD` against
`origin/main` `73053ed27` exits 0 and writes a tree with no conflict rows. `skills/**`
carries no `merge=os-regen` attribute, so that reading is a real textual merge and not
a driver deferral.

**Budget, for the record.** The landed change is **byte-identical in size** — 51918
bytes before and after, because `^6.0.0` and `^5.3.0` are the same length. File lines
1223 → 1223; the sum of all 11 `skills/**/SKILL.md` files 6853 → 6853; this file's
tokens 12980 → 12980 against its 12984 ceiling; the ratcheted authored bundle 139938 →
139938 against 157098. Nothing in the ratchet moved.

**`skip-changeset`.** Measured, not assumed: no package manifest's `files[]` names a
`skills` path, the repo root is `private: true`, and no package's `src/` or `dist/`
embeds this SKILL.md's content — grepped with a positive control that does hit
(`ObjectSchema` in `packages/spec/dist`) to prove the instrument was answering.
Nothing published moves, so the label is correct.

## 维护者速读(草稿)

**改了什么** —— 已发布技能 `objectstack-platform` 的「Complete Working Example」里那份
`package.json`,`typescript` 一行从退役的 `^6.0.0` 改成三个 scaffolder 实际发出的值。
值是飞行时从 `SCAFFOLD_TYPESCRIPT_RANGE` 常量现读的,没有从卡片或任何评论抄。
一行一值,块内其它内容一字未动,文件字节数前后相同。

**为什么改** —— 这个块是 AI 写新项目时照抄的入口。块里 `@objectstack/*` 全是当前值,
说明它随发布维护;只有 `typescript` 这一行掉队了。两个项目同一天创建却声明不同的
TypeScript 大版本,正是 #16485 要防的结果,而这是那张卡没枚举到的第四个载体。

**风险与代价(含回滚)** —— 风险极低:改的是文档里的一个版本范围,无运行时、无发布物
移动(已实测:没有任何包的 `files[]` 覆盖 `skills/`)。回滚 = revert 这一个提交,一行。
「权威声明」句按席位裁量不落,四轴理由见卡与上文「What is deliberately not here」;
不腐烂的形态是门禁读这段 fence,机械 pin 已另立一卡(#16767)。

**席位意见** ——

**你要做的** —— 受管面:请人工合并本 PR(合并即关卡)。⛔ 不走合并队列、不 auto-merge。

## 验收备注

Out-of-scope, noted and not filed:

- The `content/docs/protocol/kernel/plugin-spec.mdx:708` carrier prints
  `"typescript": "^5.0.0"` — a **third** value, disagreeing with both the scaffolder
  and this skill. It is a `content/docs/**` carrier, routed to `domain:devx` by this
  card's own triage, and the PM has already filed it. Not touched here. Carrier for
  it: the `domain:devx` card the PM filed.
- The census this card ordered was re-run in the worktree —
  `grep -rn '"typescript"' skills/ content/ packages/*/src/templates/` — and finds
  **one** carrier under `skills/` (this one, now fixed) and no fifth carrier. The
  `packages/create-objectstack/src/templates/blank/package.json:27` template already
  reads `^5.3.0`, agreeing with the scaffolder; the three
  `content/docs/references/**` hits are `formats` enum rows, not version ranges.
- This repo's own toolchain builds on `typescript` `6.0.3` while the scaffold policy
  emits `^5.3.0` to customer projects. That is a compatibility floor for generated
  apps versus the monorepo's own build, not a contradiction, and no ruling on this
  card is disturbed by it. Noted so the next reader does not re-discover it as a
  finding. Carrier: none.

---
_Generated by [Claude Code](https://claude.ai/code/session_01P58euzUXCVJNwmhuPC9DXY)_