### PR TITLE
docs(spec): drop the stale inline-locale-map population count from i18n docblocks

### DIFF
--- a/.changeset/i18n-inline-locale-map-population-count.md
+++ b/.changeset/i18n-inline-locale-map-population-count.md
@@ -1,0 +1,26 @@
+---
+"@objectstack/spec": patch
+---
+
+`i18n.zod.ts` stops asserting a stale size for the inline-locale-map population.
+
+Two docblocks in this file each stated that the repo authors 31 inline locale maps — the
+`INLINE_LOCALE_KEY` rationale ("Every inline map authored in this repo (31 of them, across
+three platform pages) uses `en` / `zh-CN` / `ja-JP` / `es-ES`, so the constraint costs no real
+authoring surface") and the `I18nLabelSchema` form-2 note ("Three published platform pages
+author 31 of these"). The measured population is 45: 33 in `sys-user.page.ts`, 6 in
+`sys-organization.page.ts`, 6 in `sys-position.page.ts`.
+
+The number is **dropped** at both sites rather than corrected to 45. Neither sentence's
+argument needs a magnitude. The first turns on the universal — *every* authored map uses those
+four tags — so the accept set is what makes the constraint free, not the size of the set. The
+second turns on the map being authored on published platform pages *and* resolved by
+`pickLocalized`; one authored-and-resolved map already refutes "a convention the runtime
+ignores", so the count was never load-bearing there either. Writing 45 would buy one release of
+accuracy in prose that is cited as evidence for a schema constraint, and the figure has already
+drifted once with nothing noticing; deriving it would mean a permanent gate whose only job is
+keeping a number in a comment true.
+
+The measured half survives untouched at both sites: three platform pages author these maps, and
+that is still exactly three. No schema arm, bound, default, `.describe()` string or export
+changes; nothing an author can write is affected.

--- a/packages/spec/src/ui/i18n.zod.ts
+++ b/packages/spec/src/ui/i18n.zod.ts
@@ -93,9 +93,9 @@ import { strictObject } from '../shared/strict-object';
  * inline locale map the resolver really honours is authorized, and the dead
  * key-reference dialect stays rejected — declared = enforced in both
  * directions, which is exactly the #4667 consistency the ruling asks for.
- * Every inline map authored in this repo (31 of them, across three platform
- * pages) uses `en` / `zh-CN` / `ja-JP` / `es-ES`, so the constraint costs no
- * real authoring surface.
+ * Every inline map authored in this repo (across three platform pages) uses
+ * `en` / `zh-CN` / `ja-JP` / `es-ES`, so the constraint costs no real
+ * authoring surface.
  *
  * The two retired spellings are rejected BY NAME, in any combination
  * (#10492). An earlier revision of this comment argued the opposite — that the
@@ -238,9 +238,9 @@ export const InlineLocaleMapSchema: z.ZodType<
  *     `pages.<page>.components.<id>.label`, …) and resolved by
  *     `system/i18n-resolver.ts`.
  *  2. **An inline locale map** — `{ en: 'Members', 'zh-CN': '成员' }`, picked at
- *     render time. Three published platform pages author 31 of these and
- *     objectui resolves them (`pickLocalized`), so the map is a delivered
- *     capability, not a convention the runtime ignores.
+ *     render time. Three published platform pages author these and objectui
+ *     resolves them (`pickLocalized`), so the map is a delivered capability,
+ *     not a convention the runtime ignores.
  *
  * Form 2 is resolved **on this side too**, since #6765: `resolveI18nLabel` in
  * `./i18n-label-resolver` is the shared `I18nLabel` → `string` resolver, pinned


### PR DESCRIPTION
Fixes #14816

`packages/spec/src/ui/i18n.zod.ts` asserted the size of the inline-locale-map population twice, and both sites said **31**. The measured population is **45**. The count is **dropped** at both sites rather than corrected.

## Clause-② ruling (carried from dispatch)

```
Clause-②: no
  Two sentences in two docblocks. No schema arm, bound, default or refusal moves; no export
  is added, removed or renamed; no accept set widens or narrows; nothing an author can write
  changes. 拉回已声明契约(把 prose 里的数字拉回可测量的事实)⇒ 常规档.
```

## The two sites — before and after, quoted whole

Both sites were located by sentence **text**, never by line number.

