### PR TITLE
fix(scripts): put the mktemp X's last in gen-sdui-manifest.sh templates

### DIFF
--- a/packages/spec/scripts/gen-sdui-manifest-collision.test.ts
+++ b/packages/spec/scripts/gen-sdui-manifest-collision.test.ts
@@ -288,6 +288,32 @@ function runHarness(): Record<string, string> {
       // quietly, since nothing else in the run would notice until two agents
       // overlapped again.
       `printf "FIXED_LOG_LITERALS=%s\\n" "$(grep -c '/tmp/sdui-dump-dev\\.log' ${JSON.stringify(SCRIPT)} || true)"`,
+      // ── 5b. every mktemp template is portable: X's terminal, no suffix ───
+      //
+      // A spelling pin like 5 above, and for a defect from the same family: a
+      // per-run temp path that is not actually per-run. `mktemp
+      // "…dump-dev.XXXXXX.log"` reads as per-run and is per-run on GNU
+      // coreutils, which splits the trailing `.log` off as an implied
+      // `--suffix` and substitutes the X's anyway. That is a coreutils
+      // extension. BSD mktemp(1) wraps mkstemp(3), which only ever replaces a
+      // TRAILING run of X's, so on stock macOS nothing is substituted: the
+      // first run creates the file called literally `sdui-dump-dev.XXXXXX.log`
+      // and every later run dies there with `File exists`. Reported from a
+      // real mac; measured here only at the libc layer, where glibc's
+      // mkstemp("./x.XXXXXX.log") refuses with EINVAL outright.
+      //
+      // CI is Linux, so CI can never see this — which is precisely why it wants
+      // a pin rather than a run. The counted shape is the ASSIGNMENT form, not
+      // the word `mktemp`: the script's own comments quote the broken spelling
+      // in order to explain it, and a pattern that read those would be red on
+      // the fixed tree.
+      //
+      // TERMINAL_X is the vacuity guard, in the same spirit as
+      // STEAL_CLAIM_ON_PICK above: SUFFIXED=0 is also what a file with no
+      // mktemp templates left in it looks like, so the count of GOOD templates
+      // is asserted beside the count of bad ones.
+      `printf "SUFFIXED_MKTEMP_TEMPLATES=%s\\n" "$(grep -cE '^[[:space:]]*[A-Za-z_]+="\\$\\(mktemp "[^"]*X{3,}[^"X][^"]*"' ${JSON.stringify(SCRIPT)} || true)"`,
+      `printf "TERMINAL_X_MKTEMP_TEMPLATES=%s\\n" "$(grep -cE '^[[:space:]]*[A-Za-z_]+="\\$\\(mktemp "[^"]*X{3,}"' ${JSON.stringify(SCRIPT)} || true)"`,
       '',
       '# ── 6. concurrent callers from ONE base get DISTINCT ports ──────────',
       // The card, as an executed assertion. Eight subshells, one base, at
@@ -423,5 +449,11 @@ describe.skipIf(!RUNNABLE)('gen-sdui-manifest.sh concurrent-run contract', () =>
 
   it('keeps no fixed dev-server log path (spelling pin)', () => {
     expect(seen.FIXED_LOG_LITERALS).toBe('0');
+  });
+
+  it("keeps every mktemp template portable — X's terminal, no suffix (spelling pin)", () => {
+    // Vacuity first: zero bad templates is also what zero templates looks like.
+    expect(seen.TERMINAL_X_MKTEMP_TEMPLATES, JSON.stringify(seen)).toBe('3');
+    expect(seen.SUFFIXED_MKTEMP_TEMPLATES, JSON.stringify(seen)).toBe('0');
   });
 });

--- a/scripts/gen-sdui-manifest.sh
+++ b/scripts/gen-sdui-manifest.sh
@@ -568,7 +568,26 @@ esac
 # started last, so a diagnosing reader could be reading another run's output —
 # and the failure branches below point readers straight at it. mktemp, matching
 # the pidfile beside it.
