### PR TITLE
fix(lint): hold the partof gate's cited contract to the file it cites

### DIFF
--- a/scripts/check-partof-closing-keyword.mjs
+++ b/scripts/check-partof-closing-keyword.mjs
@@ -350,7 +350,7 @@ const SELF_TEST_BATTERIES = Object.freeze({
   'Context reading: presence, not truthiness.': 4,
   'The wiring itself. A gate whose workflow step is deleted or whose': 6,
   'The predicate source this gate reuses must still be there to reuse.': 1,
-  'RULE 2 — every card-relation spelling in a commit message is a finding,': 19,
+  'RULE 2 — every card-relation spelling in a commit message is a finding,': 22,
   'The regression fixture: the squash that assembled a contradiction no': 4,
   'RULE 2 delegates to the sweep extractors at the commit-message reading.': 3,
   'The commit list input. An absent, broken or empty list can never read': 8,
@@ -443,6 +443,17 @@ const PREDICATE_SOURCE = 'scripts/pm/check-half-states.mjs';
 /** The wiring that gives this gate a PR to judge. */
 const WIRING_WORKFLOW = '.github/workflows/partof-closing-keyword-guard.yml';
 
+/**
+ * The file RELATION_CONTRACT quotes — a REAL input, read by the self-test.
+ *
+ * Quoted as a path literal on purpose, unlike the paths in the header. The
+ * derivation turns a quoted path in this file into a watch hint, and this one
+ * is a hint that tells the truth: editing the sentence at the other end of it
+ * breaks the citation pin below, so a card touching that file really does want
+ * this gate run. The header's last section is the authority on the distinction.
+ */
+const AGENT_RULES_SOURCE = '.claude/agents/os-dev.md';
+
 export const EXIT_CLEAN = 0;
 export const EXIT_CONTRADICTION = 1;
 export const EXIT_NOT_WIRED = 2;
@@ -458,17 +469,54 @@ export const COMMITS_FILE_ENV = 'PR_COMMITS_FILE';
  * copying it. Quoted verbatim, in its own language, because a translation of a
  * ruling is a rewrite of it.
  *
- * Named in prose rather than as a bare path literal on purpose: the
- * dispatch-gates derivation turns quoted path literals in this file into watch
- * hints, and a sentence with spaces in it cannot become one. The header's last
- * section is the authority on that.
+ * ⛔ Nothing inside the corner brackets may be written HERE. An earlier revision
+ * carried a second sentence in them — that the squash concatenates the commit
+ * messages and can assemble a contradiction out of individually honest parts —
+ * which was true on the facts and had never been in the rules file at all. That
+ * is the same failure as a translation, in the other direction: it attributes to
+ * the ruling a claim the ruling does not make, and it prints that attribution to
+ * the very population that reads the rules file. The squash fact is this gate's
+ * own, and this gate already states it in its own words twice — in the RULE 2
+ * header section and in the printed finding below — so it is not restated here
+ * a third time.
+ *
+ * The brackets are held to their source MECHANICALLY, not by care: the self-test
+ * reads AGENT_RULES_SOURCE and requires every sentence between them to appear in
+ * it verbatim. Comparing the printed finding with this constant cannot do that —
+ * both sides move together when the constant is edited, which is precisely how
+ * the added sentence survived a self-test that already claimed to check the
+ * citation.
+ *
+ * The path is named in prose here rather than as a literal because it is spelled
+ * once, as a literal, at AGENT_RULES_SOURCE; that declaration carries the
+ * watch-hint note.
  */
 const RELATION_CONTRACT =
   'The contract is written down in the agent rules at .claude/agents/os-dev.md — '
-  + '「PR 正文与 commit message 分开解析:卡片关系只在正文声明一次,commit ⛔ 不带卡片 trailer。'
-  + 'squash 会把全部 commit message 连成一条落地,逐条诚实拼成的一条自相矛盾。」 '
+  + '「PR 正文与 commit message 分开解析:卡片关系只在正文声明一次,commit ⛔ 不带卡片 trailer。」 '
   + '(The PR body and the commit messages are parsed separately: the card relation is declared ONCE, '
   + 'in the body, and a commit carries no card trailer.)';
+
+/**
+ * Every sentence inside the corner brackets of a citation, in order.
+ *
+ * Split rather than compared whole so the pin stays honest if the quotation ever
+ * grows a second sentence legitimately: each is held to the source on its own,
+ * and a sentence added here without being added there is named individually.
+ *
+ * Returns an empty array when there are no brackets at all, which the self-test
+ * refuses explicitly — an extractor that silently found nothing would make the
+ * citation pin vacuously green, the phantom-check shape this file exists to
+ * refuse elsewhere.
+ */
+function citedSentences(text) {
+  const quoted = /「([^」]*)」/.exec(String(text ?? ''));
+  if (quoted === null) return [];
+  return quoted[1]
+    .split(/(?<=。)/)
+    .map((sentence) => sentence.trim())
+    .filter((sentence) => sentence !== '');
+}
 
 /**
  * The commit rows the wiring gathered, as JSON Lines — one object per line,
@@ -941,6 +989,22 @@ function selfTest() {
     'the finding CITES the contract rather than restating it in its own words',
     named.includes(RELATION_CONTRACT),
     true,
+  );
+  // The case above compares the printed finding with THIS FILE'S constant, so
+  // both sides move together whenever the constant is edited: a sentence that
+  // was never in the rules file passes it, and one did — see the constant's
+  // docblock. These three hold the quotation to its SOURCE instead. An absent
+  // rules file reds here rather than passing quietly: a citation check that
+  // cannot read the cited file has verified nothing.
+  const agentRulesPath = join(ROOT, AGENT_RULES_SOURCE);
+  const agentRules = existsSync(agentRulesPath) ? readFileSync(agentRulesPath, 'utf8') : '';
+  const citedFromRules = citedSentences(RELATION_CONTRACT);
+  t(`the cited rules file is readable (${AGENT_RULES_SOURCE})`, agentRules !== '', true);
+  t('the citation carries quoted sentences at all (never a vacuous zero)', citedFromRules.length > 0, true);
+  t(
+    'every sentence inside the corner brackets is verbatim in the cited rules file',
+    citedFromRules.filter((sentence) => !agentRules.includes(sentence)),
+    [],
   );
   // The guidance text itself, pinned. This gate once told the author to push
   // reworded commits while also forbidding a rewrite — unsatisfiable on a


### PR DESCRIPTION
Fixes #16747

## What was wrong

`RELATION_CONTRACT` in `scripts/check-partof-closing-keyword.mjs` presents itself as a verbatim quotation of this repo's agent rules — corner brackets, a docblock saying *"Quoted verbatim, in its own language"*, and a self-test case named `the finding CITES the contract rather than restating it in its own words`. It carried two sentences. The rules file carries one.

Measured on `cf33adbd8`, the base of this branch:

```
$ git grep -n "连成一条落地"
scripts/check-partof-closing-keyword.mjs:469

$ git grep -n "卡片关系只在正文声明一次"
.claude/agents/os-dev.md:281
scripts/check-partof-closing-keyword.mjs:468
```

The second sentence exists in the gate and nowhere else in the tree. It is true on the facts — the squash really is assembled from the commit messages — so the defect is the attribution, not the content. AGENTS.md's Communication section binds it directly: 「引用中文裁决时保持原文、不翻译——改写引文就是改写裁决」. A citation that ADDS a sentence is that rule's failure in the other direction: it attributes to the ruling a claim the ruling does not make, and every red RULE 2 run printed that addition to an agent as the ruling's own words.

## What changed

1. `RELATION_CONTRACT` is trimmed to the sentence `.claude/agents/os-dev.md` line 281 actually carries.
2. The squash fact stays as the gate's **own prose**, where it already was **twice** — the RULE 2 header section (*"The squash message is assembled from the COMMITS"*) and the printed finding itself (*"every commit message on this PR is concatenated into the one message that lands on the default branch"*). It is not restated a third time.
3. The docblock is rewritten so it is true of the trimmed constant, and records why nothing may be authored inside the brackets.
4. Three self-test cases hold the quotation to its source; the RULE 2 battery floor moves 19 to 22 with them.

## Why the existing self-test did not catch it

`named.includes(RELATION_CONTRACT)` compares the printed finding with **this file's own constant**. Both sides move together whenever the constant is edited, so a sentence that was never in the rules file passes it — which is exactly how the added sentence survived a case whose name claims to check the citation.

The new cases read `.claude/agents/os-dev.md` through `AGENT_RULES_SOURCE` and require every sentence between the corner brackets to appear in it verbatim. Two silent-green shapes are refused explicitly rather than left implicit: an unreadable rules file, and an extraction that finds zero sentences (which would make the whole pin vacuous).

`AGENT_RULES_SOURCE` is a quoted path literal on purpose, unlike the paths the header names unquoted: the derivation turns a quoted path in this file into a watch hint, and this hint tells the truth — editing that sentence at the other end breaks the pin here, so a card touching that file really does want this gate run.

## Ablation — proof the new pin can fail

Fix committed first (`cd09dbd68`), then the second sentence put back inside the brackets, on disk, with a trap-restore:

```
HEAD blob                  76e6ea816da7a0bc42bb3c4c5a1f52e30f0f2427
before mutation            injected-text 0, bracket-close 1
after  mutation            injected-text 1, bracket-close 0
mutated blob               3708551ff32d6d9446195e05faf9498461760023   (moved)
ablation self-test exit     1
  ✗ every sentence inside the corner brackets is verbatim in the cited rules file
    (got ["squash 会把全部 commit message 连成一条落地,逐条诚实拼成的一条自相矛盾。"], want [])
restored blob              76e6ea816da7a0bc42bb3c4c5a1f52e30f0f2427   (== HEAD)
git diff HEAD              empty
post-restore injected-text 0
restored self-test exit     0    ✓ check-partof-closing-keyword self-test: 92 cases pass.
```

The failing case names the offending sentence rather than printing a bare false, so the next author is told which sentence is not in the source.

## Gates

Derived in the worktree with no paths passed — `node scripts/pm/dispatch-gates.mjs --commands --repo objectstack-ai/objectstack` — 31 families, identical to the set the dispatch carried. All 31 run, every one exit 0, reconciled against the record:

```
Run reconciliation — 31 derived, 31 run, 0 NOT-MEASURED, 0 UNRUN.
✓ dispatch-gates --ran: 31 derived famil(ies) accounted for — 31 run, 0 NOT-MEASURED.
```

The two judgment lines that matter here, quoted from the gates themselves:

```
✓ check-partof-closing-keyword self-test: 92 cases pass.
✓ dispatch-gates self-test: 1552 cases pass.
```

`pnpm check:pm-dispatch-gates` was run detached with its output redirected and waited on in the foreground (it runs past the shell's timeout); `check-dispatch-gates.mjs` exits with the self-test's status, and that verdict line is printed only on the zero-failure path.

Governance: `node scripts/pm/check-governed-merges.mjs --test scripts/check-partof-closing-keyword.mjs` — exit 0, `✅ NOT governed`, derived from the register rather than recalled.

## skip-changeset

Nothing published moves. Repo-root `scripts/` belongs to the private root package (`private: true`, no `files[]`), and a `files[]` entry is package-relative, so no workspace package can ship this path.

## Merge reading

Base `cf33adbd8`. `origin/main` is `8b37a0973` at the time of writing — one commit ahead, touching `AGENTS.md` only, no overlap with this diff and none with the derived family. A driver-free `merge-tree` from a throwaway bare clone sharing the object store: exit 0, no conflicted paths.

## 验收备注

- **noted, not filed:** the self-test's workflow read degrades an absent workflow file to the empty string rather than saying so. The pins that follow do go red, so the absence is loud in effect but not in wording. Successor: whoever next edits that battery.
- **noted, not filed:** the card's remedy 3 (a `check:declaration-mirrors` pair for this quotation) stays on #16747 for triage. The pin added here covers this one citation and does not generalise to other cited text in other scripts.
- **noted, not filed:** the card's remedy 2 (adding the second sentence to `.claude/agents/os-dev.md`) is a governed-surface ruling change and is deliberately not taken here — this PR corrects a text, it does not amend a ruling.


---
_Generated by [Claude Code](https://claude.ai/code/session_01P58euzUXCVJNwmhuPC9DXY)_