### PR TITLE
docs(skills): the walk-radius mandate picks the turbo task by rule, not by name

### DIFF
--- a/.claude/skills/spec-property-retirement/SKILL.md
+++ b/.claude/skills/spec-property-retirement/SKILL.md
@@ -275,10 +275,10 @@ conversion 是消费者跟的。两个都要写。
       到的那个文件,漏网的恰是他不知道的引用(实测五处、三个包、两张卡,其中两处还
       是删除**之后**新写的)。排除 `**/CHANGELOG.md`、`.changeset/` 与 pin 自身,理由
       写在旁边,⛔ 不建允许清单文件;⛔ 缺席断言不是陈旧提及,「修好它」即删掉守卫。
-      ⭐ **半径按包申报一次**:写进 `scripts/cross-package-test-inputs.mjs` 的
-      `CROSS_PACKAGE_TEST_INPUTS` 并配齐 `turbo.json` 的 `<pkg>#test` inputs,turbo 才
-      hash 得到它、CI 分片并集才看得见;walk 降在循环变量上、门禁点不出名字,那条 glob
-      还要一条 `heldBy` 证人。⛔ 半径未申报的 tree-scoped pin 不是完成的退役。
+      ⭐ **半径按包申报一次**:`CROSS_PACKAGE_TEST_INPUTS` 写进 `scripts/cross-package-test-inputs.mjs`,并配
+      齐 `turbo.json`:声明 `test:repo` 脚本的包配 `<pkg>#test:repo` 且 `<pkg>#test` 不带根输入,否则配
+      `<pkg>#test`;分歧以 `scripts/check-cross-package-test-inputs.mjs` 为准。walk 降在循环变量上、门禁
+      点不出名字的 glob 另配 `heldBy` 证人。⛔ 半径未申报的 tree-scoped pin 不是完成的退役。
 - [ ] **Examples** —— `examples/app-showcase/**` 必须停止编写该键。墓碑路线上
       `tsc` 替你找齐。
 - [ ] **已发布 skills** —— 教这个键的 `skills/*/SKILL.md`(表格、`defineX` 示例)


### PR DESCRIPTION
Fixes #16987

⚠️ **Placeholder spelling in THIS body.** The file's own placeholder is the angle-bracket form; every occurrence is rendered here as `PKG` (`PKG#test`, `PKG#test:repo`) so the body survives the platform's byte rewriting. The file is unchanged in that spelling, and every byte count below is of the FILE's bytes, never of this rendering.

## What changed

`.claude/skills/spec-property-retirement/SKILL.md`, the tree-scoped-pin checklist item's ⭐ 半径按包申报一次 bullet (lines 278–281). It named `PKG#test` unconditionally. It now states the picker **and** names the authority, in place and line-neutral.

**Before** (4 lines, 392 bytes — 89 · 90 · 113 · 100):

> ⭐ **半径按包申报一次**:写进 `scripts/cross-package-test-inputs.mjs` 的 `CROSS_PACKAGE_TEST_INPUTS` 并配齐 `turbo.json` 的 `PKG#test` inputs,turbo 才 hash 得到它、CI 分片并集才看得见;walk 降在循环变量上、门禁点不出名字,那条 glob 还要一条 `heldBy` 证人。⛔ 半径未申报的 tree-scoped pin 不是完成的退役。

**After** (4 lines, 475 bytes — 120 · 118 · 119 · 118):

> ⭐ **半径按包申报一次**:`CROSS_PACKAGE_TEST_INPUTS` 写进 `scripts/cross-package-test-inputs.mjs`,并配齐 `turbo.json`:声明 `test:repo` 脚本的包配 `PKG#test:repo` 且 `PKG#test` 不带根输入,否则配 `PKG#test`;分歧以 `scripts/check-cross-package-test-inputs.mjs` 为准。walk 降在循环变量上、门禁点不出名字的 glob 另配 `heldBy` 证人。⛔ 半径未申报的 tree-scoped pin 不是完成的退役。

Kept intact: the `CROSS_PACKAGE_TEST_INPUTS` anchor, the `heldBy` witness clause, and the closing completion condition ⛔ 半径未申报的 tree-scoped pin 不是完成的退役。

⛔ Not touched: `scripts/check-cross-package-test-inputs.mjs` and `turbo.json` — the gate is correct and #10315 / #10694 hold on that script. This is a documentation defect, and the fix is only in the documentation.

## The 83 added bytes are paid for by deleted content, not by a re-wrap

The bullet is 4 lines before and 4 lines after; the file is 337/337 with headroom 0, and the ratchet's per-line budget is 120 bytes, so the envelope is fixed at 4 × 120. The picker plus the authority pointer do not fit inside the old wording. They are paid for by **deleting** the rationale clause `turbo 才 hash 得到它、CI 分片并集才看得见` — the bullet's only pure-why clause, and the one clause nothing else in the file depends on (`git grep` for `分片` / `并集` / `hash` in this file returns no other bullet stating it). ⛔ No ceiling was raised, and no line was re-flowed to buy room.

Two smaller compressions in the same envelope: `那条 glob 还要一条` → `的 glob 另配`, and `的 PKG#test inputs` → the picker sentence itself.

## Readings — all taken on this branch at `c7178179` (base `ee2cb6b4`), not transcribed

Packages declaring a `test:repo` script — `git grep -l '"test:repo"' -- 'packages/**/package.json'` → **6**:

```
packages/core   packages/objectql   packages/rest
packages/runtime   packages/spec     packages/types
```