-DUMP_DEV_LOG="$(mktemp "${TMPDIR:-/tmp}/sdui-dump-dev.XXXXXX.log")"
+#
+# THE X'S ARE TERMINAL, AND NO SUFFIX FOLLOWS THEM — THE BSD/macOS FLOOR.
+# `mktemp "…dev.XXXXXX.log"` is a GNU coreutils spelling: coreutils splits the
+# trailing `.log` off as an implied `--suffix` (`--suffix=SUFF … is implied if
+# TEMPLATE does not end in X`, mktemp --help, coreutils 9.4) and substitutes the
+# X's anyway. BSD mktemp(1) is a thin wrapper over mkstemp(3), which takes the
+# template as-is and only ever replaces a TRAILING run of X's; measured here on
+# glibc, `mkstemp("./x.XXXXXX.log")` fails outright with EINVAL while
+# `mkstemp("./x.XXXXXX")` succeeds. On stock macOS the reported symptom is the
+# other branch of the same refusal: nothing is substituted, the literal file
+# `sdui-dump-dev.XXXXXX.log` is created on the first run, and every later run
+# dies at this line with `mkstemp failed on …: File exists` — the script
+# manufacturing its own blocking condition, one manual `rm` per pin bump.
+#
+# So: terminal X's, and the `.log` extension is simply given up. `--suffix` is
+# itself the GNU extension and is not the portable answer; a rename after the
+# fact would buy the extension back at the price of a second path and a window
+# in which the two disagree, and nothing reads these files by extension — they
+# are echoed to the operator and classified by content, never globbed.
+DUMP_DEV_LOG="$(mktemp "${TMPDIR:-/tmp}/sdui-dump-dev.XXXXXX")"
 DUMP_PID_FILE="$(mktemp "${TMPDIR:-/tmp}/sdui-dump-pid.XXXXXX")"
 
 echo "  dev server: port ${DUMP_PORT}, log ${DUMP_DEV_LOG}"
@@ -625,7 +644,9 @@ fi
 # The dump's combined output goes to a per-run file as well as to the terminal:
 # the failure branch classifies that text, and a remedy chosen from what
 # actually happened is the point (see sdui_dump_failure_advice above).
-DUMP_OUT_LOG="$(mktemp "${TMPDIR:-/tmp}/sdui-dump-out.XXXXXX.log")"
+# Terminal X's, no suffix after them — see the DUMP_DEV_LOG block above for the
+# BSD/macOS floor this shape is keeping.
+DUMP_OUT_LOG="$(mktemp "${TMPDIR:-/tmp}/sdui-dump-out.XXXXXX")"
 
 # `${PIPESTATUS[0]}`, never `$?`: after a pipeline `$?` is TEE's status, and tee
 # does not fail, so `$?` here would read every failure of the dump as a success.


### PR DESCRIPTION
Fixes #15182

Clause-②: no
Reason: `scripts/` plus a test file under `packages/spec/scripts/`. Re-derived rather than copied from the brief: `@objectstack/spec` declares `files: ["dist","json-schema","liveness","prompts","llms.txt","README.md","src/**/*.zod.ts","CHANGELOG.md","api-surface","spec-changes.json"]`, and `packages/spec/scripts/` is in none of them; the repo-root `scripts/` is in no package at all. Zero published manifests reached, no schema key, no contract surface.

## The before leg — both halves, each labelled

The card's mechanism is that BSD `mktemp` takes `foo.XXXXXX.log` literally. That had not been measured by the dispatching seat, so it is established here before anything was changed.

**GNU half — MEASURED in this container** (`mktemp (GNU coreutils) 9.4`):

```
$ mktemp "$PWD/probe-dev.XXXXXX.log"   ->  .../probe-dev.GHa218.log
$ mktemp "$PWD/probe-dev.XXXXXX.log"   ->  .../probe-dev.nkNhct.log     <- DISTINCT
$ mktemp "$PWD/probe-pid.XXXXXX"       ->  .../probe-pid.kwRt5Z         <- firing control, terminal X's
$ mktemp "$PWD/probe-nonsense.log"     ->  mktemp: too few X's in template  <- nonsense control
```

GNU substitutes the X's even with a suffix after them. That is the half that explains why CI has never noticed.

**GNU half — DOCUMENTED**, and it names the feature being relied on. From `mktemp --help` on this box:

```
--suffix=SUFF   append SUFF to TEMPLATE; SUFF must not contain a slash.
                  This option is implied if TEMPLATE does not end in X
```

So the current spelling works on GNU *because coreutils implements an implied `--suffix`*. `--suffix` is the GNU extension the brief warned against reaching for — the in-template form is the same extension, spelled implicitly.

