### PR TITLE
fix(pm): mask shell `#` comments before the JS scanner on a .sh source

### DIFF
--- a/scripts/pm/dispatch-gates.mjs
+++ b/scripts/pm/dispatch-gates.mjs
@@ -555,14 +555,42 @@ const maskedModuleBody = memoiseMask((source) => maskSelfTests(maskedComments(so
  * unbounded under-mask measured above.
  *
  * Same projection as `blank` next door — spans become spaces, newlines and byte
- * offsets survive — so this composes onto `maskedModuleBody`'s output rather
- * than replacing it. The order is measured too, and it is the one that cannot
- * widen: masking `#` FIRST stops a `#` comment containing `@objectstack/*` from
- * opening a phantom JS block comment, which UNCOVERS code below it and adds
- * hints (2 on this tree — `scripts/downstream-smoke.sh` and
- * `.claude/hooks/guard-tree-enum.sh`). Masking `#` LAST can only blank more of
- * an already-masked body, so the shell hint set is a subset of today's by
- * construction.
+ * offsets survive — so this composes WITH the JS mask rather than replacing it.
+ *
+ * ## The ORDER, and why it is now `#` FIRST (#16744)
+ *
+ * Masking `#` LAST can only blank more of an already-masked body, so the shell
+ * hint set was a subset of the JS-masked one by CONSTRUCTION. That is why the
+ * card above took it: it could not widen, and widening was out of its scope.
+ * The price it left unpaid is the OTHER direction of the same "THIRD kind"
+ * defect. A `#` comment spelling `@objectstack/*`, a glob, or any other
+ * two-character block-comment opener is not a comment to the JS scanner — it
+ * opens a BLOCK comment that runs to the next terminator and blanks every line
+ * of real shell CODE in between, with nothing in the output saying a region was
+ * skipped. Re-measured per byte on `ce7bae8b`, over the 31 tracked `.sh` files:
+ * 12 of them hand a caller shell code as prose, 73,859 bytes in
+ * `scripts/pm/os-verify-lock.sh` alone.
+ *
+ * So `#` is masked FIRST now: shell prose never reaches the JS scanner and
+ * cannot open a phantom comment. This UNCOVERS the code below such a comment
+ * and therefore ADDS hints — 2 on this tree, `node_modules/@objectstack/spec/dist`
+ * in `scripts/downstream-smoke.sh` and one site in
+ * `.claude/hooks/guard-tree-enum.sh`, both of them real code the follow was
+ * blind to. ⛔ The shell hint set is therefore NOT a subset of the JS-masked one
+ * any more, and the live sweep in the self-test pins what the additions ARE —
+ * ⛔ never that there are none, which is the blindness this removed.
+ *
+ * The JS mask still RUNS on a shell source, and still runs BEFORE
+ * `maskSelfTests` as that function's header requires. Keeping it is the whole
+ * difference between this order and "do not run the JS scanner over a non-JS
+ * kind at all": the latter also drops the `//` masking pinned below on a `.sh`
+ * source, which is a reconciliation across both cards rather than this fix.
+ *
+ * Composed from the raw maskers rather than through `maskedModuleBody` — the
+ * intermediate is a DIFFERENT string on this path, so there is no half to
+ * share, and routing it through the JS memo would only fill that cache with
+ * shell-derived keys no JS caller can hit. The memo below is keyed on the raw
+ * source, so the whole chain is still derived once per source.
  */
 const SHELL_WORD_START = /[\s;&|()<>]/;
 
@@ -621,8 +649,10 @@ export function maskShellComments(source) {
   return blank(String(source), shellCommentSpans(String(source)));
 }
 
-/** `maskShellComments(maskedModuleBody(source))`, memoised — see the block above. */
-const maskedHashCommentBody = memoiseMask((source) => maskShellComments(maskedModuleBody(source)));
+/** `maskSelfTests(maskComments(maskShellComments(source)))`, memoised — see the block above. */
+const maskedHashCommentBody = memoiseMask((source) =>
+  maskSelfTests(maskComments(maskShellComments(source))),
+);
 
 // ── What a gate that IMPORTS this module inherits (#11556) ─────────────────
 //
@@ -15541,6 +15571,46 @@ function selfTest() {
     shHints(shJsComment).length === 0,
     shHints(shJsComment),
   );
+  // ── The PHANTOM BLOCK COMMENT the order used to open (#16744) ─────────────
+  //
+  // The other direction of the same "THIRD kind" defect, and the card's whole
+  // acceptance criterion: two sources that differ in FOUR CHARACTERS OF PROSE,
+  // both of which must read the one hint their code spells. The first carries a
+  // block-comment opener inside a `#` comment; while `#` was masked LAST that
+  // opener reached the JS scanner and blanked the real `DEST=` line under it.
+  //
+  // ⛔ The control is not decoration. A change that only makes the first row
+  // fire — by disabling the mask, or by dropping the JS scanner on this kind —
+  // takes the second row down with it or leaves it as the ONLY row that fires.
+  // Both rows read 1, or this is not the fix.
+  const shPhantom = '# published @objectstack/* packages\nDEST="node_modules/@objectstack/spec/dist"\n';
+  const shPhantomControl = '# published packages\nDEST="node_modules/@objectstack/spec/dist"\n';
+  t(
+    '⭐ a `/*` inside a `#` comment no longer opens a block comment over the shell code below it',
+    shHints(shPhantom, 'scripts/x.sh').join() === 'node_modules/@objectstack/spec/dist',
+    shHints(shPhantom, 'scripts/x.sh'),
+  );
+  t(
+    '⭐ CONTROL: the same code under a comment with NO opener still reads its one hint — the mask was fixed, not switched off',
+    shHints(shPhantomControl, 'scripts/x.sh').join() === 'node_modules/@objectstack/spec/dist',
+    shHints(shPhantomControl, 'scripts/x.sh'),
+  );
+  // The span, not just the line: an unterminated opener ran to the END OF FILE,
+  // so the cost was every hint below it rather than the one line beside it.
+  const shPhantomSpan =
+    '# everything below this line is /* invisible\n'
+    + 'bash "scripts/one.sh"\n'
+    + 'bash "scripts/two.sh"\n';
+  t(
+    '…and it ran to END OF FILE, so the recovered span is every hint below the comment, not one line',
+    shHints(shPhantomSpan, 'scripts/x.sh').join() === 'scripts/one.sh,scripts/two.sh',
+    shHints(shPhantomSpan, 'scripts/x.sh'),
+  );
+  t(
+    '…non-vacuously: the JS-kind control on the same bytes still loses both, which is what this order costs a `.sh` file',
+    shHints(shPhantomSpan, 'scripts/x.sh.mjs').length === 0,
+    shHints(shPhantomSpan, 'scripts/x.sh.mjs'),
+  );
   // KIND-SCOPED, in both directions. The same bytes on a `.mjs` path must keep
   // spelling their hint: `#` is not a comment in JavaScript, and a mask that
   // fired there would be a widening rather than this card's narrowing.
@@ -15628,24 +15698,45 @@ function selfTest() {
   let shellShrank = 0;
   let shellBefore = 0;
   let shellAfter = 0;
+  const shellAddedProse = [];
   for (const f of liveShellFiles) {
     const src = readFileSync(nodePath.join(ROOT, f), 'utf8');
     const masked = extractWatchHints(src, f, { tree: hintTree });
     const unmasked = extractWatchHints(src, `${f}.mjs`, { tree: hintTree });
     shellBefore += unmasked.length;
     shellAfter += masked.length;
-    if (masked.some((h) => !unmasked.includes(h))) shellGrew++;
+    const added = masked.filter((h) => !unmasked.includes(h));
+    // An ADDED hint is admissible only if it is spelled in CODE: its literal has
+    // to survive the `#` mask. One spelled only inside a `#` comment would be
+    // the FABRICATING direction arriving through the very reorder that fixed
+    // the under-mask, so it is collected by name rather than counted.
+    const code = maskShellComments(src);
+    for (const h of added) if (!code.includes(h)) shellAddedProse.push([f, h]);
+    if (added.length) shellGrew++;
     else if (masked.length < unmasked.length) shellShrank++;
   }
   t(
-    `⭐ LIVE: over ${liveShellFiles.length} tracked .sh file(s) the mask never ADDS a hint — ${shellBefore} spelled without it, ${shellAfter} with`,
-    liveShellFiles.length > 0 && shellGrew === 0 && shellAfter < shellBefore,
-    JSON.stringify({ files: liveShellFiles.length, shellBefore, shellAfter, shellGrew, shellShrank }),
+    `⭐ LIVE: over ${liveShellFiles.length} tracked .sh file(s) every hint the \`#\` mask ADDS is spelled in CODE — ${shellBefore} hints without the mask, ${shellAfter} with`,
+    liveShellFiles.length > 0 && shellAddedProse.length === 0 && shellAfter < shellBefore,
+    JSON.stringify({ files: liveShellFiles.length, shellBefore, shellAfter, shellGrew, shellShrank, shellAddedProse }),
   );
   t(
     '…non-vacuously: at least one live file really loses a hint, so the sweep is not passing over an instrument that changed nothing',
     shellShrank >= 1,
     JSON.stringify({ shellShrank }),
+  );
+  // ⛔ This case replaced a `shellGrew === 0` pin (#16132), and the replacement
+  // is the point of #16744 rather than a relaxation of it. That spelling was
+  // true only because `#` was masked LAST, which left shell prose to reach the
+  // JS scanner first: a `#` comment containing `/*` opened a phantom block
+  // comment over the real code below it, so the code could not spell a hint in
+  // EITHER column and the difference read 0. Masking `#` FIRST uncovers that
+  // code, so additions are now expected — and the honest invariant is what they
+  // ARE, not that there are none.
+  t(
+    '…and the additions really happen, so the case above is not a subset test wearing a code test\'s name',
+    shellGrew >= 1,
+    JSON.stringify({ shellGrew }),
   );
   // The card's sharpest specimen, both ends. DEPARTURE alone would stay green
   // on a mask that emptied the file, so the ARRIVAL half names a live shell
@@ -15661,6 +15752,26 @@ function selfTest() {
     '…non-vacuously: that path IS spelled in the file, inside a `#` comment, and the unmasked control still reads it',
     extractWatchHints(liveBumpSrc, 'scripts/bump-objectui.sh.mjs', { tree: hintTree }).includes(
       'docs/releases-maintenance.md',
+    ),
+  );
+  // ⭐ LIVE RECOVERY (#16744): the site the card named, both ends. The `.mjs`
+  // control is what makes it a recovery rather than an ordinary arrival — the
+  // JS-only path STILL cannot read this line, because the phantom comment the
+  // header's `@objectstack/*` opens is what hid it, and that is precisely what
+  // masking `#` first removes.
+  const liveDownstream = 'scripts/downstream-smoke.sh';
+  const liveDownstreamSrc = readFileSync(nodePath.join(ROOT, liveDownstream), 'utf8');
+  t(
+    '⭐ LIVE RECOVERY: a path spelled in real shell CODE under a `#` comment carrying a block-comment opener is read again',
+    extractWatchHints(liveDownstreamSrc, liveDownstream, { tree: hintTree }).includes(
+      'node_modules/@objectstack/spec/dist',
+    ),
+    extractWatchHints(liveDownstreamSrc, liveDownstream, { tree: hintTree }),
+  );
+  t(
+    '…non-vacuously: the JS-kind control on the same bytes still cannot see it, so a phantom comment is what was hiding it',
+    !extractWatchHints(liveDownstreamSrc, `${liveDownstream}.mjs`, { tree: hintTree }).includes(
+      'node_modules/@objectstack/spec/dist',
     ),
   );
   const liveShardSelfTest = 'scripts/ci/select-shard-packages.selftest.sh';


### PR DESCRIPTION
Fixes #16744

`extractWatchHints` admits a THIRD file kind (`.sh`) and ran the JavaScript comment scanner over it. `#` was masked **LAST**, so shell prose reached that scanner first: a `#` comment spelling `@objectstack/*`, a glob, or any other two-character block-comment opener is not a comment to a JS scanner — it opens a **block comment that runs to the next terminator**, blanking every line of real shell CODE in between, with nothing in the output saying a region was skipped.

This is direction 1 as triage ruled (comment 5579337506): 「**方案 1（shell 源码上先掩 `#`，再进 JS 扫描器）—— 确定，本卡就做这个。**」

## The change

One line of behaviour, in `scripts/pm/dispatch-gates.mjs`:

```js
// before
const maskedHashCommentBody = memoiseMask((source) => maskShellComments(maskedModuleBody(source)));
// after
const maskedHashCommentBody = memoiseMask((source) =>
  maskSelfTests(maskComments(maskShellComments(source))),
);
```

- `maskShellComments` is **reused**, not re-implemented — triage: 「**复用 `maskShellComments`，⛔ 不要新写一个 `#` 识别器。**」
- `scripts/js-comment-mask.mjs` is **untouched** — triage: 「⛔ **不要改 `scripts/js-comment-mask.mjs`。**」 The scanner is correct; what changes is what it is fed.
- The JS mask still runs on a shell source, and still runs **before** `maskSelfTests` as that function's header requires — so the `//` masking that #16132's fourth fixture pins on a `.sh` source is kept. That is the whole difference between this fix and direction 2, which is out of scope.
- Composed from the raw maskers rather than through `maskedModuleBody`: the intermediate is a different string on this path, so there is no half to share, and routing it through the JS memo would only fill that cache with shell-derived keys no JS caller can hit. The memo is keyed on the raw source, so the chain is still derived once per source.

## Acceptance — both rows read 1

The card's criterion, verbatim: 「the fixture above must read 1, and the control must keep reading 1 rather than becoming the only row that fires.」

| row | source | before | after |
|---|---|---|---|
| fixture | `# published @objectstack/* packages` + `DEST="node_modules/@objectstack/spec/dist"` | 0 | **1** |
| control | `# published packages` + same `DEST=` line | 1 | **1** |

Both read through `extractWatchHints(src, 'scripts/x.sh', { tree })`, and both are now pinned in the tool's self-test alongside a span case (the opener ran to end of file, so the recovered region is every hint below the comment, not one line) and its JS-kind control.

## Re-measured on the merged tree, not quoted from the card

The card's byte table was taken on `b729acf`; triage did not re-measure it. Re-taken per byte on `ce7bae8b` (`maskComments` vs `maskShellComments` over tracked `.sh`): **31** tracked files (the card said 27), **12** affected (the card said 11). Every file the card listed is unchanged in size; one file is new to the list.

```
  73859  scripts/pm/os-verify-lock.sh
  17482  scripts/pm/os-regen-merge.sh
   6015  scripts/create-scaffold-smoke.sh
   5735  scripts/ci/select-gate-families.sh          NEW since b729acf
   4438  scripts/publish-smoke.sh
   1278  .claude/hooks/guard-tree-enum.sh
   1095  scripts/downstream-smoke.sh
   1094  scripts/vercel-ignore-docs.selftest.sh
   1021  scripts/gen-sdui-manifest.sh
   1001  .claude/hooks/guard-main-checkout.sh
    773  .claude/hooks/guard-main-checkout-bash.sh
    464  .claude/hooks/guard-governed-enqueue.sh
```

Hint effect of the order change, old composition vs new, over the same 31 files: **11 hints before, 13 after; 2 files gain, 0 lose.** The two gains are exactly the two live sites the card named:

- `scripts/downstream-smoke.sh` — `node_modules/@objectstack/spec/dist`, spelled at `DEST=`, hidden by the `@objectstack/*` in the header comment.
- `.claude/hooks/guard-tree-enum.sh` — `s/.*`, from the `sed -n 's/.*"command"…'` line, hidden by the `/*` in `.github/workflows/*.yml` inside a `#` comment at line 12.

Both come back. Neither **covers** a tracked file today (`hintCovers` reads 0 for each: `node_modules/` is not tracked, and no top-level `s/` directory exists), so the addition removes blindness without pairing any new family on this tree.

## The self-test case that had to change, and why that is not a weakening

The live sweep asserted 「the mask never ADDS a hint」 (`shellGrew === 0`). That was true **only** because `#` was masked last: the phantom block comment blanked the code in *both* columns, so the difference read 0. It was a pin **on** this defect — it would now be green only on a tree where the blindness survived.

It is replaced by what the additions **are**, which is the honest invariant: every hint the shell path adds over the JS-only control must be spelled in code that survives `maskShellComments` (a hint spelled only inside a `#` comment would be the fabricating direction arriving through the very reorder that fixed the under-mask; such hints are collected **by name**, not counted). A non-vacuity leg asserts additions happen at all, so the case cannot pass as a subset test wearing a code test's name. Everything else in that block — the four `#`/`//` fixture rows, the `$#` / `${#a}` / `a#b` / quoted-`#` word-start cases, the here-string and command-substitution desync cases, the deliberate here-doc over-mask, the projection contract, and the `scripts/bump-objectui.sh` departure/arrival pair — is unchanged and green.

## Acceptance notes

- `scripts/bump-objectui.sh` was **not** treated as affected (card + triage); its existing departure/arrival pin is untouched and still green.
- H17 rider #14290 (`pm:on-hold`, devx) — its pre-written re-check was re-run on this branch and this fix does **not** move it. Deriving for `scripts/bump-objectui.selftest.sh` still yields **0** matched-via mentions of `check:objectui-changeset`, and the control `scripts/bump-objectui.sh` still yields **1** — the reading its hold comment pre-wrote. The mechanism is visible: `scripts/bump-objectui.sh` spells **no** hints at all now (all 7 were prose, removed by the earlier card) and this change adds none to it, while the family edge runs through `scripts/objectui-changeset-digest.mjs`, a `.mjs` on the untouched JS path. Its riders #12797 / #12808 are named, not built.
- Out-of-scope observations noted, not filed: none that meet the (a)/(b)/(c) bar.

## Gates — 31 derived, 31 run, 0 UNRUN, all green

Re-derived on this diff with no paths (`node scripts/pm/dispatch-gates.mjs --commands --repo objectstack-ai/objectstack`, at `bec13aba`, change set `1 path(s) vs merge base ce7bae8b4`): **31 commands, identical to the dispatch's lead — no family added, none dropped.** All 31 were run; reconciliation quotes the tool's own verdict line:

```
✓ dispatch-gates --ran: 31 derived famil(ies) accounted for — 31 run, 0 NOT-MEASURED.
```

The four named for this card:

```
✓ dispatch-gates self-test: 1624 cases pass.                       (pnpm check:pm-dispatch-gates, exit 0)
✓ comment-mask corpus sweep [scripts/js-comment-mask.mjs]: 6432 files, 0 disagree, 0 unparseable
✓ check-watch-hint-literal: 72 self-test cases; 67 declaration(s), 152 literals admitted
✓ check-nul-bytes: OK (8064 text files; no raw ASCII control bytes)
```

Baseline for the battery was taken on `ce7bae8b` before any edit: **1617 cases pass, exit 0**. After: **1624**, exit 0, zero failures — +7 is exactly the seven cases added here (fixture, control, span, span control, the additions-are-code leg, and the two live-recovery legs).

Also run, outside the derived set because it is this diff's own subject matter: `node scripts/check-comment-mask-adoption.mjs` exit 0.

Ungoverned landing, quoted:

```
governed-surface predicate: 0 of 1 path(s) hit the register (5 surfaces, repo-agnostic).
  ✅  NOT governed — ordinary queue landing applies to a PR with exactly this file list.
```

`skip-changeset`: nothing published moves — the diff is one file under `scripts/pm/**` (the fast lane), and the label was applied additively and read back (`size/m`, `skip-changeset`; nothing stripped).

### Lint — a measured narrowing, not a skipped scan

`pnpm lint` is a repo-scoped scan CI owns. Narrowed here to the changed file, with the three readings that make a narrowing a measurement rather than an omission:

1. **Population** — read from eslint's own config resolution, not guessed: the file is admitted (the run returned a result object for it; stderr empty, no ignore warning).
2. **Count** — from `--format json`: **1 file linted, 0 errors, 0 warnings, exit 0** — and the diff is exactly that 1 file.
3. **Invariance for untouched files** — this repo's `eslint.config.mjs` states it in its own prose, measured with a positive control: it "never enables type-aware linting (no `parserOptions.project`, no typed `@typescript-eslint` rules) for ANY file". So a one-file edit cannot move any untouched file's verdict.

### Ablation — direction as predicted, on disk, self-restoring

The composition order was reverted in place by a script with `trap RESTORE_FN EXIT INT TERM` and absolute paths, and the mutation was proven to have reached the file node loads before any colour was read (marker counts: fixed-order 2 to 1 — the surviving copy is the docblock — and old-order 0 to 1).

| reading | mutated (old order) | restored (this PR) |
|---|---|---|
| fixture | **0** | **1** |
| control | 1 | 1 |
| span fixture | 0 | 2 |
| live files gaining a hint | 0 | 2 |
| `scripts/downstream-smoke.sh` recovery | false | true |

Restore proven the strict way, not by an exit code: `git hash-object` equals the HEAD blob (`9f1d947b…`, non-empty), and the **whole-tree** `git diff HEAD` is empty — the per-path proof alone cannot see a second file a build might have written.

Note the control column: it reads 1 in **both** rows. The mutation moves the fixture and leaves the control alone, which is the exact discrimination triage asked for — 「两行必须都读 1」 after the fix, and only the fixture falling before it.

## 维护者速读（草稿）

**改了什么** — `dispatch-gates.mjs` 里 shell 源码的掩码顺序：先掩 `#` 注释，再跑 JS 注释扫描器。一行行为改动，加自测用例。

**为什么改** — `.sh` 文件的 `#` 注释里只要出现 `/*`（比如 `@objectstack/*`、`workflows/*.yml`），JS 扫描器就会把它当成块注释的开头，一路吞到下一个终止符，把中间**真实的 shell 代码**整段抹掉。整棵树上 12 个文件中招，光 `os-verify-lock.sh` 一个就是 73,859 字节，而且输出里没有任何提示说「这段我没看」。

**风险与代价（含回滚）** — 这个改动会**增加** hint（本树 2 个），这是本卡要交付的东西，不是副作用；两个新 hint 今天都不覆盖任何被跟踪文件，所以不会新配对任何 family。原来那条「掩码永不增加 hint」的自测断言必须改——它成立的原因正是本卡要修掉的失明。回滚 = revert 这一个 commit，无数据迁移、无发布面。

**席位意见** — （待席位定稿）

**你要做的** — 无须操作；这是内部工具修复，不发布、无用户可见改动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MoTv7pn338AZ71owsp19gQ


---
_Generated by [Claude Code](https://claude.ai/code)_