### PR TITLE
docs(pm-dispatch): name what IS and is NOT build-tier evidence in the downgrade fuse

### DIFF
--- a/.claude/skills/pm-dispatch/references/contract-review.md
+++ b/.claude/skills/pm-dispatch/references/contract-review.md
@@ -44,7 +44,6 @@
 - 该命令 0 = 双肢一致且无放宽 tell,4 = 任一不成立,3 = 环境答不了;⛔ 3 不作干净。
 - 放宽 tell 由 `scripts/pm/check-widening-tells.mjs` 判,`no` 撞新键/成员/导出/登记即拒,附 file:line。
 - ③ PR 全部 check 全绿,⛔ 非 required 子集;受管面不适用,draft-only 终局不变。
-- 外部评审链是可选事后审计:分诊定时轮与总监席召唤 ⛔ 不是放行必要条件。
 
 ## 降档保险丝(机读)
 
@@ -54,6 +53,7 @@
 - 保险丝只测座位自会话:`mode:subagent` 里 `get_session` 量的是派发会话,⛔ 不作互证。
 - 传参只是配置 ⛔ 不作达档读数;条款②的 `mode:subagent` 派发恒保留标至席内复核完成。
 - 转录档位核验:采信或清标前 grep 子代理 transcript 中 harness 逐消息盖章的 `model` 字段。
+- 施工档只取 harness `model` 盖章或认领 Container & model 行;`Co-Authored-By` = 署名常量 ⛔ 非证据。
 - 产出裁决的每轮都须读到契约复审档位,见回退证据 ⇒ 裁决整体作废。
 - 父会话只有两个合法动作:逐字采纳,或整体作废(核验失败、越范围、格式不完整)。
 - ⛔ 永不改写、删节或润色子代理裁决。


### PR DESCRIPTION
Fixes #17139

One line added to `.claude/skills/pm-dispatch/references/contract-review.md` under 〈降档保险丝(机读)〉, naming what IS admissible evidence of the tier a build ran at and what is NOT. Docs-only, governed surface, no package touched.

**Added** (118 bytes measured, under the 120-byte per-line pin):

```
- 施工档只取 harness `model` 盖章或认领 Container & model 行;`Co-Authored-By` = 署名常量 ⛔ 非证据。
```

It carries both halves of the director seat's instruction: the two admissible sources (the harness `model` stamps; the claim's `Container & model:` line) and the exclusion (the `Co-Authored-By` trailer is a session-attribution constant, never evidence of tier). `施工档` is this corpus's own term for the tier work was built at (`references/lanes/cli.md`: 「只定复核档不定施工档」), the counterpart to `服役档` already used three lines above. The card's working spelling measured 145 bytes and did not fit, so the spelling was tightened; both halves survive intact and no model identifier appears in it.

**Placed** directly after 「转录档位核验:… harness 逐消息盖章的 `model` 字段。」 — that line names the harness stamp as a reading; the new line closes the set around it and names the artefact that is not in it.

## Line budget — paid by deletion, not by re-wrap

The file sits at its ratchet ceiling: `check-skill-line-ratchet` reads it at `60 lines (ceiling 60; headroom 0)` both before and after. The added line is paid by deleting one line **inside the same file**:

```
- 外部评审链是可选事后审计:分诊定时轮与总监席召唤 ⛔ 不是放行必要条件。
```

Why it was the redundant one:

- Its rule is already stated in `SKILL.md` 〈入队与落地〉: 「外部评审链降为可选事后审计,非放行前提。」 The rules-only rewrite convention for this corpus is *one rule per line, no rule already stated in SKILL.md* — the ratchet's own ceiling comment states it, and this file's first line scopes itself to 载体纪律、归属资格与降档保险丝.
- Its extra specificity — *which* chains — is stated in `references/lanes/director.md`, where those chains' duties live: `:31` 「裁决仍被尊重但非放行必要条件」 and `:71` 「契约复核的放行归派发席席内,定时轮与本席降为可选事后审计」.
- `check-skill-line-ratchet.mjs`'s own header had already classified this bullet as a restatement, rejected as payment then only because a byte trim (−24 B) could not move a LINE ratchet. After the rules-only rewrite the bullet is exactly one line, so deleting it banks the line the ratchet prices.
- `director.md:71` defers to this file (「`../contract-review.md` 为准」) for 契约复核的放行归属 — that deferral still resolves: 放行 = 清标即落地 and 落地前检三条 are untouched here.
- It is not pinned by any gate: `外部评审链` / `事后审计` / `放行必要条件` appear in no gate assertion (only in a `check-skill-line-ratchet.mjs` narrative comment). A per-line scan of the file against every file under `scripts/` and `.claude/` shows the pinned lines are elsewhere — L16/L19/L20/L23 (`check-half-states`, `check-clause2-carriers`), L29/L44 (`check-clause2-carriers`) — and none of them is the deleted line or a line in the edited section.

No ceiling raise, no re-wrap, no edit to `check-skill-line-ratchet.mjs`, no `SKILL.md` edit.

## 维护者速读(草稿)

**改了什么** — 内部 PM 技能里的一份参考文档加了一行:说清「这次活是在哪个档位上干的」这件事,证据只认两处(harness 逐消息盖的 `model` 戳、认领评论里的 Container & model 行),并点名一个不算证据的东西(commit 的 `Co-Authored-By` 署名行)。同一份文档里删掉一行重复内容付账,总行数不变。

