### PR TITLE
docs(data-modeling): drop the flowchart edge that routed secret values to `password`

### DIFF
--- a/content/docs/data-modeling/field-type-decision-tree.mdx
+++ b/content/docs/data-modeling/field-type-decision-tree.mdx
@@ -33,6 +33,7 @@ flowchart TD
     TEXT -->|Email address| T5[email]
     TEXT -->|Website URL| T6[url]
     TEXT -->|Phone number| T7[phone]
+    TEXT -->|Sensitive secret value| S5[secret]
 
     %% Number branch
     NUM -->|Any number| N1[number]

--- a/content/docs/data-modeling/field-type-decision-tree.mdx
+++ b/content/docs/data-modeling/field-type-decision-tree.mdx
@@ -33,7 +33,6 @@ flowchart TD
     TEXT -->|Email address| T5[email]
     TEXT -->|Website URL| T6[url]
     TEXT -->|Phone number| T7[phone]
-    TEXT -->|Secret value| T8[password]
 
     %% Number branch
     NUM -->|Any number| N1[number]
@@ -88,7 +87,6 @@ flowchart TD
     style T5 fill:#059669,color:#fff
     style T6 fill:#059669,color:#fff
     style T7 fill:#059669,color:#fff
-    style T8 fill:#059669,color:#fff
     style N1 fill:#d97706,color:#fff
     style N3 fill:#d97706,color:#fff
     style N4 fill:#d97706,color:#fff


### PR DESCRIPTION
Fixes #16366

## What

`content/docs/data-modeling/field-type-decision-tree.mdx`'s decision-tree flowchart had a `Text?`-branch edge (`TEXT -->|Secret value| T8[password]`) that routed a secret value to `password`, contradicting the same page's own quick-reference table, the flowchart's own `STRUCT -->|Sensitive secret value| S5[secret]` edge, ADR-0100, and the published skill rule.

**Round 1 (superseded):** deleted the wrong edge outright rather than relabeling it, reasoning that pointing it at `secret` too would create a second, differently-labeled edge into the same node. Reviewer correctly flagged this as wrong: the chart's root branches on *shape* (`Text?` vs `Structured Data?`), and an `api_key`/`db_password` — the table's own `secret` examples — **is text**. A reader who answers "Text? yes" for a credential found no secret-value edge at all after round 1; the only surviving `secret` edge hung off `Structured Data?`, which that reader answers "no" to. That replaced "routes credentials to the wrong type" with "doesn't route credentials at all" on the branch a text-credential reader actually walks — worse for the reader who filed the card, and two legitimately-converging edges into one node is ordinary in a decision tree, not ambiguous.

**Round 2 (current):** the Text branch now points at `secret` instead of being dropped — `TEXT -->|Sensitive secret value| S5[secret]` — so "Text? yes → is it a secret?" lands on `secret`. The pre-existing `STRUCT -->|Sensitive secret value| S5[secret]` edge stays too (kept both, per reviewer's recommendation): an api_key is text and a credential blob is structured, and both are true. `S5` already carries a style rule from the Structured branch, so no new style line was needed. `password` and its table row remain untouched — still a real, supported type, just no longer the flowchart's answer for a secret value.

## Audit (card's A2)

Every edge in the flowchart was checked against its corresponding quick-reference-table row, twice: once after round 1's delete (35 edges, one disagreement found and fixed, zero remaining), and again after round 2's add (36 edges — the new `TEXT -> secret` edge matches the `secret` table row) — zero disagreeing edges either time. (`code` and `html` each appear in a table but have no flowchart edge at all — an omission, not a contradiction, a different defect class per repo scoping rules, so noted but not filed; see the terminal report's `out_of_scope_findings`.)

## Testing

38 gate families derived via `node scripts/pm/dispatch-gates.mjs --commands content/docs/data-modeling/field-type-decision-tree.mdx`, all run, all green at commit `856264d8b8` (`--ran` reconciliation: 38 derived, 38 run, 0 NOT-MEASURED, 0 UNRUN). Fresh worktree needed `@objectstack/spec`, `@objectstack/lint`, `@objectstack/client`, `@objectstack/client-react` built before 10 of the 38 (docs-registry / skill-example / formula / security-posture / transcript-drift checks) could run past `PREREQUISITE NOT MET`; all 10 green after building.

No changeset: `content/docs/**` is part of the private `@objectstack/docs` app; nothing published from any released package moves.

---
_Generated by [Claude Code](https://claude.ai/code/session_012GKcPZbMoGq7WPzKLfRBTU)_