### PR TITLE
fix(check-watch-hint-literal): red on a declared watch-hint literal the extractor drops at admission

### DIFF
--- a/scripts/check-manifest-repository-directory.mjs
+++ b/scripts/check-manifest-repository-directory.mjs
@@ -306,10 +306,17 @@ const EXIT_PREREQ = 3;
  * retries it: `**\/package.json` is judged correctly by `hintCovers` and is
  * never SEEN, because `extractWatchHints` admits a literal only if it starts
  * with a word character, a dot or an `@`. A leading glob is dropped at
- * admission, so that declaration extracts to zero hints -- the exact silent
- * drop `check:watch-hint-literal` exists for, arrived at through the value
- * rather than through the spelling. Measured while writing this gate: the
- * one-line form extracted `[]`; the four below extract all four.
+ * admission, so that declaration extracts to zero hints -- the exact drop
+ * `check:watch-hint-literal` exists for, arrived at through the value rather
+ * than through the spelling. Measured while writing this gate: the one-line
+ * form extracted `[]`; the four below extract all four.
+ *
+ * ⚠️ That drop was SILENT when this gate was written, and is not any more:
+ * `check:watch-hint-literal` now puts every declared literal through the
+ * extractor and reds on one that yields no hint, naming this remedy. So the
+ * one-line form is refused loudly rather than dropped quietly -- retry it and
+ * a gate tells you to enumerate, which is the only part of the cost this
+ * enumeration ever paid twice.
  *
  * ⛔ NOT the workspace-root spelling `check-published-files.mjs` uses
  * (`packages/*`, `apps/*`, …). That declaration is honest THERE -- it walks

--- a/scripts/check-watch-hint-literal.mjs
+++ b/scripts/check-watch-hint-literal.mjs
@@ -107,13 +107,69 @@
  * masked before the statement is located, through the repo's one comment
  * scanner (`scripts/js-comment-mask.mjs`).
  *
+ * ## The SECOND way a declaration is invisible: the VALUE, not the spelling
+ *
+ * Everything above is about the SPELLING -- a declaration computed instead of
+ * written out. A declaration can be a perfect literal array and STILL
+ * contribute nothing, because `scripts/pm/dispatch-gates.mjs#extractWatchHints`
+ * admits a literal only when it STARTS with a word character, a dot or an `@`.
+ * A literal opening with a glob never reaches the resolve step, never becomes a
+ * hint, and places its gate on NO card:
+ *
+ *     ['scripts/**']          -> ["scripts/**"]
+ *     ['**\/package.json']    -> []            <- literal, and dropped anyway
+ *
+ * Four instruments passed that drop, because each asked its own question and
+ * none asked whether the literals were ADMISSIBLE: this gate saw a literal
+ * array, the gate's own self-test saw its own constant,
+ * `check:declared-population-live` was satisfied by nothing (a family
+ * declaring zero literals "declares nothing", a legitimate state), and it scored
+ * `undetermined` or `silent` for every card in the tree. A declaring-zero gate
+ * and a declared-but-eaten gate are the same colour on all of them.
+ *
+ * So the sweep asks the second question too, and it asks it OF THE EXTRACTOR
+ * rather than of a copy of its rule -- a second copy of an admission regex is
+ * a thing that drifts, and the drift would be silent in the same direction.
+ * Each declared literal is put through `extractWatchHints` on its own, and a
+ * literal that yields NO hint is the finding.
+ *
+ * ⛔ Admission is NOT widened to accept a leading glob, and this gate exists
+ * BECAUSE it is not: that refusal is measured (the admission comment inside
+ * `extractWatchHints` prices bare-top-level-word admission at +139084
+ * fabricated pairs, and records a re-measured refusal of the resolved-form
+ * widening), and relaxing it is a change to every gate in the farm rather than
+ * a repair to one declaration. The remedy this gate prints is therefore the
+ * enumerable root-prefixed spelling, never a request to change the rule.
+ *
+ * ⭐ What this buys is NOT cheaper enumeration -- the author of a file-kind
+ * population still has to name every root that holds the kind, and still has to
+ * pin that enumeration against the gate's own scan. It solves the other half:
+ * it does not solve the trouble of enumerating, it solves not knowing that you
+ * need to enumerate.
+ *
+ * ## Why ONE literal at a time, and never the module's whole extraction
+ *
+ * The tempting spelling is to extract the whole module and diff the declared
+ * literals against the result. Measured on this tree, that spelling is wrong in
+ * both directions. It FALSELY accuses: `scripts/pm/dispatch-gates.mjs` spells a
+ * rostered declaration inside its own self-test as a fixture string, which
+ * `extractWatchHints` blanks along with the rest of the self-test, so a
+ * perfectly admissible literal is absent from that module's extraction. And it
+ * would falsely accuse again on any declaration written module-relative, whose
+ * extracted hint is the RESOLVED path and not the literal as spelled. Probing
+ * one literal at a time asks exactly the question the finding is about -- does
+ * this literal produce a hint at all -- and neither residue reaches it.
+ *
  * ## What is asserted, and what is deliberately NOT
  *
  * Asserted: the right-hand side of the declaration is an ARRAY OF QUOTED STRING
