### PR TITLE
docs(pm-dispatch): give the domain:ui lane its versioned job description

### DIFF
--- a/.claude/skills/pm-dispatch/references/lanes/ui.md
+++ b/.claude/skills/pm-dispatch/references/lanes/ui.md
@@ -1,0 +1,38 @@
+# 车道岗位说明:domain:ui
+
+见 SKILL.md 〈多仓协调〉;本文是本席的岗位说明,现值状态恒在座位贴,⛔ 不迁入本文件。
+
+## 形态
+
+- 本席为姊妹仓执行座位:在 objectui 仓认领、派发、复核、落地。
+- ⛔ 不产 `domain:*`、type 与定级,中央分诊唯一生产,见 SKILL.md 多仓协调规则 1 与 4。
+- 误标 ⛔ 不自改:挂 `pm:retriage` 加异议评论同笔,见同节规则 4。
+
+## 范围
+
+- 三流分流的残余流归本席:发布库 `@object-ui/*` 与 `apps/*`,判据见 SKILL.md 〈多仓协调〉。
+- objectui 的 `domain:devx` 与 `domain:spec` 卡归各自跨仓车道,⛔ 不归本席。
+- 症状位置不改流向,docs 随所记录的面走,两条同上节,⛔ 不在此另抄。
+- 落点不明留分诊首触,⛔ 不猜、不代判。
+
+## 常设承诺
+
+- 构建产物经 `pnpm objectui:refresh` 回流,见 SKILL.md 〈多仓协调〉。
+- 回流后的 console pin bump 是 objectstack 的单张卡,⛔ 永不做本仓 PR 的 rider。
+- 凡触 `packages/spec` 一律转 `domain:spec` 座位,见 SKILL.md 〈多仓协调〉。
+- `scripts/pm/**` 单写手恒在 objectstack 侧 ⇒ 本席的工具需求走上游卡带 `Blocked-by:` 回链。
+- 受管面五项含仓根发布 `skills/**`,清单、判据与禁令见 objectui AGENTS.md §9 受管面段。
+- ⇒ 命中即整 PR 停在 draft 等人合,⛔ 不 ready、不入队、不 auto-merge、不自合、不留批准。
+- 未命中的 PR 按同节走合并队列落地;changeset 与版本纪律见 objectui AGENTS.md §9。
+- 半状态巡查在本仓有载体:定时 workflow 与 sweeper 皆在,自 objectstack 移植。
+- 锚 issue 未配置 ⇒ 写锚步骤 skip,发现只落 run summary,绿不等于已交付读锚腿。
+- ⇒ 手工半边照 `hotcrm.md` 那条办,并每轮实测锚是否已配,⛔ 不沿用本行读数。
+
+## 席内判断
+
+- 卡正文是快照不是状态:⛔ 不凭正文单读裁决或派发,读全线程并对 `origin/main` 重测。
+- `pm:queue` 在本仓兼指已分诊与可派发 ⇒ 逐张重验可派性,⛔ 不按标签直派。
+- 零读数恒配点亮的正控,且正控须经被测机制本身生效;本仓 search 假零,查重只引命中。
+- 脚本能滚动不证明用户能滚动:可达性断言必须驱动真实输入管道。
+- 落地验证按内容,正控须在合并前证明会响,⛔ 不按 sha 判已落地。
+- 档位与复核豁免边界读源码与 `references/contract-review.md`,⛔ 不凭记忆或继承的注记。

