### PR TITLE
feat(spec): a blueprint nav entry can name the VIEW it opens (cloud#2150)

### DIFF
--- a/.changeset/blueprint-nav-view-name.md
+++ b/.changeset/blueprint-nav-view-name.md
@@ -1,0 +1,11 @@
+---
+"@objectstack/spec": minor
+---
+
+A blueprint nav entry can say WHICH view it opens: `viewName` is added to `BlueprintNavItemSchema` and, in lockstep, to the strict mirror's `StrictNavItem` (required-but-nullable, per the strict convention).
+
+Without it the shape could only say which OBJECT an entry opens, so a model that had just designed a kanban and wanted it in the menu had one move left: emit a SECOND entry at the same `target` and carry the intent in `label`/`icon` alone. Both entries then opened the object's default view, and the consumer derived both ids from the target, so they collided — the user clicked 「工单看板」 and got the list, with nothing to see anywhere (the target object really exists, so a dangling-target lint has nothing to say). The runtime nav item could always express this — `ObjectNavItemSchema.viewName` is "Default list view to open" — so the gap was the blueprint's alone, and the model's duplicate entry was the reasonable move under the expressiveness it was given.
+
+`viewName` is deliberately NOT `.regex(SNAKE_CASE)` on either side, unlike `target`. A view answers to two interchangeable spellings — the bare key a blueprint's `views[].name` carries and the qualified `<object>.<key>` a staged view record's `name` carries — and consumers normalize between them. Constraining the leaf would make one spelling legal to GENERATE and illegal to APPLY, the failure mode that once refused an already-approved blueprint wholesale.
+
+The key-parity pin between the strict mirror and the lenient schema is widened a level further out — fields → objects → NAV ITEMS — so the next nav-level divergence fails a test rather than shipping as "the lenient side accepts a key no proposal can contain".

--- a/content/docs/references/ai/solution-blueprint.mdx
+++ b/content/docs/references/ai/solution-blueprint.mdx
@@ -30,7 +30,7 @@ const result = BlueprintAppSchema.parse(data);
 | **name** | `string` | ✅ | App machine name (snake_case) |
 | **label** | `string` | optional | App display label |
 | **icon** | `string` | optional | Lucide icon for the App Launcher |
-| **nav** | `{ type: Enum<'object' \| 'dashboard'>; target: string; label?: string; icon?: string }[]` | optional | Navigation entries; omit to auto-surface every created object and dashboard |
+| **nav** | `{ type: Enum<'object' \| 'dashboard'>; target: string; label?: string; icon?: string; … }[]` | optional | Navigation entries; omit to auto-surface every created object and dashboard |
 
 ### Nested Shape: `BlueprintApp.nav[number]`
 
@@ -40,6 +40,7 @@ const result = BlueprintAppSchema.parse(data);
 | **target** | `string` | ✅ | Object or dashboard machine name to surface (snake_case) |
 | **label** | `string` | optional | Nav entry label (defaults to the target label/name) |
 | **icon** | `string` | optional | Lucide icon name for the nav entry |
+| **viewName** | `string` | optional | For type:"object" only — the `views[].name` this entry opens (e.g. "ticket_status_board"). Omit for the object's default list. SET it whenever this blueprint authors a kanban/calendar/gallery/gantt view the menu should reach: give the object ONE entry per view (a 「工单列表」 entry with no viewName plus a 「工单看板」 entry with viewName:"ticket_status_board"). Without it every entry on the same target opens the SAME default list, and a label/icon saying otherwise is decoration. |
 
 
 ---
@@ -173,6 +174,7 @@ const result = BlueprintAppSchema.parse(data);
 | **target** | `string` | ✅ | Object or dashboard machine name to surface (snake_case) |
 | **label** | `string` | optional | Nav entry label (defaults to the target label/name) |
 | **icon** | `string` | optional | Lucide icon name for the nav entry |
+| **viewName** | `string` | optional | For type:"object" only — the `views[].name` this entry opens (e.g. "ticket_status_board"). Omit for the object's default list. SET it whenever this blueprint authors a kanban/calendar/gallery/gantt view the menu should reach: give the object ONE entry per view (a 「工单列表」 entry with no viewName plus a 「工单看板」 entry with viewName:"ticket_status_board"). Without it every entry on the same target opens the SAME default list, and a label/icon saying otherwise is decoration. |
 
 
 ---
@@ -323,7 +325,7 @@ const result = BlueprintAppSchema.parse(data);
 | **name** | `string` | ✅ | App machine name (snake_case) |
 | **label** | `string` | optional | App display label |
 | **icon** | `string` | optional | Lucide icon for the App Launcher |
-| **nav** | `{ type: Enum<'object' \| 'dashboard'>; target: string; label?: string; icon?: string }[]` | optional | Navigation entries; omit to auto-surface every created object and dashboard |
+| **nav** | `{ type: Enum<'object' \| 'dashboard'>; target: string; label?: string; icon?: string; … }[]` | optional | Navigation entries; omit to auto-surface every created object and dashboard |
 
 ### Nested Shape: `SolutionBlueprint.seedData[number]`
 
@@ -386,7 +388,7 @@ const result = BlueprintAppSchema.parse(data);
 | **name** | `string` | ✅ | App machine name (snake_case) |
 | **label** | `string \| null` | ✅ | App display label, or null |
 | **icon** | `string \| null` | ✅ | Lucide icon for the App Launcher, or null |
-| **nav** | `{ type: Enum<'object' \| 'dashboard'>; target: string; label: string \| null; icon: string \| null }[] \| null` | ✅ | Navigation entries; null to auto-surface every created object and dashboard |
+| **nav** | `{ type: Enum<'object' \| 'dashboard'>; target: string; label: string \| null; icon: string \| null; … }[] \| null` | ✅ | Navigation entries; null to auto-surface every created object and dashboard |
 
 
 ---

--- a/packages/spec/authorable-surface/ai.json
+++ b/packages/spec/authorable-surface/ai.json
@@ -60,6 +60,7 @@
     "ai/BlueprintNavItem:label",
     "ai/BlueprintNavItem:target",
     "ai/BlueprintNavItem:type",
+    "ai/BlueprintNavItem:viewName",
     "ai/BlueprintObject:description",
     "ai/BlueprintObject:fields",
     "ai/BlueprintObject:label",

--- a/packages/spec/scripts/liveness/empty-state-registry.mts
+++ b/packages/spec/scripts/liveness/empty-state-registry.mts
@@ -180,6 +180,13 @@ export const EMPTY_STATE_REGISTRY: EmptyStateEntry[] = [
       'Which error a catch node handles; empty catches all of them. Catching broadly is the safe direction for an error handler — the failure mode of the opposite default is an unhandled fault, not an over-grant.',
   },
   {
+    file: 'packages/spec/src/ai/solution-blueprint.zod.ts',
+    property: 'viewName',
+    semantics: 'scope',
+    rationale:
+      "Which VIEW a proposed app-menu entry opens; absent/null means the object's default list. It is presentation breadth, not authorization — the entry's `target` already fixes WHICH OBJECT is reachable, and record- and field-level security are enforced downstream, so naming a view can only ever change how the same permitted rows are laid out. The empty state is also the pre-existing behaviour every app already has, which is what makes it the safe default here (cloud#2150 added the key precisely because there was no way to say anything ELSE). Note the failure direction is cosmetic and visible: an entry labelled 「工单看板」 that omits this opens the list — wrong-looking, never over-granting.",
+  },
+  {
     file: 'packages/spec/src/ai/knowledge-source.zod.ts',
     property: 'mimeTypes',
     semantics: 'scope',

--- a/packages/spec/src/ai/solution-blueprint.test.ts
+++ b/packages/spec/src/ai/solution-blueprint.test.ts
@@ -439,6 +439,56 @@ describe('SolutionBlueprintStrictSchema (OpenAI strict mirror)', () => {
     expect(() => SolutionBlueprintStrictSchema.parse(missingKey)).toThrow();
   });
 
+  it('carries viewName on a strict nav item — nullable, and REQUIRED to be present (OpenAI strict)', () => {
+    // cloud#2150 shape pin. This mirror is the design step's output contract,
+    // so a `viewName` that exists only in the lenient schema is a fix on no
+    // path the product actually runs: `propose_blueprint` could never author a
+    // board entry, and `apply_blueprint` would accept a key nothing emits.
+    const navShape = (SolutionBlueprintStrictSchema as any).shape.app.unwrap().shape.nav.unwrap().element.shape;
+    expect('viewName' in navShape).toBe(true);
+
+    // null is accepted (the entry opens the object's default list)…
+    const bare = SolutionBlueprintStrictSchema.parse({
+      ...strictBp,
+      app: { name: 'ticketing', label: null, icon: null, nav: [
+        { type: 'object', target: 'ticket', label: '工单列表', icon: 'list', viewName: null },
+      ] },
+    });
+    expect(bare.app?.nav?.[0].viewName).toBeNull();
+
+    // …and the whole point of the card: list AND board for ONE object, told
+    // apart by the view each entry opens rather than by decoration.
+    const board = SolutionBlueprintStrictSchema.parse({
+      ...strictBp,
+      app: { name: 'ticketing', label: null, icon: null, nav: [
+        { type: 'object', target: 'ticket', label: '工单列表', icon: 'list', viewName: null },
+        { type: 'object', target: 'ticket', label: '工单看板', icon: 'kanban', viewName: 'ticket_status_board' },
+      ] },
+    });
+    expect(board.app?.nav?.map((n) => n.viewName)).toEqual([null, 'ticket_status_board']);
+
+    // …and OMITTING the key throws (strict mode: every key in `required`).
+    const missingKey = {
+      ...strictBp,
+      app: { name: 'ticketing', label: null, icon: null, nav: [{ type: 'object', target: 'ticket', label: null, icon: null }] },
+    };
+    expect(() => SolutionBlueprintStrictSchema.parse(missingKey)).toThrow();
+  });
+
+  it('accepts the QUALIFIED <object>.<view> spelling too — the applier normalizes, the mirror must not refuse', () => {
+    // `viewName` is deliberately un-regexed on BOTH sides: a view answers to a
+    // bare key and to the `<object>.<key>` name its staged record carries.
+    // Constraining it here would make one of the two legal to generate and
+    // illegal to apply (cloud#1967).
+    const parsed = SolutionBlueprintStrictSchema.parse({
+      ...strictBp,
+      app: { name: 'ticketing', label: null, icon: null, nav: [
+        { type: 'object', target: 'ticket', label: '工单看板', icon: 'kanban', viewName: 'ticket.ticket_status_board' },
+      ] },
+    });
+    expect(parsed.app?.nav?.[0].viewName).toBe('ticket.ticket_status_board');
+  });
+
   it('accepts a dashboard widget carrying the (nullable) measure + groupBy + condition keys', () => {
     const parsed = SolutionBlueprintStrictSchema.parse({
       ...strictBp,
@@ -509,6 +559,56 @@ describe('strict mirror ↔ lenient schema — key parity', () => {
       (SolutionBlueprintStrictSchema as any).shape.objects.element.shape,
     ).sort();
     expect(strictObjectKeys).toEqual(lenientObjectKeys);
+  });
+
+  it('the NAV ITEM schemas carry exactly the same keys', () => {
+    // Widened for cloud#2150, the third time the same gap was found one level
+    // further out (fields → objects → nav items). The nav item is where "which
+    // VIEW does this menu entry open" lives; with `viewName` on one side only,
+    // the design step could not author a board entry (mirror missing) or the
+    // applier would drop one it was handed (lenient missing). There are NO
+    // deliberate nav-level exclusions; if one ever becomes deliberate, list it
+    // explicitly here with its reason.
+    const lenientNavKeys = Object.keys(
+      (SolutionBlueprintSchema as any).shape.app.unwrap().shape.nav.unwrap().element.shape,
+    ).sort();
+    const strictNavKeys = Object.keys(
+      (SolutionBlueprintStrictSchema as any).shape.app.unwrap().shape.nav.unwrap().element.shape,
+    ).sort();
+    expect(strictNavKeys).toEqual(lenientNavKeys);
+  });
+
+  it('carries `viewName`, so a menu entry can say WHICH view it opens', () => {
+    // Guards the specific hole (cloud#2150): this surface can always author a
+    // kanban view AND a nav entry, so without a way to bind the two the model's
+    // only remaining move is a duplicate entry distinguished by label alone —
+    // which is what shipped, silently, to users.
+    const lenientNavKeys = Object.keys(
+      (SolutionBlueprintSchema as any).shape.app.unwrap().shape.nav.unwrap().element.shape,
+    );
+    const strictNavKeys = Object.keys(
+      (SolutionBlueprintStrictSchema as any).shape.app.unwrap().shape.nav.unwrap().element.shape,
+    );
+    expect(lenientNavKeys).toContain('viewName');
+    expect(strictNavKeys).toContain('viewName');
+  });
+
+  it('round-trips a list + board pair on ONE object through the lenient schema', () => {
+    const parsed = SolutionBlueprintSchema.parse({
+      summary: 's',
+      objects: [{ name: 'ticket', fields: [{ name: 'title', type: 'text' }, { name: 'status', type: 'select' }] }],
+      views: [{ object: 'ticket', name: 'ticket_status_board', type: 'kanban', groupBy: 'status' }],
+      app: {
+        name: 'ticket_management',
+        nav: [
+          { type: 'object', target: 'ticket', label: '工单列表', icon: 'list' },
+          { type: 'object', target: 'ticket', label: '工单看板', icon: 'kanban', viewName: 'ticket_status_board' },
+        ],
+      },
+    });
+    // The negative control rides along: the entry that named no view keeps
+    // carrying none, so the default-list behaviour is untouched.
+    expect(parsed.app?.nav?.map((n) => n.viewName)).toEqual([undefined, 'ticket_status_board']);
   });
 
   it('carries `expression`, so a formula field can state what it computes', () => {

--- a/packages/spec/src/ai/solution-blueprint.zod.ts
+++ b/packages/spec/src/ai/solution-blueprint.zod.ts
@@ -160,12 +160,35 @@ export type BlueprintDashboard = z.input<typeof BlueprintDashboardSchema>;
  * A proposed navigation item in the blueprint app — points at one of the
  * created objects or dashboards. `apply_blueprint` expands it into the full
  * `AppSchema` nav item (object → list view, dashboard → dashboard view).
+ *
+ * `viewName` is what makes "list AND board for the same table" expressible
+ * (cloud#2150). Without it this shape could only say WHICH OBJECT an entry
+ * opens, so a model that had just designed a kanban and wanted it in the menu
+ * had exactly one move left: emit a SECOND entry at the same `target`, with the
+ * intent carried only by `label`/`icon`. Both entries then opened the object's
+ * default view, and the cloud applier derived both ids from the target, so they
+ * collided — the user clicked 「工单看板」 and got the list, with no error
+ * anywhere (the target object really does exist, so the lint had nothing to
+ * say). The runtime could always express this: `ObjectNavItemSchema.viewName`
+ * is "Default list view to open". Only the blueprint could not, which is why
+ * the model's behaviour was reasonable and the schema was the defect.
+ *
+ * Deliberately NOT `.regex(SNAKE_CASE)`, unlike `target`. A view is identified
+ * downstream in two interchangeable spellings — the bare key a blueprint's
+ * `views[].name` carries (`ticket_status_board`) and the qualified
+ * `<object>.<key>` a staged view record's `name` carries — and the applier
+ * normalizes between them. Constraining this leaf to snake_case would make the
+ * qualified spelling legal to GENERATE (a strict mirror is per-leaf) and
+ * illegal to APPLY, which is the cloud#1967 failure mode: a blueprint the user
+ * already approved, refused wholesale at apply time.
  */
 export const BlueprintNavItemSchema = lazySchema(() => z.object({
   type: z.enum(['object', 'dashboard']).default('object').describe('What this nav entry opens'),
   target: z.string().regex(SNAKE_CASE).describe('Object or dashboard machine name to surface (snake_case)'),
   label: z.string().optional().describe('Nav entry label (defaults to the target label/name)'),
   icon: z.string().optional().describe('Lucide icon name for the nav entry'),
+  viewName: z.string().optional()
+    .describe('For type:"object" only — the `views[].name` this entry opens (e.g. "ticket_status_board"). Omit for the object\'s default list. SET it whenever this blueprint authors a kanban/calendar/gallery/gantt view the menu should reach: give the object ONE entry per view (a 「工单列表」 entry with no viewName plus a 「工单看板」 entry with viewName:"ticket_status_board"). Without it every entry on the same target opens the SAME default list, and a label/icon saying otherwise is decoration.'),
 }));
 export type BlueprintNavItem = z.input<typeof BlueprintNavItemSchema>;
 /** Post-parse shape of {@link BlueprintNavItem} — defaults applied, transforms run (ADR-0122). */
@@ -347,6 +370,16 @@ const StrictNavItem = z.object({
   target: strictIdent('Object or dashboard machine name to surface (snake_case)'),
   label: z.string().nullable().describe('Nav entry label, or null'),
   icon: z.string().nullable().describe('Lucide icon name, or null'),
+  // ⛔ Must stay in lockstep with the lenient `BlueprintNavItemSchema.viewName`
+  // (cloud#2150). THIS side is the one that decides whether the design step can
+  // author a board entry at all: `propose_blueprint`'s structured output is
+  // validated against this mirror, so a key present only in the lenient schema
+  // is a fix that exists nowhere on the main path — the applier would accept a
+  // `viewName` no proposal can ever contain. That is the `seedData` divergence
+  // (cloud#2118) with a different key name; the nav key-parity pin below fails
+  // if this line is removed.
+  viewName: z.string().nullable()
+    .describe('For type:"object" only — the `views[].name` this entry opens (e.g. "ticket_status_board"), or null for the object\'s default list. SET it whenever this blueprint authors a kanban/calendar/gallery/gantt view the menu should reach: give the object ONE entry per view (a 「工单列表」 entry with viewName null plus a 「工单看板」 entry with viewName "ticket_status_board"). Null on every entry means they all open the SAME default list, and a label/icon saying otherwise is decoration.'),
 });
 
 const StrictApp = z.object({


### PR DESCRIPTION
## What

`BlueprintNavItemSchema` gets an optional `viewName`, and the OpenAI-strict mirror's `StrictNavItem` gets it in lockstep (required-but-nullable, per the strict convention).

## Why

Until now the blueprint nav shape could only say which **object** an entry opens. A model that had just designed a kanban and wanted it in the app menu therefore had exactly one move left: emit a **second** entry at the same `target`, with the intent carried by `label`/`icon` alone.

Measured downstream (objectstack-ai/cloud#2150, a real tenant DB):

```json
[0] {"id": "nav_frez_ticket", "label": "工单列表", "icon": "list",   "type": "object", "objectName": "frez_ticket"}
[1] {"id": "nav_frez_ticket", "label": "工单看板", "icon": "kanban", "type": "object", "objectName": "frez_ticket"}
```

Two identical ids, both opening the object's default view. The kanban view (`frez_ticket.ticket_status_board`) really was built — the menu just could not reach it. And nothing complained: the target object exists, so the dangling-target lint had nothing to say.

The **runtime** could always express this — `ObjectNavItemSchema.viewName` is `'Default list view to open. Defaults to "all". …'` — so the gap was the blueprint's alone, and the duplicate entry was the reasonable move under the expressiveness the model was given.

## Both halves, deliberately

A key on the lenient side only is a fix on no path the product runs: `propose_blueprint` validates its structured output against the **mirror**, so the design step could never author a board entry while `apply_blueprint` accepted a key nothing emits. That is the `seedData` divergence (cloud#2118) with a different key name.

**Ablation** — reverting only the `StrictNavItem` half and re-running `packages/spec/src/ai/solution-blueprint.test.ts`:

```
⎯⎯⎯⎯⎯⎯⎯ Failed Tests 4 ⎯⎯⎯⎯⎯⎯⎯
 FAIL  src/ai/solution-blueprint.test.ts > SolutionBlueprintStrictSchema (OpenAI strict mirror) > carries viewName on a strict nav item — nullable, and REQUIRED to be present (OpenAI strict)
 FAIL  src/ai/solution-blueprint.test.ts > SolutionBlueprintStrictSchema (OpenAI strict mirror) > accepts the QUALIFIED <object>.<view> spelling too — the applier normalizes, the mirror must not refuse
 FAIL  src/ai/solution-blueprint.test.ts > strict mirror ↔ lenient schema — key parity > the NAV ITEM schemas carry exactly the same keys
 FAIL  src/ai/solution-blueprint.test.ts > strict mirror ↔ lenient schema — key parity > carries `viewName`, so a menu entry can say WHICH view it opens
      Tests  4 failed | 39 passed (43)
```

Restored: `43 passed (43)`.

## Why no `SNAKE_CASE` regex

`viewName` is deliberately un-regexed on **both** sides, unlike `target`. A view answers to two interchangeable spellings — the bare key a blueprint's `views[].name` carries, and the qualified `<object>.<key>` a staged view record's `name` carries — and the applier normalizes between them. Constraining the leaf would make one spelling legal to GENERATE and illegal to APPLY: the cloud#1967 shape, where an already-approved blueprint was refused wholesale at apply time. VALUE parity holds because neither side constrains it.

## Parity pin widened

Third time the same gap was found one level further out: fields → objects → **nav items**. The nav-level key-parity test now fails on the next divergence in either direction.

## Verification

- `packages/spec` full suite: **13328 passed | 23 skipped (13351)**
- `tsc --noEmit -p packages/spec`: clean
- `check:authorable-surface`, `check:docs`: in sync (both regenerated in this commit — `authorable-surface/ai.json` gains one key, the blueprint reference gains one row)

## Companion

The cloud half — passing `viewName` through to the runtime nav entry, and the nav-id derivation change that lets one object legitimately carry two entries — is objectstack-ai/cloud#2156 (draft, and it pins this branch head until this one merges). Part of objectstack-ai/cloud#2150.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
