### PR TITLE
docs(ui): state the one-app-per-package rule where an app author reads it, and cite the ADR that says so

### DIFF
--- a/.changeset/one-app-rule-adr-0019-citation.md
+++ b/.changeset/one-app-rule-adr-0019-citation.md
@@ -1,0 +1,17 @@
+---
+"@objectstack/spec": patch
+---
+
+fix(spec): the one-app-per-package refusal cites the record it means, `ADR-0019 (app-as-consumer-unit) D3`
+
+`ADR-0019` names **two** records in this repository — `0019-app-as-consumer-unit` (D3 = a `type: 'app'` package defines at most one app) and `0019-approval-as-flow-node` (D3 = deprecating `ApprovalProcessSchema`). Both have a D3, and `stack.zod.ts` cited the bare number for both, so an author following the refusal's own citation was as likely to reach the wrong decision record as the right one.
+
+The three citations of the app-cap rule now name the record:
+
+- the `STACK_SINGLE_APP_VIOLATION` message — the only one an app author ever sees;
+- the `validateSingleApp` docblock;
+- the `StackSingleAppViolationError` docblock.
+
+Only the message tail changed: `An 'app' package must define at most one app, but found N (…)` is untouched, so any consumer matching on that prefix is unaffected. The rule, the refusal's condition and `defineStack`'s behaviour are unchanged.
+
+The approvals-side citations are deliberately left bare — repo-wide ADR-number disambiguation is tracked separately.