**BSD half — NOT measured by me. I have no macOS.** I also could not read the BSD manual: this container's egress proxy blocks `man.freebsd.org`, `man.netbsd.org`, `man.openbsd.org`, `keith.github.io` (the Xcode man-page mirror) and `pubs.opengroup.org`, no man pages are installed locally, and the GitHub MCP is scoped to this repo so `freebsd/freebsd-src` could not be read either. Rather than repeat the card's claim, here is what I *could* measure, at the layer underneath the utility:

**MEASURED here — `mkstemp(3)`, the libc call BSD `mktemp(1)` wraps** (glibc 2.39, via a compiled C probe):

```
mkstemp("./libc-suffix.XXXXXX.log")  -> FAILED errno=22 (Invalid argument)
mkstemp("./libc-terminal.XXXXXX")    -> ok, produced "./libc-terminal.rMENXW"   <- firing control
mkstemp("./libc-nonsense.log")       -> FAILED errno=22 (Invalid argument)      <- nonsense control
```

⇒ Substituting non-terminal X's is **not** a libc/POSIX capability. It is something the *utility* must add on top, and GNU documents adding exactly that. Any `mktemp(1)` that is a thin wrapper over `mkstemp(3)` therefore cannot substitute the X's in `foo.XXXXXX.log`.

**Verdict: the card stands.** The two symptoms it reports from a real mac are internally consistent with the classic BSD `_gettemp()` algorithm — with no trailing X's it substitutes nothing, creates the literal path once with `O_CREAT|O_EXCL`, and returns `EEXIST` on every later call. That is exactly `probe-demo.XXXXXX.log` coming back from the first run and `mkstemp failed on ...: File exists` from the second.

⚠️ **One honest divergence, which the card does not name.** glibc's `mkstemp` refuses with `EINVAL` *up front*, whereas the mac reportedly created the literal file and only collided on the second run. Both refuse to substitute; they differ in *when* they fail. So on a stricter BSD variant the failure could land on the **first** run, not the second. The fix is the same either way and the card's conclusion is unaffected, but "cannot run twice" may understate it for some hosts.

## The change

Two of the three call sites carried the broken shape; `DUMP_PID_FILE` was already correct and is untouched. All three now use its shape.

```
-DUMP_DEV_LOG="$(mktemp "${TMPDIR:-/tmp}/sdui-dump-dev.XXXXXX.log")"
+DUMP_DEV_LOG="$(mktemp "${TMPDIR:-/tmp}/sdui-dump-dev.XXXXXX")"
-DUMP_OUT_LOG="$(mktemp "${TMPDIR:-/tmp}/sdui-dump-out.XXXXXX.log")"
+DUMP_OUT_LOG="$(mktemp "${TMPDIR:-/tmp}/sdui-dump-out.XXXXXX")"
```

The `.log` extension is **given up**, not bought back. A rename after the fact would restore it at the price of a second path and a window in which the two disagree; `--suffix` is the GNU extension itself. Nothing reads these files by extension — swept below — they are echoed to the operator and classified by content.

⚠️ **Operator-visible**: the paths the script prints no longer end in `.log`. An editor keyed on the extension will open them as plain text instead.

## Negative control — a STUB, not a real BSD

