### PR TITLE
docs(spec): cite engine symbols, not line numbers, in functional-completeness

### DIFF
--- a/.changeset/spec-functional-completeness-symbol-anchors.md
+++ b/.changeset/spec-functional-completeness-symbol-anchors.md
@@ -1,0 +1,29 @@
+---
+"@objectstack/spec": patch
+---
+
+docs(spec): `functional-completeness`'s three `objectql/engine.ts` citations name symbols instead of line numbers (#16960)
+
+The module doc block of `kernel/functional-completeness.ts` cited the runtime that
+justifies each rule by line number. All three had rotted: re-measured on `origin/main`
+`7ddf13dca` (`engine.ts` is 15,309 lines), the quoted texts live at 8630, 8978 and 921
+against cited 3001, 3191 and 346 — drifts of 5,629, 5,787 and 575. Each quoted text
+occurs exactly once in `engine.ts`, so those are readings rather than artefacts.
+
+The citations are the only limb tying a rule's justification to the runtime that
+implements it, and that limb is walked by a human reading it — nothing in the module can
+notice the runtime moved. `:3191` was the dangerous one: the line it names today is
+ordinary-looking `dispatch:` code, so a reader following it lands somewhere plausible and
+never learns they were sent to the wrong place.
+
+Each now names the enclosing symbol in the repo-root `path#symbol` form
+`packages/spec/liveness/field.json` already uses —
+`packages/objectql/src/engine.ts#buildSummaryIndex`, `#planFormulaProjection`,
+`#expandRelatedRecords` — beside the verbatim snippet. A corrected line number would rot
+again on the next refactor; a symbol plus a unique snippet is greppable and survives
+movement. The anchor form also moves these three from
+`check-spec-docblock-symbol-anchors`' not-judged bucket into resolution (that gate now
+reports `3 symbol (3 declaration)` where it reported `0`), so a rename reddens CI.
+
+Doc text only — no schema, export, type or runtime behaviour changes. It ships because
+this block is emitted into the published `dist/kernel/index.d.ts`.

--- a/packages/spec/src/kernel/functional-completeness.ts
+++ b/packages/spec/src/kernel/functional-completeness.ts
@@ -19,7 +19,7 @@
  * duplicate rules onto it so the AI-build path cannot drift from the framework
  * (ADR-0078 §2 — the path-asymmetry the ADR exists to kill).
  *
- * ## Discipline: every rule here cites the runtime line that makes it true
+ * ## Discipline: every rule here cites the runtime site that makes it true
  *
  * The completeness audit's scariest candidate (a "fail-open sharing rule")
  * collapsed on a three-file read, and this campaign shipped four confidently
@@ -28,12 +28,16 @@
  * recorded with the evidence that exempts it. The codebase can be asked;
  * these were:
  *
- * - `summary` w/o `summaryOperations` → `objectql/engine.ts:3001`
+ * - `summary` w/o `summaryOperations` →
+ *   `packages/objectql/src/engine.ts#buildSummaryIndex`, verbatim
  *   `if (d?.type !== 'summary' || !d.summaryOperations) continue;`
- * - `formula` w/o `expression` → `objectql/engine.ts:346` builds the formula
- *   plan only from fields WITH an expression; a bare formula never computes.
- * - `lookup`/`master_detail` w/o `reference` → `objectql/engine.ts:3191`
- *   `$expand` `if (!referenceObject) continue;` — the relationship silently
+ * - `formula` w/o `expression` →
+ *   `packages/objectql/src/engine.ts#planFormulaProjection`, verbatim
+ *   `def?.type === 'formula' && def.expression`: it builds the formula plan
+ *   only from fields WITH an expression, so a bare formula never computes.
+ * - `lookup`/`master_detail` w/o `reference` →
+ *   `packages/objectql/src/engine.ts#expandRelatedRecords` (`$expand`),
+ *   verbatim `if (!referenceObject) continue;` — the relationship silently
  *   never resolves, and the record picker has no target to search.
  * - `select`/`radio` w/o `options` → `record-validator.ts`'s `validateOne`,
  *   verbatim `allowed.length > 0 && !allowed.includes(String(value))`: an


### PR DESCRIPTION
Fixes #16960

```
Clause-②: no
```

The module doc block of `packages/spec/src/kernel/functional-completeness.ts` cited the runtime that justifies each rule by line number. All three `objectql/engine.ts:NNNN` citations had rotted. Each now names the enclosing symbol plus the verbatim snippet.

## Re-measured on current `origin/main`

⛔ Not transcribed from the card. Ref: `origin/main` `7ddf13dca` (branch point). `packages/objectql/src/engine.ts` is **15,309** lines — it moved since the card's `97adce2fa` reading of 15,020, and every drift figure moved with it.

| citation | quoted text | `grep -cF` | actual line | drift | card said |
| --- | --- | --- | --- | --- | --- |
| `engine.ts:3001` | `if (d?.type !== 'summary' \|\| !d.summaryOperations) continue;` | **1** | **8630** | **5,629** | 8520 / 5,519 |
| `engine.ts:3191` | `if (!referenceObject) continue;` | **1** | **8978** | **5,787** | 8868 / 5,677 |
| `engine.ts:346` | `def?.type === 'formula' && def.expression` | **1** | **921** | **575** | 859 / 513 |

Uniqueness holds at **1 / 1 / 1**, so "the text is at line N" is a reading and not an artefact. No snippet needed lengthening and none had vanished — the card's premise stands, only its arithmetic aged.

## What a reader following each stale citation lands on today

