### PR TITLE
ci(lint): add a `.sh` arm to select-gate-families's pm_dispatch_gates read-set

### DIFF
--- a/scripts/ci/select-gate-families.selftest.sh
+++ b/scripts/ci/select-gate-families.selftest.sh
@@ -67,6 +67,7 @@ printf '{"name":"a"}\n' > "$UP/packages/a/package.json"
 printf 'export const a = 1;\n' > "$UP/packages/a/src/index.ts"
 printf 'export const t = 1;\n' > "$UP/packages/a/src/index.test.ts"
 printf '{"rows":[]}\n' > "$UP/packages/a/src/data.json"
+printf '#!/usr/bin/env bash\necho foo\n' > "$UP/packages/a/foo.sh"
 printf 'dist/\n' > "$UP/packages/a/.gitignore"
 printf 'console.log(1);\n' > "$UP/packages/a/scripts/build.mjs"
 printf 'export const site = 1;\n' > "$UP/apps/site/src/page.tsx"
@@ -427,6 +428,13 @@ run_case 'merge_group: a non-source, non-manifest workspace file skips every fam
 expect_rc 0
 expect_warnings '' ''
 expect_verdicts
+
+S=$(scenario M:packages/a/foo.sh)
+run_case 'merge_group: a workspace shell script outside scripts/ is still gate source, not a skipped non-source workspace file (#16769)' "$REPO" merge_group '' "$C0"
+expect_rc 0
+expect_warnings '' ''
+expect_verdicts pm_dispatch_gates
+expect_reason pm_dispatch_gates packages/a/foo.sh
 
 S=$(scenario M:packages/a/scripts/build.mjs)
 run_case 'merge_group: a package-local script is a gate source (PM) and a masked source (corpus)' "$REPO" merge_group '' "$C0"

--- a/scripts/ci/select-gate-families.sh
+++ b/scripts/ci/select-gate-families.sh
@@ -61,17 +61,17 @@
 #                          `AGENTS.md`, `CLAUDE.md`, `tsconfig.json`,
 #                          .gitignore, and sweeps `git ls-files` for hint
 #                          reachability and test-file residue. It also reads
-#                          the CONTENT of every JS/TS file in the tree: the
-#                          compound-anchor census of `function ...SelfTest...(`
-#                          declarations asserts none is unlisted, and the
-#                          exposed-scratch-dir sweep reads every
-#                          mkdtempSync/mkdirSync caller and consults nested
-#                          .gitignore files. So any masked source file and any
-#                          .gitignore runs it, and because the name sweep reads
-#                          the tracked NAME set an ADDED file anywhere runs it
-#                          too; only modifications of docs, changesets and
-#                          non-source workspace files that are neither a
-#                          manifest nor a script skip it.
+#                          the CONTENT of every JS/TS and shell (`.sh`) file in
+#                          the tree: the compound-anchor census of
+#                          `function ...SelfTest...(` declarations asserts none
+#                          is unlisted, and the exposed-scratch-dir sweep reads
+#                          every mkdtempSync/mkdirSync caller and consults
+#                          nested .gitignore files. So any masked source file,
+#                          any `.sh` file, and any .gitignore runs it, and
+#                          because the name sweep reads the tracked NAME set an
+#                          ADDED file anywhere runs it too; only modifications
+#                          of docs, changesets and non-source workspace files
+#                          that are neither a manifest nor a script skip it.
 #   query_options_erasure  `pnpm check:query-options-erasure`. Lints
 #                          packages/**/*.{ts,tsx,mts,cts} under
 #                          `eslint.config.mjs`, reads its baseline
@@ -314,9 +314,12 @@ family_reads() {
       # The self-test reads the CONTENT of every JS/TS file in the tree (the
       # compound-anchor census of `function ...SelfTest...(` declarations, the
       # exposed-scratch-dir sweep of every mkdtempSync/mkdirSync caller) and
-      # consults nested .gitignore files, so any masked source and any
-      # .gitignore runs it whatever class it sits in.
+      # every tracked `.sh` file (the same watch-hint extraction, run through
+      # the comment mask), and consults nested .gitignore files, so any masked
+      # source, any `.sh` file, and any .gitignore runs it whatever class it
+      # sits in.
       is_masked_source "$path" && return 0
+      case "$path" in *.sh) return 0 ;; esac
       case "$path" in */.gitignore) return 0 ;; esac
       case "$class" in
         docs|changeset) return 1 ;;


### PR DESCRIPTION
Part of #16769.

## Half 1 only — half 2 stays open, the card stays queued

This PR lands only the first of the card's two halves: the one-line `*.sh` arm
in `pm_dispatch_gates`'s read-set, plus a self-test case that drives the real
window. It closes nothing. Half 2 — pinning the selector's key sets to the
gates' *live* read-sets so this class of drift cannot recur — is a design
question the card explicitly declines to prescribe a shape for, and stays
unaddressed here. `objectstack-ai/objectstack#16769` remains open and queued
after this merges.

## What changed