--- a/scripts/pm/check-skill-line-ratchet.mjs
+++ b/scripts/pm/check-skill-line-ratchet.mjs
@@ -874,6 +874,13 @@ export const CEILINGS = new Map([
   // ruling citations and incident narrative left; every rule stayed. Landed count,
   // headroom 0, same convention (lowering is always legitimate).
   ['.claude/skills/pm-dispatch/references/lanes/spec.md', 43],
+  // domain:ui lane charter — the objectui execution seat's job description. It is
+  // the one lane the multi-repo charter ADDS beyond the domain table, and it was
+  // the only live lane in that directory carrying no versioned charter. A lane
+  // charter is read per seat session like every entry above. Set at the landed
+  // line count read from this ratchet's own run (headroom 0, same convention as
+  // above); it is a NEW file, so this is an added row and no other row moves.
+  ['.claude/skills/pm-dispatch/references/lanes/ui.md', 38],
   // repo:hotcrm lane charter (maintainer rulings 2026-08-20: exemplar-app repo —
   // platform capabilities implemented upstream, 展现平台能力, 不扩散需求, runs on
   // community edition). Set at landed line count (headroom 0, same convention).
@@ -1307,6 +1314,7 @@ export const MAX_TABLE_ROW_BYTES = new Map([
   ['.claude/skills/pm-dispatch/references/lanes/devx.md', 0],
   ['.claude/skills/pm-dispatch/references/lanes/skills.md', 0],
   ['.claude/skills/pm-dispatch/references/lanes/spec.md', 0],
+  ['.claude/skills/pm-dispatch/references/lanes/ui.md', 0],
   ['.claude/skills/pm-dispatch/references/lanes/hotcrm.md', 0],
   ['.claude/skills/pm-dispatch/references/lanes/director.md', 0],
   ['.claude/skills/pm-dispatch/references/lanes/triage.md', 0],


### PR DESCRIPTION
Fixes #17236

`.claude/skills/pm-dispatch/SKILL.md` rules that a lane's 范围与常设承诺 are a job
description, not state, and are versioned in `references/lanes/` under the lane's own
name. The directory held nine such files; `domain:ui` — the one lane the multi-repo
charter itself ADDS beyond the domain table, and the one given the widest residual
scope of objectui's three streams — had none. This PR writes it. ⛔ No lane assignment
changes, ⛔ no SKILL.md edit: the rule is satisfied by the file existing.

## The file — `.claude/skills/pm-dispatch/references/lanes/ui.md` (38 lines, widest line 117 bytes, no table)

```markdown
# 车道岗位说明:domain:ui

见 SKILL.md 〈多仓协调〉;本文是本席的岗位说明,现值状态恒在座位贴,⛔ 不迁入本文件。

## 形态

- 本席为姊妹仓执行座位:在 objectui 仓认领、派发、复核、落地。
- ⛔ 不产 `domain:*`、type 与定级,中央分诊唯一生产,见 SKILL.md 多仓协调规则 1 与 4。
- 误标 ⛔ 不自改:挂 `pm:retriage` 加异议评论同笔,见同节规则 4。

## 范围

- 三流分流的残余流归本席:发布库 `@object-ui/*` 与 `apps/*`,判据见 SKILL.md 〈多仓协调〉。
- objectui 的 `domain:devx` 与 `domain:spec` 卡归各自跨仓车道,⛔ 不归本席。
- 症状位置不改流向,docs 随所记录的面走,两条同上节,⛔ 不在此另抄。
- 落点不明留分诊首触,⛔ 不猜、不代判。

## 常设承诺

- 构建产物经 `pnpm objectui:refresh` 回流,见 SKILL.md 〈多仓协调〉。
- 回流后的 console pin bump 是 objectstack 的单张卡,⛔ 永不做本仓 PR 的 rider。
- 凡触 `packages/spec` 一律转 `domain:spec` 座位,见 SKILL.md 〈多仓协调〉。
- `scripts/pm/**` 单写手恒在 objectstack 侧 ⇒ 本席的工具需求走上游卡带 `Blocked-by:` 回链。
- 受管面五项含仓根发布 `skills/**`,清单、判据与禁令见 objectui AGENTS.md §9 受管面段。
- ⇒ 命中即整 PR 停在 draft 等人合,⛔ 不 ready、不入队、不 auto-merge、不自合、不留批准。
- 未命中的 PR 按同节走合并队列落地;changeset 与版本纪律见 objectui AGENTS.md §9。
- 半状态巡查在本仓有载体:定时 workflow 与 sweeper 皆在,自 objectstack 移植。
- 锚 issue 未配置 ⇒ 写锚步骤 skip,发现只落 run summary,绿不等于已交付读锚腿。
- ⇒ 手工半边照 `hotcrm.md` 那条办,并每轮实测锚是否已配,⛔ 不沿用本行读数。

## 席内判断

- 卡正文是快照不是状态:⛔ 不凭正文单读裁决或派发,读全线程并对 `origin/main` 重测。
- `pm:queue` 在本仓兼指已分诊与可派发 ⇒ 逐张重验可派性,⛔ 不按标签直派。
- 零读数恒配点亮的正控,且正控须经被测机制本身生效;本仓 search 假零,查重只引命中。
- 脚本能滚动不证明用户能滚动:可达性断言必须驱动真实输入管道。
- 落地验证按内容,正控须在合并前证明会响,⛔ 不按 sha 判已落地。
- 档位与复核豁免边界读源码与 `references/contract-review.md`,⛔ 不凭记忆或继承的注记。
```

## Where each line points — ⛔ no rule is restated

The directory exists to prevent 「同一概念两份真理」, so every line that touches a rule
stated elsewhere is a POINTER plus, at most, the one-clause consequence for this seat.

| 段 | 行 | 指向 |
|:--|:--|:--|
| 形态 | 不产 `domain:*` / type / 定级 | SKILL.md 〈多仓协调〉规则 1(中央分诊唯一生产)与规则 4(执行座位信任标签) |
| 形态 | 误标挂 `pm:retriage` | SKILL.md 〈多仓协调〉规则 4 的同一句 |
| 范围 | 残余流 = 发布库 `@object-ui/*` 与 `apps/*` | SKILL.md 〈多仓协调〉的 objectui 三流分流条 |
| 范围 | `domain:devx` / `domain:spec` 归各自跨仓车道 | 同上,三流分流的另外两流 |
| 范围 | 症状位置不改流向、docs 随所记录的面走 | 同上;本文只指,⛔ 不抄 |
| 范围 | 落点不明留分诊首触 | 同节「落点不明留分诊首触」 |
| 常设承诺 | `pnpm objectui:refresh` 产物回流 | SKILL.md 〈多仓协调〉的产物回流条 |
| 常设承诺 | console pin bump 是 objectstack 的单张卡 | SKILL.md 分诊座位职责的 console bump 单条 + 〈多仓协调〉「pin bump 不做 rider」 |
| 常设承诺 | 凡触 `packages/spec` 一律转 `domain:spec` | SKILL.md 〈多仓协调〉规则 5 的同名句 |
| 常设承诺 | `scripts/pm/**` 单写手在 objectstack | SKILL.md 〈多仓协调〉的单写手条;本席的一句后果 = 上游卡带 `Blocked-by:` |
| 常设承诺 | 受管面五项、禁令、合并队列、changeset | objectui `AGENTS.md` §9(受管面段 + 版本号策略);⛔ 本文不复述清单 |
| 常设承诺 | 半状态巡查载体 | 实测,非指针 —— 见下 |
| 席内判断 | 六条 | 现任 `domain:ui @ objectui` 座位贴自己记录的常设判据,⛔ 无一条自创 |

## The one measured claim, and how it was measured

`lanes/hotcrm.md` records its repo's patrol carrier as a fact, so this file does the same
for objectui. Measured on objectui `main` today, not assumed:

- `.github/workflows/half-state-patrol.yml` — present (adopted copy of objectstack's).
- `scripts/pm/check-half-states.mjs` — present, and it is the ONLY file in objectui's
  `scripts/pm/` (so ⛔ no `dispatch-gates.mjs` there; that reading is a per-repo gate fact
  and belongs to `references/platform-readings.md`, ⛔ not to a lane charter).
- The latest scheduled run: job `success`, step **`Update the pinned anchor issue` → skipped**,
  step `Publish the rendered body to the run summary` → success.

⇒ the carrier EXISTS and the run is green, but no anchor issue is configured, so the read-anchor
leg is empty and the findings only reach the run summary. The file states exactly that, names the
manual half (the `hotcrm.md` clause), and requires the seat to RE-MEASURE the anchor each round
rather than inherit this reading.

⚠️ This corrects the dispatch brief's assumption C (「objectui has no `half-state-patrol.yml`」)
and it also corrects the live seat post, which still records the patrol as DEAD here — that was
true until earlier today; the degrade-gracefully fix has since landed and the last two scheduled
runs are green.

## Ratchet registration — ⛔ not a raise

Two rows added to `scripts/pm/check-skill-line-ratchet.mjs`, placed and commented the way the
sibling lane rows are (the `triage.md` row is the model: a NEW file, an added row, no other row
moves):

- `CEILINGS`: `.claude/skills/pm-dispatch/references/lanes/ui.md` → **38** (the landed count, headroom 0)
- `MAX_TABLE_ROW_BYTES`: same key → **0** (the file carries no table)

⛔ No existing ceiling or pin moves; the map-wide total rises by exactly the new file's own count.
The gate's own verdict lines:

```
✓ check-skill-line-ratchet: .claude/skills/pm-dispatch/references/lanes/ui.md: widest table row is 0 bytes (pin 0; headroom 0).
✓ check-skill-line-ratchet: .claude/skills/pm-dispatch/references/lanes/ui.md is 38 lines (ceiling 38; headroom 0).
```

The self-test does NOT pin a `CEILINGS` key COUNT and does NOT pin a lanes-directory file list —
it DERIVES the roster from disk (`laneFilesOnDisk()` + `laneRosterVerdict`), and an empty roster is
red rather than vacuously green. So there is no count to move in this PR; the new file simply had
to carry a row or that derived assertion would have gone red. `--self-test`: **157 cases pass**.

## 维护者速读(草稿)

### 改了什么
给 `domain:ui`(objectui 前端执行席)补上它的岗位说明文件,并把该文件登记进技能行数棘轮。
没有改任何路由规则、没有改 SKILL.md、没有动 objectui 仓的任何文件。

### 为什么改
派发协议里写着「每个车道的范围与常设承诺版本化在车道文件里」,但九个车道文件里恰恰缺 `domain:ui`
这一个 —— 而它是协议自己新增、且承接面最宽的那个车道。规则有、载体无,新座位上任只能靠口口相传和
翻座位贴,容易把「现值状态」当成「岗位说明」继承下去。

### 风险与代价(含回滚)
代价是多一个每次座位会话都要读的文件(38 行,已按 headroom 0 登记,之后再长必须先删内容)。
风险主要是「写重复」—— 若把 SKILL.md 已有的规则再抄一遍,就制造了第二份真理,以后两边会漂移。
本 PR 的写法是逐行指针,上面「Where each line points」表可逐条复核。回滚 = 删文件 + 撤两行登记,
无其它依赖,不影响任何运行时行为。

### 席位意见

### 你要做的
确认两点即可合并:①「半状态巡查」那三行是本文件唯一的实测事实,读起来是否是你要的记录方式;
② 席内判断六条是否都值得作为该席的常设判据(它们全部取自现任座位贴,⛔ 无一条自创)。

## Acceptance notes

- 受管面(`.claude/**`)⇒ 本 PR 停在 draft 等人合;⛔ 未 ready、未入队、未 auto-merge、未留批准。
- `skip-changeset`:`.claude/**` 与 `scripts/pm/**` 都不在任何包的 `files[]` 发运面内,不发布任何东西;
  ⛔ 未创建 changeset,也没有任何门禁要求一个。
- 门禁:`dispatch-gates.mjs --commands` 推导出 37 条,全部前台跑绿(`check:pm-dispatch-gates` 因
  超前台上限改 detach + `tail --pid`)。一条 `check:doc-formula-expressions` 首次以 **exit 3
  = PREREQUISITE NOT MET** 返回(它自己印明「Nothing was measured … NOT a finding」),按它给的
  命令建好 `@objectstack/formula` + `@objectstack/lint` 后重跑,exit 0。
- ⛔ 文件内不出现 issue 编号(`check:pm-skill-id-lint` 机械强制),所以本文件对姊妹卡与事故一律不引号。
- filed as #17244:`.claude/agents/os-dev.md` 有一行写「姊妹仓(objectui / cloud)没有 `scripts/pm/`」,
  实测 objectui 有 `scripts/pm/check-half-states.mjs` 与它的定时 workflow。该行的操作性结论(objectui 没有
  `dispatch-gates.mjs`,门禁族要手工推)仍然成立,错的是它给出的前提面 —— 而本次派发词的假设 C 正是同一个
  前提,差一步就被版本化进受管文件。⛔ 本 PR 不修它:不同文件、不同卡。
- noted, not filed:现任 `domain:ui` 座位贴仍记「半状态巡查在本仓 DEAD」,已被今日两次绿跑推翻;
  座位贴是现值状态、由在任座位 PM 单写,⛔ 不是本 PR 能碰的东西。承接者:该席下一轮刷新。

---
_Generated by [Claude Code](https://claude.ai/code/session_01MoTv7pn338AZ71owsp19gQ)_