### PR TITLE
skills(pm-dispatch): the lane table routes a `scripts/` gate three ways by pointer and names every row-less path

### DIFF
--- a/.claude/skills/pm-dispatch/SKILL.md
+++ b/.claude/skills/pm-dispatch/SKILL.md
@@ -245,11 +245,11 @@ PM 的工作是循环:选卡 → 认领 → 派发 → 收集 → 复核 → 报
 |:--|:--|
 | `domain:engine` | `packages/objectql`、`packages/core`、`packages/formula`(CEL / `matches-filter` / RLS 谓词求值)、`plugin-pinyin-search`;`packages/metadata*`、`packages/platform-objects`;`packages/drivers/driver-*`;退役标签 `domain:engine-core` / `domain:metadata` / `domain:drivers` 只退出流通,GitHub 标签对象保留 |
 | `domain:services` | `packages/services/*`、`packages/connectors/*`、`packages/triggers/*`、`plugin-approvals`、`plugin-webhooks`、`plugin-email`、`plugin-reports`、`embedder-openai`、`knowledge-*`;`plugin-auth`、`plugin-security`、`plugin-sharing`、`plugin-audit`;退役标签 `domain:identity` 同上只退流通 |
-| `domain:devx` | `packages/lint`(与 spec 相交的面均按锚定规则的例外切分)、`packages/sdui-parser`、`content/docs/**`、`apps/docs`、`scripts/`(门禁类;与 `domain:skills` 的分界按门禁的 SUBJECT:治理 agent 指令面/governed 面的归 skills,治理代码/文档质量的归本域) |
-| `domain:skills` | `.claude/skills/**`(含本文件)+ `skills/**`;根 `AGENTS.md` + 根 `CLAUDE.md`;governed 面的治理执行文件:`.github/CODEOWNERS` + SUBJECT 是 governed 面本身的门禁/审计(现为 `scripts/pm/check-governed-merges.mjs`) |
+| `domain:devx` | `packages/sdui-parser`、`content/docs/**`、`apps/docs`;`packages/lint`、`scripts/`(门禁类)、`.github/workflows/`(门禁接线);三者与 spec 相交的面按锚定规则的例外归 `domain:spec`,门禁再按 SUBJECT:治理 agent 指令面/governed 面的归 skills,治理代码/文档质量的归本域 |
+| `domain:skills` | governed 面全量(含本文件;统一定义见「governed 面统一定义」行);governed 面的治理执行文件:`.github/CODEOWNERS` + SUBJECT 是 governed 面本身的门禁/审计(现为 `scripts/pm/check-governed-merges.mjs`) |
 | `domain:spec` | `packages/spec` 整包:schema 形状、`contracts/**`、退役行为半边、strictness 台账;describe/JSDoc/墓碑散文/错误 guidance 与 alias 表;`packages/spec/scripts/**`、`packages/spec/docs/**` 及按锚定规则的例外归本域的工具链(域边界枚举与席内分派见 `references/lanes/spec.md`) |
-| `domain:cli` | `packages/cli`、`runtime`、`verify`、`qa`、`types`、`packages/rest`、`packages/mcp`、`packages/observability`、`packages/client*`、`cloud-connection`、`create-objectstack`、`packages/adapters/*`、`plugin-hono-server`、`plugin-dev` |
-| (无固定归属,按落点分诊) | `packages/apps/*`、`packages/console`(dist 由脚本生成 ⛔ 不手改;UI 缺陷走 `repo:objectui`)、`examples/*`(归它演练的子系统) |
+| `domain:cli` | `packages/cli`、`runtime`、`verify`、`packages/qa`、`types`、`packages/rest`、`packages/mcp`、`packages/observability`、`packages/client*`、`cloud-connection`、`create-objectstack`、`packages/adapters/*`、`plugin-hono-server`、`plugin-dev` |
+| (无固定归属,按落点分诊) | `packages/apps/*`、`packages/console`(dist 由脚本生成 ⛔ 不手改;UI 缺陷走 `repo:objectui`)、`examples/*`(归它演练的子系统)、`docs/audits/**` |
 
 - 表未覆盖的包首次分诊时归类并走 PR 更新本表;新增或退役 `domain:*` 必须同批改本表。
 - 座位在编情况以 `label:pm:seat` 索引为准,每个 `domain:*` 与 `repo:*` 恰一张座位贴。