- * LITERALS and nothing else. That is stronger than "each declared hint appears
- * quoted inside the statement", and it needs no runtime value, so this gate
- * never imports the files it judges -- a gate that imported 14 modules to read
- * one constant would run their module bodies to do it.
+ * LITERALS and nothing else, and every literal in it is one the hint extractor
+ * admits. The first is stronger than "each declared hint appears quoted inside
+ * the statement"; neither needs a runtime value, so this gate never imports the
+ * files it judges -- a gate that imported 14 modules to read one constant would
+ * run their module bodies to do it. The extractor itself IS imported, and that
+ * is the opposite case: it is the authority being consulted, not a subject
+ * being read, and it is a pure string function with no module-scope work.
  *
  * NOT asserted: that a declaration is CORRECT -- that it names the roots the
  * gate really walks, and only those. That claim is local to each gate and each
@@ -147,6 +203,7 @@ import { fileURLToPath } from 'node:url';
 
 import { isEntrypoint } from './invoked-as.mjs';
 import { maskComments } from './js-comment-mask.mjs';
+import { extractWatchHints } from './pm/dispatch-gates.mjs';
 
 // ── The self-test's own battery roster and floor (#13489) ──────────────────
 //
@@ -181,8 +238,8 @@ const SELF_TEST_BATTERIES = Object.freeze({
   'the per-name floor': 5,
   'discovery of an UNROSTERED spelling of the idiom': 5,
   'the empty population is refused, not passed': 1,
-  "literals the extractor's admission DROPS": 1,
-  'the live tree': 14,
+  "literals the extractor's admission DROPS": 14,
+  'the live tree': 15,
 });
 
 // DELETING an entry silences that battery's floor exactly as effectively as
@@ -398,6 +455,57 @@ export function literalHints(rhs) {
 }
 
 /**
+ * The hints `extractWatchHints` builds from ONE declared literal, standing
+ * alone under `name`.
+ *
+ * The probe source is a declaration and not a bare string on purpose: the
+ * extractor's exclusion channel keys on the DECLARATION NAME, so a future
+ * rostered name that happened to read as an exclusion would drop its literals
+ * here and be reported LOUDLY rather than judged under a rule that does not
+ * apply to it.
+ *
+ * A literal carrying both quote characters cannot be delimited, and the
+ * extractor cannot read such a span out of the real source either -- so it
+ * yields nothing here, which is the same verdict for the same reason.
+ */
+function admittedHints(name, literal) {
+  const quote = literal.includes("'") ? (literal.includes('"') ? null : '"') : "'";
+  if (quote === null) return [];
+  return extractWatchHints(`const ${name} = [${quote}${literal}${quote}];\n`);
+}
+
+/**
+ * The declared literals that produce NO hint at all -- the value-side drop.
+ *
+ * Pure over the list, and split out of `auditSourceName` for the same reason
+ * `missingNames` is split out of `main`: the self-test drives it directly, and
+ * the shape it guards against is one a healthy live tree cannot exhibit.
+ */
+export function droppedByAdmission(name, hints) {
+  return hints.filter((h) => admittedHints(name, h).length === 0);
+}
+
+/**
+ * What a dropped literal's author is told: what happened, what to write
+ * instead, and why the rule that dropped it is not the thing being changed.
+ */
+function admissionRemedy(name, dropped) {
+  return `the ${name} declaration is a literal array, and ${dropped.length} of its literal(s) build NO `
+    + `hint at all: ${dropped.map((h) => JSON.stringify(h)).join(', ')}. The hint extractor admits a `
+    + 'literal only when it STARTS with a word character, a dot or an @, so one opening with a glob '
+    + 'never reaches the resolve step, never becomes a hint, and places this gate on NO card -- the '
+    + 'same silent drop this gate exists for, arrived at through the VALUE instead of the spelling. '
+    + 'Remedy: spell the population as one enumerable root-prefixed entry per root that holds the '
+    + 'kind, and pin that enumeration against the walk this gate really performs so it cannot go '
+    + 'stale quietly. Admission is deliberately NOT widened to accept a leading glob: see the '
+    + 'admission comment inside extractWatchHints, which prices bare-top-level-word admission at '
+    + '+139084 fabricated pairs and records a re-measured refusal of the resolved-form widening -- '
+    + 'relaxing it is a change to every gate in the farm, not a repair to one declaration. This '
+    + 'finding does not solve the trouble of enumerating; it solves not knowing that you need to '
+    + 'enumerate.';
+}
+
+/**
  * One file's verdict for ONE rostered name. `null` means the file does not
  * declare that name at all -- it mentions it in prose, or reads someone else's.
  */