**为什么改** — 这份文档原本只写了「档位怎么读」,从没写「哪些东西不是档位证据」。commit 的署名行里带模型名,没读过 AGENTS.md 那条署名规则的人会把它当档位盖章;这个误读真的发生过一次,拦住了一个 PR 并导致撤回。规则缺口的代价是重复的返工,补一行就堵住。

**风险与代价(含回滚)** — 风险很低:纯文档、不发布、不进产品,任何包都没碰,不需要 changeset。代价是文档预算:文件已经顶到 60 行天花板,新增一行必须删一行,这里删的是 SKILL.md 已经写过、总监席车道文件也写过的那条「外部评审链是可选事后审计」。若判断删错,回滚就是 revert 这一个提交,单文件一行进一行出,没有连带。

**席位意见** —

**你要做的** — 读一遍新增那行和被删那行,确认这个交换你认可,然后合并这个 PR(受管面,走人工合并)。

## Acceptance notes

Gates — all 14 families `dispatch-gates.mjs` derives for this change set, run locally, exit code captured before any pipe:

| gate | exit | verdict line |
| --- | --- | --- |
| `check:pm-skill-ratchet` | 0 | `✓ check-skill-line-ratchet: .claude/skills/pm-dispatch/references/contract-review.md is 60 lines (ceiling 60; headroom 0).` |
| `check:nul-bytes` | 0 | `check-nul-bytes: OK (scanned 8079 text file(s) … no raw ASCII control bytes).` |
| `check:doc-authoring` | 0 | `✓ doc authoring guard: 403 files clean — no bare metadata literals.` |
| `check:pm-skill-id-lint` | 0 | `✓ check-skill-id-lint: 26 file(s) clean` |
| `check:skill-frame-sync` | 0 | `✓ check-skill-frame-sync: 2 copies of the decision frame are structurally isomorphic across 2 files` |
| `check:pm-governed-merges` | 0 | `✓ check-governed-merges --self-test: 274 assertions` |
| `check:agent-test-spelling` | 0 | self-test + sweep green |
| `check:doc-formula-expressions` | 0 | green after the declared prerequisite build |
| `check:driver-memory-census` | 0 | `check-driver-memory-census: OK` |
| `check:refd-timer-probe` | 0 | `OK check-refd-timer-probe: 6433 source file(s) swept` |
| `check:watch-hint-literal` | 0 | `✓ check-watch-hint-literal: 67 declaration(s) across 4 rostered name(s)` |
| `check-closing-keyword-parity.mjs` (+ `--self-test`) | 0 | `check-closing-keyword-parity: OK (3 parsers agree on all 9 keywords …)` |
| `check-comment-mask-corpus.mjs` | 0 | `✓ comment-mask corpus sweep: 6438 files, 0 disagree` |

Reconciliation: `dispatch-gates.mjs --ran` reads `14 derived, 14 run, 0 NOT-MEASURED, 0 UNRUN`.

`check:doc-formula-expressions` first exited **3 — PREREQUISITE NOT MET** (`@objectstack/formula` / `@objectstack/lint` not built), which is NOT MEASURED, not a finding. It was re-run green after `turbo run build --filter=@objectstack/formula --filter=@objectstack/lint` under the shared verify lock (`VERDICT command-exit 0 · held the lock 289s`).

Self-tests run where the gate carries one: `check-half-states --self-test` (2976 cases), `check-widening-tells --self-test` (150 cases), `check-clause2-carriers --self-test` (299 cases) — all exit 0. Repo-wide `pnpm lint` is CI's run, not owed here; the diff adds no source file.

Control-character self-scan beyond the gate, on the edited file: `grep -naP` over the C0 range plus DEL → no match.

PM mechanism assumptions, measured:

- **A holds.** The 60-line ceiling and the 120-byte per-line pin are both `check-skill-line-ratchet.mjs` (`MAX_LINE_BYTES = 120`; `['.claude/skills/pm-dispatch/references/contract-review.md', 60]`). Measured before and after; the verdict line is quoted above.
- **B holds, and it changes nothing here.** `check-half-states.mjs` and `check-clause2-carriers.mjs` do pin strings inside this file — but in 载体纪律 (L16/L19/L20/L23) and 复核归属 (L29/L44), never the deleted line and never a line in 降档保险丝. `check-widening-tells.mjs` pins none of this file's lines. The edited section carries no gate-pinned string.
- **C is stale in the safe direction.** `7337179d` is no longer the tip: `origin/main` is `c3756ff0`, 4 commits ahead, **none** of which touches this file. Work is based on `c3756ff0`; the target section's line numbers were re-read from that tree rather than from the card.

Scope: nothing else changed. No changeset — `.claude/**` publishes nothing (no package `files[]` ships it), so `skip-changeset` is the honest label; no changeset gate demanded one in the run above.

Out-of-scope, noted and not filed: `check-skill-line-ratchet.mjs`'s ceiling narrative still describes the 外部评审链 bullet as a rejected payment candidate. That text is a record of a past raise, not a live claim about the tree, and the ratchet reads line counts rather than that prose — history, not a defect. 承接者:无 — no PR or person has reason to open that comment block for this reason.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MoTv7pn338AZ71owsp19gQ)_