@@ -625,7 +625,7 @@ PM 的工作是循环:选卡 → 认领 → 派发 → 收集 → 复核 → 报
 - ④ 轮次报告单列 awaiting a human merge。
 - 已入队才读到本条 ⇒ 转 draft 与 disable 都做;出队以阳性探针答,ref 缺席只旁证。
 - skills 车道自有 PR 再按 diff 内容分流:diff 含任一 `.md` 文件 ⇒ 终局四件套照旧。
-- 纯代码面(`scripts/pm/` 工具、`.claude/` hooks/workflows/settings、非 md 产物)⇒ skills 席自审。
+- 纯代码面(`scripts/pm/`、`.claude/` hooks/workflows/settings、非 md 产物)⇒ 复核席为 skills 席自审。
 - skills 席自审按契约复审档、清单不减,然后直接落地(ready → 入队),⛔ 不推维护者。
 - 路径面干净的才转 ready → 入队;队列是唯一被认可的落地路径,⛔ 永不队列外合并。
 - 入队资格 = PR 上每一个 check 全绿,⛔ 不是 required 子集;required 集是队列强制的地板。


### PR DESCRIPTION
Fixes #17222

One governed file, both halves of the card, under the card's own discipline (quoted on #16993 and #17222): 「同一概念两份真理」 is the failure mode — **one statement, pointers to it**. ⛔ Not a routing dispute: no lane assignment changes. Every edit is a pointer or a data row; no rule text is added, none is restated. Line-neutral: `.claude/skills/pm-dispatch/SKILL.md` stays at 812/812, every edited table row stays under the 342-byte pin, and the one edited prose line is 119 of 120 bytes.

## Half A — a `scripts/` gate resolves from the row a reader lands on

### `domain:devx` row (:248) — 311 → 330 bytes (pin 342)

before:

> `| domain:devx | packages/lint(与 spec 相交的面均按锚定规则的例外切分)、packages/sdui-parser、content/docs/**、apps/docs、scripts/(门禁类;与 domain:skills 的分界按门禁的 SUBJECT:治理 agent 指令面/governed 面的归 skills,治理代码/文档质量的归本域) |`

after:

> `| domain:devx | packages/sdui-parser、content/docs/**、apps/docs;packages/lint、scripts/(门禁类)、.github/workflows/(门禁接线);三者与 spec 相交的面按锚定规则的例外归 domain:spec,门禁再按 SUBJECT:治理 agent 指令面/governed 面的归 skills,治理代码/文档质量的归本域 |`

(inline code spans inside the row are shown without their backticks so the quote stays one line)

- The `scripts/` clause no longer presents a two-way split. `packages/lint`, `scripts/`(门禁类) and `.github/workflows/`(门禁接线) share **one** pointer — 「三者与 spec 相交的面按锚定规则的例外归 `domain:spec`」 — to the anchoring exception at :241 (「围着 spec 契约转的归 `domain:spec`,余留 devx」) and, through the `domain:spec` label, to the spec row's tool-chain clause at :250 (「按锚定规则的例外归本域的工具链」). The three-way answer (spec / skills / devx) is now reachable from this row without carrying :241's 「等」 across two rows.
- The SUBJECT split between skills and devx keeps its wording byte-for-byte (「治理 agent 指令面/governed 面的归 skills,治理代码/文档质量的归本域」); only its lead-in changed (「门禁再按 SUBJECT」 instead of 「与 `domain:skills` 的分界按门禁的 SUBJECT」).
- The list order changed so the three spec-intersecting surfaces are adjacent (one pointer instead of three copies of it); nothing left the row.
- :240–:241 (pointer targets) and :206 (the single-writer statement — who WRITES the tool chain, a different rule) are untouched.

### :628, the ACCEPT path-fork line — 113 → 119 bytes (cap 120)

before:

> `- 纯代码面(scripts/pm/ 工具、.claude/ hooks/workflows/settings、非 md 产物)⇒ skills 席自审。`

