### PR TITLE
docs(pm-skill): the eighth readings increment — 17 landed lines, five in-place corrections, ceiling 402 → 419

### DIFF
--- a/.claude/skills/pm-dispatch/references/platform-readings.md
+++ b/.claude/skills/pm-dispatch/references/platform-readings.md
@@ -51,6 +51,8 @@
 - 设方法的 GraphQL mutation 不服务 agent 会话 ⇒ 席位既设不了也纠不了。
 - 它在本仓无实效:`main` 的合并队列规则带 `merge_method: SQUASH`,合并由队列执行。
 - ⇒ 落地方法读分支规则,⛔ 永不读 auto-merge 请求;树上每 PR 一个 squash 提交。
+- `auto_merge_enabled` webhook 载荷同报 `merge` ⇒ 三个载体一致也不作数,判据是落地提交的父数。
+- squash 落地重写署名 trailer:作者行按提交作者身份改拼,`Claude-Session:` 原样存活。
 - `enable_pr_auto_merge` 对已 `mergeable_state: clean` 的 PR 照样成功,与工具描述的优雅失败相反。
 - 回显两向不可靠,空回显不等于未挂上 ⇒ ⛔ 不拿它当任何方向的证据、不为它空转。
 - 配额枯竭时 `enable_pr_auto_merge` 回成功而挂载根本没发生 ⇒ 验效果,不验回应。
@@ -77,6 +79,7 @@
 - 吞吐两则:合并队列落地 ≈ 每 PR 15–30 分钟且串行,⛔ 不据还没落提前判异常。
 - 单容器重验证(build 加 test)并发甜点 ≈3,排批按它定上限。
 - 入队事件与队列 ref 迟 1–3 分钟才出现 ⇒ 轮询预算按 3 分钟,⛔ 不按 1 分钟判没挂上。
+- 队列窗口有界:满窗条目 ref 与 `merge_group` run 双缺席,ref 随前一条落地才现,不按计时器。
 - ready 翻转触发检查重跑 ⇒ 入队落在翻转之后约一分钟,那段空窗不是挂载失败。
 - `behind` 的 PR 照常入队:落后于 main 不是入队否决,⛔ 不为它先跑 update-branch。
 - `check_suite.completed` 会命名过期 head,check-run 也只属最后一次 push ⇒ 用前先重读当前 head。
@@ -106,7 +109,7 @@
 - CCR 容器的 GitHub 出口是代理加凭据的:无 header 的 REST 读回 200 带会话身份,core 上限 15000。
 - 调用方自带的 `Authorization` 头被代理覆盖;`HTTPS_PROXY` 端口打死也不切断网络。
 - ⇒ 容器内得出的 token 作用域结论 ⛔ 不迁移到出口未经代理的会话。
-- 同因:`check-clause2-carriers.mjs --pair` 在容器内带与不带 token 都 exit 0,不再是 403 退 3。
+- 同因:`check-clause2-carriers.mjs --pair` 带与不带 token 都不再 403 退 3;真缺声明照常退 4。
 - 两通道的信封在配额、权限、传输三样上都不同 ⇒ 任一侧的拒绝只是那一侧的读数。
 - 限流、403、传输失败都要试过另一侧才说得出我没手段。
 - 读数:`POST /actions/runs/{id}/rerun-failed-jobs` REST 回 403 而 MCP 回 201。
@@ -148,6 +151,8 @@
 - 重试对齐整点(REST core 整点重置)优于指数退避,⛔ 绝不忙轮询。
 - 文档载明未实测:条件请求答 `304` 不计 core 池。
 - 公开仓零配额读法两档,payload 档优先 —— 只有 body 精确。
+- 网页档可达性逐会话逐 URL 形状分叉:一处容器 `/actions/**` 与 api. 回 403,另一处网页全 200。
+- ⇒ 要用哪个形状先探哪个;本地权限分类器在网络之前的拒绝是第三种机制,⛔ 不记 403。
 - 单卡页 `/issues/N` 内嵌 JSON 载原始 body:取含 `bodyHTML` 的 `script[type="application/json"]` 块。
 - 读 `payload.preloadedQueries[0].result.data.repository.issue.body` 与 `frontTimelineItems`/`backTimelineItems`。
 - 评论表与标量字段都不可信:时间线只渲染前 15 项且 `hasNextPage: true`。
