### PR TITLE
docs(rest,runtime,qa): attribute the 80 route registrations to both spellings, and re-measure the gated split

### DIFF
--- a/packages/qa/dogfood/test/authz-conformance.test.ts
+++ b/packages/qa/dogfood/test/authz-conformance.test.ts
@@ -162,11 +162,24 @@ const PROBES: readonly Probe[] = [
   // never authorization: `sdk` / `server-only` / `public` / `gap` / `mismatch`
   // say nothing about whether a caller is authenticated. Deriving "gated" from
   // source syntax instead was measured and rejected — scanning all 80
-  // `this.routeManager.register(` sites in `rest-server.ts` for `enforceAuth`
-  // reads 50/30 and 22 of the 30 ungated are FALSE (a wrapping
-  // `guardedRouteManager` for 19 of them, a shared handler const for 3), a 73%
-  // false-ungated rate on the largest registrar. What these two probes supply
-  // is the POPULATION; the classification stays a reviewed row.
+  // registration sites in `rest-server.ts` for `enforceAuth` (TWO spellings: 72
+  // direct `this.routeManager.register(` sites plus 8 `registerPerItemRoute(`
+  // calls through the per-item family's switch-carrying helper) reads 51/29 and
+  // 22 of the 29 ungated are FALSE (a wrapping `guardedRouteManager` for 19 of
+  // them, a shared handler const for 3), a 76% false-ungated rate concentrated
+  // on the largest registrar.
+  //
+  // ⚠️ RE-MEASURED 2026-09-08. The 22 = 19 + 3 decomposition did NOT move when
+  // the per-item helper landed — the same 19 routes, 11 still direct and 8 now
+  // helper-routed through the same wrapping registrar — and the population
+  // stayed 80. Only the headline split moved, earlier and unrelatedly: 50/30
+  // became 51/29 when `registerUiEndpoints`, the one route in that file
+  // resolving no identity, was guarded. Recorded so the next reader does not
+  // re-derive a figure that has now been checked; the full reading lives in
+  // `authz-probe-blind-spot.census.ts`, the authority on this population.
+  //
+  // What these two probes supply is the POPULATION; the classification stays a
+  // reviewed row.
   {
     kind: 'ROUTE_ENUMERATION',
     file: 'packages/rest/src/rest-route-ledger.ts',

--- a/packages/qa/dogfood/test/authz-probe-blind-spot.census.ts
+++ b/packages/qa/dogfood/test/authz-probe-blind-spot.census.ts
@@ -136,15 +136,42 @@
 //     built as one.
 //
 //  2. DERIVING "gated" FROM SOURCE SYNTAX IS UNSAFE — measured, not assumed.
-//     Scanning each of the 80 `this.routeManager.register(` call sites in
-//     `rest-server.ts` for `enforceAuth` reads 50 gated / 30 ungated, and 22 of
-//     those 30 are FALSE, in two structural shapes: `registerMetadataEndpoints`
+//     Scanning each of the 80 registration sites in `rest-server.ts` for
+//     `enforceAuth` — the SAME two spellings the `populationRule` below counts,
+//     72 direct `this.routeManager.register(` call sites plus 8
+//     `registerPerItemRoute(` calls — reads 51 gated / 29 ungated, and 22 of
+//     those 29 are FALSE, in two structural shapes: `registerMetadataEndpoints`
 //     installs a wrapping `guardedRouteManager` so its 19 inner routes are
 //     gated with no `enforceAuth` at the call site, and
 //     `registerSecurityExplainEndpoints` shares one `handler` const declared
-//     outside its 3 `register(` calls. A 73% false-ungated rate, concentrated
+//     outside its 3 `register(` calls. A 76% false-ungated rate, concentrated
 //     on the largest registrar, and hand-annotating the exceptions is the same
 //     rot this instrument already has.
+//
+//     ⚠️ RE-MEASURED 2026-09-08 against `0bb2318685`, because the 19 is a count
+//     inside the very registrar the per-item helper re-spelled, and because
+//     this paragraph attributed all 80 sites to the direct spelling alone
+//     while `:82` above already knew there were two — the authority on this
+//     population contradicting itself 57 lines apart.
+//
+//     WHAT DID NOT MOVE: 22 = 19 + 3. The same 19 routes, 11 still direct and
+//     8 now helper-routed, all through the same wrapping; the same 3 sharing
+//     one handler const; the population still 80. The re-spelling moved none
+//     of the five figures.
+//
+//     WHAT DID MOVE, and not here: 50 gated / 30 ungated became 51 / 29 when
+//     `registerUiEndpoints` — the one route in this file that resolved no
+//     identity, the same repair recorded as `enforceAuth` 61 -> 64 on the
+//     rest-server.ts row below — was guarded. That landed the day AFTER this
+//     paragraph was first written and hours BEFORE it was copied into
+//     `rest-route-ledger.ts`, `route-ledger.ts` and `authz-conformance.test.ts`,
+//     which is why four sites carried 50/30 in step. ⛔ Written down as a
+//     checked figure rather than left as one nobody dared touch: the two read
+//     identically on the page, and only this note tells them apart.
+//
+//     ⛔ The rejection stands whatever the numbers do, and the second spelling
+//     strengthens it: a naive scanner now has to know both spellings before it
+//     can read the file even this badly.
 //
 //  3. A LEDGER IS A DERIVED DATA FILE, ONE GUARDED STEP BEHIND THE SOURCE.
 //     Adding a route to a registrar in `rest-server.ts` does not touch
@@ -184,7 +211,7 @@
 // point, where a new route is already being read.
 //
 // ⛔ Two readings stay REJECTED and are recorded here so they are not
-// re-proposed: deriving "gated" from source syntax (73% false-ungated), and
+// re-proposed: deriving "gated" from source syntax (76% false-ungated), and
 // taking a ledger disposition as an authorization fact (blocker 1).
 
 import { readFileSync } from 'node:fs';

--- a/packages/qa/dogfood/test/authz-probe-blind-spot.census.ts
+++ b/packages/qa/dogfood/test/authz-probe-blind-spot.census.ts
@@ -148,7 +148,7 @@
 //     on the largest registrar, and hand-annotating the exceptions is the same
 //     rot this instrument already has.
 //
-//     ⚠️ RE-MEASURED 2026-09-08 against `0bb2318685`, because the 19 is a count
+//     ⚠️ RE-MEASURED 2026-09-08 against `5abca1792e`, because the 19 is a count
 //     inside the very registrar the per-item helper re-spelled, and because
 //     this paragraph attributed all 80 sites to the direct spelling alone
 //     while `:82` above already knew there were two — the authority on this

--- a/packages/rest/src/rest-route-ledger.ts
+++ b/packages/rest/src/rest-route-ledger.ts
@@ -109,15 +109,30 @@ export interface RestRouteLedgerEntry {
    * SDK expressibility; none of them says whether a caller must be
    * authenticated, and `public` states INTENT for a handful of browser-facing
    * routes rather than measuring a gate. Deriving the answer from source
-   * syntax instead was measured and rejected: scanning all 80
-   * `this.routeManager.register(` sites in `rest-server.ts` for `enforceAuth`
-   * reads 50 gated / 30 ungated, and 22 of those 30 are FALSE — a wrapping
-   * `guardedRouteManager` gates 19 of them with no `enforceAuth` at the call
-   * site, and one registrar shares a handler const across its 3 mounts. A 73%
-   * false-ungated rate on the largest registrar is a written-down false
-   * assurance, which is strictly worse than an honest blank. So the posture is
-   * DECLARED at the producer, where a new route is already reviewed, instead of
-   * guessed at the consumer.
+   * syntax instead was measured and rejected: scanning all 80 registration
+   * sites in `rest-server.ts` for `enforceAuth` — TWO spellings, 72 direct
+   * `this.routeManager.register(` sites plus 8 `registerPerItemRoute(` calls
+   * through the per-item family's switch-carrying helper — reads 51 gated / 29
+   * ungated, and 22 of those 29 are FALSE: a wrapping `guardedRouteManager`
+   * gates 19 of them with no `enforceAuth` at the call site, and one registrar
+   * shares a handler const across its 3 mounts. A 76% false-ungated rate,
+   * concentrated on the largest registrar, is a written-down false assurance,
+   * which is strictly worse than an honest blank. So the posture is DECLARED at
+   * the producer, where a new route is already reviewed, instead of guessed at
+   * the consumer.
+   *
+   * ⚠️ RE-MEASURED 2026-09-08, and the two halves moved differently. The
+   * 22 = 19 + 3 decomposition did NOT move when the per-item helper landed —
+   * the same 19 routes, 11 still direct and 8 now helper-routed, all through
+   * the same wrapping registrar — and the population stayed 80. Only the
+   * headline split moved, earlier and for an unrelated reason: 50/30 became
+   * 51/29 when `registerUiEndpoints`, the one route in that file resolving no
+   * identity, was guarded. Recorded so the next reader does not re-derive a
+   * figure that has now been checked. ⛔ The rejection stands either way, and
+   * the second spelling strengthens it — a syntactic scanner has to know both
+   * before it can read the file even this badly. The full reading lives in
+   * `packages/qa/dogfood/test/authz-probe-blind-spot.census.ts`, the
+   * authority on this population.
    *
    * ABSENT MEANS "UNDECLARED", and that is the state of nearly the whole
    * surface. This field is filled INCREMENTALLY, exactly like `responseSchema`

--- a/packages/runtime/src/route-ledger.ts
+++ b/packages/runtime/src/route-ledger.ts
@@ -157,15 +157,30 @@ export interface RouteLedgerEntry {
    * SDK expressibility; none of them says whether a caller must be
    * authenticated, and `public` states INTENT for a handful of browser-facing
    * routes rather than measuring a gate. Deriving the answer from source
-   * syntax instead was measured and rejected: scanning all 80
-   * `this.routeManager.register(` sites in `rest-server.ts` for `enforceAuth`
-   * reads 50 gated / 30 ungated, and 22 of those 30 are FALSE — a wrapping
-   * `guardedRouteManager` gates 19 of them with no `enforceAuth` at the call
-   * site, and one registrar shares a handler const across its 3 mounts. A 73%
-   * false-ungated rate on the largest registrar is a written-down false
-   * assurance, which is strictly worse than an honest blank. So the posture is
-   * DECLARED at the producer, where a new route is already reviewed, instead of
-   * guessed at the consumer.
+   * syntax instead was measured and rejected: scanning all 80 registration
+   * sites in `rest-server.ts` for `enforceAuth` — TWO spellings, 72 direct
+   * `this.routeManager.register(` sites plus 8 `registerPerItemRoute(` calls
+   * through the per-item family's switch-carrying helper — reads 51 gated / 29
+   * ungated, and 22 of those 29 are FALSE: a wrapping `guardedRouteManager`
+   * gates 19 of them with no `enforceAuth` at the call site, and one registrar
+   * shares a handler const across its 3 mounts. A 76% false-ungated rate,
+   * concentrated on the largest registrar, is a written-down false assurance,
+   * which is strictly worse than an honest blank. So the posture is DECLARED at
+   * the producer, where a new route is already reviewed, instead of guessed at
+   * the consumer.
+   *
+   * ⚠️ RE-MEASURED 2026-09-08, and the two halves moved differently. The
+   * 22 = 19 + 3 decomposition did NOT move when the per-item helper landed —
+   * the same 19 routes, 11 still direct and 8 now helper-routed, all through
+   * the same wrapping registrar — and the population stayed 80. Only the
+   * headline split moved, earlier and for an unrelated reason: 50/30 became
+   * 51/29 when `registerUiEndpoints`, the one route in that file resolving no
+   * identity, was guarded. Recorded so the next reader does not re-derive a
+   * figure that has now been checked. ⛔ The rejection stands either way, and
+   * the second spelling strengthens it — a syntactic scanner has to know both
+   * before it can read the file even this badly. The full reading lives in
+   * `packages/qa/dogfood/test/authz-probe-blind-spot.census.ts`, the
+   * authority on this population.
    *
    * ABSENT MEANS "UNDECLARED", and that is the state of nearly the whole
    * surface. This field is filled INCREMENTALLY, exactly like `responseSchema`


### PR DESCRIPTION
Fixes #16307

Clause-②: no
Prose only, re-declared from the DELIVERED diff rather than from card content. Every
changed line is a comment — measured, not asserted: stripping comment prefixes from
`git diff origin/main...HEAD -- packages/` leaves no added or removed line. No accept set,
schema, export or route moves. The population stays **80**; only the attribution of that
number changes, plus the figures that number's sentence carries.

## What was wrong

Four docblocks said the 80 route registrations in `rest-server.ts` are all
`this.routeManager.register(` sites. Once the per-item family gained a switch-carrying
helper that stopped being true. The population is still 80, but it is now counted across
**two spellings** — 72 direct `this.routeManager.register(` call sites plus 8
`registerPerItemRoute(` calls. (`this.routeManager.register(` itself reads 73; the helper's
own forwarding call is one of them and is sliced out before counting.)

⛔ **The number was not changed.** 80 is correct and stays 80 in all four places.

Site 4 leads because it is inside the census file that is the authority on this population,
and whose `:82` already knew about the second spelling while `:139` did not — the file
contradicted itself 57 lines apart, so a reader landing on `:139` first got the pre-change
model from the very artifact that changed it. That the repair updated `:82` and not `:139`
is an ordinary miss, not a defect in the repair.

## The four sites, before → after

| # | site | before | after |
|:--|:--|:--|:--|
| 1 | `packages/rest/src/rest-route-ledger.ts:112` | "scanning all 80 `this.routeManager.register(` sites … reads 50 gated / 30 ungated, and 22 of those 30 are FALSE … A 73% false-ungated rate on the largest registrar" | "scanning all 80 registration sites … — TWO spellings, 72 direct `this.routeManager.register(` sites plus 8 `registerPerItemRoute(` calls … — reads 51 gated / 29 ungated, and 22 of those 29 are FALSE … A 76% false-ungated rate, concentrated on the largest registrar" + a dated RE-MEASURED note |
| 2 | `packages/runtime/src/route-ledger.ts:160` | identical sentence (the twin docblock) | identical replacement — the two docblocks are still byte-identical after the change (md5 compared) |
| 3 | `packages/qa/dogfood/test/authz-conformance.test.ts:164` | "scanning all 80 `this.routeManager.register(` sites … reads 50/30 and 22 of the 30 ungated are FALSE … a 73% false-ungated rate on the largest registrar" | "scanning all 80 registration sites … (TWO spellings: 72 direct … plus 8 `registerPerItemRoute(` calls …) reads 51/29 and 22 of the 29 ungated are FALSE … a 76% false-ungated rate concentrated on the largest registrar" + a dated RE-MEASURED note |
| 4 | `packages/qa/dogfood/test/authz-probe-blind-spot.census.ts:139` | "Scanning each of the 80 `this.routeManager.register(` call sites …" | "Scanning each of the 80 registration sites … — the SAME two spellings the `populationRule` below counts, 72 direct `this.routeManager.register(` call sites plus 8 `registerPerItemRoute(` calls —" + the full RE-MEASURED record (what moved, what did not, and why) |

One further line in the same file was changed and is called out rather than slipped in —
see **One in-place fix beyond the four named lines** below.

⚠️ Wording fidelity: sites 1–3 read "a 73% false-ungated rate **on** the largest
registrar", which is literally wrong (the rate on that registrar is 19/19 = 100%); site 4
already said "**concentrated on** the largest registrar", which is the correct reading of
22/29 across the file. Since the figure was being re-measured anyway, all four now use site
4's spelling.

## The re-derivation — method, control, arithmetic

Neither the card nor triage had measured whether the 50/30/22/19/3 decomposition survived
the re-spelling, and both said so. It was re-derived, not worded around.

**Method.** A scanner that re-implements the census's OWN population rule verbatim: direct
`this.routeManager.register(` call sites, LESS the ones inside the helper's declaration
slice (bounded by the declaration's own indentation, exactly as `forwarderSlice` does),
PLUS `registerPerItemRoute(` call sites. For each site it then extracts the call's balanced
argument span — string-, template- and comment-aware — and tests that span for
`enforceAuth`, classifying each site by its enclosing `private register*Endpoints(`.

**Instrument control — the reading is faithful to the original.** Run unchanged against
`936893f802`, the commit that first WROTE the census sentence, the scanner reads **50 gated
/ 30 ungated**, with **19** ungated inside `registerMetadataEndpoints`, **3** inside
`registerSecurityExplainEndpoints`, and 8 genuinely ungated. Five independent numbers
reproduced from the original tree, so the scanner is the original instrument and any
difference it reports today is a difference in the tree, not in the ruler.

**The readings.**

| commit | date | population | direct + helper | gated / ungated | inside `registerMetadataEndpoints` | shared handler const |
|:--|:--|--:|:--|:--|--:|--:|
| `936893f802` — census sentence written | 2026-08-30 12:33Z | 80 | 80 + 0 | **50 / 30** | 19 | 3 |
| `cc837dbfec` — the guard landed | 2026-08-31 07:53Z | 80 | 80 + 0 | **51 / 29** | 19 | 3 |
| `469cbc991a` — sites 1–3 written | 2026-08-31 12:45Z | 80 | 80 + 0 | 51 / 29 | 19 | 3 |
| `784cb92bf2` — the re-spelling | 2026-09-06 13:04Z | 80 | **72 + 8** | 51 / 29 | 19 | 3 |
| `5abca1792e` — `origin/main` today | 2026-09-08 | 80 | 72 + 8 | 51 / 29 | 19 | 3 |

**The arithmetic.**

- population `= 73 direct occurrences − 1 forwarder + 8 helper calls = 80`
- ungated `29 = 2 discovery + 2 openapi + 19 metadata + 3 form + 3 securityExplain`
- FALSE `22 = 19 (wrapping guardedRouteManager) + 3 (shared handler const)`
- rate `22 / 29 = 75.9% → 76%` (was `22 / 30 = 73.3% → 73%`)
- the 19 `= 11 direct + 8 helper-routed` (was `19 direct + 0`)

### ⭐ What did NOT move — written down so it is not re-opened

**The re-spelling moved none of the five figures.** The 19 is the same 19 routes inside
`registerMetadataEndpoints` — 11 still direct call sites, 8 now reached through
`registerPerItemRoute(`, all going through the identical wrapping `guardedRouteManager` —
and the 3 sharing one `handler` const in `registerSecurityExplainEndpoints` are untouched.
`22 = 19 + 3` stands, and the population stayed 80 across it. This is exactly the figure the
card flagged as most at risk, because the 19 counts routes inside the very registrar whose
later members were re-spelled; it was checked and it holds.

That sentence is now in the tree at all four sites. *一个被验证过仍然成立的数字，和一个没人敢碰的数字，在文本上长得一样。*

### What DID move — and it is not the re-spelling

**50 gated / 30 ungated became 51 / 29 at `cc837dbfec`** (2026-08-31T07:53Z), which guarded
`GET /ui/view/:object/:type` — the one route in `rest-server.ts` that resolved no identity.
The census file already records that same event from the other side, as "`enforceAuth`
61 -> 64 … `registerUiEndpoints` was the ONE route in this file that resolved no identity,
and it is now guarded"; it simply never carried the consequence back into blocker 2.

⭐ The timing is the whole story: that guard landed **the day after** the census paragraph
was first written (2026-08-30 12:33Z) and **4h52m before** the sentence was copied into
`rest-route-ledger.ts`, `route-ledger.ts` and `authz-conformance.test.ts` (all three in
`469cbc991a`, 2026-08-31 12:45Z). The three external copies were transcribed from the
census rather than re-measured, so they were one off on the day they were written — which
is why four sites carried `50/30` in perfect step for a week.

### ⛔ The conclusion is untouched

Deriving "gated" from source syntax stays rejected, and posture stays a declared, reviewed
fact. The measured false-ungated rate did not fall — it rose, from 73% to 76% — so the
argument is if anything stronger, and the second spelling strengthens it independently: a
naive scanner now has to know both spellings before it can read the file even this badly.
⛔ Nothing in this PR may be read as reopening that question.

## Changeset — `skip-changeset`, measured rather than assumed

The obvious guess was measured wrong on another card today (a source docblock that turned
out to be emitted into `dist`), so this was built and searched, not reasoned about.

- `@objectstack/dogfood` is `private: true` — two of the four files can never be published.
- `@objectstack/rest` and `@objectstack/runtime` both declare `files: ["dist","README.md","CHANGELOG.md"]` and exactly one export, `"." → dist/index.*`.
- Both closures were built, then **every shipped byte** was searched for the new prose: `76% false-ungated` → **0**, `RE-MEASURED 2026-09-08` → **0**, across `dist/`, `README.md` and `CHANGELOG.md` of both packages.
- **Positive control (the search fires, and source docblocks in these packages DO reach published bytes):** `Register OpenAPI 3.1 spec + interactive docs viewer.` — a docblock sentence in `packages/rest/src/rest-server.ts` — is present in `packages/rest/dist/index.d.ts`; `Wraps ObjectKernel and provides standard orchestration for:` from `packages/runtime/src/runtime.ts:64` is present in `packages/runtime/dist/index.d.ts`. Both `dist/index.d.ts` files carry 170 and 100+ docblock openers respectively, so comment stripping is not what produced the zeros.
- **Structural corroboration:** `RestRouteLedgerEntry`, `REST_ROUTE_LEDGER`, `RouteLedgerEntry` and `ROUTE_LEDGER` each appear **0 times** anywhere in either `dist/`. Neither ledger module is re-exported from its package index, so its docblocks have no path to published bytes.

⇒ **Reading: nothing published moves.** `skip-changeset` is available and is applied to this
PR. The difference from the other card is structural, not lucky — a docblock ships only if
its module is exported, and these two are not.

## Docs drift — re-derived from a clean worktree, with a live control

The tool's zero was not taken as a clean bill.

- `node scripts/docs-audit/affected-docs.mjs --json` from a **clean** worktree: `"dirty": false`, `head d18064d5b8`, `diffBase 5abca1792e` → **0 docs**, 2 anchors (`RestRouteLedgerEntry`, `RouteLedgerEntry`, both "a top-level interface"), 0 anchorless changes, 0 unanchored rule blocks.
- **Hand sweep** of `content/` (441 files) for this change's tokens — `routeManager.register`, `registerPerItemRoute`, `all 80`, `50 gated`, `guardedRouteManager`, plus `false-ungated`, `RestRouteLedgerEntry`, `RouteLedgerEntry` → **0 files each**.
- **Live positive controls in the same sweep:** `enforceAuth` → 3 files, `authz` → 9, `route` → 134, `/api/v1` → 98. The sweep is live; the zeros are readings, not a dead probe.
- **The semantic half** — a page can state a rule by its inputs and share no identifier with the emitter — so the 11 pages mentioning `enforceAuth` or `authz` were read for the population or the derivation claim. None carries either; the single regex hit is an unrelated metadata-registry table row.
- `content/docs/releases/` is untouched.

## The three unrelated "80"s — checked and excluded, not re-filed

`packages/spec/scripts/liveness/check-liveness.test.ts:413` and
`packages/spec/scripts/liveness/check-liveness.mts:461` are **80 `dead` ledger rows**;
`packages/spec/scripts/lib/format-type.ts:182` is a third, different 80. All three were
read, none is a route registration, and `git status` shows no change anywhere under
`packages/spec/`. Recorded here so the next person's grep does not re-file them.

## One in-place fix beyond the four named lines

`packages/qa/dogfood/test/authz-probe-blind-spot.census.ts:187` back-references the same
derivation as "(73% false-ungated)". Left alone it would have made that file contradict
itself again, 42 lines from the line this PR just repaired — the exact defect the card
exists to remove, freshly re-introduced. Same file (inside the declared surface), same
figure, same derivation, purely mechanical: updated to 76%.

## Out of scope — reported, not written

⭐ **A fifth carrier of these figures exists and is deliberately NOT edited here**:
`packages/qa/dogfood/test/authz-conformance.matrix.ts:33-36` says "22 of 30 apparently
ungated `register(` sites … a 73% false-ungated rate". It spells the call `register(` and
never says "80", so neither of the two queries this card was scoped by can see it. It is
outside the declared four-file surface. After this PR it is the only remaining carrier of
22/30 and 73%.

A second, in this card's file but outside its named lines: the census's blocker 1 says "of
the 8 REST route mounts measured to carry no `enforceAuth`" — 29 − 22 = 7 today. Not
repaired here because it is not mechanical: the 8 is tied to a ledger-grade decomposition
(3 `server-only` / 3 `public` / 2 `sdk`) that needs its own measurement.

Both are filed together as #16954 after a duplicate check.

## Verification

- **Gate families** — `node scripts/pm/dispatch-gates.mjs --commands` derived 52 families; all 52 run; `--ran` reconciles **52 derived, 52 run, 0 UNRUN**. After merging current `origin/main` the derivation grew to 55; the 3 new changeset families were run and are green.
- **Two of the 52 returned NOT MEASURED rather than a verdict**, both declared to CI: `check:dual-build-cjs-loads` prints `PREREQUISITE NOT MET` (37 packages have no `dist/`; it needs a whole-tree `pnpm build`), and `check:type-check-debt --re-measure` prints `PREREQUISITE NOT MET` then OOMs under the 4096 MB ceiling this box mandates and refuses to record. Neither can be moved by comments that provably do not reach any `dist/`.
- **Lint** — `pnpm lint` (`eslint . --no-inline-config`, the whole repo, no narrowing) → exit **0**.
- **Typecheck** — `@objectstack/rest`, `@objectstack/runtime`, `@objectstack/dogfood` → exit **0**. Coverage proved rather than assumed: `tsc --noEmit --listFiles` in `packages/qa/dogfood` lists both edited test files in the program.
- **Tests** — `@objectstack/rest` 184 files / 3057 tests passed; `@objectstack/runtime` 247 files / 3504 tests passed; the two dogfood suites that read these files, `authz-probe-blind-spot.test.ts` and `authz-conformance.test.ts`, 2 files / 80 tests passed. The rest of the dogfood tier is declared to CI — a proven narrowing, not a blind one: the complete consumer set of the edited census module is those two suites plus `packages/rest/src/rest-meta-auth.test.ts`, which the full rest suite covers.
- Exit codes were captured before any pipe throughout.

---
_Generated by [Claude Code](https://claude.ai/code/session_015QE8qk46e5CHJxyQEUjbf8)_