```
:346   (blank line, between ENGINE_QUERY_SLOTS and the next doc block)
:3001    * undefined`. The runtime layer sets this once per engine (same boot point
:3191        dispatch: { ...(batchCtx.dispatch as object), index } as HookContext['dispatch'],
```

`:3191` is still the dangerous one, and it has drifted onto *different* plausible code than the card recorded: a `dispatch:` property in a per-row hook-context build rather than the `for` loop the card saw. A reader lands on something that reads like a real answer and never learns they were sent to the wrong place.

## Before / after

| | before | after |
| --- | --- | --- |
| `summary` | `` `objectql/engine.ts:3001` `` | `` `packages/objectql/src/engine.ts#buildSummaryIndex` `` + verbatim snippet |
| `formula` | `` `objectql/engine.ts:346` builds the formula plan… `` | `` `packages/objectql/src/engine.ts#planFormulaProjection` `` + verbatim snippet |
| `lookup`/`master_detail` | `` `objectql/engine.ts:3191` `` | `` `packages/objectql/src/engine.ts#expandRelatedRecords` `` + verbatim snippet |

Both `buildSummaryIndex` and `expandRelatedRecords` are private methods of `export class ObjectQL` (declared at `engine.ts` line 2573, closing at 14757); `planFormulaProjection` is module-level.

## The anchor form is load-bearing, not cosmetic

The repo-root `path#symbol` form is the one `packages/spec/liveness/field.json` already uses (`packages/objectql/src/engine.ts#expandRelatedRecords`), and it does more than read well:

`scripts/check-spec-docblock-symbol-anchors.mjs` (registered by #17065 on 2026-09-09, **after** this card was filed) judges `packages/spec/src/**` doc-block anchors. It declares `judgeUntrackedLineAnchors: false`, and the old citations spelled a *relative* `objectql/engine.ts`, which names no tracked file — so all three sat in its not-judged bucket. Measured both ways on this tree:

```
pre-fix  ✅ … 0 NEW line anchors …  (183 citations name no tracked file and are not judged)
post-fix ✅ … 0 symbol …            (180 citations name no tracked file and are not judged)
probe    ✅ … 3 symbol (3 declaration, 0 literal) …  (180 not judged)
```

The delta is exactly 3 — these citations were precisely the difference. In anchor form the gate **resolves** them (`3 symbol (3 declaration)` where it reported `0`), so renaming any of the three methods now reddens CI instead of rotting silently. That is a stronger outcome than the card's criterion asked for, at no cost to it.

## One extra word, declared

The section heading read *"every rule here cites the runtime **line** that makes it true"*. That sentence is the instruction that produced this drift, and after this change it describes none of the block's citations. Corrected to *"the runtime **site**"* — one word, same doc block, same write surface. Called out here so it is reviewed rather than absorbed.

## Scope

- Write surface: `packages/spec/src/kernel/functional-completeness.ts` + one changeset. `packages/objectql/src/engine.ts` was read-only — it is where the truth was measured, not where the fix lands.
- ⛔ Not widened into a repo-wide anchor gate. That is #16441's closing question; a view on it is in the report for the seat to file, and is ⛔ not filed here.
- ⛔ Not rework on #16441. That card's census was `record-validator.ts`-only by design; its dev measured these three, left them and reported them. The fence held.

## Changeset — derived, not inherited

`packages/spec`'s `files[]` carries `dist`, and `src/kernel/index.ts:142` re-exports this module (`export * from './functional-completeness'`). Measured after `pnpm --filter @objectstack/spec build`: the edited prose reaches `dist/kernel/index.d.ts` (and `.d.mts`) at line 5186, verbatim anchors included, with two positive controls from the same file also landing. Published text moves ⇒ a **`patch`** changeset is owed and `skip-changeset` would have been wrong.

## Verification

Derived with `node scripts/pm/dispatch-gates.mjs --commands --repo objectstack-ai/objectstack`, then re-derived once the changeset existed (it added 5 commands) and those run too. All exit 0:

- `check-spec-docblock-symbol-anchors` + `--self-test`; `check:nul-bytes`; control-byte scan of the touched file (no hits)
- `pnpm --filter @objectstack/spec check:generated` — all 15 generated artifacts up to date
- spec `check:api-surface` · `check:docs` · `check:authorable-surface` · `check:liveness` · `check:exported-any` · `check:dual-source-exports` · `check:llms-txt` · `check:empty-state` · `check:skill-refs` · `check:variant-docs` · `check:objectui-pin-citations`
- changeset family: `check-changeset-no-major` (+self-test) · `check-adr-0087-registration` · `check-changeset-fixed` · `check:changeset-gate-self-tests` · `check-empty-changeset` (+self-test) · `check:objectui-changeset` · `check:pm-changeset-deadline-census` · `release-rehearsal-clone --self-test`
- `check:doc-authoring` · `check:published-files` · `check:cross-package-test-inputs` · `check:test-source-alias` · `check:dts-closure` · `check-closing-keyword-parity` · `check-comment-mask-adoption` · `check-system-context-census` · `check-keyed-text-bounds` · `check-undeclared-dep-imports` · `docs-audit/check-affected-docs`
- `pnpm --filter @objectstack/spec test` — **470 files / 13,218 tests passed**
- `pnpm --filter @objectstack/spec typecheck` — exit 0
- `pnpm lint` repo-wide (`eslint . --no-inline-config`) at `973daafe2` — **6,466 files, 0 errors, 0 warnings**. Run in full, so no narrowing argument is claimed.

Heavy runs went through `scripts/pm/os-verify-lock.sh`; exit codes were landed to disk before reading, never through a pipe.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MkQhmuuJAVDjmeWNixwDDH)_