@@ -160,11 +165,15 @@
 - 内容可滞后数分钟到数十分钟;它没有位置性对照 —— 更早内容全在,只有最新几条缺席。
 - ⇒ 前 15 项那条判别式在此不成立,唯一出路是第二通道。
 - 失效方向是据它对别人的工作下没有认领的判词。
-- 边界:⛔ 只因仓库公开成立;⛔ 覆盖单卡读、不覆盖 issue search,搜索页无 SSR 结果。
+- PR 页把正文与每条评论的原始 markdown 放进 `clipboard-copy` 的 value 属性,是另一条零配额读。
+- issue 页无此载体,且盲态与好态的提及计数相同 ⇒ 卡片评论只走 API,⛔ 不套 PR 页读法。
+- 边界:⛔ 只因仓库公开成立;⛔ 覆盖单卡读,搜索页只给锚点不给正文。
 - ⛔ 永不拿渲染列表定规模:静默只显一页。渲染层 WebFetch 仍在,~15 分缓存、有损。
+- issue 查询页有 SSR 锚点且 `label:` 是真 AND:小结果与 REST 逐号相等,大结果静默截到十余条。
 - 查重先 `search_issues`,并按它的契约拼:它是语义匹配器。
 - ⛔ `query` 里永不放 GitHub 限定符(`repo:` / `is:` / `label:` / `in:title`),范围走 `owner`/`repo` 参数。
-- `query` 写成描述缺陷的句子;限定符形回 `total_count: 0` 且 `incomplete_results: false`。
+- `query` 写成描述缺陷的句子;限定符形亦可回 `total_count: 0` 且 `incomplete_results: false`。
+- 零还按词形分叉:camelCase 标识符与带引号短语回 0,同序列里连字符 slug 照常回全集。
 - 同一意图换文档形则命中,首条即目标;body 文本匹配是 repo-scoped `list` 做不到的。
 - `list` 加本地扫描是确定性回退,⛔ 不是默认。
 - `search_issues` 可整会话静默归零,控制词一并归零 —— 故障是会话级,同刻别的会话正常。
@@ -211,6 +220,7 @@
 - 腿 ③:payload 档 —— issue 页的 `href` 锚点 grep(`/labels/NAME`)在 PR 页命中零。
 - PR 侧拼写是 `data-name="NAME"`,片链到 `issues?q=…label%3A…`。
 - 腿 ④:`list_pull_requests` 与 `search_pull_requests` 传 PR 号回完整 `labels`,是可用读腿。
+- 同接口按 `head: owner:分支` 加 `fields` 一次回全 draft、labels、assignees 与请审人。
 - 反向不对称:`issue_write update` 传 PR 号写 `labels` 与 `assignees` 生效,而读腿 ① 拒 PR 号。
 - ⇒ ⛔ 读成功而标签空或缺席不读作没有标签:按 `data-name=` 确认,否则整集作 UNKNOWN。
 - 可达时优先加法端点;⛔ 单读与单次即时读回都不决断。
@@ -308,11 +318,17 @@
 - 裸 REST `PATCH /pulls` 追加一个裸页脚并保留既有 session-URL 页脚,差恰 58 字节。
 - 同一 MCP 包装器上有反例:把已带页脚的正文整体重送,两条页脚均逐字节存活。
 - 送无页脚正文经 MCP 编辑回读仍无页脚(两次实测)⇒ 它不为无页脚正文合成页脚。
-- 第四形:裸 REST `POST /pulls` 建 PR 时,在已带 session-URL 页脚的正文后再追加一条同形页脚。
+- 第四形:建 PR 两通道同判 —— 送出体尾部不是 `---` 加页脚块时,追加一条同形页脚。
 - 该追加带前置横线、恰 90 字节,送出体是存储体的严格前缀。