--- a/content/docs/ui/audience-based-interfaces.mdx
+++ b/content/docs/ui/audience-based-interfaces.mdx
@@ -18,6 +18,8 @@ description: The same data serves different audiences. Give end users a curated 
 
 The built-in permission sets already encode this split: `member_default` and `viewer_readonly` do **not** carry `studio.access` / `manage_metadata`, so Studio and schema-design surfaces are invisible to them; `admin_full_access` carries both, while `organization_admin` gets `setup.access` only — the Setup shell is reachable but Studio and schema design stay hidden from org-scoped admins (see [`default-permission-sets.ts`](https://github.com/objectstack-ai/objectstack/blob/main/packages/plugins/plugin-security/src/objects/default-permission-sets.ts)).
 
+**One package, one app.** A package of `type: 'app'` exposes **exactly one** App — `defineStack` refuses a second at load, per ADR-0019 (app-as-consumer-unit) D3. More audiences therefore never mean more apps: they are navigation groups **inside** that one app, gated by `requiredPermissions` exactly as below.
+
 ### 1. Gate the app and its navigation
 
 ```ts
@@ -68,6 +70,6 @@ This is the lesson from Airtable's surfaces: the **Automations tab is visible to
 
 ## See also
 
-- Decision records: **ADR-0047** (run modes), **ADR-0066** (unified authorization, dual-surface gates).
+- Decision records: **ADR-0019** (app-as-consumer-unit — one app per package), **ADR-0047** (run modes), **ADR-0066** (unified authorization, dual-surface gates).
 - [Who can see data / automation / interface](/docs/permissions/access-recipes).
 - Guide: [Security](/docs/permissions); reference: [App schema](/docs/references/ui/app), [Permission schema](/docs/references/security/permission).

--- a/packages/spec/src/stack.zod.ts
+++ b/packages/spec/src/stack.zod.ts
@@ -1460,7 +1460,7 @@ function validateNamespacePrefix(config: ObjectStackDefinition): string[] {
 }
 
 /**
- * Validate the "at most one App per package" rule — ADR-0019 (D1/D3).
+ * Validate the "at most one App per package" rule — ADR-0019 (app-as-consumer-unit) D1/D3.
  *
  * A consumer package (`manifest.type === 'app'`) must not define **more than
  * one** app — that is the banned "suite contains apps" shape. Fold the apps
@@ -1479,7 +1479,7 @@ function validateSingleApp(config: ObjectStackDefinition): string[] {
   const names = apps.map((a) => a.name).join(', ');
   return [
     `An 'app' package must define at most one app, but found ${apps.length} (${names}). ` +
-      `Fold them into one app with multiple tabs, or split into separate packages (ADR-0019 D3).`,
+      `Fold them into one app with multiple tabs, or split into separate packages — ADR-0019 (app-as-consumer-unit) D3.`,
   ];
 }
 
@@ -1943,7 +1943,8 @@ class StackNamespacePrefixInvalidError extends StackRefusalError {
 
 /**
  * [ADR-0112 · #15963] An `app` package declares more than one app — the banned
- * "suite contains apps" shape, ADR-0019 D3 — {@link validateSingleApp}.
+ * "suite contains apps" shape, ADR-0019 (app-as-consumer-unit) D3 —
+ * {@link validateSingleApp}.
  * Spelled `_VIOLATION` like the ledger's other rule-violation refusals
  * (`UNIQUE_VIOLATION`, `EXTERNAL_SCHEMA_MODE_VIOLATION`).
  */


### PR DESCRIPTION
Addresses items 1 and 3 of #16565. **This PR does not close that card** — item 4 (an author-time `packages/lint` rule) is deliberately not taken, and item 2 ships as a separate governed PR. #16565 stays open; no closing keyword is used here.

**Clause-②**: no — the diff puts no new key on any published payload: one docs sentence, one See-also entry, and three citation strings inside an existing function and two docblocks. No export is added, no schema member appears, no payload shape moves. This agrees with the claim comment on #16565. The measured `patch` grading stands.

Companion, kept out of this diff on purpose: `claude/issue-16565-one-app-rule-ui-skill` (item 2). `skills/**` is a governed surface and a mixed diff is governed whole, so it is a separate draft PR for manual merge.

## What an author reads today

`defineStack` refuses a second app in a `type: 'app'` package, loudly and immediately. The rule is right. The problem is that nothing an app author reads states it, so the refusal is discovered after the architecture is designed against a shape the platform will not accept.

`content/docs/ui/audience-based-interfaces.mdx` is the sharpest miss: it is *the* page about serving several audiences, and its worked example is already the correct pattern — one `crm` app whose navigation is gated by `requiredPermissions`. It demonstrates the rule and never claims it, so a reader designing for three business audiences sees a page about gating, not a page about a cap.

## Re-derived measurements

Every zero below has a same-corpus positive control taken in the same pass, on `origin/main` at `b90aff81f2`.

```
content/docs/ui/audience-based-interfaces.mdx   (BEFORE)
  'exactly one app'                                       0
  'only one app'                                          0
  'at most one app'                                       0
  ADR-0019                                                0
  positive control  requiredPermissions                   4   -> right page
  positive control  'ADR-'                                4   -> the page DOES cite ADRs
  negative control  'zzz-nonsense-control-zzz'            0
```

The `ADR-` control matters on its own: the page cites ADR-0047 and ADR-0066 four times between them, so the zero for `ADR-0019` is a reading about that number and not an artefact of a page that cites no decisions.

## The citation is ambiguous, and the evidence is inside one file

`ADR-0019` names two records here — `docs/adr/0019-app-as-consumer-unit.md` (D3 = the one-app rule) and `docs/adr/0019-approval-as-flow-node.md` (D3 = deprecating `ApprovalProcessSchema`). Both exist, both have a D3, and the collision is already frozen on `check-adr-anchors.mjs`'s shrink-only `KNOWN_NUMBER_COLLISIONS`.

Anchored by content, `packages/spec/src/stack.zod.ts` cited the bare number for **both** records:

| site (content-anchored) | record meant | before |
|---|---|---|
| `flows` field docblock, "approvals are no longer a top-level collection" | approval-as-flow-node | bare |
| `guidance.approvals` | approval-as-flow-node | bare |
| `guidance.approvalProcesses` | approval-as-flow-node | bare |
| `validateSingleApp` docblock | app-as-consumer-unit | bare |
| the `STACK_SINGLE_APP_VIOLATION` message | app-as-consumer-unit | bare |
| `StackSingleAppViolationError` docblock | app-as-consumer-unit | bare |

One file, one bare number, two different records, both with a D3. An author following the refusal's own citation was as likely to reach the wrong record as the right one.

## Decision on the two docblocks — stated, not silent

The card names the throw. Two further citations of **the same rule** sit in the same file: the `validateSingleApp` docblock immediately above the message, and the `StackSingleAppViolationError` docblock. (The second was not in the dispatch's measurement; it is a third app-cap site, found by content.)

**All three are disambiguated.** Fixing only the message would leave the paragraph that produces it saying `ADR-0019` bare two lines higher — the same fork, re-created for the next reader, and fixing one docblock but not the other would be the same fault at one remove. The three sites are one rule, in one file; that is the occurrence this card is about.

**The three approvals-side citations are deliberately left bare.** Disambiguating those is the other half of the collision and belongs to a repo-wide sweep, not here.

Only the message tail moved. `An 'app' package must define at most one app, but found N (...)` is byte-identical, so the two suites that pin it (`stack.test.ts`, `stack-refusal-envelopes.test.ts`, both matching on `at most one app`) are unaffected. The rule, the refusal's condition and `defineStack`'s behaviour are unchanged.

## Changeset: measured, not defaulted

`skip-changeset` does **not** apply. Measured after a real build of `@objectstack/spec`:

```
packages/spec/package.json files[]  ->  ["dist", ..., "src/**/*.zod.ts", ...]
  src/stack.zod.ts matches src/**/*.zod.ts        true   -> the edited file is itself published

grep over the published dist/:
  'app-as-consumer-unit'                             4    dist/index.js, dist/index.mjs,
                                                          dist/browser/index.js, dist/browser/index.mjs
  'separate packages (ADR-0019 D3)'  (old spelling)  0
  positive control 'must define at most one app'    28
  negative control 'zzz-nonsense-zzz'                0
```

Published bytes move on two independent routes, so this carries a real changeset, graded **patch**: a user-visible message string improves, no API shape moves, no behaviour changes.

## Verification

Gate family derived from the diff rather than recalled — `node scripts/pm/dispatch-gates.mjs --commands --repo objectstack-ai/objectstack`, reconciled afterwards with `--ran`:

```
Run reconciliation - 96 derived, 96 run, 0 NOT-MEASURED, 0 UNRUN.
```

Three gates first returned `PREREQUISITE NOT MET` (exit 3 twice, plus `check:skill-examples` refusing on an unbuilt `client-react`). Exit 3 is NOT MEASURED, neither green nor red, so each was driven to a real verdict after the missing builds — all three then exit 0. The six roster gates whose allowlists sit under a path in this diff were run explicitly rather than read as silent.

```
pnpm --filter @objectstack/spec test        470 files / 13233 tests passed
pnpm --filter @objectstack/spec typecheck   OK (test layer compiles; debt ledger held)
pnpm lint                                   exit 0  (repo-wide, eslint . --no-inline-config)
node scripts/check-skills-token-ratchet.mjs exit 0  (this diff moves no skill file)
```

`pnpm lint` was run whole rather than narrowed, so no narrowing needs declaring. Build and test ran through `scripts/pm/os-verify-lock.sh`; verdicts read from its `VERDICT command-exit` lines, never a bare `$?`.

## Acceptance notes (not filed as cards)

- Bare `ADR-0019` still means the app cap in `packages/spec/src/api/error-code-ledger.zod.ts`, `examples/app-showcase/src/coverage.ts`, `examples/app-showcase/src/security/permission-sets.ts` and `docs/adr/0130-release-artifact-as-co-ownership-boundary.md`. Left alone: `check-adr-anchors.mjs`'s header records that slug-qualifying the three frozen collisions is separate work "amortised as those files are touched", which is exactly the disposition applied here.
- `docs/adr/0130-release-artifact-as-co-ownership-boundary.md` names `docs/adr/0019-app-as-consumer-unit.md` twice in one parenthesis, where the second path looks like it was meant to be something else. A one-line doc nit in a file this PR does not touch.
- The one-app rule is also absent from `skills/objectstack-ui/rules/navigation.md`, which is at its token ceiling (2273/2273, headroom 0) — the same budget wall the companion PR reports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012GKcPZbMoGq7WPzKLfRBTU

---
_Generated by [Claude Code](https://claude.ai/code)_