@@ -426,6 +534,13 @@ export function auditSourceName(rel, source, name) {
   }
   if (hints.length === 0) {
     return { rel, name, ok: false, why: `the ${name} declaration is EMPTY -- it names no subtree at all` };
+  }
+  // The value-side question, asked only once the spelling-side one has passed:
+  // an empty or computed declaration has no literals to judge, and naming the
+  // same declaration under two remedies would leave its author choosing.
+  const dropped = droppedByAdmission(name, hints);
+  if (dropped.length > 0) {
+    return { rel, name, ok: false, why: admissionRemedy(name, dropped) };
   }
   return { rel, name, ok: true, hints };
 }
@@ -531,7 +646,8 @@ function main() {
   if (bad.length) {
     console.error(
       `✗ check-watch-hint-literal: ${bad.length} of ${rows.length} declaration(s) are not readable `
-      + 'as literals. Spell the hints inside the declaration statement.',
+      + 'by the hint extractor. Spell the hints inside the declaration statement, and spell each one '
+      + 'so the extractor admits it.',
     );
     return 1;
   }
@@ -539,10 +655,12 @@ function main() {
   const perName = DECL_NAMES
     .map((n) => `${n} ${rows.filter((r) => r.name === n).length}`)
     .join(', ');
+  const literals = rows.reduce((n, r) => n + r.hints.length, 0);
   console.log(
     `✓ check-watch-hint-literal: ${rows.length} declaration(s) across ${DECL_NAMES.length} rostered `
-    + `name(s) -- ${perName} -- every one an array of quoted literals inside its own statement, `
-    + 'every rostered name non-empty, and no unrostered spelling of the idiom in the tree.',
+    + `name(s) -- ${perName} -- every one an array of quoted literals inside its own statement, all `
+    + `${literals} of those literals admitted by the hint extractor, every rostered name non-empty, `
+    + 'and no unrostered spelling of the idiom in the tree.',
   );
   return 0;
 }
@@ -688,9 +806,58 @@ export function selfTest() {
     audit([]).rows.length === 0 && missingNames(audit([]).rows).length === DECL_NAMES.length);
 
   // -- literals the extractor's admission DROPS ------------------------------
+  // ⭐ The value-side drop. Every case here declares a perfect literal array,
+  // so every one of them passes the spelling-side question above; what
+  // separates them is whether the hint extractor can make a hint out of what
+  // is inside it.
   battery("literals the extractor's admission DROPS");
+  const KIND_ONE_LINER = "['**/package.json']";
   t('a declaration whose only literal opens with a glob is rejected',
-    rejected(decl("['**/package.json']")));
+    rejected(decl(KIND_ONE_LINER)));
+  t('...and it is rejected on the VALUE, not on the spelling -- the declaration IS a literal array',
+    literalHints(KIND_ONE_LINER) !== null && literalHints(KIND_ONE_LINER).length === 1);
+  const globWhy = verdict(decl(KIND_ONE_LINER))?.why ?? '';
+  t('the remedy names the literal that was dropped', globWhy.includes('**/package.json'));
+  t('the remedy states the admission rule that dropped it',
+    globWhy.includes('STARTS with a word character, a dot or an @'));
+  t('the remedy prescribes the enumerable root-prefixed spelling rather than only refusing',
+    globWhy.includes('enumerable root-prefixed entry per root that holds the kind'));
+  t('the remedy carries the measurement behind the refusal, so widening admission is not the obvious read',
+    globWhy.includes('+139084') && globWhy.includes('every gate in the farm'));
+  t('the remedy says what the finding is actually for',
+    globWhy.includes('it solves not knowing that you need to enumerate'));
+
+  // The negatives PR #16446 shipped: the same population, enumerated.
+  const ADMISSIBLE_KIND = [
+    'packages/**/package.json',
+    'apps/**/package.json',
+    'examples/**/package.json',
+    'package.json/**',
+  ];
+  t('the enumerated spelling of the same population is accepted',
+    accepted(decl(`[${ADMISSIBLE_KIND.map((h) => `'${h}'`).join(', ')}]`)),
+    ADMISSIBLE_KIND.join(' · '));
+  t('...and every one of those literals is admitted individually',
+    droppedByAdmission(DIR_NAME, ADMISSIBLE_KIND).length === 0);
+  t('one dropped literal among admissible ones still fails, and only it is named',
+    rejected(decl(`['scripts/**', '**/package.json']`))
+      && droppedByAdmission(DIR_NAME, ['scripts/**', '**/package.json']).join() === '**/package.json');
+
+  // ⭐ The false positive a whole-MODULE diff would produce, which is why the
+  // probe is per literal: `scripts/pm/dispatch-gates.mjs` spells a rostered
+  // declaration inside its own self-test, and the extractor blanks self-tests --
+  // so that literal is absent from that module's extraction while being
+  // perfectly admissible.
+  t('a literal is judged on its own admissibility, not on whether its module extraction carries it',
+    droppedByAdmission(DIR_NAME, ['packages/drivers/**']).length === 0);
+  t('...and a module-relative literal, whose extracted hint is the RESOLVED path, is not accused either',
+    droppedByAdmission(DIR_NAME, ['../../packages/spec/**']).length === 0);
+
+  // The two states that must keep their OWN remedy rather than acquiring this one.
+  t('an EMPTY declaration keeps the empty-population remedy, not the admission one',
+    (verdict(decl('[]'))?.why ?? '').includes('names no subtree at all'));
+  t('a COMPUTED declaration keeps the computed remedy, not the admission one',
+    (verdict(decl('[`${SCAN_ROOT}/**`]'))?.why ?? '').includes('is COMPUTED, not a literal array'));
 
   // -- the live tree ---------------------------------------------------------
   battery('the live tree');