after:

> `- 纯代码面(scripts/pm/、.claude/ hooks/workflows/settings、非 md 产物)⇒ 复核席为 skills 席自审。`

- The line now says in its own words that its arrow names the **review seat** (复核席), so a grep for `scripts/pm` no longer reads it as a lane attribution. The two surface spans (`scripts/pm/`, `.claude/`) are byte-identical. The word 工具 after `scripts/pm/` was dropped to pay for 复核席为 under the 120-byte line cap — the path names the same thing.
- This line sits inside the `check-governed-prose` pinned region (:607–:633, from `**ACCEPT 之后的路径分叉` to `本段只适用本循环派发的 dev PR`); the region still names all five registered surfaces and no `**`-shaped span was added, so the gate stays green (verdict quoted below). :609/:610 (the governed-surface definition) are untouched.

## Half B — every path has a row or a stated non-assignment

### `domain:skills` row (:249) — 253 → 254 bytes

before:

> `| domain:skills | .claude/skills/**(含本文件)+ skills/**;根 AGENTS.md + 根 CLAUDE.md;governed 面的治理执行文件:.github/CODEOWNERS + SUBJECT 是 governed 面本身的门禁/审计(现为 scripts/pm/check-governed-merges.mjs) |`

after:

> `| domain:skills | governed 面全量(含本文件;统一定义见「governed 面统一定义」行);governed 面的治理执行文件:.github/CODEOWNERS + SUBJECT 是 governed 面本身的门禁/审计(现为 scripts/pm/check-governed-merges.mjs) |`

- The row cites the one definition (:609 「governed 面统一定义:`docs/adr/**` + `.claude/**`(全量,含 agents/hooks/settings)+ `skills/**`」, :610 for `AGENTS.md` + `CLAUDE.md`) instead of re-enumerating a subset of it. An ADR edit, and any `.claude/**` file, now has a row — through the definition, which stays the single statement. The pointer names :609's literal phrase so a grep finds it in one hop.
- Consequence to state plainly: `grep -n docs/adr` on SKILL.md still lands on :609 only — by design, the row points rather than re-spells.

### `(无固定归属,按落点分诊)` row (:252) — 184 → 203 bytes

- `docs/audits/**` joins as a **stated** non-assignment. No lane invented: nothing under `.claude/**` or in `AGENTS.md` assigns it (the only mentions are tooling paths in `scripts/`).

### `domain:cli` row (:251) — 262 → 271 bytes

- `qa` → `packages/qa`, so the grep speaks. The row already named it; not a routing change.

### `.github/workflows/` — in the `domain:devx` row (see the deviation below)

## Deviation from dispatch ruling 3(b), declared

