### PR TITLE
docs(spec): stop restating a plugin-local union's members, and name the mis-aimed nav-group case

### DIFF
--- a/.changeset/expired-docblock-member-and-command-counts.md
+++ b/.changeset/expired-docblock-member-and-command-counts.md
@@ -1,0 +1,13 @@
+---
+"@objectstack/spec": patch
+---
+
+Two spec docblocks now say what the tree does: `StrandedRunState` is no longer given a member list here, and the `navigationContributions[].group` JSDoc names the mis-aimed case (#16708, #16507)
+
+**`contracts/automation-service.ts`** — the `AutomationResult.status` docblock explains why plugin-approvals' `StrandedRunState` is deliberately *not* promoted to this status, and it did so through a parenthetical copy of that union's members, `'missing' | 'failed'`. The plugin has since split `'failed'` into `'repairable'`, `'snapshot_dropped'` and `'unrepairable'` (the #15358 discriminator), so the copy described a shape the type contradicted — a spec docblock telling a reader the type cannot express a distinction the platform had already published. The copy is **removed rather than refreshed**: the union is plugin-local, is declared and documented member by member on the type itself, and `automation-result-status.pin.test.ts` excludes it from its pins *on purpose*, so any member list restated in this package is unpinned prose with nothing to keep it honest. The docblock now names where the members live instead of counting them.
+
+**`ui/app.zod.ts`** — the JSDoc above `NavigationContributionSchema` documented only the case where `group` is **omitted**, while the `.describe()` a few lines below it (corrected in #14925) also names the case where `group` is **present and names no group the target app declares**. The two halves of one key's authoring-time documentation disagreed, and they disagreed on the case an author cannot detect from their own source — the target app belongs to another package. The JSDoc now carries that case in the spelling the `.describe()` and `content/docs/ui/setup-app.mdx` already use: not refused, items appended at the app top level anyway, a `nav_contribution_group_missing` diagnostic emitted by the runtime at `warn` and by `os build` and `os validate` at compile time.
+
+Prose only, in both files. No type, no schema, no accept set and no exported name moves; nothing that reaches a generated artefact changed, so the reference pages, the authorable surface and the JSON-Schema manifest are byte-identical. The changeset exists because both strings **ship**: `src/**/*.zod.ts` is in this package's `files[]`, and both docblocks are emitted into the published `dist/*.d.ts`.
+
+One private fixture comment rides along, outside any published package: `examples/app-multi-package/src/packages/orders/index.ts` credited only `os build` with the compile-time finding, where `findNavGroupDiagnostics` has been folded into both `os build` and `os validate` since #14920.

--- a/examples/app-multi-package/src/packages/orders/index.ts
+++ b/examples/app-multi-package/src/packages/orders/index.ts
@@ -44,10 +44,11 @@ import { defineStack } from '@objectstack/spec';
  * ⚠️ `group` names `sales_group`, a container the CORE package declares. A
  * module cannot see that id at authoring time, and a typo in it does not fail:
  * the runtime RELOCATES the items to the app's top level and says so
- * (`nav_contribution_group_missing`, at `warn`), and `os build` reports the
- * same finding at compile time. This fixture is where that is measured — keep
- * the id spelled correctly here, so a build of this example stays clean and the
- * pin that typos it has something to differ from.
+ * (`nav_contribution_group_missing`, at `warn`), and `os build` and
+ * `os validate` report the same finding at compile time. This fixture is
+ * where that is measured — keep the id spelled correctly here, so a build of
+ * this example stays clean and the pin that typos it has something to differ
+ * from.
  */
 export default defineStack({
   manifest: {

--- a/packages/spec/src/contracts/automation-service.ts
+++ b/packages/spec/src/contracts/automation-service.ts
@@ -342,10 +342,15 @@ export interface AutomationResult {
      * something to repair. This member is the ruling's contract half; the
      * engine begins stamping it when #13937's services half (the re-arm verb
      * and the catch-arm stamp in `resumeInternal`) lands. plugin-approvals'
-     * `StrandedRunState` (`'missing' | 'failed'`) is a report-only label over
-     * a request's run and is deliberately NOT promoted to this status (same
-     * ruling): it classifies WHY a request's run is unrecoverable, this names
-     * the run's own lifecycle verdict.
+     * `StrandedRunState` is a report-only label over a request's run and is
+     * deliberately NOT promoted to this status (same ruling): it classifies
+     * WHY a request's run is unrecoverable, this names the run's own lifecycle
+     * verdict. ⛔ Its members are deliberately NOT restated here: the union is
+     * plugin-local — declared, and documented member by member, on the type
+     * itself in `plugins/plugin-approvals/src/approval-service.ts` — and
+     * `automation-result-status.pin.test.ts` excludes it from its pins on
+     * purpose, so a member list copied into this file is unpinned prose that
+     * goes stale the next time the plugin splits an arm.
      *
      * `'refused'` names the run that reached an `end` node declaring
      * `outcome: 'refused'` (#14945; maintainer ruling 2026-09-05, option 2′):

--- a/packages/spec/src/ui/app.zod.ts
+++ b/packages/spec/src/ui/app.zod.ts
@@ -753,9 +753,15 @@ export const NavigationItemSchema: z.ZodType<NavigationItem, NavigationItemInput
  * The runtime merges all contributions into the owning app's `navigation`
  * tree by **target group id + priority** (lower priority applied first,
  * mirroring object extender ordering). When `group` is omitted the items are
- * appended at the app's top level. Contributed items keep the normal nav
- * gating fields (`requiresObject` / `requiredPermissions` / `visible`), so an
- * uninstalled capability simply contributes nothing and its slot stays empty.
+ * appended at the app's top level. Naming a group the target app does not
+ * declare is not refused either: the items are appended at the app top level
+ * anyway and a `nav_contribution_group_missing` diagnostic is emitted — by the
+ * runtime at `warn`, and by `os build` and `os validate` at compile time. That
+ * second case is the one an author cannot detect from their own source,
+ * because the target app belongs to another package. Contributed items keep
+ * the normal nav gating fields (`requiresObject` / `requiredPermissions` /
+ * `visible`), so an uninstalled capability simply contributes nothing and its
+ * slot stays empty.
  *
  * @example
  * {


### PR DESCRIPTION
Fixes #16708
Fixes #16507

Clause-②: no
  Both defects are a **source comment** that states a count or a scope the tree contradicts.
  Rewriting them moves no accept set, adds no export, changes no type and puts no new key on
  any payload. The whole diff is comment text plus one changeset. 拉回已声明契约 ⇒ 常规档.

Two cards, one family: a comment that stated a **count** (#16708) or a **command scope**
(#16507) the tree had already contradicted. One fix method in both — rewrite the sentence to
what the tree does, code untouched.

## #16708 — the member list is removed, not refreshed

**Re-derived from the type itself**, not from the card's count
(`packages/plugins/plugin-approvals/src/approval-service.ts:516`, the tree's only declaration
of it):

```ts
export type StrandedRunState = 'missing' | 'failed' | 'repairable' | 'snapshot_dropped' | 'unrepairable';
```

**Five members** — the card's number is correct. The spec docblock named two.

The copy is **deleted rather than corrected**, and that is a measurement, not a preference. A
two-leg ablation from the committed state, each leg proved on disk and each restore proved by
blob hash against `HEAD`:

| leg | mutation, proved on disk | `automation-result-status.pin.test.ts` |
|:---|:---|:---|
| baseline | — | exit **0**, 8 passed |
| **A** | the token `StrandedRunState` removed from that docblock (occurrences 1 → 0, injected marker present 1×) | exit **1** — `AssertionError: expected '/**\n * Lifecycle status…' to contain 'StrandedRunState'`; 1 failed / 7 passed |
| **B** | the deleted two-member list put back verbatim, `'missing'` then `'failed'`, in its original parenthetical | exit **0**, 8 passed |

Leg A proves the pin really reads this docblock — the instrument is not blind. Leg B proves
**nothing pins the member list**: a refreshed five-member copy would sit exactly as unguarded
as the two-member one did, and would go stale the next time the plugin splits an arm. The pin
test says so itself in its header — plugin-approvals' `StrandedRunState` is on its list of
things "⛔ Not pinned, deliberately". So the docblock now names **where the members live** and
why they are not restated here, instead of counting them.

Restore after each leg: blob `2d82047493ca63e6b4ea7f945de61ba74370844c` == `HEAD`,
`git diff HEAD` empty, `git status --porcelain` empty.

## #16507 — both spots, line numbers re-taken from the tree

The card's line numbers were stale; these are this tree's.

1. `packages/spec/src/ui/app.zod.ts` — the `NavigationContributionSchema` JSDoc (the card said
   "around :739"; the block is **:744-769**, the schema at **:770**). It documented only the
   **omitted** `group` case while the `.describe()` at **:780** — corrected in #14925 — also
   names the case where `group` is present and names no group the target app declares. The
   JSDoc now carries that case in the spelling the `.describe()` and
   `content/docs/ui/setup-app.mdx:99` already use, plus the one clause that makes it matter:
   an author cannot detect it from their own source, because the target app belongs to another
   package. ⛔ No third spelling was invented.
2. `examples/app-multi-package/src/packages/orders/index.ts` — the fixture comment (the card
   said `:47`; it is **:47** still) credited only `os build`. `findNavGroupDiagnostics` is
   imported by `packages/cli/src/commands/compile.ts:49` **and**
   `packages/cli/src/commands/validate.ts:44` (the card said `:43`) and folded into the same
   `warnings` key from `compile.ts:506` / `validate.ts:355`. It now names both commands.

**Closing self-check, with a firing control** (triage's acceptance point 4 — ⛔ not a single
grep):

| probe | tracked-file hits |
|:---|:---|
| the JSDoc-unique phrase `declare is not refused either` | **1** — `packages/spec/src/ui/app.zod.ts` only |
| **control**, the sibling `.describe()` phrase, same instrument, same tree | **3** — the source **plus** `content/docs/references/ui/app.mdx` and `content/docs/references/kernel/manifest.mdx` |
| the JSDoc phrase inside `packages/spec/json-schema/` | **0** |
| **control**, the `.describe()` phrase inside `packages/spec/json-schema/` | **24** |

The control fires, so the zero is a reading. The edited JSDoc reaches no generated artefact;
the `.describe()` beside it does, and it was already correct.

**Hand-scan of the docs, not an anchor check** — every page that carries this claim already
says "`os build` **and `os validate`**" (`content/docs/ui/setup-app.mdx:99`,
`references/ui/app.mdx:569`, `references/kernel/manifest.mdx:108`). `docs/audits/**` and
`content/**` carry no occurrence of `StrandedRunState`, `snapshot_dropped` or `unrepairable`
(control on the same file set: `nav_contribution_group_missing` → 2 files). ⛔
`content/docs/releases/**` untouched.

## Changeset — measured in two halves, and they DISAGREE on one file

⛔ `skip-changeset` was not assumed. Positive and negative controls on both halves.

| file | half 1 — path vs `files[]` | half 2 — text in the built `dist` | verdict |
|:---|:---|:---|:---|
| `packages/spec/src/contracts/automation-service.ts` | **NO** — `files[]` publishes `src/**/*.zod.ts`, and this is not a `.zod.ts` | **YES** — `report-only label` → `dist/contracts/index.d.ts` + `.d.mts` | **published** |
| `packages/spec/src/ui/app.zod.ts` | **YES** — matched by `src/**/*.zod.ts`, shipped as source | **YES** — `mirroring object extender ordering` → `dist/app.zod-CHxLLVKs.d.ts` + `.d.mts` | **published** |
| `examples/app-multi-package/src/packages/orders/index.ts` | not published — `"private": true`, no `files[]` | n/a | **not published** |

Controls for half 2, over the same `dist/`: positive `Naming a group the target app does not
declare` → **20 files**; negative `zzz_no_such_string_control` → **0**.

⇒ Half 1 alone would have called `automation-service.ts` unpublished and been **wrong**: its
TSDoc is emitted into the published `.d.ts`. A `patch` changeset for `@objectstack/spec` is
owed and is in the diff. Nothing that reaches a generated artefact moved —
`pnpm --filter @objectstack/spec check:generated` reports all 15 artifacts up to date and left
`git status` empty.

## Gates — derived, run, reconciled

`node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack --commands` → **71
families**; every one run; reconciled with `--ran`:

```
✓ dispatch-gates --ran: 71 derived famil(ies) accounted for — 71 run, 0 NOT-MEASURED.
Run reconciliation — 71 derived, 71 run, 0 NOT-MEASURED, 0 UNRUN.
```

Six of them first refused with **PREREQUISITE NOT MET** (a stale `packages/spec/dist`; unbuilt
`@objectstack/formula` / `@objectstack/lint`; and `check:dual-build-cjs-loads` wanting every
package's `dist`). ⛔ Those were **NOT MEASURED**, never red — so the prerequisite was built
rather than declared: `pnpm --filter @objectstack/spec build`, then
`turbo run build --filter=@objectstack/spec --filter=@objectstack/formula --filter=@objectstack/lint`,
then a full `turbo run build --concurrency=2` (74/74 tasks). All six then ran and returned **0**:
`check:doc-formula-expressions`, `check:api-surface`, `check:browser-reachable-entries`,
`check:dual-source-exports`, `check:entry-nameability`, `check:dual-build-cjs-loads`.

Every heavy run went through `scripts/pm/os-verify-lock.sh`; exit codes read from its printed
`VERDICT command-exit` line, ⛔ never from a bare `$?` behind a pipe.

## Tests

| run | result |
|:---|:---|
| `pnpm --filter @objectstack/spec test` (full, under the lock) | `VERDICT command-exit 0` — **467 files, 13100 tests passed** |
| targeted: `automation-result-status.pin.test.ts` + `ui/app.test.ts` | `VERDICT command-exit 0` — 2 files, **110 passed** |
| `pnpm --filter @objectstack/spec typecheck` | `SPEC_TC_EXIT=0` |
| `pnpm --filter @objectstack/example-multi-package typecheck` | `EX_TC_EXIT=0` |
| ablation, both legs | table above |

**Lint — a declared narrowing, with its three readings** (all at `c0143fd83`, the final commit):

1. **Receiving population, read from eslint's own config** — not guessed:
   `ESLint#isPathIgnored` answers `false` for all three changed paths, so no part of this diff
   sits outside the lint population.
2. **File count from `--format json`** — `eslint --no-inline-config --format json` over the three
   paths: **3 files linted, 0 errors, 0 warnings**, exit **0**.
3. **Invariance for untouched files** — `eslint.config.mjs:324-334` records that this repo
   "never enables type-aware linting (no `parserOptions.project`, no typed
   `@typescript-eslint` rules) for ANY file". A comment-only diff in three files therefore
   cannot move any untouched file's verdict.

All three are present, so the narrowing is a measurement rather than a skipped run. The
repo-wide `pnpm lint` remains CI's.

## 验收备注

Triage's acceptance criteria for #16507, answered in order:

1. **Wording taken from `setup-app.mdx` and the post-#14925 `.describe()`** — ⛔ no third
   spelling invented.
2. **`os validate` added** to the fixture comment, matching "`os build` **and `os validate`**".
3. **⛔ Nothing behavioural touched** — `findNavGroupDiagnostics` untouched,
   `nav_contribution_group_missing` still `warn`.
4. **Closing check ran with a firing control**, table above — ⛔ not one bare grep.
5. **⛔ `content/docs/releases/` untouched.**

**On triage's 第 4 条 (the "cannot be split" judgement) — reported, ⛔ not acted on.** Triage is
right that the two spots are uncoupled: different files, different packages, different facts,
and neither reaches a generated artefact. Splitting was mechanically available. It was **not**
done, per the dispatch fence. Measured cost of folding, for triage's ledger: the two halves
shared one gate sweep (71 families), one full spec build and one changeset — a split would have
paid all three twice, and `examples/app-multi-package` typechecks against the built spec anyway,
so the "`examples/` half need not wait for the spec half" argument does not hold in this tree.
⇒ The fold looks cheaper here than the split; triage's instinct is sound in general but the
saving would have been negative on this pair.

**Notes, not filed** (⛔ neither is a reproducible defect, a contract violation, or an
authoring trap, so ⛔ no card):

- `packages/spec/CHANGELOG.md:678` and `packages/plugins/plugin-approvals/CHANGELOG.md:336`
  still spell the old two-member union. They are **historical records and must stay** — the
  card says so explicitly, and ⛔ they were not touched.
- The spec docblock's neighbouring sentences still carry "the engine begins stamping it when
  #13937's / #10025's services half … lands" — the same expired-temporal-promise shape as the
  defect this PR fixes, but for members that genuinely have not landed yet. Left alone: they
  are true today, and rewriting them is a different card's judgement, not this one's. Carrier
  for whoever files it: `packages/spec/src/contracts/automation-service.ts`, the
  `AutomationResult.status` and `.code` docblocks. ⛔ Not filed here — 承接者:无.

---
_Generated by [Claude Code](https://claude.ai/code/session_016N6xmWt5hYm94ffVEwGH8x)_