@@ -700,6 +867,10 @@ export function selfTest() {
     `${live.length} declaration(s)`);
   t('every live declaration is a literal', live.every((r) => r.ok),
     live.filter((r) => !r.ok).map((r) => `${r.rel}:${r.name}`).join(' · '));
+  t('and every literal in every live declaration is one the hint extractor admits',
+    live.every((r) => !r.ok || droppedByAdmission(r.name, r.hints).length === 0),
+    live.flatMap((r) => (r.ok ? droppedByAdmission(r.name, r.hints)
+      .map((h) => `${r.rel}:${r.name}:${h}`) : [])).join(' · '));
   t('EVERY rostered name has a live declarer -- the floor is armed, not merely coded',
     missingNames(live).length === 0, `missing: ${missingNames(live).join(', ') || 'none'}`);
   for (const name of DECL_NAMES) {
@@ -743,7 +914,8 @@ export function selfTest() {
     + 'spellings rejected, the statement-scoped search proved against runtime and comment copies of '
     + `the literal beside it, all ${DECL_NAMES.length} rostered names judged for both spellings, the `
     + 'per-name floor proved against a population that is healthy on every name but one, unrostered '
-    + 'spellings of the idiom discovered, and the live repo-wide population judged.',
+    + 'spellings of the idiom discovered, the value-side drop proved on a literal array the extractor '
+    + 'admits nothing out of, and the live repo-wide population judged on both questions.',
   );
   selfTestReachedVerdict = true;
   return 0;

--- a/scripts/check-watch-hint-literal.mjs
+++ b/scripts/check-watch-hint-literal.mjs
@@ -181,6 +181,7 @@ const SELF_TEST_BATTERIES = Object.freeze({
   'the per-name floor': 5,
   'discovery of an UNROSTERED spelling of the idiom': 5,
   'the empty population is refused, not passed': 1,
+  "literals the extractor's admission DROPS": 1,
   'the live tree': 14,
 });
 
@@ -685,6 +686,11 @@ export function selfTest() {
   battery('the empty population is refused, not passed');
   t('an empty file list produces no rows, which the floor above refuses',
     audit([]).rows.length === 0 && missingNames(audit([]).rows).length === DECL_NAMES.length);
+
+  // -- literals the extractor's admission DROPS ------------------------------
+  battery("literals the extractor's admission DROPS");
+  t('a declaration whose only literal opens with a glob is rejected',
+    rejected(decl("['**/package.json']")));
 
   // -- the live tree ---------------------------------------------------------
   battery('the live tree');


### PR DESCRIPTION
Fixes #16447

`check:watch-hint-literal` now reds on a `*_WATCH_HINTS` literal that the hint extractor's
admission silently drops, names the remedy, and carries the measurement behind the refusal.
The admission rule itself is untouched — this is triage's option 2, and nothing that is
refused today becomes accepted.

## What was silent

A watch-hint declaration can be a perfect literal array and still contribute nothing:
`extractWatchHints` admits a literal only when it STARTS with a word character, a dot or an
`@`, so one opening with a glob never reaches the resolve step, never becomes a hint, and
places its gate on NO card. Four instruments passed that drop, because each asked its own
question and none asked whether the literals were admissible.

| declaration | `extractWatchHints` |
|:---|:---|
| `const ROOT_DIR_WATCH_HINTS = ['**/package.json'];` | `[]` |
| the four literals PR #16446 enumerates instead | all four |

The sweep now asks the second question, **of the extractor** rather than of a copy of its
rule — a second copy of an admission regex is a thing that drifts, and it would drift in the
same silent direction.

## Why one literal at a time, rather than a whole-module diff

The obvious spelling is to extract the whole module and diff the declared literals against
the result. Measured on this tree, that spelling is wrong in both directions:

- it **falsely accuses** `scripts/pm/dispatch-gates.mjs`, which spells a rostered declaration
  inside its own self-test as a fixture string — the extractor blanks self-tests, so a
  perfectly admissible literal is absent from that module's extraction. Measured: 1 of 151
  live declared literals falsely flagged by the whole-module diff, 0 by the per-literal probe;
- it would falsely accuse again on any declaration written module-relative, whose extracted
  hint is the RESOLVED path and not the literal as spelled.

Probing one literal at a time asks exactly the question the finding is about — does this
literal produce a hint at all — and neither residue reaches it.

## 验收备注

Answering triage's five acceptance items one by one (ruling comment 5579014475).

**1. finding 必须先红.** The known positive was added to the self-test FIRST and run against
the UNFIXED implementation, which does not report it:

```
$ node scripts/check-watch-hint-literal.mjs --self-test      # commit 93f311eb6, finding class absent
  ✗ a declaration whose only literal opens with a glob is rejected
✗ check-watch-hint-literal self-test: 1 of 58 case(s) failed.
```

With the finding class in place (commit 59a0adb3c) the same case passes, and the whole battery
is 14 cases. An ablation from the committed state confirms it is the finding class doing the
work, not the fixture: deleting it on disk (blob `b129dfe8` → `6d9673fc`; anchor occurrences
1 → 0, injected marker 0 → 1) turns 7 cases red; restoring with `git checkout HEAD --` puts the
blob back at `b129dfe8` with an empty `git diff HEAD` and 0 leftover markers, and the self-test
returns to 72 passing cases.

**2. finding 的文案要说清补救.** The remedy text names the dropped literal, states the
admission rule that dropped it, prescribes the enumerable root-prefixed spelling plus the pin
against the gate's own walk, cites the measurement — `+139084` fabricated pairs for
bare-top-level-word admission, and the re-measured refusal of the resolved-form widening — and
says relaxing it is a change to every gate in the farm rather than a repair to one declaration.
It closes with the ruling's own sentence in the checker's register: *"This finding does not
solve the trouble of enumerating; it solves not knowing that you need to enumerate."* Five
self-test cases assert those five properties of the text, so it cannot decay into "not legal".

**3. 阴性对照必测.**

- PR #16446's four admissible literals are accepted, together and individually — two self-test
  cases, plus `pnpm check:manifest-repository-directory` green.
- A zero-literal declaration keeps its OWN remedy (`names no subtree at all`) and a computed one
  keeps its own (`is COMPUTED, not a literal array`); the value-side question is asked only after
  the spelling-side one passes, so no declaration is named under two remedies. Two self-test cases.
- `extractWatchHints` over the derivation's whole corpus: **225 of 226 gate files byte-identical**,
  **280 of 281 family hint-sets byte-identical**. The one delta is this gate's own entry, and it is
  the import of the extractor it now consults — see *Declared deviation* below, with the measurement
  that placement is unchanged.

**4. ⛔ 不动 `dispatch-gates.mjs` 的 admission 正则.** Untouched — the diff is two files and
neither is it. Nothing that fails admission today is admitted by this PR; the only thing that
changed is whether the failure is reported.

**5. `check-manifest-repository-directory.mjs`'s docblock.** No longer accurate, and edited —
only that sentence. It called the drop *silent*; after this PR it is not. The paragraph now says
so and points at the remedy the gate prints.

## Declared deviation — one hint, and it does not place anything

Consulting the extractor means importing it, and the import specifier is itself a path-shaped
literal in this gate's module body, so this gate's own extraction gains `scripts/pm/dispatch-gates.mjs`
(and, through the import follow, `.github/workflows`). Measured before and after:

```
scripts/check-watch-hint-literal.mjs   ["scripts/**"]
                                    -> ["scripts/pm/dispatch-gates.mjs","scripts/**"]
check:watch-hint-literal (family)      ["scripts/**"]
                                    -> [".github/workflows","scripts/**","scripts/pm/dispatch-gates.mjs"]
```

Acceptance item 3's third bullet asks for byte-identical extraction over every gate; this is the
one place it is not, and it is structural — a gate that calls the extractor cannot be invisible to
it. What the bullet's second half asks for **does** hold, and it is measured rather than argued:
`check:watch-hint-literal` declares `dispatch-gates: whole-tree-population`, so it is placed by
declaration and never by its hints — it is in the `alwaysRunsPopulation` column for every card and
in `matched` for none. Across `--json` runs before and after, on probe paths chosen to expose the
delta (`scripts/pm/dispatch-gates.mjs`, `scripts/check-watch-hint-literal.mjs`,
`packages/spec/src/index.ts`, and separately `.github/workflows/lint.yml`):

```
matched column        byte-identical (81 families)
alwaysRunsPopulation  identical (7)      widePopulation identical (10)
counts                identical          runnable union identical (82 commands)
```

⇒ no card's brief moves. The alternative — routing the import through a shim module so the
specifier carries no slash — was rejected: a file whose only purpose is to be invisible to a
detector is the workaround Prime Directive #5 refuses, and the next author would copy it.

## Verification

Re-derived in the worktree at `59a0adb3c` with
`node scripts/pm/dispatch-gates.mjs --commands --repo objectstack-ai/objectstack` (no paths) —
**31 families**, the 30 the dispatch named plus `pnpm check:manifest-repository-directory`, which
arrived because this diff now touches that file. All 31 run; reconciled with `--ran`:

```
✓ dispatch-gates --ran: 31 derived famil(ies) accounted for — 31 run, 0 NOT-MEASURED.
```

`pnpm check:pm-dispatch-gates` exit 0 (`✓ dispatch-gates self-test: 1552 cases pass.`).
`pnpm check:watch-hint-literal` exit 0 — 72 self-test cases, then 66 declarations across 4
rostered names with all 151 of their literals admitted.

**Lint, as a proven narrowing** — three readings, taken at `59a0adb3c`:

1. the population is read from eslint's own config, not guessed: 6347 tracked JS/TS files, and
   `ESLint#isPathIgnored` says 6347 of 6347 are not ignored;
2. files actually linted, counted from `--format json`: **2**, 0 errors, 0 warnings;
3. invariance: `eslint.config.mjs` never enables type-aware linting for ANY file —
   `calculateConfigForFile` on the changed file returns
   `parserOptions {"ecmaVersion":"latest","sourceType":"module"}`, no `parserOptions.project`, no
   typed rules — so this diff cannot move the verdict on any untouched file.

Merge-tree against `origin/main` `b38821d1c`, probed from a throwaway bare clone with no custom
merge driver registered: exit 0, no conflicted paths.
`node scripts/pm/check-governed-merges.mjs --test` on the final file list: `NOT governed`.
`skip-changeset`: the repo-root package is private (`@objectstack/spec-monorepo`), the two changed
files sit outside every workspace package, and the new symbol has zero occurrences anywhere under
`packages/` while the positive control (`defineStack` in `packages/spec/src/index.ts`, 6 hits) shows
the grep channel works — nothing published moves.

Deliberately out of scope, per the ruling: widening admission to accept a leading glob (triage's
option 1) is a separate card and a decision-box one, because it changes the derivation's admission
semantics for every gate in the farm and owes an answer to the `+139084` measurement. No card is
opened for it here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01P58euzUXCVJNwmhuPC9DXY)_