The ruling placed `.github/workflows/**` in the no-fixed-home row as a stated non-assignment, on the premise that no lane statement covers it. Measured on `origin/main` `bccf3111`: `.claude/skills/pm-dispatch/references/lanes/devx.md:8` — the devx lane's own job description — already states 「`scripts/`(门禁类)、`.github/workflows/`(门禁接线)」 as devx scope. A no-fixed-home entry would contradict that maintainer-merged line, which is the 「两份真理」 the card's discipline forbids (the card's own ⚠️ makes the same argument for `docs/adr/**` against :609). So the devx row mirrors devx.md:8 byte-for-byte into its gate clause instead. This is not a new lane assignment: it is the existing one, made visible where the reader lands, under the same SUBJECT split a `scripts/` gate gets — which is the reading the ruling itself anticipated a triage seat would apply, and that per-card SUBJECT call stays triage's. If the seat rules otherwise, the swap is one line: drop 、`.github/workflows/`(门禁接线) from :248 (row would read 「三者」 → 「二者」, 289 bytes) and append 、`.github/workflows/**` to :252 (228 bytes).

## Ceilings and pins (`check-skill-line-ratchet`, before → after, both on this branch)

- lines: 812/812 → 812/812. No line added or deleted (rows and :628 edited in place), so nothing to pay and no `paid_by`.
- widest table row: 342 → 342 (the `domain:engine` row :246, untouched); pin 342 unchanged, headroom 0 before and after.
- edited rows: :248 311 → 330 · :249 253 → 254 · :251 262 → 271 · :252 184 → 203 (all ≤ 342).
- non-table lines: every line ≤ 120 bytes; :628 is 119.
- Mechanism assumption A confirmed by measurement: the pin is over the file's WIDEST row, not per row — :248 grew by 19 bytes with the gate green, and the widest stayed the untouched engine row. Mutation probe in a detached probe worktree at `cdefa340` (row :246 widened by one ASCII byte to 343, on-disk anchor `grep -c` = 1): `✗ check-skill-line-ratchet: .claude/skills/pm-dispatch/SKILL.md has a 343-byte table row at L246; the max-table-row-bytes pin is 342.` — exit 1; probe worktree removed, main worktree `git status --porcelain` empty.

## Re-check (the card's block, on `cdefa340`)

- `grep -c "domain:spec"` → 5 (was 4: the devx row now names `domain:spec` as its pointer)
- `grep -c ".github/workflows"` → 1 (:248) · `grep -c "docs/audits"` → 1 (:252) · `grep -c "packages/qa"` → 1 (:251)
- `grep -n "docs/adr"` → :609 only (the skills row points at it; see above)
- `grep -n "scripts/pm"` → :206 (single writer, untouched) · :249 (the skills row's named governed-surface gate) · :628 (now the review seat, in its own words) · the rest are command spellings and the 机械守卫索引 table

## Gates (every family `dispatch-gates.mjs` derives for this file, plus the dispatch-named ones; all at `cdefa340`)

- `pnpm check:pm-skill-ratchet` — `✓ check-skill-line-ratchet self-test: 157 cases pass.` · `✓ … SKILL.md: widest table row is 342 bytes (pin 342; headroom 0).` · `✓ … SKILL.md is 812 lines (ceiling 812; headroom 0).`
- `pnpm check:pm-governed-prose` — `✓ check-governed-prose self-test: 28 cases pass.` · `✓ check-governed-prose: 2 instruction surface(s) name all 5 registered governed surfaces (docs/adr/** · .claude/** · skills/** · AGENTS.md · CLAUDE.md) and claim no others.`
- `pnpm check:pm-skill-id-lint` — `✓ check-skill-id-lint: 26 file(s) clean (pattern /#[0-9]{3,}/g).`
- `pnpm check:skill-frame-sync` — `✓ check-skill-frame-sync: 2 copies of the decision frame are structurally isomorphic across 2 files`
- `pnpm check:skill-frame-freshness` — `✓ … the decision frame in this tree is current with origin/main (fetched just now).`
- `pnpm check:pm-half-states` — `✓ check-half-states self-test: 3019 cases pass.` · `pnpm check:pm-clause2-carriers` — `✓ check-clause2-carriers self-test: 319 cases pass (…)` · `pnpm check:pm-widening-tells` — `✓ check-widening-tells self-test: 173 cases pass (…)` — assumption D holds: no edited line is a pinned string in any of the three (grep of every edited phrase over `scripts/` returns nothing).
- `pnpm check:pm-dispatch-gates` (run detached, over the 600 s cap) — `✓ dispatch-gates self-test: 1624 cases pass.`
- `pnpm check:agent-test-spelling`, `pnpm check:doc-authoring`, `pnpm check:pm-governed-merges`, `node scripts/pm/check-governed-queue-guard.mjs --self-test`, `pnpm --filter @objectstack/lint run check:doc-formula-expressions` (after building `@objectstack/formula` + `@objectstack/lint` under the verify lock — the gate refuses on an unbuilt dist), `pnpm check:nul-bytes`, `node scripts/check-closing-keyword-parity.mjs --self-test` and the gate, `node scripts/check-comment-mask-corpus.mjs`, `pnpm check:watch-hint-literal`, `pnpm check:refd-timer-probe`, `pnpm check:driver-memory-census` — all exit 0.
- Reconciliation: `✓ dispatch-gates --ran: 16 derived famil(ies) accounted for — 16 run, 0 NOT-MEASURED.` (change set derived from the merge base `bccf3111`: the one file).
- `node scripts/pm/check-governed-queue-guard.mjs` (the gate itself) is CI-measured only — it reads the workflow event payload.

## core-rules.md twin

`references/core-rules.md` 〈域车道〉 (:64–:65) carries only the anchoring rule with a pointer to SKILL.md's exception; no sentence changed here has a twin there (each edited phrase grepped over `references/` — nothing). Left untouched, as ruling 5 requires.

## PR #17220 regions and merge order

PR #17220 (`origin/claude/issue-17017-awaiting-maintainer-carrier` at `af85c612`) touches SKILL.md at :108, :128 and :707–:711; this PR touches :248, :249, :251, :252 and :628 — disjoint, not touched. Both merge orders are clean (HEAD `cdefa340`, `origin/main` `bccf3111`):

- `git merge-tree --write-tree origin/main HEAD` → exit 0, tree `6463089164df2920162298ab3670d9aa139b6da2`
- `git merge-tree --write-tree origin/claude/issue-17017-awaiting-maintainer-carrier HEAD` → exit 0, tree `d3800a96a05da4381eec04aa133ec6d37ab3617d`

## Changeset

`skip-changeset`: `.claude/**` publishes nothing (a governed, repo-internal agent playbook; no package `files[]` reaches it). No gate demanded a changeset.

## Acceptance notes

- filed as #17225: the table's `scripts/` clause covers gates only — a non-gate `scripts/**` script still has no row, `scripts/pm/**` is stated only in `references/lanes/skills.md:7`, and three paths `lanes/devx.md:8` states (`.githooks/`, `docker/README.md`, `examples/**` 测试基建面) have none. Same class as this card, outside its rulings; routing is triage's, so it is a card, not a rider here.
- noted, not filed: the cli row's other bare names (`runtime`, `verify`, `types`) grep 0 as `packages/…` too; the ruling spelled only `qa` and that is what landed. 承接者: the skills seat, next time it edits the table.
- noted, not filed: `references/lanes/skills.md:6–9` and `lanes/devx.md:8–11` are lane-file summaries of the table that both say the table is the 全量判据; after this PR they are consistent with it for the paths the card measured. 承接者: the skills seat (it owns both files).

## 维护者速读(草稿)

**改了什么**:只改一个文件 `.claude/skills/pm-dispatch/SKILL.md`,五行原地改写、行数不变(812/812)。域车道表里:devx 行的 `scripts/` 条从「devx 与 skills 二选一」改成指向锚定规则例外的一句(与 spec 契约相关的门禁归 spec,其余按 SUBJECT 分 skills/devx),并把 `.github/workflows/` 照 devx 车道岗位说明原样列入;skills 行改为引用「governed 面统一定义」那一行,不再自抄一份子集(于是 ADR 与整棵 `.claude/` 都有了归属);「无固定归属」行加上 `docs/audits/**`;cli 行把 `qa` 写全成 `packages/qa`。复核段的「纯代码面 ⇒ skills 席自审」一行加上「复核席为」三字,说明它讲的是谁复核、不是归哪个车道。

**为什么改**:分诊席实测,同一目录 `scripts/pm/` 在文件里有四处说法互不衔接,而 `docs/adr/**` 等路径在表里根本没有行;已经造成一张卡分错车道、一张险些分错。修法遵守上一张同类卡定下的纪律:一处陈述、其他地方只做指针,不再多抄一份规则。

**风险与代价(含回滚)**:纯文档指针改动,不动任何门禁脚本、不动锚定规则本身、不改任何既有归属;所有相关门禁本地全绿,行数上限与表格行宽度上限都没抬。唯一需要维护者过目的判断:`.github/workflows/` 我按 devx 车道岗位说明列进了 devx 行,而不是派发裁决建议的「无固定归属」行,理由是岗位说明已经这样写了,两处说法不一才是这张卡要消灭的东西;不同意时只需把它从 devx 行挪到「无固定归属」行,一行的事。回滚 = revert 这一个提交。

**席位意见**:

**你要做的**:确认 `.github/workflows/` 的放行位置后,人工合并本 PR。

---
_Generated by [Claude Code](https://claude.ai/code/session_01MoTv7pn338AZ71owsp19gQ)_