**Site 1** — the `INLINE_LOCALE_KEY` rationale.

Before:

```
 * Every inline map authored in this repo (31 of them, across three platform
 * pages) uses `en` / `zh-CN` / `ja-JP` / `es-ES`, so the constraint costs no
 * real authoring surface.
```

After:

```
 * Every inline map authored in this repo (across three platform pages) uses
 * `en` / `zh-CN` / `ja-JP` / `es-ES`, so the constraint costs no real
 * authoring surface.
```

The argument is untouched. It turns on the **universal** — *every* authored map uses those four tags — so what makes the constraint free is the accept set, not the size of the population.

**Site 2** — the `I18nLabelSchema` form-2 note.

Before:

```
 *  2. **An inline locale map** — `{ en: 'Members', 'zh-CN': '成员' }`, picked at
 *     render time. Three published platform pages author 31 of these and
 *     objectui resolves them (`pickLocalized`), so the map is a delivered
 *     capability, not a convention the runtime ignores.
```

After:

```
 *  2. **An inline locale map** — `{ en: 'Members', 'zh-CN': '成员' }`, picked at
 *     render time. Three published platform pages author these and objectui
 *     resolves them (`pickLocalized`), so the map is a delivered capability,
 *     not a convention the runtime ignores.
```

Both sites were read against the question "does this argument need a magnitude?", and neither does — so both are dropped and neither is flagged. Site 2 was the one worth pausing on, since a "delivered capability, not a convention the runtime ignores" claim can want evidence of scale. It does not: the claim rests on the maps being authored on *published* platform pages **and** resolved by `pickLocalized`, and a single authored-and-resolved map already refutes "a convention the runtime ignores". The magnitude that does carry weight there — *three published platform pages* — survives verbatim.

The measured half survives at **both** sites: "three platform pages" / "Three published platform pages", still exactly three.

## Count re-derivation, with controls

Re-derived on this branch's base `2fd714f4f` (the seat measured `fe2b7554a`; the figure is unchanged):

| page | `'zh-CN':` |
|:--|--:|
| `packages/platform-objects/src/pages/sys-user.page.ts` | 33 |
| `packages/platform-objects/src/pages/sys-organization.page.ts` | 6 |
| `packages/platform-objects/src/pages/sys-position.page.ts` | 6 |
| **total** | **45** |

- **Discriminating negative control:** `examples/app-showcase/objectstack.config.ts` gives **0**.
- **Firing control on that same file:** `defineStack` gives **2** — so the zero is a reading, not a broken grep.
- **The "three platform pages" half re-verified:** exactly **3** files under `packages/platform-objects/src/pages/` author these maps.

## No `31` claim survives — wrap-tolerant, with firing controls

Both sentences were line-wrapped with the number at a line boundary in one, so a single-line grep is not a valid instrument here. The file was **flattened** (comment decoration stripped, all newlines collapsed; 0 newlines remained) and searched:

| probe | expect | hits | verdict |
|:--|:--|--:|:--|
| bare `31` anywhere | absent | 0 | PASS |
| `31 of them` | absent | 0 | PASS |
| `author 31 of these` | absent | 0 | PASS |
| any digits + `of them\|of these` | absent | 0 | PASS |
| `three platform pages` | **present** | 1 | PASS |
| `Three published platform pages` | **present** | 1 | PASS |
| site-1 argument intact | **present** | 1 | PASS |
| site-2 argument intact | **present** | 1 | PASS |
| accept set `en / zh-CN / ja-JP / es-ES` intact | **present** | 1 | PASS |
| some 4-digit sequence still in file | **present** | 44 | PASS |

The last row is the matcher's own firing control: the digit matcher demonstrably fires 44 times on other numbers in the same flattened text, so the four zeros above are readings.

## Changeset — both halves measured

A real `patch` changeset is included. Both halves say yes, measured rather than assumed:

- **Half 1 — is the path on `files[]`?** Yes. `@objectstack/spec`'s `files[]` carries `src/**/*.zod.ts`, and `src/ui/i18n.zod.ts` matches it.
- **Half 2 — is the changed text in what the package publishes?** Yes, measured with `npm pack` on this tree (276 tarball entries).
  - **Positive control:** `src/ui/i18n.zod.ts` — PRESENT.
  - **Discriminating negative controls** (siblings in the same directory that the same `files[]` mechanism does **not** ship): `src/ui/i18n.test.ts` — ABSENT; `src/ui/i18n-label-resolver.ts` — ABSENT. The mechanism discriminates: `src/ui/` holds 96 `.ts` files on disk and ships exactly the 18 `.zod.ts` ones.
  - **Docblock comments ship with the source — confirmed, not assumed:** the tarball was extracted and its copy of the file re-read. The shipped bytes carry both new sentences and carry **no** `31` claim.