-- ⇒ 追加形态随通道与动作(建 / 改)变,⛔ 不由任一条推其余;写后必回读。
+- 尾部已是该块则一字不追加,两通道各实测两向 ⇒ 建侧通道不是变量,判据是送出体尾部。
+- ⛔ 无受控对照(同通道只差该块两送)⇒ 是拟合不是定论,⛔ 不外推到别的动作。
+- 调用不带 `body` 参数则页脚状态不动:`draft` 或 `title` 单字段更新既不删也不合成。
+- 删页脚那条读数没记送入体形态,是唯一不合此判据的观察 ⇒ 该格按最坏走,写后必回读。
+- 正文把 harness 两行块叠在页脚之上,存回是三条署名块;单块形态才复现成一条。
+- ⇒ 形态随动作与送出体尾部变,改侧还随通道变;⛔ 不由任一条推其余,写后必回读。
 - 平台在尾部 `---` 前后正反两向归一空行:比对正文只按首个差异偏移,⛔ 不按长度。
 - 评论创建两通道都追加 58 字节 ⇒ 严格解析 `os-dev-report` 必须停在最后一个右花括号。
+- 评论 `PATCH` 重送含尾部页脚块的存储体是幂等的:逐字节一条页脚,与创建的追加相反。
 - 并行 spec PR 同动 pin 计数断言:被踢不是事故,按 os-regen 序再解一轮。
 - 解冲突两侧收据都保留、按合并顺序堆叠;新计数从合并后源码重数,⛔ 不从收据做算术。
 - 操作数是文件本身不是历史;双方占同一编号是常态,重编号后进侧。
@@ -353,6 +369,7 @@
 - ⛔ 别处写下的计数值一律先复测再用。
 - MCP `issue_write create` 落库丢掉正文尾部的署名页脚块,正文其余部分完好。
 - 建卡改走 REST `POST /issues` 页脚存活;回读后 `PATCH /issues/{n}` 重送正文逐字节存下。
+- issue 正文 `PATCH` 存回可多一条裸页脚,已有页脚被归一到末尾而非复制,总数恒一条。
 - 内联双引号 JSON 建卡:标题反引号标识符被 shell 以 root 展开,正文完好 —— 内容被执行。
 - CI job 的失败 step 不必与 job 名一致 ⇒ ⛔ 不由 job 名推原因,先读 step 名再下结论。
 - Actions 日志保留把老 job 截到 post-job cleanup ⇒ 归档只剩清理输出时原因不可断言。

