### PR TITLE
feat(pm): dispatch-gates names the CI workflow jobs a card's paths schedule

### DIFF
--- a/scripts/pm/dispatch-gates.mjs
+++ b/scripts/pm/dispatch-gates.mjs
@@ -1349,10 +1349,19 @@ export function jobFilterPopulation(job, filterStepsByOutputSource) {
 }
 
 /**
- * Every job in one workflow that resolves to a path population, with the check
- * families it invokes: `[{ job, name, outputs, paths, dropped, checks }]`.
+ * Every job in one workflow whose `if:` resolves to a path population, WITH the
+ * job's own text: `[{ job, name, text, outputs, paths, dropped }]`.
+ *
+ * ⛔ No check filter here, and that is the whole reason this is its own
+ * function. The caller below drops a job that invokes no discoverable check
+ * family, because a family is what IT is keying; `jobFilteredSteps` keeps
+ * exactly those jobs, because a job CI schedules for your path and whose work
+ * this derivation names no family for is the thing that reader is owed. Two
+ * callers, opposite dispositions, ONE walk — spelled twice they would be two
+ * readings of one workflow, which is the drift this file's whole contract
+ * refuses.
  */
-export function jobPathPopulations(workflowText, workflowFile) {
+export function jobFilterPopulations(workflowText) {
   const stepFilters = extractPathsFilterSteps(workflowText);
   if (stepFilters.size === 0) return [];
   const jobs = extractJobBlocks(workflowText);
@@ -1370,9 +1379,21 @@ export function jobPathPopulations(workflowText, workflowFile) {
   for (const job of jobs) {
     const population = jobFilterPopulation(job, byOutput);
     if (!population) continue;
-    const checks = [...new Set(extractCheckInvocations(job.text, workflowFile).map((i) => i.check))];
+    out.push({ job: job.id, name: job.name, text: job.text, ...population });
+  }
+  return out;
+}
+
+/**
+ * Every job in one workflow that resolves to a path population, with the check
+ * families it invokes: `[{ job, name, outputs, paths, dropped, checks }]`.
+ */
+export function jobPathPopulations(workflowText, workflowFile) {
+  const out = [];
+  for (const { text, ...population } of jobFilterPopulations(workflowText)) {
+    const checks = [...new Set(extractCheckInvocations(text, workflowFile).map((i) => i.check))];
     if (!checks.length) continue;
-    out.push({ job: job.id, name: job.name, ...population, checks });
+    out.push({ ...population, checks });
   }
   return out;
 }
@@ -2462,6 +2483,139 @@ export function alwaysRunSteps(entries) {
     }
   }
   counts.unaccounted = rows.length;
+  return { rows, counts };
+}
+
+/**
+ * ⭐ The OTHER half of the same partition: every step of a CI job that YOUR
+ * paths schedule, which this derivation names no check family for.
+ *
+ * `alwaysRunSteps` above answers "what does CI run on every PR that I derive
+ * nothing for". It answers that question only for the jobs CI CANNOT narrow —
+ * it excludes a path-filtered workflow, and it excludes any job carrying an
+ * `if:`, which is every job whose schedule a `dorny/paths-filter` output
+ * decides. Those two exclusions are correct for the claim that tail makes
+ * ("CI runs this whatever your diff is") and they are exactly why the
+ * path-narrowed jobs had no reader at all: the family derivation looks INSIDE
+ * them for `check:*` invocations and reports what it finds, and nothing
+ * anywhere reported the rest of what those jobs run.
+ *
+ * ## The measured failure (#16285)
+ *
+ * `packages/qa/dogfood` routes to no gate family. A dev editing
+ * `packages/qa/dogfood/test/authz-probe-blind-spot.census.ts` derived 43
+ * commands with not one mention of dogfood on stdout, ran all 43, reconciled
+ * with `--ran`, and truthfully reported full coverage while
+ * `Dogfood Regression Gate (3/3)` was red on a test file in the very package
+ * they had edited. `--ran` cannot catch it: it reconciles against what the
+ * derivation produced, and the derivation never named the job.
+ *
+ * ⛔ The instance fix is REFUSED, and the count is why. Of the 74 workspace
+ * packages that declare a `test` script, ZERO are run by any of the 215
+ * `check:*` scripts in this tree — every one of them is run by a workflow job
+ * (`Test Core (N/6)` over the affected set, `Dogfood Regression Gate (N/3)`
+ * over the one package the partitioner excludes from it). So `packages/qa/
+ * dogfood` is not a missing edge, it is the first instance of a whole
+ * VOCABULARY this derivation did not have: its words are `check:*` families,
+ * and a workflow job watches a path just as much as a gate script does. A
+ * per-package edge would have to be re-derived for every one of the 74 and
+ * would still say nothing about the 75th.
+ *
+ * ## What is claimed for a row, and what is deliberately NOT
+ *
+ * Claimed: CI schedules this JOB for this path of yours, through the job
+ * `if:` this tool already resolves for the family derivation — and this step
+ * of it runs a command no discovered family accounts for. Both halves are
+ * read off the workflow text on every run; nothing here is listed.
+ *
+ * ⛔ NOT claimed: that a row is a test, a build or a setup step.
+ * `alwaysRunLines` refuses that classification for its own rows and the reason
+ * carries unchanged — every rule that separates them is a guess about a step's
+ * intent, and a guess in this position fabricates. `pnpm install
+ * --frozen-lockfile` and the sharded `turbo run test` sit in the same job and
+ * the reader judges which is which; what the tool states is only what it
+ * measured.
+ *
+ * ⛔ NOT a runnable command. Every row is CI's own shell, in CI's environment,
+ * with `${{ … }}` and `$RUNNER_TEMP` in it — so this block is OUTSIDE the
+ * runnable total and ⛔ never in `--commands`' stdout, for the reason
+ * `notRunnableRows` states one channel over: a stream a consumer executes must
+ * not carry a command that cannot run.
+ *
+ * ## What is excluded, and why each exclusion is the safe direction
+ *
+ *   - a job whose `if:` this tool cannot resolve to a filter output: it
+ *     contributes no population, exactly as it contributes none to the family
+ *     derivation, and a population guessed at would fabricate a schedule;
+ *   - a job whose population covers none of your paths: CI may skip it, so no
+ *     per-card claim is available;
+ *   - a step carrying an `if:`: counted and RETURNED, never silently dropped —
+ *     the claim is "CI runs this for your path", and a condition this walk did
+ *     not evaluate could falsify it, the same standard the tail holds;
+ *   - a step the family derivation DOES name a check family for: it is already
+ *     in the matched block above, and a row here would double-count it. The two
+ *     halves are disjoint by construction, which is what makes either count
+ *     mean anything.
+ */
+export function jobFilteredSteps(entries, paths) {
+  const rows = [];
+  const counts = {
+    populations: 0,
+    covering: 0,
+    named: 0,
+    steps: 0,
+    accounted: 0,
+    unaccounted: 0,
+    conditionalSteps: 0,
+  };
+  for (const { file, text } of entries) {
+    for (const job of jobFilterPopulations(text)) {
+      counts.populations += 1;
+      // Every path of yours this job's population covers, with the pattern that
+      // covered it — the same provenance the matched column carries, and for
+      // the same reason: a row is a claim and the reader is owed what backs it.
+      const hits = [];
+      for (const path of paths) {
+        const pattern = triggerListCovers(job.paths, path);
+        if (pattern) hits.push({ path, pattern });
+      }
+      if (hits.length === 0) continue;
+      counts.covering += 1;
+      const steps = [];
+      for (const step of extractStepBlocks(job.text)) {
+        // Continuations are SPLICED before the split, so a row is the command
+        // the shell sees rather than a fragment of its argv. It is the same
+        // reading `extractCheckInvocations` takes for the same body, and here
+        // it is what keeps the disclosure intact under the cap below: the
+        // dogfood job's test invocation is the FIFTH physical line of a
+        // backslash-continued command and the FIRST logical one, so unspliced
+        // it is the line the elision eats — a pointer that elides the one line
+        // the reader came for. ⛔ The always-runs tail is deliberately left
+        // reading physical lines: its rows are a disjoint set of jobs with
+        // their own pins, and changing a rendering this card does not touch is
+        // scope this card does not have.
+        const commands = runCommandTexts(step.text)
+          .flatMap((c) => joinLineContinuations(c).split('\n'))
+          .map((l) => l.trim())
+          .filter((l) => l !== '');
+        if (commands.length === 0) continue;
+        if (step.if) {
+          counts.conditionalSteps += 1;
+          continue;
+        }
+        counts.steps += 1;
+        if (extractCheckInvocations(step.text, file).length > 0) {
+          counts.accounted += 1;
+          continue;
+        }
+        counts.unaccounted += 1;
+        steps.push({ step: step.name, commands });
+      }
+      if (steps.length === 0) continue;
+      counts.named += 1;
+      rows.push({ workflow: file, job: job.name, outputs: job.outputs, hits, dropped: job.dropped, steps });
+    }
+  }
   return { rows, counts };
 }
 