## Gates

Every reading below is on the final commit `1bf6a9e85`.

- **Governed surface:** `node scripts/pm/check-governed-merges.mjs --test packages/spec/src/ui/i18n.zod.ts .changeset/i18n-inline-locale-map-population-count.md` — "0 of 2 path(s) hit the register (5 surfaces, repo-agnostic)", **NOT governed**. Exit code **0**.
- **`check:generated`:** exit **0** — all 15 generated artifacts up to date. **Nothing regenerated:** `git status --porcelain` is byte-identical before and after the run. No artifact landed under `skills/**`. (`check:react-declaration-parity` is the one gate this repo cannot run at all — it needs objectui's `sdui.manifest.json`; that is its standing condition, not something this change caused.)
- **Gate families** were derived from the real change set with `node scripts/pm/dispatch-gates.mjs --commands --repo objectstack-ai/objectstack`, never from a hand-written list, and re-derived once the changeset existed (which added 4 families). **All 70 derived commands were run.** Reconciliation with `--ran`: *"70 derived, 70 run, 0 NOT-MEASURED, 0 UNRUN"*, exit **0**, re-confirmed after a fresh `git fetch origin main`.
- **69 of 70 are green (exit 0).** Three initially exited **3** — `PREREQUISITE NOT MET`, the gates' own self-declared *NOT MEASURED* code, because they read built output and packages had no `dist/`. Two were cleared by building their prerequisites and re-run to a real reading: `check:doc-formula-expressions` exit **0**, and `check:lean-entry-closure` exit **0** ("2 published condition(s) measured from a real load").
- **One gate is NOT MEASURED, named:** `pnpm check:dual-build-cjs-loads` — exit **3**, `PREREQUISITE NOT MET`, 47 packages still without `dist/`. It needs a full `pnpm build` of the monorepo. **Declared narrowing:** that full build was attempted under the shared verify lock and returned `VERDICT queue-timeout (exit 99) · never acquired · waited 540s` — nothing was built and nothing was decided, so this is recorded as NOT MEASURED rather than as a pass or a red. CI builds fresh and runs it. Reasoning, kept separate from measurement: this diff is two comment lines inside a docblock and emits no different bytes, so it has no mechanism by which to move a CJS-load gate — but that is an argument, not a reading.
- **Typecheck:** `pnpm --filter @objectstack/spec typecheck` — green (`tsc --noEmit` clean, `check:scripts-typecheck` OK, `check:test-typecheck: OK`), lock verdict `command-exit 0`.
- **Spec tests:** `@objectstack/spec` has a split test project. `local` is the one this change set implicates — the i18n tests are not listed in `vitest.repo-tests.json`, so they belong to `local`, not `repo`. `pnpm --filter @objectstack/spec test` (= `vitest run --project local`): **467 test files, 13100 tests, all passed**, lock verdict `command-exit 0`.
- No pin test asserts either changed sentence: the repo carries no occurrence of `31 of them` / `author 31 of these` outside this file and two historical `CHANGELOG.md` rows.

## 验收备注

Out of scope, noted and not folded in:

- `packages/spec/CHANGELOG.md` carries the same stale figure in two historical release entries ("which three published platform pages author 31 times"). These are release-history records of what was written at the time, not live prose, and `CHANGELOG.md` is changeset-owned — left untouched. Carrier: the release-notes lane, if anyone wants it corrected.
- The dispatch's depth fence recorded the checkout as shallow. This worktree's checkout reports `git rev-parse --is-shallow-repository` = **false**. Dating the drift remains deliberately out of scope and was **not** attempted or measured here; the discrepancy is reported to the seat rather than acted on.

_Generated by [Claude Code](https://claude.ai/code/session_016N6xmWt5hYm94ffVEwGH8x)_

---
_Generated by [Claude Code](https://claude.ai/code/session_016N6xmWt5hYm94ffVEwGH8x)_