### PR TITLE
feat(cli)!: rename the `--json` payload key `specVersionGap` to `protocolVersionGap`

### DIFF
--- a/.changeset/protocol-version-gap-key-rename.md
+++ b/.changeset/protocol-version-gap-key-rename.md
@@ -2,6 +2,8 @@
 "@objectstack/cli": minor
 ---
 
+<!-- adr-0087: not-required (no-migration-prescription) the renamed member is a CLI `--json` OUTPUT key emitted from an inline object literal — no Zod schema, no `packages/spec` declaration, no stored representation, so `objectstack migrate meta` has nothing to reach. The affected party is a script reading stdout (ADR-0087 D8). -->
+
 feat(cli)!: the `--json` payload key `specVersionGap` is renamed to `protocolVersionGap` (#14261)
 
 **BREAKING** — a published machine surface changes a key name. `os validate --json` and

--- a/.changeset/protocol-version-gap-key-rename.md
+++ b/.changeset/protocol-version-gap-key-rename.md
@@ -1,0 +1,44 @@
+---
+"@objectstack/cli": minor
+---
+
+feat(cli)!: the `--json` payload key `specVersionGap` is renamed to `protocolVersionGap` (#14261)
+
+**BREAKING** — a published machine surface changes a key name. `os validate --json` and
+`os build --json` emit **`protocolVersionGap`** where they emitted `specVersionGap`. A
+consumer reading `specVersionGap` reads `undefined` after this release and must switch to
+the new name. There is **no alias and no dual-key transition window**: one axis, one name.
+
+The value shape is unchanged — `null` when the app's declared compatibility range admits
+the installed `@objectstack/spec`, otherwise the same advisory record with the same
+members. Nothing else on either payload moves: no other key is added, removed or
+reshaped, and the text faces of both commands are byte-identical.
+
+## Why the name had to move
+
+The axis this advisory reports moved in **#13860**: it used to read the undeclared
+`manifest.specVersion` and now reads `manifest.engines.protocol`, which is declared
+(`PluginEnginesSchema`), stamped by every scaffold, and enforced at boot. The published
+key name stayed behind for one release, deliberately — renaming a machine face with
+pinned consumers is a break, and no ruling covered it at the time.
+
+Leaving it is a correctness problem, not untidiness. A key spelled `specVersion*` invites
+the reader — an AI agent above all — to infer that a writable `manifest.specVersion`
+exists. `ManifestSchema` is not `.strict()` and **silently drops unknown keys** (#14192),
+so acting on that inference does not produce an error: it produces a manifest that looks
+entirely normal and whose `specVersion` line never took effect. That is the same
+ghost-key breadcrumb mechanism that caused #13860 in the first place, left standing on
+the output side.
+
+## What a consumer should do
+
+```diff
+- if (payload.specVersionGap) { … }
++ if (payload.protocolVersionGap) { … }
+```
+
+The breaking surface was measured before the rename and is closed inside this repository:
+the only consumers of the old key were three in-repo e2e suites, which move in this same
+change; **zero external consumers were found**. Graded `minor` by the maintainer's
+explicit grading of 2026-09-02; the banner above carries the breaking-ness the level
+cannot.

--- a/packages/cli/src/commands/compile.ts
+++ b/packages/cli/src/commands/compile.ts
@@ -908,9 +908,11 @@ export default class Compile extends Command {
           // Same key `os validate --json` uses, so a CI consumer reads one shape
           // from either command rather than learning two.
           conversions: conversionNotices,
-          // Published key name kept; the axis behind it moved to
-          // `manifest.engines.protocol` (#13860). See validate.ts.
-          specVersionGap: protocolGap,
+          // [#14261] Renamed from the retired `specVersion*` spelling: one
+          // axis, one name. The axis itself moved to
+          // `manifest.engines.protocol` in #13860; the published key name
+          // follows it here. Value shape unchanged. See validate.ts.
+          protocolVersionGap: protocolGap,
           stats,
           duration: timer.elapsed(),
         }, 0, { compact: true });

--- a/packages/cli/src/commands/validate.ts
+++ b/packages/cli/src/commands/validate.ts
@@ -541,12 +541,17 @@ export default class Validate extends Command {
             // this one.
             warnings: warningsSoFar(),
             conversions: conversionNotices,
-            // The payload key keeps its published name. The AXIS it reports
+            // [#14261] The key now spells the axis it reports. That axis
             // moved from the undeclared `manifest.specVersion` to
-            // `manifest.engines.protocol` (#13860), but this is a machine face
-            // with pinned consumers, and renaming it is a break nobody asked
-            // for. Its value shape is unchanged.
-            specVersionGap: protocolGap,
+            // `manifest.engines.protocol` in #13860, and the published key
+            // name lagged one release behind it. A key spelled `specVersion*`
+            // invites the inference that `manifest.specVersion` is writable;
+            // `ManifestSchema` is not `.strict()` and drops unknown keys with
+            // nothing said (#14192), so acting on that inference produces a
+            // manifest that looks fine and whose line never took effect. The
+            // rename is one stroke, no alias, no dual-key window; its value
+            // shape is unchanged.
+            protocolVersionGap: protocolGap,
             duration: timer.elapsed(),
           },
           // `--strict` means one thing — "treat warnings as errors" — and it now
@@ -556,8 +561,8 @@ export default class Validate extends Command {
           // its `⚠` block while the payload carries them under `conversions`.
           // Gating on the payload field would have left `--json --strict` at 0
           // for a config whose only advisories are conversion notices — the
-          // same divergence one collection narrower. `specVersionGap` stays out
-          // on both faces; it is never gated by `--strict` (see below).
+          // same divergence one collection narrower. `protocolVersionGap` stays
+          // out on both faces; it is never gated by `--strict` (see below).
           //
           // `valid: true` beside a 1 is not a contradiction, it is the text
           // face verbatim: that path prints "Validation passed" and THEN fails

--- a/packages/cli/test/build-json-advisory-parity.e2e.test.ts
+++ b/packages/cli/test/build-json-advisory-parity.e2e.test.ts
@@ -310,7 +310,7 @@ describe('#11727 — `os build --json` carries the capability-provider and packa
         'runtimeModule',
         'runtimeModuleSize',
         'size',
-        'specVersionGap',
+        'protocolVersionGap',
         'stats',
         'success',
         'warnings',

--- a/packages/cli/test/build-json-undeclared-key-parity.e2e.test.ts
+++ b/packages/cli/test/build-json-undeclared-key-parity.e2e.test.ts
@@ -256,7 +256,7 @@ describe('#11643 — `os build --json` carries the undeclared-authoring-key warn
         'runtimeModule',
         'runtimeModuleSize',
         'size',
-        'specVersionGap',
+        'protocolVersionGap',
         'stats',
         'success',
         'warnings',

--- a/packages/cli/test/validate-json-warning-parity.e2e.test.ts
+++ b/packages/cli/test/validate-json-warning-parity.e2e.test.ts
@@ -35,7 +35,7 @@
  *
  * The text face folds two more advisory streams into the same `⚠` block that
  * the JSON payload carries as its own top-level fields instead — `conversions`
- * (ADR-0087 D2 load-time conversion notices) and `specVersionGap`. Those are a
+ * (ADR-0087 D2 load-time conversion notices) and `protocolVersionGap`. Those are a
  * declared difference in SHAPE, not a drop: the information is reachable on both
  * faces. Rather than silently ignoring them, every fixture ASSERTS both are
  * empty, so the exact set equality below is honest about its scope — and if a
@@ -242,12 +242,12 @@ describe('#10953 — text and --json carry the same warning set', () => {
       const payload = JSON.parse(json.stdout) as {
         warnings?: unknown;
         conversions?: unknown;
-        specVersionGap?: unknown;
+        protocolVersionGap?: unknown;
       };
 
       // Scope declaration, asserted rather than assumed — see the header.
       expect(payload.conversions, 'fixture must raise no conversion notices').toEqual([]);
-      expect(payload.specVersionGap, 'fixture must raise no spec-version gap').toBeNull();
+      expect(payload.protocolVersionGap, 'fixture must raise no protocol-version gap').toBeNull();
 
       const lines = textWarnings(text.stdout);
       const messages = jsonWarnings(payload);


### PR DESCRIPTION
Fixes #14261

Clause-②: no

Renames the published `--json` payload key `specVersionGap` to `protocolVersionGap` in one
stroke — no alias, no dual-key window, value shape unchanged.

## Why this is a correctness change, not a tidy-up

Because `ManifestSchema` is not `.strict()` and **silently drops unknown keys** (#14192), a
reader who infers a writable `manifest.specVersion` from the key's old name does not get an
error — they get 「一份看起来正常、而那一行从未生效的 manifest」. The output-side breadcrumb
is the same ghost-key mechanism that caused the parent card #13860; this removes it.

## Which option was ruled, and by whom (history, not a question)

Maintainer, 2026-09-02, comment `5507416523`, verbatim:

> 14361 你不处理；14261 现在就改，定位为 minor；其他同意

Option B, now, graded `minor`. Option C (dual keys for a transition window) stays refused,
consistent with the 2026-08-27 ruling 「项目在创业阶段…短期不考虑渐进」.

## The occurrence set, re-derived rather than inherited

`specVersionGap` on `origin/main` at `bccf311100`, measured with a control (`protocolGap`,
which fires 5/4/5 in `compile.ts` / `doctor.ts` / `validate.ts`):

| site | disposition |
|:--|:--|
| `packages/cli/src/commands/compile.ts` — the `os build --json` emit | renamed |
| `packages/cli/src/commands/validate.ts` — the `os validate --json` emit, plus its `--strict` scope comment | renamed |
| `packages/cli/test/build-json-advisory-parity.e2e.test.ts` | pin moved to the new name |
| `packages/cli/test/build-json-undeclared-key-parity.e2e.test.ts` | pin moved to the new name |
| `packages/cli/test/validate-json-warning-parity.e2e.test.ts` — header prose, payload type member, assertion | moved |
| `scripts/pm/check-half-states.mjs:22779` | ⛔ untouched — row H54's anchor fixture is about a card TITLE, not a consumer of the key |
| `packages/cli/CHANGELOG.md` (3 rows) | ⛔ untouched — published release history records what shipped under the old name |

**`os doctor` is NOT a third emitter, measured.** The parent card touched three commands, so
this was checked rather than assumed: `doctor.ts` calls `checkProtocolVersionGap()` and prints
a human-readable line; it has no `--json` face at all. Two emitters, not three.

There is no pending changeset naming the old key — the one the 2026-09-02 ruling asked to move
has since been released into `packages/cli/CHANGELOG.md`, which is history and stays as written.

## ⚠️ Per-PR CI does not run the pins that protect this rename

All three suites carry `*.e2e.test.*`, which `test-nightly-tiers.yml` moved to the **nightly**
tier (#16455). `ci.yml`'s Test Core and the merge queue run under `OS_TEST_TIERS=queue`, which
**excludes** them. So a reviewer reading a green merge queue has not seen these pins pass. They
were driven by hand here, under `OS_TEST_TIERS=nightly`:

```
OS_TEST_TIERS=nightly pnpm --filter @objectstack/cli exec vitest run --maxWorkers=2 \
  test/build-json-advisory-parity.e2e.test.ts \
  test/build-json-undeclared-key-parity.e2e.test.ts \
  test/validate-json-warning-parity.e2e.test.ts
```
`Test Files 3 passed (3)` · `Tests 17 passed (17)` · lock VERDICT `command-exit 0`.

## Ablation — prediction recorded BEFORE any leg ran

For a rename the interesting leg is the one proving the pins bind the **new** name. Predicted,
in writing, before the first mutation: restoring `specVersionGap` at the two emit sites reddens
all three suites by three distinct mechanisms — exact key-set equality in the two build-parity
suites, and `expect(payload.protocolVersionGap).toBeNull()` reading `undefined` in the third
(`toBeNull()` rejects `undefined`, which is what makes that pin non-vacuous).

**Observed: exactly that, all three mechanisms.** `Test Files 3 failed (3)` · `Tests 4 failed | 13 passed`:

```
- "protocolVersionGap",
+ "specVersionGap",              (both build-parity suites, key-set equality)
AssertionError: fixture must raise no protocol-version gap: expected undefined to be null
```

On-disk proof of the mutation, and of the restore, under `trap ... EXIT INT TERM` with absolute
paths:

| | `compile.ts` | `validate.ts` |
|:--|:--|:--|
| HEAD blob | `bbb743b63ef26f27b74c09976993caf838424dc1` | `057339febb0da7c707ae442ec0acf64acd54524d` |
| mutated blob (differs ⇒ reached disk) | `b4fca212193e5e0fa8cfe895d33bc3b0643f6ce2` | `125c64e99ba4b9074e7cd92b9e511ec69a53fcfe` |
| restored blob | `bbb743b6…` — equal to HEAD | `057339fe…` — equal to HEAD |

Anchor counts moved 1→0 (new name) and 0→1 (old name) per file and back. Restore was
`git checkout HEAD -- ABSPATH`, never bare; `git diff HEAD` empty, `git status --porcelain` empty.
No `dist` leg: these suites spawn `bin/run-dev.js` under tsx, which reads `src/`.

## Verification

Every exit code captured by redirect-then-`$?`, never through a pipe.

| what | result |
|:--|:--|
| dependency closure — `pnpm --filter '@objectstack/cli^...' build --concurrency=2` | lock VERDICT `command-exit 0` |
| `pnpm --filter @objectstack/cli build` | VERDICT `command-exit 0` |
| `pnpm --filter @objectstack/cli typecheck` | VERDICT `command-exit 0` — and `check:test-typecheck` compiles the test layer, with all three edited e2e files proven in the program by `tsc -p tsconfig.test.json --listFiles` |
| `vitest run --project unit` | 190 files / 2606 tests pass |
| nightly-tier e2e (the three pins) | 3 files / 17 tests pass |
| `pnpm lint` (`eslint . --no-inline-config`) | exit 0 — **not a narrowing**: the full repo-wide run, 6442 files by eslint's own config, 0 errors / 0 warnings, on `141f5faf66` |
| derived gate family — `dispatch-gates.mjs --commands --repo objectstack-ai/objectstack` | 60 derived, reconciled with `--ran`: **60 run, 0 NOT-MEASURED, 0 UNRUN** |
| the 5 artifact-roster gates whose roster sits under a path in this diff | all exit 0 |

Two of the 60 returned **exit 3 = PREREQUISITE NOT MET**, which is ⛔ not a pass and ⛔ not a
finding — `check:dual-build-cjs-loads` and `check:i18n-coverage` both need a full-repo `pnpm build`
(they name absent `dist/` in studio, client-react, the connectors and several plugins — none of
them a surface this diff touches). Declared as NOT MEASURED locally and left to CI, which builds
the repo fresh.

`check-adr-0087-registration` initially reported a real problem against this diff — a
declared-breaking changeset with no ledger disposition — and is now green with
`not-required (no-migration-prescription)`: the renamed member is an output key on an inline
object literal, with no Zod schema, no `packages/spec` declaration and no stored representation,
so `objectstack migrate meta` has nothing to reach.

## Docs-drift round, on the final head

`check-affected-docs` and `check-drift-comment` both exit 0. Because a published `--json` key is
the kind of thing a page states **by its output**, this was also swept by hand rather than left to
the emitter-only tool: no page under `content/docs/` or `docs/` prints or enumerates either
payload's key set, and the prose-class sweep over pages naming `os validate --json` /
`os build --json` found only flag lists. `docs/` is outside the tool's walk, so it was grepped
directly. **No release page is wrong**, so there is nothing to hand back as a docs-only PR.

## Single-writer

Measured from the open PR list (26 open PRs, 359 (PR, file) rows), each PR against **its own**
merge base via `pulls/{n}/files`, never remote branches. None of the five faces is held by any
open PR. Control fired: `packages/cli/test/i18n-walk-output-parity.test.ts` matched on PR #17223,
so the exact-path matcher was live.

⚠️ The claim-time control named at `5607961637` — `packages/cli/src/commands/generate.ts` held by
#17230 — did **not** fire on re-measure. Reason established rather than assumed: **#17230 merged at
2026-09-09T20:45:29Z**, during this run. Reported as observed; a replacement control was used.

## 验收备注

- `packages/cli/CHANGELOG.md` carries three historical rows naming `specVersionGap`. Left exactly
  as written — they record what shipped under that name and rewriting release history would make
  them false. Not a finding.
- `scripts/pm/check-half-states.mjs:22779` uses this card's own title as row H54's anchor fixture.
  Deliberately untouched: it is a fixture about a title string, not a consumer of the key.
- The source comments at both emit sites previously asserted that the key keeps its published name
  because renaming it is "a break nobody asked for". They are rewritten, not deleted — a stale
  comment asserting the opposite of the code is worse than none.

---
_Generated by [Claude Code](https://claude.ai/code/session_015QE8qk46e5CHJxyQEUjbf8)_