`family_reads`'s `pm_dispatch_gates` branch classified a modified (`M`) shell
script that is not masked source, not a `.gitignore`, and sits directly under
`packages/**` / `apps/**` / `examples/**` (not inside a `*/scripts/*`
subdirectory) into the `workspace` class, whose arm returns 1 (skip) for
anything but `*/package.json` or `*/scripts/*`. But `scripts/pm/dispatch-gates.mjs`'s
self-test reads the CONTENT of every tracked `.sh` file (a live census
asserting the shell-comment mask never adds a watch hint), so such a path
should always run `pm_dispatch_gates`.

Added `case "$path" in *.sh) return 0 ;; esac` beside the existing
`*/.gitignore` arm, before the class switch — so any `.sh` file runs the
family whatever class it sits in, matching how masked source and
`.gitignore` are already handled. Updated both comments describing this
family's read-set in the same voice.

This is superset-only by construction: it can only make `pm_dispatch_gates`
run *more* often on a path that previously skipped, never less.

## Self-test case, and the before/after ablation the card requires

Added `packages/a/foo.sh` (workspace class, not under `*/scripts/*`) to the
self-test's fixture tree, and a case modifying it at status `M`:

```
S=$(scenario M:packages/a/foo.sh)
run_case 'merge_group: a workspace shell script outside scripts/ is still gate source, not a skipped non-source workspace file (#16769)' "$REPO" merge_group '' "$C0"
expect_rc 0
expect_warnings '' ''
expect_verdicts pm_dispatch_gates
expect_reason pm_dispatch_gates packages/a/foo.sh
```

Run against the **unmodified** script (the `.sh` arm reverted, self-test
otherwise identical) — the new case fails, demonstrating the real hole:

```
FAIL  pm_dispatch_gates reason mentions: packages/a/foo.sh
      got: pm_dispatch_gates skip no changed path is in its read-set
      -- output --
      | Gate families: 0 run, 5 skipped  (event: merge_group; changed paths: 1)
      |   skip  pm_dispatch_gates      no changed path is in its read-set
      |   skip  query_options_erasure  no changed path is in its read-set
      ...
SELFTEST FAILED (40 cases, 192 checks)
```

Run against the **fixed** script — the case passes and the full battery is
green:

```
all 40 cases passed (192 checks)
```

**Negative control (mandatory)**: the pre-existing case at
`M:packages/a/src/data.json` ("a non-source, non-manifest workspace file
skips every family") still asserts `expect_verdicts` (empty — all skip) and
passes post-fix, confirming the new arm did not escape its intended scope
into an early, over-broad `return 0`. The pre-existing merge_group docs-only
case (`docs/guide.md`, status `M`) likewise still asserts `expect_verdicts`
empty (all skip) post-fix.

## Re-check commands, re-derived before and after (on `origin/main` `3030369e94`)

```bash
grep -n 'gitignore' scripts/ci/select-gate-families.sh
grep -c 'shellGrew' scripts/pm/dispatch-gates.mjs
git ls-files '*.sh' | wc -l
```

| command | before (this branch's base) | after (this PR) |
|---|---|---|
| `.gitignore` arm line | `:320  case "$path" in */.gitignore) return 0 ;; esac` | `:323  case "$path" in */.gitignore) return 0 ;; esac` (the new `*.sh` arm now sits at `:322`, immediately above it) |
| `shellGrew` in `dispatch-gates.mjs` | 4 | 4 (unchanged — out of scope, read-only) |
| tracked `.sh` files | **31** | 31 (unchanged by this PR) |

The card said 27 at filing, triage said 29 sixteen hours later; this run
re-derives **31**. That drift is the card's own argument for half 2 — three
data points now, not two. **Control**: all 31 tracked `.sh` files still live
under `scripts/**` or `.claude/hooks/**` (classes where `pm_dispatch_gates`
already ran before this fix); files matching
`^(packages|apps|examples|docs|content)/` and not under `*/scripts/*` → **0**
— the hole was real but its firing window was, and remains, shut by where
people happen to put shell scripts, not by any rule. This PR closes that
rule-level gap for the one class this half addresses.

## Local checks run (this file surface has no `package.json`; not a package)

- `pnpm check:select-gate-families` (= this file's own self-test): 40/40
  cases, 192/192 checks — before-fix red demonstrated above, after-fix green.
- `pnpm check:nul-bytes`: OK (8403 tracked text files, 0 raw control bytes).
- `pnpm check:scripts-symbol-anchors`: OK (3041 anchors, 234 scripts).
- `node scripts/check-self-test-wired.mjs`: OK.
- `node scripts/check-self-test-workflow-commands.mjs`: OK.
- `node scripts/check-comment-mask-corpus.mjs`: OK (6389 files, 0 disagree).
- `pnpm check:pm-dispatch-gates` (`scripts/pm/dispatch-gates.mjs`'s own
  self-test, run detached per that gate's own header instruction since it
  exceeds a practical foreground budget): PASS — `dispatch-gates self-test:
  1561 cases pass` (~530s wall time, this run).

No changeset: nothing in `packages/**`'s published `files[]` references
`scripts/ci/**`; this is unpublished, repo-root CI tooling under a private
package, so no user-visible surface moved.

---
_Generated by [Claude Code](https://claude.ai/code/session_012GKcPZbMoGq7WPzKLfRBTU)_