`turbo.json` inputs, counted per task on this branch:

| package | `#test` inputs | `#test` ROOT | `#test:repo` inputs | `#test:repo` ROOT |
|---|---:|---:|---:|---:|
| core | 4 | **0** | 5 | 1 |
| objectql | 4 | **0** | 6 | 2 |
| rest | 4 | **0** | 9 | 5 |
| runtime | 4 | **0** | 8 | 4 |
| spec | 4 | **0** | 34 | 30 |
| types | 4 | **0** | 5 | 1 |

⇒ 6 of 6, zero exceptions: on every split package the root inputs sit on `#test:repo` and `#test` carries none. The rule is flat, so it is written flat — no "in most cases", no carve-out.

The authority already knows about the split, and says so itself. `pnpm check:cross-package-test-inputs` on this branch prints, unprompted:

> OK: 28 package(s) read outside themselves, all declared, and turbo.json hashes every declared glob (6 of them on a split "test:repo" task).

And its own self-test pins the failing direction (`scripts/check-cross-package-test-inputs.mjs:2569`, verbatim except the placeholder substitution declared at the top of this body):

> 'split: a wide input LEFT on PKG#test reds even when test:repo is complete'

The playbook's blindness to the split, and its repair:

```
git grep -c "test:repo" -- .claude/skills/spec-property-retirement/SKILL.md
  before (ee2cb6b4): 0     control, same file: CROSS_PACKAGE_TEST_INPUTS = 1
  after  (c7178179): 1     and check-cross-package-test-inputs = 1
```

## Gates — 16 derived, 16 run, 16 green, 0 NOT-MEASURED

Derived from the real change set, not from the dispatch list: `node scripts/pm/dispatch-gates.mjs --commands --repo objectstack-ai/objectstack` at `c7178179`, reconciled afterwards with `--ran`:

> ✓ dispatch-gates --ran: 16 derived famil(ies) accounted for — 16 run, 0 NOT-MEASURED.

Each exit code was captured after redirecting to a file, never across a pipe. All 16 exited 0. The two that speak directly to this diff:

> ✓ check-skill-line-ratchet: .claude/skills/spec-property-retirement/SKILL.md is 337 lines (ceiling 337; headroom 0).
> ✓ check-skill-line-ratchet: .claude/skills/spec-property-retirement/SKILL.md: widest table row is 326 bytes (pin 326; headroom 0).

`pnpm check:nul-bytes` is green, and an independent scan of the changed file for control bytes returned no match.

**Lint, narrowed and proved narrowed.** ① The linted population is read from `eslint.config.mjs` itself: every config object's `files` is a `ts/tsx/mts/cts/js/jsx/mjs/cjs` glob, and markdown matches none — ESLint says so in its own words, `File ignored because no matching configuration was supplied.` ② The count is read from `--format json`: 1 result, **0 files actually linted**, 0 errors. ③ Invariance for untouched files: this repo "never enables type-aware linting (no `parserOptions.project`, no typed `@typescript-eslint` rules) for ANY file" (`eslint.config.mjs`, its own comment), so a diff confined to one markdown file cannot move any untouched file's verdict. The repo-wide `pnpm lint` is CI's run.

**No package tests are owed.** The diff touches no workspace package, so there is no dependency closure to build and no affected package's `test` / `typecheck` to run. `@objectstack/lint` and `@objectstack/formula` were built only because `check:doc-formula-expressions` reads their `dist/`.

`skip-changeset`: `.claude/**` is not published — nothing in any package's `files[]` moves.

## 维护者速读(草稿)

### 改了什么

退役 playbook(`.claude/skills/spec-property-retirement/SKILL.md`)里那条「半径按包申报一次」的检查项,原来无条件点名一个 turbo 任务。现在它写出**选任务的规则**(声明了 `test:repo` 脚本的包申报在 `PKG#test:repo`、其 `PKG#test` 不带根输入;否则 `PKG#test`),并**点名权威**(`scripts/check-cross-package-test-inputs.mjs`,两者分歧时以它为准)。原地改写,4 行进 4 行出,文件仍是 337 行。

### 为什么改

这句话是**判定一次退役有没有做完的条件**,而它把人送去撞门禁:门禁两个方向都管——半径没落在 `#test:repo` 上是一红,留在 `#test` 上又是一红。红的消息指向 `turbo.json`,不指向送他去那里的那句话,读者最省力的「修法」是去改门禁,而门禁是对的。卡面自陈:同一次派发里,卡、分诊评论、派发词三份独立文本全部继承了同一个错任务名。这次改的就是那个源头。

### 风险与代价(含回滚)

风险低:只动一段说明文字,不动任何门禁、不动 `turbo.json`,行为面零变化。代价是**删掉了那条「turbo 才 hash 得到它、CI 分片并集才看得见」的理由句**——4 行 × 120 字节的信封装不下新规则,而抬棘轮上限需要维护者裁决,所以用删内容付账,没有 re-wrap 凑行。回滚就是 revert 这一个提交,没有迁移、没有下游依赖。

### 席位意见

(留空,待评审席位填写。)

### 你要做的

这是 governed surface(`.claude/**`),按规则由维护者人工确认并合并。本 PR 保持 draft,未入队、未挂 auto-merge。要看的两处:一是新句子的规则写得对不对(6/6 实测在上面),二是同意用「删理由句」来付那 83 个字节。

_Generated by [Claude Code](https://claude.ai/code/session_01HxLw5aKDPR5RJgyUR7Exkd)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01HxLw5aKDPR5RJgyUR7Exkd)_