--- a/scripts/pm/check-skill-line-ratchet.mjs
+++ b/scripts/pm/check-skill-line-ratchet.mjs
@@ -659,7 +659,52 @@ export const CEILINGS = new Map([
   // line-neutral folds among this file's adjacent rule pairs, and re-wrap funding
   // is refused per the 2026-08-17 rule in any case. Landed count, headroom 0,
   // same convention.
-  ['.claude/skills/pm-dispatch/references/platform-readings.md', 402],
+  // Raised 402 → 419 by the EIGHTH readings increment, again under the STANDING
+  // one-file exception quoted above rather than a fresh decision card, and again
+  // recorded as a `ruledRaises` record citing it. Its carrier card invited riders
+  // as comments, so the candidate set was 25 readings across the body and eleven
+  // rider comments; deduplicated against the file they land as 17 lines, one per
+  // reading, each written in this file's voice: the footer appender's
+  // discriminator is the SENT body's tail rather than the channel — a body
+  // already ending in the rule line + session-URL block gets nothing appended,
+  // measured in both directions on both channels (+1) — with its boundary, that
+  // no controlled pair has been sent and the fit is not a finding (+1); a call
+  // carrying no `body` argument changes the footer state not at all (+1); the
+  // strip reading recorded no input shape and is the one observation outside the
+  // fit (+1); a body stacking the harness's two-line block over the footer
+  // stores THREE attribution blocks (+1); the comment EDIT path is idempotent on
+  // a body that already ends in its block, unlike comment creation (+1); an
+  // issue-body `PATCH` normalises a pre-existing footer to the end instead of
+  // duplicating it (+1); the merge queue builds a BOUNDED window, so an entry
+  // past it shows neither queue ref nor `merge_group` run (+1); the
+  // `auto_merge_enabled` webhook payload names `merge` too, so the landing
+  // method is read off the squash commit's parent count (+1); the squash
+  // rewrites the authored co-author trailer while `Claude-Session:` survives
+  // (+1); web-page reachability forks per session AND per URL shape (+1), with
+  // the local permission classifier's pre-network refusal named as a THIRD
+  // mechanism that is not a 403 (+1); the PR page carries every comment's raw
+  // markdown in `clipboard-copy` value attributes (+1) while the ISSUE page
+  // carries no such thing and its mention counts are identical blind and
+  // sighted (+1); the public issues query page DOES serve SSR anchors and ANDs
+  // its `label:` filters, matching REST number for number on a small result and
+  // truncating silently on a large one (+1); the search index's zeros fork by
+  // TERM SHAPE — camelCase identifiers and quoted phrases return 0 where a
+  // hyphenated slug in the same sequence returns the full set (+1); and
+  // `list_pull_requests` addressed by `head: owner:branch` returns draft,
+  // labels, assignees and requested reviewers in ONE call (+1) = +17 exactly.
+  //
+  // FIVE corrections are paid in place and buy nothing: the create-side row's
+  // bare-REST-only attribution (both channels behave alike, keyed on the sent
+  // tail); the cell's closing row, which named the CHANNEL as the create-side
+  // variable; the `--pair` row, which lifted out of its paragraph read as
+  // "always exits 0 in-container" and now carries the exit-4 verdict it must not
+  // suppress; the search row's flat claim that a qualifier-shaped query returns
+  // 0, which a same-session control carrying a qualifier disproves; and the
+  // public-page boundary row's "no SSR results". Nothing else was paid in place:
+  // the fourth increment MEASURED zero line-neutral folds among this file's
+  // adjacent rule pairs, and re-wrap funding is refused per the 2026-08-17 rule
+  // in any case. Landed count, headroom 0, same convention.
+  ['.claude/skills/pm-dispatch/references/platform-readings.md', 419],
   // Per-operation REST/GraphQL/git channel mapping — which fleet operation has
   // a REST twin (each row executed in a real session, provenance date carried
   // per row), the handful that are GraphQL-only, and the queue-routing
@@ -1148,6 +1193,23 @@ export const CROSS_FILE_MOVES = new Map([
             + '逐条核实、去重计数(候选/落地/已有/拒收)、一事一行、不计重排」',
           date: '2026-09-08',
           delta: 7,
+        },
+        {
+          // The EIGHTH increment, under the same STANDING exception — the same
+          // words again, for the same reason: a record that quotes no ruling is
+          // RED and each record stands alone. The +17 is accounted for line by
+          // line beside this entry's ceiling above, and the exception's own
+          // conditions (per-item verification and the candidate / landed /
+          // already-present / refused counts) are carried by the raising PR's
+          // dedup table and the seat's ACCEPT.
+          ruling:
+            'the standing one-file exception for'
+            + ' `.claude/skills/pm-dispatch/references/platform-readings.md` — pm-dispatch'
+            + ' SKILL.md, verbatim and untranslated: 「唯一例外:`platform-readings.md`'
+            + ' 增量抬上限到落地行数,免决策卡,记 `ruledRaises` 引常设裁决。条件:席位验收评论'
+            + '逐条核实、去重计数(候选/落地/已有/拒收)、一事一行、不计重排」',
+          date: '2026-09-09',
+          delta: 17,
         },
       ],
       sources: [


### PR DESCRIPTION
Fixes #16779

Governed surface (`.claude/**`) — **draft only**. No seat flips this ready, enqueues it, or arms auto-merge (Prime Directive #14); a human merge is the review record.

The **eighth** `platform-readings.md` increment. The carrier card invited riders as comments, so the candidate set is **25 readings** — 4 in the body, 21 across its eleven rider comments. Deduplicated against the file: **20 landed** (17 new lines plus 5 corrections paid in place), **3 already present**, **2 refused**. Ceiling `402 → 419`, taken under the STANDING one-file exception rather than a decision card, recorded as a `ruledRaises` record quoting the exception verbatim.

## 1. The footer family, folded into one truth table before any line was written

Five riders and both body readings land in one cell, and they **disagree** as long as the channel is read as the variable. Sorted by what the SENT body ended with, they stop disagreeing:

| channel | action | sent body's tail | stored result |
|---|---|---|---|
| bare REST `POST /pulls` | create | not rule-line terminated | 90 B block appended (ledger `:311`, re-confirmed by one rider) |
| MCP `create_pull_request` | create | footer with **no** rule line above it | whole block appended (body reading 1; riders A and the 02:2xZ rider) |
| MCP `create_pull_request` | create | blank line, rule line, session-URL footer | **exactly one footer — nothing appended** (body reading 1) |
| bare REST `POST /pulls` | create | rule line + session-URL footer | **nothing appended**, Δ = one stripped trailing newline (rider D) |
| bare REST `POST /pulls` | create | rule line + footer, one block | **nothing appended**, unified diff empty (rider E) |
| MCP `update_pull_request` | edit, **no `body` in the call** | — | three tail blocks survived verbatim (rider C) |
| MCP `update_pull_request` | edit, `title` + `draft`, no body | — | footerless body stayed footerless (body reading 2) |
| MCP `update_pull_request` | edit, whole body re-sent with its footers | already terminated | both survived byte-for-byte (ledger `:309`) |
| MCP `update_pull_request` | edit, footerless body | no footer | still no footer — no synthesis (ledger `:310`) |
| MCP `update_pull_request` | edit | **not recorded** | footer block DELETED (ledger `:307`) |
| bare REST `PATCH /pulls` | edit | — | bare footer appended, existing session-URL footer kept, Δ 58 B (ledger `:308`) |
| REST `PATCH /issues/comments/{id}` | comment edit ×6 | block already present | byte-identical, one footer (rider F) |
| both channels | comment create | — | +58 B (ledger `:315`) |

⇒ **On create the channel is not the variable — the sent body's tail is.** That is what the ledger's create row got wrong by attributing the append to bare REST only, and what rider A's framing got wrong by widening the attribution instead of replacing it. One row is outside the fit — `:307`, the strip — and its input shape was never recorded, so it lands as exactly that: the one observation the discriminator does not explain, handled at worst case. ⛔ No controlled pair exists (two bodies differing **only** in the rule-line block, same channel, same session), so this is written as a fit, not as a finding, and the standing 写后必回读 is untouched.

Two first-hand corroborations taken in this container while writing the increment, on the two PRs the body reading names: the stored body of the PR created with the block form carries **exactly one** footer (`_Generated by …/session_…_`, one occurrence, zero `Generated with` blocks); the PR whose body was later edited footerless carries **zero** — the title-only update neither stripped nor synthesised anything.

## 2. In-place corrections (line-neutral, they buy nothing)

| line | before → after | the reading that forced it |
|---|---|---|
| `:311` | bare-REST-only attribution → both channels, keyed on the sent tail | riders A, D, E + body reading 1 |
| `:313` | 「随通道与动作变」 → 「随动作与送出体尾部变,改侧还随通道变」 | same — the create side is channel-invariant |
| `:109` | 「带与不带 token 都 exit 0」 → adds 「真缺声明照常退 4」 | rider F reading 2 — lifted out of its paragraph the row read as "always exits 0 in-container", and the error direction is that a seat discounts a **real** refusal |
| `:167` | 「限定符形回 `total_count: 0`」 → 「限定符形**亦可**回 …」 | the camelCase rider's own control: `repo:` qualifier + hyphenated slug returned the full result set in the same sequence |
| `:163` | 「不覆盖 issue search,搜索页无 SSR 结果」 → 「搜索页只给锚点不给正文」 | re-measured here, see §3 |

## 3. What was re-measured in this container rather than relayed

- **The public issues query page does serve SSR anchors, and its `label:` filters really AND.** `…/issues?q=is:issue+is:open+label:"pm:queue"+label:"domain:skills"` → HTTP 200, 10 distinct `href="/objectstack-ai/objectstack/issues/N"` anchors; REST `GET /issues?state=open&labels=pm:queue,domain:skills&per_page=100` → the **same 10 numbers**. Positive control that the anchors are not page chrome: the one-label page returns a **different** set, and all four numbers present only in the two-label page carry both labels on an API read.
  ⚠️ And the counterpart negative that keeps it usable: the one-label page rendered **12** anchors where REST returns a full first page of **100**. The anchor set is the answer only where it can prove it is complete — which is why the line records both halves and `:164`'s 「⛔ 永不拿渲染列表定规模」 is left standing.
- **The PR page carries raw comment markdown; the issue page does not.** the PR page for #16764 on `github.com` → 200, two `clipboard-copy` `value=` carriers holding the PR body (15,452 chars) and a comment verbatim. The same extraction over this card's own issue page yields **zero** comment carriers — its nine `clipboard-copy` hits are code-block copy buttons.
- **`api.github.com` answers 200 here** with no `Authorization` header at all, while the rider's container got 403 with the proxy's own body on the same path. Reachability forks per session **and** per URL shape; neither reading generalises, which is what the new line says.

## 4. Dedup — every landed reading grepped against the ledger at `origin/main`

Two zero-hit greps per reading (one Chinese term, one English/identifier term) plus a positive control that hits, all run against `git show HEAD:.claude/skills/pm-dispatch/references/platform-readings.md` (402 lines):

| reading | CN term (hits) | EN term (hits) | positive control (hits) |
|---|---|---|---|
| create-side discriminator | `尾部已是` 0 | `create_pull_request` 0 | `POST /pulls` 2 |
| body-less call changes nothing | `既不删也不合成` 0 | `no body` 0 | `update_pull_request` 3 |
| no controlled pair ⇒ a fit | `受控对照` 0 | `controlled pair` 0 | `实测` 10 |
| the strip is the one row outside the fit | `唯一不合` 0 | `strip` 0 | `update_pull_request` 3 |
| stacked harness block ⇒ three blocks | `三条署名块` 0 | `attribution block` 0 | `署名页脚` 3 |
| comment `PATCH` is idempotent | `评论 PATCH` 0 | `comments/{id}` 0 | `评论创建两通道` 1 |
| issue-body `PATCH` normalises to one | `归一到末尾` 0 | `one footer` 0 | `PATCH /issues/{n}` 1 |
| bounded queue window | `满窗` 0 | `merge_group run` 0 | `merge_group` 5 |
| webhook payload also names `merge` | `载体一致` 0 | `auto_merge_enabled` 0 | `merge_method` 2 |
| squash rewrites the co-author trailer | `作者身份改拼` 0 | `Claude-Session` 0 | `squash` 3 |
| web reachability forks per URL shape | `网页档` 0 | `/actions/**` 0 | `403` 20 |
| classifier refusal is a third mechanism | `权限分类器` 0 | `permission classifier` 0 | `403` 20 |
| PR page carries raw comment markdown | `原始 markdown` 0 | `clipboard-copy` 0 | `payload` 5 |
| issue page is blind to that carrier | `盲态` 0 | `value 属性` 0 | `issue 页` 1 |
| query page anchors AND, and truncate | `逐号相等` 0 | `SSR 锚点` 0 | `SSR` 1 |
| search zeros fork by term shape | `带引号短语` 0 | `camelCase` 0 | `search_issues` 3 |
| head-filtered four-piece read-back | `请审人` 0 | `head: owner` 0 | `list_pull_requests` 3 |
| `--pair` exits 4 on a real failure | `真缺声明` 0 | `exit 4` 0 | `check-clause2-carriers.mjs` 1 |

**Already present — not rewritten** (the grep HITS, and that is the verdict):

| reading | the row that already carries it |
|---|---|
| direct REST is reachable from this container | `REST 可达性是会话属性` 1 · `core 上限 15000` 1 |
| `auto_merge` reads null after a successful enable ⇒ read the timeline | `auto_merge` 字段…不稳定 1 · `timeline 入队事件` 1 |
| `removed_from_merge_queue` on a clean landing is not an eviction | `后 ~1 秒内跟` 1 (`removed_from_merge_queue` 2) |
| `list_issues` does not AND its `labels` array | `数组是并集` 1 |

**Refused, with the reason:**

| reading | why it is not a line |
|---|---|
| repo merge configuration (`allow_auto_merge` / `allow_squash_merge` / …) | a settings snapshot, not a platform behaviour; `allow_merge_commit` already appears where it changes a reading, and provenance-style records were removed from this corpus by the rules-only rewrite |
| 「一条标着未复测的继承事实,在你依据它改变做法的那一刻必须复测」 | a PRESCRIPTION, and this card's acceptance says the lines record the readings, ⛔ not a new rule. It belongs to whoever owns the prescription file |
| the proposed AGENTS.md CREATE-clause wording | another file and another card; ⛔ this PR touches no prescription |
| rider F's `:109` re-measurement read as *falsifying* the row | it does not: both runs had a token present, so the token axis the row is about was never varied. Recorded as a SCOPE correction instead, which is what the rider itself argued |

## 5. Line budget

`402 → 419` (+17 new lines, 5 corrections in place, ⛔ no re-wrap counted as payment — the fourth increment measured zero line-neutral folds in this file and re-wrap funding is refused in any case).

Per-line bytes of everything added or rewritten (cap 120):

```
 54 120B  auto_merge_enabled webhook payload names `merge` too
 55 106B  squash rewrites the authored co-author trailer
 82 117B  the queue's bounded build window
112 110B  --pair: no 403/exit-3 in-container, exit 4 on a real failure   (correction)
154 119B  web-page reachability forks per session and per URL shape
155 118B  the local classifier's pre-network refusal is not a 403
168 119B  PR page carries raw markdown in clipboard-copy value
169 117B  issue page carries no such thing
170  94B  public-page boundary row                                       (correction)
172 119B  query-page anchors AND, and truncate silently
175 111B  qualifier-shaped queries: 亦可回 0                              (correction)
176 112B  the zeros fork by term shape
223 104B  head-filtered one-call read-back
321 113B  create-side discriminator                                      (correction)
323 120B  nothing appended when the tail is already the block
324 107B  no controlled pair ⇒ a fit, not a finding
325 109B  a call with no body argument changes nothing
326 120B  the strip is the one observation outside the fit
327 106B  a stacked harness block stores three
328 112B  the cell's closing row                                         (correction)
331 115B  comment PATCH is idempotent
372 112B  issue-body PATCH normalises to one footer
```

The `ruledRaises` record added to `scripts/pm/check-skill-line-ratchet.mjs` quotes the standing exception verbatim and untranslated, in the shape the previous seven records use, with `delta: 17`.

## 6. Gates

Derived, not recalled: `node scripts/pm/dispatch-gates.mjs --commands --repo objectstack-ai/objectstack` with no paths (it takes its own change set from the merge base) → 38 commands. All 38 run, exit code captured before any pipe.

- `pnpm check:pm-skill-ratchet` → **0** (the ceiling row equals the landed count; its own 157-case self-test passes)
- `pnpm check:pm-skill-id-lint` → **0** · `pnpm check:skill-frame-sync` → **0** · `pnpm check:doc-authoring` → **0** · `pnpm check:nul-bytes` → **0** · `pnpm check:pm-governed-merges` → **0**
- `pnpm check:ratchet-remedy-authority` → **0** · `pnpm check:required-contexts` → **0** · the remaining 29 → **0**
- `pnpm --filter @objectstack/lint run check:doc-formula-expressions` first returned **exit 3, PREREQUISITE NOT MET** (unbuilt workspace packages — NOT a finding and not a measurement). Built `@objectstack/formula` + `@objectstack/lint` through the shared verify lock and re-ran → **0**.
- `node scripts/pm/check-governed-merges.mjs --test` on the two changed paths → **exit 3**, `.claude/**` ×1: *"GOVERNED — a human merge is the review record for this PR"*, one hit governs the whole PR.

`skip-changeset`: nothing published moves — `.claude/**` and `scripts/pm/**` are both on the fast track.

## 维护者速读(草稿)

**改了什么** — 平台读数账本 `platform-readings.md` 的第八次增量:落 17 行新读数、原地改 5 行(不是新增),行数 402 → 419;棘轮脚本里该文件的上限行同步抬到 419,并按常设例外记一条 `ruledRaises`(逐字引 SKILL.md 那句,不翻译)。候选 25 条(卡正文 4 条 + 11 条 rider 评论),去重后 20 落地 / 3 已有 / 2 拒收。

**为什么改** — 这张卡是本轮读数的载体卡,十一条 rider 评论各带自己的 n。它们里最要紧的一组彼此矛盾:署名页脚到底会不会被平台追加,同一条通道有人测到追加、有人测到不追加。把它们按「送出体尾部长什么样」排成一张真值表,矛盾就消失了 —— 判据是你送出去的正文结尾,不是你走 MCP 还是裸 REST。账本原来那行把追加归因给「裸 REST 建 PR」,是错的归因,这次原地改掉。另外四条原地改的行,都是同一形状:话本身没错,但脱离上下文读会把人引到危险方向(尤其 `--pair` 那行,会让人把一次真实的拒绝当成容器假象)。

**风险与代价(含回滚)** — 只动两个文件,都是 agent 自己读的规则/事实,不进产物、不影响任何发布包(所以 `skip-changeset`)。风险面是「写错事实比不写更糟」:因此每条落地行都做了中英各一次零命中 grep 加一个必中的阳性对照,三条命令与计数在正文第 4 节;三条来自别人容器的读数,我在本容器里重测了(搜索页锚点、PR 页评论载体、api 主机可达性),重测结果与相邻行一起写进去。回滚 = revert 这一个提交,账本回到 402 行、上限行回到 402,无生成物、无下游依赖。

**席位意见** — (留空,待席位复核填写)

**你要做的** — 这是受管面(`.claude/**`),按 Prime Directive #14 只能由您手工合并:任何 agent 都不会把它转 ready、不会入队、不会挂 auto-merge。您需要看的是三样:① 第 1 节那张真值表的结论您认不认(「建 PR 侧通道不是变量」);② 第 2 节五条原地改的前后对照,尤其 `:109` 和 `:167` —— 它们弱化了两句原来说得很硬的话;③ 第 4 节的拒收四条,看有没有您认为不该拒的。认可就手工合并,不认可直接在 PR 上说撤哪一条。

## 验收备注(范围外的观察 — noted, not filed)

- 本 PR 自己的建 PR 调用是第四条同向读数:裸 REST `POST /pulls`,送出体尾部是空行 + 横线 + session-URL 页脚块,存回 15520 B 对送出 15521 B,差恰一个被剥的行尾换行,页脚一条、零追加、unified diff 只剩那一行。它与第 1 节真值表同向,⛔ 不写进本次账本 —— 本卡的候选集在派发时封口 —— 留给第九次增量。
- 卡的验收段把 `check-skill-line-ratchet` / `check-skill-id-lint` 与 `check-governed-merges --test` 并列写成「exit 3」。实测:前两者通过时是 **exit 0**,只有 governed-merges 的治理判定是 exit 3。按实测报告,⛔ 未改卡。
- 卡的验收段还列了 `needs-user-decision` 标签与 os-zhuang 请审。派发词的裁决区只授权 draft PR 加 `skip-changeset`,所以这两件留给席位在 ACCEPT 时武装,dev ⛔ 未代做。

---
_Generated by [Claude Code](https://claude.ai/code/session_01HxLw5aKDPR5RJgyUR7Exkd)_


---
_Generated by [Claude Code](https://claude.ai/code)_