@@ -9985,6 +10139,75 @@ export function alwaysRunLines(rows, counts) {
 }
 
 /**
+ * The path-scheduled CI jobs, rendered (#16285) — printed BELOW the
+ * reconciliation, because everything under that total names something OUTSIDE
+ * this card's runnable answer and these rows are outside it by construction:
+ * they are CI's own shell, in CI's environment, and no local run of them is on
+ * offer.
+ *
+ * Placed directly ABOVE the always-runs tail because the two are the halves of
+ * one partition and the adjacency is the claim: the tail reads the jobs CI
+ * CANNOT narrow by path, this reads the jobs your paths narrow it TO. A reader
+ * meeting one and not the other has half the account of what CI runs.
+ *
+ * Rows carry the job NAME, which is what CI, branch protection and a red check
+ * call it — a lead a dev cannot find in the Checks tab is a lead they will not
+ * act on, the reason `extractJobBlocks` reads the name at all.
+ *
+ * The command transcript is capped and elided on `ALWAYS_RUN_COMMAND_CAP`, the
+ * tail's own cap and the same pointer text, because it is the same decision for
+ * the same reason: a row is a POINTER to a step, not a transcript of it, and a
+ * block nobody reads discloses nothing. ⛔ One cap, one spelling — a second
+ * constant here would be a second rule about one thing.
+ */
+export function jobFilteredStepLines(rows, counts) {
+  if (rows.length === 0) return [];
+  const { covering = 0, named = 0, steps = 0, accounted = 0, unaccounted = 0, conditionalSteps = 0 } = counts ?? {};
+  if (named !== rows.length) {
+    throw new Error(
+      `the path-scheduled job block counted ${named} job(s) with an unnamed step but carries ${rows.length} row(s)`,
+    );
+  }
+  if (accounted + unaccounted !== steps) {
+    throw new Error(
+      `the path-scheduled job block does not account for its own steps: ${accounted} accounted + ` +
+        `${unaccounted} unaccounted != ${steps} walked`,
+    );
+  }
+  const lines = [
+    `CI jobs YOUR paths schedule — ${covering} job(s) CI runs because one of your paths is in the population its \`if:\` reads,` +
+      ` ${named} of them carrying ${unaccounted} step(s) this derivation names NO check family for (over ${accounted} it does).`,
+    '  ⛔ NOT runnable and ⛔ NOT in --commands: every row is CI\'s own shell in CI\'s environment. They sit OUTSIDE the runnable',
+    '    total above — running every family named there does NOT cover them, which is the gap this block exists to close.',
+    '  ⛔ NOT classified into tests, builds and setup — the same refusal the always-runs tail makes, for the same reason: every rule',
+    '    that tells them apart is a guess about a step\'s intent. What is claimed for a row is only what was measured — YOUR path puts',
+    '    this job on the PR, and nothing above names a family for this step. The reader judges the rest.',
+    '  ⇒ The always-runs tail below is the OTHER half of this partition: it reads the jobs CI cannot narrow by path, this one reads',
+    '    the jobs your paths narrow it TO — and a job carrying an `if:` is excluded there, which is every job on this list.',
+  ];
+  if (conditionalSteps) {
+    lines.push(
+      `  Excluded as conditional, and sized rather than dropped: ${conditionalSteps} step(s) of these jobs carry an \`if:\`,` +
+        ' so CI may skip them and this block makes no claim about those.',
+    );
+  }
+  for (const row of rows) {
+    const via = row.hits.map((h) => `${h.path} ⇢ '${h.pattern}'`).join('; ');
+    const dropped = row.dropped ? `, ${row.dropped} glob(s) of it untranslatable and dropped` : '';
+    lines.push(
+      `  - [${row.workflow} · ${row.job}]   scheduled by ${via}   (job \`if:\` reads ${row.outputs.join(', ')}${dropped})`,
+    );
+    for (const { step, commands } of row.steps) {
+      lines.push(`      · ${step}`);
+      for (const command of commands.slice(0, ALWAYS_RUN_COMMAND_CAP)) lines.push(`          ${command}`);
+      const elided = commands.length - ALWAYS_RUN_COMMAND_CAP;
+      if (elided > 0) lines.push(`          … ${elided} more line(s) — read the step in ${row.workflow}`);
+    }
+  }
+  return lines;
+}
+
+/**
  * The whole-tree channel, rendered (#14189) — its own heading, identical on
  * every card, printed ABOVE the reconciliation because its commands are inside
  * that total.
@@ -11060,6 +11283,7 @@ export function commandsFor({ matchedRows = [], kindGroups = [], alwaysRunsRows 
  */
 export function familyReconciliation({
   matchedRows = [], kindGroups = [], alwaysRunsRows = [], rosterRows = [], widePopulationRows = [], pendingRows = [],
+  jobFilteredRows = [],
 } = {}) {
   const commands = commandsFor({ matchedRows, kindGroups, alwaysRunsRows });
   // The SAME expression commandsFor uses for its matched half. Written as a
@@ -11149,6 +11373,11 @@ export function familyReconciliation({
     // other way, and it is fixed the same way: by counting the array that
     // renders the block rather than by writing the name out.
     pendingChangeset: pendingRows.length,
+    // The FOURTH block size (#16285), carried on exactly the same terms as the
+    // three above: not a term of the total, never in the closure assertion, and
+    // read off the array `jobFilteredStepLines` renders so the enumeration
+    // cannot name a heading the output does not print.
+    jobFilteredJobs: jobFilteredRows.length,
   };
   if (recon.matched + recon.convention - recon.both + recon.alwaysRunsOnly !== recon.total) {
     throw new Error(
@@ -11198,12 +11427,24 @@ export function familyReconciliation({
  * Named in the order a plain run PRINTS them, so a reader walking down the
  * output meets the blocks in the order this list promised them.
  */
-export function outsideBlockNames({ artifactRosters = 0, widePopulation = 0, pendingChangeset = 0 } = {}) {
+export function outsideBlockNames({
+  artifactRosters = 0, widePopulation = 0, pendingChangeset = 0, jobFilteredJobs = 0,
+} = {}) {
   return [
     ...(artifactRosters > 0 ? [`the ${artifactRosters} artifact-roster famil(ies)`] : []),
     ...(widePopulation > 0 ? [`the ${widePopulation} declared WIDE-population famil(ies)`] : []),
     ...(pendingChangeset > 0 ? [`the ${pendingChangeset} pending-changeset famil(ies)`] : []),
     'the unreachable listing',
+    // The FOURTH conditional name (#16285), and the only one that is not last
+    // among the conditionals: the list is spelled in the order a plain run
+    // PRINTS the blocks, and this block prints between the unreachable listing
+    // and the always-runs tail, beside the partition half it belongs to. It
+    // arrives HERE and nowhere else for the reason this function exists at all:
+    // the same enumeration is rendered by three lanes, and a block a lane
+    // spells for itself is a block another lane forgets. Counted off the array
+    // that renders it, like the three above, so the name cannot outlive the
+    // heading.
+    ...(jobFilteredJobs > 0 ? [`the ${jobFilteredJobs} path-scheduled CI job(s)`] : []),
     'the always-runs tail',
   ];
 }
@@ -11236,6 +11477,7 @@ export function outsideBlockCounts(recon) {
     artifactRosters: recon?.artifactRosters ?? 0,
     widePopulation: recon?.widePopulation ?? 0,
     pendingChangeset: recon?.pendingChangeset ?? 0,
+    jobFilteredJobs: recon?.jobFilteredJobs ?? 0,
   };
 }
 
@@ -11755,7 +11997,7 @@ export function runReconciliationLines(recon, outside = {}) {
  * That distinction is the card's own subject matter: what is left out of a list
  * must be visible in the list.
  */
-export function derivationJson({ paths, matchedRows, kindGroups, pending, counts, identity, alwaysRunsRows = [], widePopulationRows = [], rosters = [] }) {
+export function derivationJson({ paths, matchedRows, kindGroups, pending, counts, identity, alwaysRunsRows = [], widePopulationRows = [], rosters = [], jobFiltered = { rows: [], counts: {} } }) {
   const commands = commandsFor({ matchedRows, kindGroups, alwaysRunsRows });
   const { otherCommands, ...spelling } = spellingSplit(commands);
   return {
@@ -11804,6 +12046,17 @@ export function derivationJson({ paths, matchedRows, kindGroups, pending, counts
         workflows: [...entry.workflows],
       })),
     },
+    // IN this document and ⛔ NOT in `commands` (#16285) — the same disposition
+    // as `widePopulation` above and for a stricter reason: these rows are not
+    // check families at all. They are CI's own steps, in CI's environment, in
+    // jobs THIS CARD'S PATHS schedule, that no discovered family accounts for.
+    // Its own key so a machine consumer reads the omission the human block
+    // names rather than inferring it from an absence — the whole contract of
+    // this document. `counts` travels beside the rows because the block's
+    // heading is arithmetic (how many jobs cover, how many steps are accounted
+    // for) and a consumer that had to recount it could name a set the rows do
+    // not contain.
+    jobFilteredSteps: { jobs: jobFiltered.rows, counts: jobFiltered.counts },
     counts,
   };
 }
@@ -11827,13 +12080,13 @@ export function derivationJson({ paths, matchedRows, kindGroups, pending, counts
  * and the declared WIDE population was not mentioned in it at all. It reads
  * `outsideBlockNames` now, with the counts this function already holds (#16795).
  */
-function machineReadableOutput(mode, { paths, matchedRows, kindGroups, pending, counts, alwaysRunsRows = [], widePopulationRows = [], rosters = [] }) {
+function machineReadableOutput(mode, { paths, matchedRows, kindGroups, pending, counts, alwaysRunsRows = [], widePopulationRows = [], rosters = [], jobFiltered = { rows: [], counts: {} } }) {
   const identity = repoIdentity();
   const commands = commandsFor({ matchedRows, kindGroups, alwaysRunsRows });
   const split = spellingSplit(commands);
 
   if (mode === 'json') {
-    console.log(JSON.stringify(derivationJson({ paths, matchedRows, kindGroups, pending, counts, identity, alwaysRunsRows, widePopulationRows, rosters }), null, 2));
+    console.log(JSON.stringify(derivationJson({ paths, matchedRows, kindGroups, pending, counts, identity, alwaysRunsRows, widePopulationRows, rosters, jobFiltered }), null, 2));
   } else {
     for (const command of commands) console.log(command);
   }
@@ -11907,6 +12160,27 @@ function machineReadableOutput(mode, { paths, matchedRows, kindGroups, pending, 
         'they are derived against a path that does not exist yet. Write the changeset, then derive again.',
     );
   }
+  // The SIXTH thing stdout deliberately omits (#16285), and the one a consumer
+  // of THIS lane is least able to infer: it is not a check family at all, so no
+  // key on any row above hints that it exists. The jobs are NAMED one per line
+  // rather than counted, for the reason the NOT MEASURED lines above are: a
+  // count says something is missing; it does not say that the thing missing is
+  // the CI job that runs the tests of the package this card edits — which is
+  // exactly the report this block was filed on.
+  if (jobFiltered.rows.length) {
+    console.error(
+      `  + ${jobFiltered.rows.length} CI job(s) are scheduled BY YOUR PATHS and run ${jobFiltered.counts.unaccounted} step(s) no family above names` +
+        ` — ${mode === 'json' ? 'under jobFilteredSteps, not in commands' : 'NOT above'}. They are CI's own shell in CI's environment,` +
+        ' so there is no local invocation to hand you, and running every command on stdout does ⛔ NOT cover them.',
+    );
+    for (const row of jobFiltered.rows) {
+      console.error(
+        `      ⊘ NOT MEASURED — [${row.workflow} · ${row.job}] ${row.steps.length} step(s):` +
+          ` ${row.steps.map((s) => s.step).join(' · ')}`,
+      );
+    }
+    console.error('      ⇒ Run without --commands/--json to see each step printed as CI spells it.');
+  }
   // The FOURTH thing stdout deliberately omits (#14880), on stderr for exactly
   // the reason the three above are: the block is prose, and prose in the stream
   // a consumer executes is the harvest hazard this mode exists to make
@@ -11929,6 +12203,7 @@ function machineReadableOutput(mode, { paths, matchedRows, kindGroups, pending, 
       artifactRosters: rosters.length,
       widePopulation: widePopulationRows.length,
       pendingChangeset: pending.length,
+      jobFilteredJobs: jobFiltered.rows.length,
     })} are each OUTSIDE the ${commands.length} command(s) on stdout. Run without --commands/--json to see every one of them named.`,
   );
 }
@@ -12065,6 +12340,12 @@ function derive(paths, { showResidue = false, mode = 'human', runRecord = [] } =
   // and this comes back empty. See pendingChangesetFamilies for the round of
   // five dispatches that measured the gap.
   const pending = pendingChangesetFamilies([...byCheck], new Set(matched.keys()));
+  // Read from the SAME `workflowEntries` the discovery and the always-runs tail
+  // read, for the reason they share it: a block derived from a second read
+  // could describe a different revision of a workflow than the families it is
+  // printed beside, and the whole point of this block is that it states what
+  // the family list does not cover (#16285).
+  const jobFiltered = jobFilteredSteps(workflowEntries, paths);
 
   if (mode === 'ran') {
     // Built from the SAME four expressions the other renderings read, in this
@@ -12099,6 +12380,7 @@ function derive(paths, { showResidue = false, mode = 'human', runRecord = [] } =
       artifactRosters: rosters.length,
       widePopulation: widePopulationRows.length,
       pendingChangeset: pending.length,
+      jobFilteredJobs: jobFiltered.rows.length,
     })) console.log(line);
     return recon.ok ? 0 : 1;
   }
@@ -12112,6 +12394,7 @@ function derive(paths, { showResidue = false, mode = 'human', runRecord = [] } =
       alwaysRunsRows,
       widePopulationRows,
       rosters,
+      jobFiltered,
       counts: {
         discovered: byCheck.size,
         workflows: workflows.length,
@@ -12139,6 +12422,7 @@ function derive(paths, { showResidue = false, mode = 'human', runRecord = [] } =
   // output does not contain (#16398, #16795).
   const recon = familyReconciliation({
     matchedRows, kindGroups, alwaysRunsRows, rosterRows: rosters, widePopulationRows, pendingRows: pending,
+    jobFilteredRows: jobFiltered.rows,
   });
 
   console.log(`dispatch-gates: ${byCheck.size} check famil(ies) discovered across ${workflows.length} workflow file(s) — derived at runtime, nothing listed in this script.\n`);
@@ -12392,6 +12676,21 @@ function derive(paths, { showResidue = false, mode = 'human', runRecord = [] } =
   // pass — see `unreachableLines` for the CI failure that made that concrete.
   console.log('');
   for (const line of unreachableLines(unreachable, swept.length)) console.log(line);
+
+  // The path-scheduled CI jobs (#16285), printed on EVERY run for the reason
+  // the unreachable listing and the always-runs tail are: neither is about the
+  // card's paths at all and both print unconditionally, while THIS one is about
+  // the card's paths and is the block whose absence was measured — a truthful
+  // "N derived, N run, 0 NOT-MEASURED" report standing for three hours beside a
+  // red gate in the very package the card edited. Directly ABOVE the always-runs
+  // tail because the two are the halves of ONE partition — the tail reads the
+  // jobs CI cannot narrow by path, this reads the jobs your paths narrow it TO
+  // — and a reader meeting one without the other has half the account.
+  const jobFilteredOut = jobFilteredStepLines(jobFiltered.rows, jobFiltered.counts);
+  if (jobFilteredOut.length) {
+    console.log('');
+    for (const line of jobFilteredOut) console.log(line);
+  }
 
   // The always-runs tail prints on every run for the same reason and with the
   // same standing: it is not about the card's paths either, and the family list
@@ -21712,6 +22011,202 @@ function selfTest() {
   );
   t('the live tail renders without refusing', alwaysRunLines(liveTail.rows, liveTail.counts).length > 0);
 
+  // ── The OTHER half of that partition: the jobs YOUR paths schedule (#16285) ─
+  //
+  // The tail above excludes a path-filtered workflow and every job carrying an
+  // `if:` — which is every job a `dorny/paths-filter` output schedules. Those
+  // exclusions are right for the claim the tail makes and they are exactly why
+  // nothing reported what those jobs run: the family derivation looks INSIDE
+  // them for `check:*` invocations, and the rest of their work had no reader.
+  //
+  // FIXTURE first, so every branch is pinned on input this tree may not hold
+  // tomorrow; the LIVE half below is the card's own acceptance baseline and
+  // cannot be faked by a fixture. ⛔ Neither half touches the network.
+  const jobWf = [
+    'name: Fixture',
+    'on:',
+    '  pull_request:',
+    'jobs:',
+    '  filter:',
+    '    outputs:',
+    "      core: ${{ steps.changes.outputs.core || 'true' }}",
+    "      docs: ${{ steps.changes.outputs.docs || 'true' }}",
+    '    steps:',
+    '      - uses: dorny/paths-filter@v4',
+    '        id: changes',
+    '        with:',
+    '          filters: |',
+    '            core:',
+    "              - 'packages/**'",
+    '            docs:',
+    "              - 'content/**'",
+    '  suite:',
+    '    name: Suite (1/2)',
+    "    if: ${{ !cancelled() && needs.filter.outputs.core != 'false' }}",
+    '    steps:',
+    '      - name: Setup',
+    '        uses: actions/checkout@v4',
+    '      - name: A discoverable family',
+    '        run: pnpm check:engine-double-contract',
+    '      - name: Run the package suite',
+    '        run: |',
+    '          pnpm turbo run test \\',
+    '            --filter=@objectstack/dogfood',
+    '      - name: Conditional, so no claim is made about it',
+    "        if: github.event_name == 'push'",
+    '        run: pnpm exec turbo run build',
+    '  docs-only:',
+    '    name: Docs Only',
+    "    if: ${{ !cancelled() && needs.filter.outputs.docs != 'false' }}",
+    '    steps:',
+    '      - name: Never claimed for a packages path',
+    '        run: pnpm docs:build',
+    '  unresolvable:',
+    '    name: Unresolvable',
+    "    if: github.event_name == 'push'",
+    '    steps:',
+    '      - name: Never claimed at all',
+    '        run: pnpm lint',
+  ].join('\n');
+
+  const jobFixture = jobFilteredSteps([{ file: 'fixture.yml', text: jobWf }], ['packages/qa/dogfood/test/x.test.ts']);
+  const jobRowNames = jobFixture.rows.map((r) => r.job);
+  t('a job whose declared population covers one of your paths is named — by the name CI calls it', jobRowNames.includes('Suite (1/2)'));
+  t('a job whose population covers NONE of your paths is not named', !jobRowNames.includes('Docs Only'));
+  t(
+    'a job whose `if:` resolves to no filter output contributes no population at all — a schedule guessed at would fabricate',
+    !jobRowNames.includes('Unresolvable') && jobFixture.counts.populations === 2,
+  );
+  const suiteRow = jobFixture.rows.find((r) => r.job === 'Suite (1/2)');
+  const suiteSteps = suiteRow.steps.map((s) => s.step);
+  t('the step CI runs that no family names IS listed — the whole point of the block', suiteSteps.includes('Run the package suite'));
+  t(
+    'a step whose family the derivation names is NOT listed — the two halves are disjoint',
+    !suiteSteps.includes('A discoverable family') && jobFixture.counts.accounted === 1,
+  );
+  t(
+    'a conditional STEP is excluded and COUNTED, never silently dropped',
+    !suiteSteps.includes('Conditional, so no claim is made about it') && jobFixture.counts.conditionalSteps === 1,
+  );
+  t(
+    'a `uses:` step with no command is neither counted nor listed',
+    !suiteSteps.includes('Setup') && jobFixture.counts.steps === 2,
+  );
+  t('the block accounts for every step it walked', jobFixture.counts.accounted + jobFixture.counts.unaccounted === jobFixture.counts.steps);
+  t(
+    'the row carries the provenance the claim rests on — YOUR path and the pattern that covered it',
+    suiteRow.hits.length === 1
+      && suiteRow.hits[0].path === 'packages/qa/dogfood/test/x.test.ts'
+      && suiteRow.hits[0].pattern === 'packages/**'
+      && suiteRow.outputs.includes('filter.core'),
+  );
+  const suiteRun = suiteRow.steps.find((s) => s.step === 'Run the package suite');
+  t(
+    'a shell line-continuation is spliced, so a row is the command the shell sees rather than a fragment of its argv',
+    suiteRun.commands.length === 1 && suiteRun.commands[0] === 'pnpm turbo run test --filter=@objectstack/dogfood',
+  );
+
+  const jobLines = jobFilteredStepLines(jobFixture.rows, jobFixture.counts);
+  t('the rendered block sizes itself against the jobs your paths schedule', jobLines[0].includes('1 job(s) CI runs because one of your paths'));
+  t('the rendered block refuses to be read as runnable', jobLines.some((l) => l.includes('NOT in --commands')));
+  t('the rendered block refuses to classify its rows into tests, builds and setup', jobLines.some((l) => l.includes('NOT classified into tests, builds and setup')));
+  t('the rendered block names the always-runs tail as the other half of one partition', jobLines.some((l) => l.includes('OTHER half of this partition')));
+  t('an excluded conditional step is sized in the rendering rather than left as an absence', jobLines.some((l) => l.includes('1 step(s) of these jobs carry an `if:`')));
+  t('a block with no rows renders NOTHING — a zero heading would invite a hunt for rows that are not there', jobFilteredStepLines([], jobFixture.counts).length === 0);
+
+  const longJobRow = [{
+    workflow: 'a.yml',
+    job: 'J',
+    outputs: ['filter.core'],
+    hits: [{ path: 'p/x.ts', pattern: 'p/**' }],
+    dropped: 0,
+    steps: [{ step: 'S', commands: Array.from({ length: 30 }, (_, i) => `line ${i}`) }],
+  }];
+  const longJobCounts = { covering: 1, named: 1, steps: 1, accounted: 0, unaccounted: 1, conditionalSteps: 0 };
+  const longJobLines = jobFilteredStepLines(longJobRow, longJobCounts);
+  t(
+    'a long step is elided to a pointer rather than transcribed, on the TAIL\'s own cap and in its own words',
+    longJobLines.some((l) => l.includes(`${30 - ALWAYS_RUN_COMMAND_CAP} more line(s) — read the step in a.yml`)),
+  );
+  t('the elision still prints the capped head of the command', longJobLines.filter((l) => /^ {10}line \d+$/.test(l)).length === ALWAYS_RUN_COMMAND_CAP);
+
+  const refusedJobBlock = (rows, counts) => {
+    try {
+      jobFilteredStepLines(rows, counts);
+      return false;
+    } catch {
+      return true;
+    }
+  };
+  t(
+    'a block whose row count contradicts its own job count refuses rather than prints a total nobody can trust (#4690)',
+    refusedJobBlock(longJobRow, { ...longJobCounts, named: 2 }),
+  );
+  t('a block whose step counts do not add up refuses', refusedJobBlock(longJobRow, { ...longJobCounts, steps: 5 }));
+
+  // ── LIVE, on this tree: the card's own acceptance baseline ────────────────
+  //
+  // ⛔ No count is pinned. The number of path-scheduled jobs moves with every
+  // workflow edit and a frozen one would go stale with nothing failing — the
+  // defect this whole file is about. What is pinned is the CLASS and its two
+  // controls.
+  const liveWorkflows = readdirSync(nodePath.join(ROOT, '.github/workflows'))
+    .filter((f) => /\.ya?ml$/.test(f))
+    .map((f) => ({ file: f, text: readFileSync(nodePath.join(ROOT, '.github/workflows', f), 'utf8') }));
+  const dogfoodCard = 'packages/qa/dogfood/test/authz-probe-blind-spot.census.ts';
+  const liveJobFiltered = jobFilteredSteps(liveWorkflows, [dogfoodCard]);
+  // ⭐ THE POSITIVE CONTROL. This exact change set derived 43 commands with zero
+  // mentions of dogfood while `Dogfood Regression Gate (3/3)` was red on a test
+  // file in the same package. Both halves are asserted, for the reason the tail's
+  // own retirement case states: the job being named is only meaningful while the
+  // family derivation still names nothing for the step that runs its suite —
+  // either half alone goes green for the wrong reason.
+  const dogfoodRow = liveJobFiltered.rows.find((r) => r.job.startsWith('Dogfood Regression Gate'));
+  t(
+    'LIVE: the change set that produced a false "authored to green" claim now names the CI job that runs the package it edits',
+    Boolean(dogfoodRow),
+  );
+  t(
+    '...and names the invocation itself, not just the job — the one line the reader came for',
+    Boolean(dogfoodRow) && dogfoodRow.steps.some((s) => s.commands.some((c) => c.includes('run test') && c.includes('--filter=@objectstack/dogfood'))),
+  );
+  t(
+    '...while the family derivation still names NO check family for that step, which is why the block has to exist',
+    Boolean(dogfoodRow)
+      && dogfoodRow.steps.every((s) => extractCheckInvocations(s.commands.join('\n'), dogfoodRow.workflow).length === 0),
+  );
+  // ⭐ THE NEGATIVE CONTROL. A path no job's declared population covers must be
+  // pointed at NO job. Without it every case above is satisfied by a walk that
+  // names every job for every card, which is the "22 leads is the same as none"
+  // failure this file's header prices.
+  t(
+    'LIVE: a repo-root document no job filter covers is pointed at no job at all',
+    jobFilteredSteps(liveWorkflows, ['ROADMAP.md']).rows.length === 0,
+  );
+  t(
+    '...and that negative is not a broken walk — the same walk finds jobs for a packages path',
+    liveJobFiltered.rows.length > 0,
+  );
+  // The partition, live: every row is a step the family derivation names nothing
+  // for, so a row that yields an invocation would mean this block and the family
+  // list double-count the same step.
+  t(
+    'LIVE: no row yields a check invocation — this block and the family list are disjoint',
+    liveJobFiltered.rows.every((r) => r.steps.every((s) => extractCheckInvocations(s.commands.join('\n'), r.workflow).length === 0)),
+  );
+  t('the live block renders without refusing', jobFilteredStepLines(liveJobFiltered.rows, liveJobFiltered.counts).length > 0);
+  // ⛔ The block sits OUTSIDE the runnable total, and the enumeration that says
+  // so is `outsideBlockNames` — the one place the list of outside blocks exists.
+  t(
+    'the block is NAMED among what sits outside the runnable total, and only while it has rows',
+    outsideBlockNames({ jobFilteredJobs: 3 }).includes('the 3 path-scheduled CI job(s)')
+      && !outsideBlockNames({ jobFilteredJobs: 0 }).some((n) => n.includes('path-scheduled')),
+  );
+  t(
+    'and the count reaches that enumeration off the ARRAY that renders the block, never a recount of it',
+    outsideBlockCounts(familyReconciliation({ jobFilteredRows: [{}, {}] })).jobFilteredJobs === 2,
+  );
+
   // ── The seam between this tool and its caller (#13462) ────────────────────
   //
   // Unit half first: the split and the footer are pure, so their edge cases are
@@ -22570,7 +23065,7 @@ function selfTest() {
     // ⭐ Pinned NAME BY NAME and with a NEGATIVE beside every positive, because
     // the weak shape is what failed before: a case asking only for a substring
     // stayed green for the whole time the sentence was naming three of five.
-    const laneCounts = { artifactRosters: 2, widePopulation: 1, pendingChangeset: 3 };
+    const laneCounts = { artifactRosters: 2, widePopulation: 1, pendingChangeset: 3, jobFilteredJobs: 4 };
     const outsideOf = (lines) => (lines.find((l) => l.includes('This answers ONE link')) ?? '');
     const ranAllBlocks = outsideOf(runReconciliationLines(full, laneCounts));
     for (const name of [
@@ -22578,23 +23073,25 @@ function selfTest() {
       'the 1 declared WIDE-population famil(ies)',
       'the 3 pending-changeset famil(ies)',
       'the unreachable listing',
+      'the 4 path-scheduled CI job(s)',
       'the always-runs tail',
     ]) {
       t(`--ran's disclaimer names "${name}" — every block a plain run prints, not a subset`, ranAllBlocks.includes(name));
     }
     t('and spells them in PRINT order, as the one phrase the human lane spells', ranAllBlocks.includes(
       'the 2 artifact-roster famil(ies), the 1 declared WIDE-population famil(ies), the 3 pending-changeset famil(ies),'
-        + ' the unreachable listing and the always-runs tail are each outside the derived total',
+        + ' the unreachable listing, the 4 path-scheduled CI job(s) and the always-runs tail are each outside the derived total',
     ));
     // The NEGATIVE: at zero rows those three blocks are not printed by the run
     // this sentence points at, so naming them would send a reader to headings
     // that are not there — the same defect facing the other way.
-    const ranNoBlocks = outsideOf(runReconciliationLines(full, { artifactRosters: 0, widePopulation: 0, pendingChangeset: 0 }));
+    const ranNoBlocks = outsideOf(runReconciliationLines(full, { artifactRosters: 0, widePopulation: 0, pendingChangeset: 0, jobFilteredJobs: 0 }));
     t(
-      '--ran names NONE of the three conditional blocks on a derivation that has none',
+      '--ran names NONE of the four conditional blocks on a derivation that has none',
       !ranNoBlocks.toLowerCase().includes('artifact-roster')
         && !ranNoBlocks.toLowerCase().includes('wide-population')
-        && !ranNoBlocks.toLowerCase().includes('pending-changeset'),
+        && !ranNoBlocks.toLowerCase().includes('pending-changeset')
+        && !ranNoBlocks.toLowerCase().includes('path-scheduled'),
     );
     t('...while still naming the two that print unconditionally', ranNoBlocks.includes('the unreachable listing and the always-runs tail'));
 
@@ -22632,6 +23129,17 @@ function selfTest() {
         { check: 'check:r1', command: 'pnpm check:r1', workflows: ['w.yml'], artifacts: [], dir: 'scripts', coversYourPath: false, checkerHealth: null },
         { check: 'check:r2', command: 'pnpm check:r2', workflows: ['w.yml'], artifacts: [], dir: 'scripts', coversYourPath: false, checkerHealth: null },
       ],
+      jobFiltered: {
+        rows: Array.from({ length: 4 }, (_, i) => ({
+          workflow: 'w.yml',
+          job: `Job ${i}`,
+          outputs: ['filter.core'],
+          hits: [{ path: 'scripts/pm/dispatch-gates.mjs', pattern: 'scripts/**' }],
+          dropped: 0,
+          steps: [{ step: 'Run it', commands: ['pnpm turbo run test'] }],
+        })),
+        counts: { populations: 4, covering: 4, named: 4, steps: 4, accounted: 0, unaccounted: 4, conditionalSteps: 0 },
+      },
       ...over,
     })).find((l) => l.includes('Not a complete account of what CI runs')) ?? '';
     const commandsAllBlocks = laneTwo();
@@ -22640,6 +23148,7 @@ function selfTest() {
       'the 1 declared WIDE-population famil(ies)',
       'the 3 pending-changeset famil(ies)',
       'the unreachable listing',
+      'the 4 path-scheduled CI job(s)',
       'the always-runs tail',
     ]) {
       t(`--commands' closing disclaimer names "${name}" — every block outside the command list, where it used to name one`, commandsAllBlocks.includes(name));
@@ -22651,12 +23160,15 @@ function selfTest() {
     // The NEGATIVE, for the reason the --ran one is there: a sentence that
     // cannot drop a name is the same broken instrument as one that cannot add
     // one, pointed the other way.
-    const commandsNoBlocks = laneTwo({ rosters: [], widePopulationRows: [], pending: [] });
+    const commandsNoBlocks = laneTwo({
+      rosters: [], widePopulationRows: [], pending: [], jobFiltered: { rows: [], counts: {} },
+    });
     t(
-      '--commands names NONE of the three conditional blocks when the run has none of them',
+      '--commands names NONE of the four conditional blocks when the run has none of them',
       !commandsNoBlocks.toLowerCase().includes('artifact-roster')
         && !commandsNoBlocks.toLowerCase().includes('wide-population')
-        && !commandsNoBlocks.toLowerCase().includes('pending-changeset'),
+        && !commandsNoBlocks.toLowerCase().includes('pending-changeset')
+        && !commandsNoBlocks.toLowerCase().includes('path-scheduled'),
     );
     t('...while still naming the two that print unconditionally', commandsNoBlocks.includes('the unreachable listing and the always-runs tail'));
     // ⛔ And the stream stays a STREAM: the accounting is stderr-only, so a
@@ -22676,6 +23188,14 @@ function selfTest() {
           kindGroups: [], pending: [{ check: 'check:p1' }], counts: {}, alwaysRunsRows: [],
           widePopulationRows: [{ check: 'check:w1', command: 'pnpm check:w1', workflows: ['w.yml'], reason: 'whole root', refused: null }],
           rosters: [],
+          jobFiltered: {
+            rows: [{
+              workflow: 'w.yml', job: 'Job 0', outputs: ['filter.core'], dropped: 0,
+              hits: [{ path: 'scripts/pm/dispatch-gates.mjs', pattern: 'scripts/**' }],
+              steps: [{ step: 'Run it', commands: ['pnpm turbo run test'] }],
+            }],
+            counts: { populations: 1, covering: 1, named: 1, steps: 1, accounted: 0, unaccounted: 1, conditionalSteps: 0 },
+          },
         });
       } finally {
         console.log = realLog;

--- a/scripts/pm/dispatch-gates.mjs
+++ b/scripts/pm/dispatch-gates.mjs
@@ -22077,7 +22077,11 @@ function selfTest() {
     'a job whose `if:` resolves to no filter output contributes no population at all — a schedule guessed at would fabricate',
     !jobRowNames.includes('Unresolvable') && jobFixture.counts.populations === 2,
   );
-  const suiteRow = jobFixture.rows.find((r) => r.job === 'Suite (1/2)');
+  // ⛔ Every reader below DEGRADES to a failing case rather than a TypeError. The
+  // ablation that proves these cases can fail removes the very row they read, and
+  // a battery that throws there stops before the LIVE controls underneath it are
+  // decided — turning "this pin can fail" into "this pin was never reached".
+  const suiteRow = jobFixture.rows.find((r) => r.job === 'Suite (1/2)') ?? { steps: [], hits: [], outputs: [] };
   const suiteSteps = suiteRow.steps.map((s) => s.step);
   t('the step CI runs that no family names IS listed — the whole point of the block', suiteSteps.includes('Run the package suite'));
   t(
@@ -22100,14 +22104,14 @@ function selfTest() {
       && suiteRow.hits[0].pattern === 'packages/**'
       && suiteRow.outputs.includes('filter.core'),
   );
-  const suiteRun = suiteRow.steps.find((s) => s.step === 'Run the package suite');
+  const suiteRun = suiteRow.steps.find((s) => s.step === 'Run the package suite') ?? { commands: [] };
   t(
     'a shell line-continuation is spliced, so a row is the command the shell sees rather than a fragment of its argv',
     suiteRun.commands.length === 1 && suiteRun.commands[0] === 'pnpm turbo run test --filter=@objectstack/dogfood',
   );
 
   const jobLines = jobFilteredStepLines(jobFixture.rows, jobFixture.counts);
-  t('the rendered block sizes itself against the jobs your paths schedule', jobLines[0].includes('1 job(s) CI runs because one of your paths'));
+  t('the rendered block sizes itself against the jobs your paths schedule', (jobLines[0] ?? '').includes('1 job(s) CI runs because one of your paths'));
   t('the rendered block refuses to be read as runnable', jobLines.some((l) => l.includes('NOT in --commands')));
   t('the rendered block refuses to classify its rows into tests, builds and setup', jobLines.some((l) => l.includes('NOT classified into tests, builds and setup')));
   t('the rendered block names the always-runs tail as the other half of one partition', jobLines.some((l) => l.includes('OTHER half of this partition')));


### PR DESCRIPTION
Fixes #16285

Authored by Claude Code in session `session_01HxLw5aKDPR5RJgyUR7Exkd`.

## The count, taken first — and what it decided

Triage's hard constraint was to count before adding any per-package edge. The count, on `854639b3`:

| reading | value | where it is read |
| --- | --- | --- |
| workspace packages `turbo ls` reports | 80 | `pnpm exec turbo ls --output=json` (the repo-root package is **not** in it) |
| packages declaring a `test` script | 74 | every workspace manifest, root included |
| `check:*` scripts in the tree | 215 | 145 root + 70 package-scoped |
| …of those, running any package's `test` task | **0** | scanned every script body for `vitest` / `turbo run test` / `pnpm test` |
| covered by `Test Core (N/6)` | 72 | `turbo ls --affected`, `--exclude @objectstack/dogfood` |
| covered by `Dogfood Regression Gate (N/3)` | 1 | `--filter=@objectstack/dogfood`, named literally in the job |
| covered by neither | 1 | the repo-root package: it declares `test` but is not in `turbo ls`, so it is on no shard |

⇒ **Universal, not a handful.** `packages/qa/dogfood` is not a missing edge; it is the first instance of a vocabulary
the derivation did not have. Per-package edges would have to be re-derived for every one of the 74 and would still
say nothing about the 75th. So this is the **vocabulary extension** branch of triage's own fork, and direction 2 of
the card: the tool does not execute anything new, it says what watches this path.

## What landed

`jobFilteredSteps` / `jobFilteredStepLines` — the complement of the always-runs step tail.

- The tail reads the jobs CI **cannot** narrow by path: it excludes a path-filtered workflow and every job carrying
  an `if:`, which is every job a `dorny/paths-filter` output schedules. Those exclusions are right for the claim the
  tail makes, and they are exactly why the path-narrowed jobs had no reader — the family derivation looks *inside*
  them for `check:*` invocations and nothing reported the rest of what they run.
- The new block reads the jobs **your paths narrow CI to**, and names the steps of them no discovered family accounts
  for. It uses the job populations this tool already resolves for the family derivation (`jobFilterPopulations`, now
  one walk with two callers of opposite disposition) — nothing new is listed, nothing is hardcoded.

Claimed per row: CI schedules this **job** for this path of yours, via the job `if:` this tool already reads, and
this step runs a command no discovered family names. ⛔ Not claimed: that a row is a test, a build or a setup step —
the same refusal `alwaysRunLines` makes, for the same reason. ⛔ Not runnable: every row is CI's own shell in CI's
environment, so the block sits **outside** the runnable total and never reaches `--commands` stdout.

The block is named on all three lanes through `outsideBlockNames` — the one place that list exists (the defect class
#16795 closed). ⛔ No lane spells its own prose copy.

## The self-test assertion triage told me to read first

`llmsReaches('packages/qa/dogfood/package.json') && !llmsReaches('packages/qa/dogfood/test/two-factor-lockout.dogfood.test.ts')`
(at `:16029` on the base tree, located by symbol as triage instructed) pins that `check:llms-txt` reaches every
workspace **manifest** — its package-ecosystem denominator — and reaches **no** workspace source. Its stated reason is
that `packages/spec` or `packages/**` "would have bought the flip too, and named this gate on nearly every card in
the repo": the "22 leads is the same as none" failure the tool's own header prices.

That judgement is untouched here, and it is why the new edge is **not** in a family's population. This change adds
no watch hint, moves no family into or out of any bucket, and does not call `extractWatchHints`, `placeFamily` or
`classifyEntry`. Both assertions triage cited (`llmsReaches`, and `classifyEntry(livenessEntry, ['packages/qa/dogfood/src/some.test.ts'])`)
are green in the battery below, unedited.

## Acceptance baseline — the same change set, before and after

`node scripts/pm/dispatch-gates.mjs --commands --repo objectstack-ai/objectstack packages/qa/dogfood/test/authz-probe-blind-spot.census.ts`

| lane | before (`854639b3`) | after |
| --- | --- | --- |
| `--commands` **stdout** | 43 lines, 0 hits for `dogfood`/`qa` | **43 lines, byte-identical** (`diff` empty) — the command stream is unchanged by design |
| `--commands` **stderr** | 3 `dogfood` hits, all incidental argv text inside the value-bearing block (`--job dogfood`, `"$RUNNER_TEMP/dogfood.log"`) — no job named | a named block: 5 CI jobs, 27 unaccounted steps, one line per job, `Dogfood Regression Gate (${{ matrix.shard }}/3)` among them; the closing disclaimer names "the 5 path-scheduled CI job(s)" |
| **human** | no mention of any job that runs the package's suite | the block, printed between the unreachable listing and the always-runs tail, with `pnpm turbo run test --filter=@objectstack/dogfood --log-order=stream -- --shard=${{ matrix.shard }}/3` spelled in full |
| `--ran` | `43 derived famil(ies) accounted for — 43 run, 0 NOT-MEASURED.` with no hint anything was missed | same verdict, and the disclaimer beside it now names "the 5 path-scheduled CI job(s)" |

Those three stderr mentions were checked before deciding: they are the argv of two gate scripts, not a job
indication, so this is a **new** block rather than an upgrade of an existing mention.

Note on the transcript: shell line-continuations are spliced before the split, so a row is the command the shell
sees. Unspliced, the dogfood invocation is the fifth physical line of a continued command and the first logical one —
exactly the line the cap would have elided. The always-runs tail is deliberately left reading physical lines; its
rows are a disjoint set of jobs with their own pins, and changing a rendering this card does not touch is scope this
card does not have.

## Controls

- **Positive** (pinned live): the card's own change set names a job starting `Dogfood Regression Gate`, names the
  invocation itself, and — the other half — the family derivation still names **no** check family for that step.
  Either half alone goes green for the wrong reason.
- **Negative** (pinned live): `ROADMAP.md`, a repo-root document no job filter covers, is pointed at **no** job at
  all, with a companion case asserting the same walk still finds jobs for a `packages/**` path so the zero is not a
  broken walk.
- **Disjointness** (pinned live): no row yields a check invocation, so this block and the family list cannot
  double-count a step.
- ⛔ No count is pinned. The number of path-scheduled jobs moves with every workflow edit; a frozen one would go
  stale with nothing failing.

## Verification — all on head `9954b7c7e`, ⛔ no build, no package test run, no shared verify lock

The change is a node script and its self-test; the dogfood gate's redness is CI history read from run `34019739422`,
not reproduced.

**Derived families for this diff** — `node scripts/pm/dispatch-gates.mjs --commands --repo objectstack-ai/objectstack`
(no paths, three-dot off the merge base) ⇒ **30 commands. 30 run, every one exit 0**, each command recorded byte for
byte as the tool printed it, then reconciled:

```
✓ dispatch-gates --ran: 30 derived famil(ies) accounted for — 30 run, 0 NOT-MEASURED.
Run reconciliation — 30 derived, 30 run, 0 NOT-MEASURED, 0 UNRUN.        (--ran exit 0)
```

That reconciliation's own disclaimer now names "the 1 path-scheduled CI job(s)" for this very card — the new block
working on its own diff, since `Test Core (N/6)` watches `scripts/**`.

**Re-derived after `git fetch origin main`** (the run had flagged the checkout 6 commits behind): the list is
**identical, 30 commands** — none of the upstream commits added a family this diff owes. The post-fetch banner does
report one stale gate file, `scripts/pm/check-skill-line-ratchet.mjs`; it is not in this card's derived list and this
diff touches no skill.

**`pnpm check:pm-dispatch-gates`** — exit **0**, `✓ dispatch-gates self-test: 1617 cases pass.`, zero `✗`. Run
detached per the script's own header (the battery re-spawns this CLI many times and exceeds an agent container's
foreground cap). 46 of those cases are new here.

**Lint** — `npx eslint --no-inline-config --format json scripts/pm/dispatch-gates.mjs`: exit 0, **1 file linted**
(count read from the JSON output, not assumed), 0 errors, 0 warnings. The narrowing is a measurement rather than a
skip: `eslint.config.mjs` states in its own text that this repo runs **no** `parserOptions.project` and **no** typed
`@typescript-eslint` rules, so a one-file diff cannot move the verdict of any file it does not touch. The repo-wide
`pnpm lint` run is CI's.

**`pnpm check:nul-bytes`** — exit 0 (`scanned 8021 text file(s) … no raw ASCII control bytes`), plus a direct sweep
of the changed file for control bytes outside the gate's own population: zero hits.

### Ablation — the new pin CAN fail, proven on disk and restored byte-exact

Mutation: the one predicate that decides whether a job's population covers a path,
`const pattern = triggerListCovers(job.paths, path);` becomes `const pattern = null;`. Run as one self-restoring
script carrying `trap restore EXIT INT TERM` with an absolute restore target.

| leg | reading |
| --- | --- |
| anchored on-disk observation | removed text 1 ⇒ 0 occurrences, injected marker 0 ⇒ 1 occurrence |
| blob before ⇒ after | `d5e7b990…` ⇒ `faa8ab3b…` — the mutation reached bytes, it was not a no-op edit |
| mutated battery | **exit 1**, **17 cases red** |
| ⭐ the LIVE POSITIVE control | **RED** — "LIVE: the change set that produced a false 'authored to green' claim now names the CI job that runs the package it edits" |
| ⭐ the LIVE NEGATIVE control | **GREEN** — vacuously, which is the point: it is not what detects the change |
| ⭐ its companion guard | **RED** — "...and that negative is not a broken walk — the same walk finds jobs for a packages path". That case exists precisely so a vacuous negative cannot pass for a working one, and the ablation is what shows it earning its place |
| restore | `git checkout HEAD -- ...`; blob back to `d5e7b990…` = the HEAD blob; `git diff HEAD` empty; injected marker 0 occurrences |

⚠️ Stated because it changed the diff: the **first** ablation attempt reddened the first fixture case and then
**aborted the battery** with a `TypeError`, before any LIVE control was decided — a pin that cannot be shown to fail
because the harness dies on the way to it. Commit `9954b7c7e` makes those fixture readers degrade to failing cases,
and the ablation above is the re-run on the guarded tree. The reading that motivated it is in that commit message.

## 验收备注

- **H17 re-check for #14290** (`pm:on-hold`, report-only), re-run on this branch:
  `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack --residue scripts/objectui-changeset-digest.mjs`
  exits 0 and derives 31 families. The defect it records **still holds and is unmoved by this change**: deriving for
  the novel lead `scripts/bump-objectui.selftest.sh` yields **0** mentions of `check:objectui-changeset`
  (the STAGE-THEN-RUN edge is still traversed by neither follow), while the control — deriving for
  `scripts/bump-objectui.sh` itself — yields **1**, so the read-follow identity key is live and the zero is not a
  broken walk. ⛔ Its STAGE-THEN-RUN follow-up is not built here.
- Noted, not filed: the block runs to about 110 lines on a `packages/**` card, because it refuses to classify its
  rows and therefore names `pnpm install --frozen-lockfile` beside the sharded test run. That is the same posture
  the always-runs tail takes and the same posture the artifact-roster block takes at 45 rows; it is a cost, not a
  defect, and no rule that trims it exists that is not a guess about a step's intent. Carrier: the next card that
  reads this block and finds it long.
- Noted, not filed: `Temporal Conformance (live PG + MySQL)` and `Build Core` appear on every `packages/**` card, as
  they should — CI really does schedule them for those paths. If that ever reads as dilution the fix belongs to the
  workflow's own filters, not to this tool.

---
_Generated by [Claude Code](https://claude.ai/code)_