I could not reach a mac, so this is a Python stub named `mktemp` placed on `PATH`, implementing BSD `_gettemp()` semantics (substitute only a trailing run of X's; otherwise attempt the literal path with `O_CREAT|O_EXCL`). **It emulates the behaviour; it is not evidence about any real BSD binary.**

```
--- OLD shape (sdui-dump-dev.XXXXXX.log) ---
  run 1 -> exit=0 : .../sdui-dump-dev.XXXXXX.log
  run 2 -> exit=1 : mktemp: mkstemp failed on .../sdui-dump-dev.XXXXXX.log: File exists
  files left in TMPDIR: sdui-dump-dev.XXXXXX.log

--- NEW shape (sdui-dump-dev.XXXXXX) ---
  run 1 -> exit=0 : .../sdui-dump-dev.n5rwsp
  run 2 -> exit=0 : .../sdui-dump-dev.sfRMmm
  files left in TMPDIR: sdui-dump-dev.n5rwsp  sdui-dump-dev.sfRMmm
```

The stub reproduces the card's reported error text and its leftover literal file.

## The GNU path is unchanged

The three lines extracted verbatim from this branch, executed twice under real GNU `mktemp` 9.4: six files, all distinct. So for CI — which is Linux — this is a no-op in behaviour; only the printed names lose four characters.

## Cleanup still removes what it created

All **9** `trap` occurrences in the file were classified, not just the ones near the change: **5 executable** (`:416` `trap - "$sig" EXIT`, `:599` EXIT, `:600` INT, `:601` TERM, `:602` HUP) and **4 in comments** (`:29`, `:31`, `:596`, `:615`).

Only one variable is consumed by any trap — `DUMP_PID_FILE`, via `sdui_stop_detached`, whose template I did **not** change. Every removal goes through the shell variable (`rm -f "$pidfile"` at `:125`, `rm -f "$DUMP_OUT_LOG"` at `:661`); nothing globs or reconstructs a name from the pattern, so no cleanup can miss a renamed file.

## Ratchet

The pre-existing spelling pin `FIXED_LOG_LITERALS` is **unmoved at 0** before and after — and, measured, it stays `0` against the broken shape too, which is why it did not catch this class and why a second pin is added beside it.

New counts in `gen-sdui-manifest-collision.test.ts`, on the **assignment form** rather than the word `mktemp` — the script's own comments quote the broken spelling in order to explain it, and a pattern that read those would be red on the fixed tree:

| count | origin/main | this branch |
|:--|:--|:--|
| `SUFFIXED_MKTEMP_TEMPLATES` | 2 (`:571`, `:628`) | **0** |
| `TERMINAL_X_MKTEMP_TEMPLATES` | 1 (`:572`) | **3** |

- **Firing control**: reintroducing the old shape on disk (proved landed, then restored — working blob and HEAD blob hash-identical afterwards) drives the new test RED: `SUFFIXED=1 TERMINAL=2`, `expected '2' to be '3'`, 1 failed / 8 passed. `FIXED_LOG_LITERALS` stayed `0` through that run.
- **Nonsense control**: the same assignment-anchored pattern with a template that appears nowhere counts `0`.
- **Vacuity guard**: `TERMINAL_X` is asserted beside `SUFFIXED`, so a file with every template deleted cannot read as green.

## Gates — TEXT, not exit codes

| gate | verdict text |
|:--|:--|
| `check:bash32-floor` | `33 tracked shell file(s) ... name no bash 4+ construct`; self-test 153 cases pass |
| `check:nul-bytes` | `OK (scanned 8044 text file(s) ...; no raw ASCII control bytes)` |
| `check:scripts-symbol-anchors` | `3072 anchors across 237 scripts resolve` |
| `check:agent-test-spelling` | `0 violations — 490 file(s)` |
| `check:cross-package-test-inputs` | `OK: 28 package(s) read outside themselves, all declared` |
| `check:test-source-alias` | `OK — 73 packages with tests scanned` |
| `check-closing-keyword-parity` | `OK (3 parsers agree on all 9 keywords ...)` |
| `check-comment-mask-adoption` | `OK — 14 private comment-stripper(s) ... all 14 recorded` |
| `check-self-test-wired` | `every one of the 195 script(s) CI runs that ship a --self-test has that self-test run by CI` |
| `check:partof-closing-keyword` | run against THIS body and this branch's commit: `this PR carries no Part-of/closing-keyword contradiction ... its 1 commit message(s) carry no card-relation trailer` |
| pin tests | `Test Files 2 passed (2) · Tests 10 passed (10)` |

⚠️ `check-partof-closing-keyword.mjs` run bare exits **2 = NOT MEASURED** (`was handed no pull request and judged nothing ... a wiring or usage failure, NOT a verdict`) — the row above is the wired run, not the bare one.

A control-character sweep over both edited files beyond the gate found none.

## Hazards — what I swept, and what I did not

Swept: every `mktemp` call in the repo (only these two carried X's-before-a-suffix, confirming the triage seat's one-file scope); every reference to `sdui-dump` repo-wide; all 9 `trap` occurrences; every `rm -f` naming one of these files; both pin tests that cover this script.

**Not swept, and not claimed clean**: I did not run the script end-to-end (it needs a console build and a vite dev server); I did not run the wider gate farm — the derivation names 71 runnable commands plus 45 artifact-roster families whose silence is explicitly *not* a clearance, and those are CI's; and I verified no BSD behaviour on real hardware. This list is not complete.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012GKcPZbMoGq7WPzKLfRBTU

---
_Generated by [Claude Code](https://claude.ai/code/session_012GKcPZbMoGq7WPzKLfRBTU)_