### PR TITLE
docs(pm-dispatch): three measured container readings into the platform table (419 to 422)

### DIFF
--- a/.claude/skills/pm-dispatch/references/platform-readings.md
+++ b/.claude/skills/pm-dispatch/references/platform-readings.md
@@ -104,6 +104,7 @@
 - `/rate_limit` 照答 200,兼任不了探针;403 后凭据形态判别见 `rest-channel.md`。
 - 门态逐会话变,同窗顶层席可分裂成两 403 一 200 ⇒ ⛔ 不据他席、他日读数推本席。
 - 门开会话实测通道宽于标签:issue POST 201、评论写、卡与评论读同通,加法 POST 200。
+- 标签事件流 `GET /issues/{n}/events` 归门态:200 带 labeled/unlabeled 名与时刻,三容器两通一 403。
 - 门关着时的降级梯 ①:git 先行,走下方零成本等价物。
 - 降级梯 ②:公开仓 payload 档。③:MCP —— search 定向一击、单标签读全加求交。④:等重置。
 - CCR 容器的 GitHub 出口是代理加凭据的:无 header 的 REST 读回 200 带会话身份,core 上限 15000。
@@ -259,6 +260,7 @@
 - ③:裸名 grep 被幸存家族当子串命中 —— 退役核验带引号精确名。
 - 更硬判据是查声明式 `^(export )?(const|type|interface) <Name>\b` 而非查提及。
 - ④:浅检出上的历史读数不可信 —— `merge-base --is-ancestor` 假非祖先、`rev-list --count` 截断。
+- ④ 里最静默的是窗口式 `git log --grep`:回 0 结果、exit 0、无警告,读作该提交从不存在。
 - 同族 `branch -r --contains` 零输出;先 `--deepen` 再判,或走 REST `compare`。
 - ⑤:容器里没有 `gh`,于是 `gh … || echo "none"` 是不可证伪的否定。
 - 127 命令不存在与 grep 没命中输出同值 ⇒ 回退分支照打印安心结论而一次都没检查。
@@ -379,6 +381,7 @@
 - corepack 下载 pnpm 可在检查体开跑前崩 undici(`assert(!this.paused)`)⇒ 是基础设施红。
 - 落地探针除命名代码形外,还必须在落地前的 tip 上读出不同值,否则它分不开两棵树。
 - `check-governed-merges` 浅克隆上拒答而非少报,并报未审计仓数;补救 `git fetch --shallow-since=`。
+- ⛔ 不越过该拒答自行枚举:短清单读作合规;加深日期取窗口起点之前,不猜深度。
 - 前台 `sleep` 被 harness 拒 ⇒ 等待写成带 until 条件的前台阻塞等待,⛔ 不写 sleep 轮询循环。
 - `check:pm-dispatch-gates` 逾容器 600 秒前台上限 ⇒ detach 加 `tail --pid` 前台等;超时不是读数。
 - 分支删除被拒有第二形态:代理回 403,与既有 send-pack 断连同处置 ⇒ 不可删,⛔ 不重试。

--- a/scripts/pm/check-skill-line-ratchet.mjs
+++ b/scripts/pm/check-skill-line-ratchet.mjs
@@ -704,7 +704,36 @@ export const CEILINGS = new Map([
   // the fourth increment MEASURED zero line-neutral folds among this file's
   // adjacent rule pairs, and re-wrap funding is refused per the 2026-08-17 rule
   // in any case. Landed count, headroom 0, same convention.
-  ['.claude/skills/pm-dispatch/references/platform-readings.md', 419],
+  // Raised 419 → 422 by the NINTH readings increment, again under the STANDING
+  // one-file exception quoted above rather than a fresh decision card, and again
+  // recorded as a `ruledRaises` record citing it. Spent at ONE line per
+  // deduplicated reading, each written in this file's voice: the label-event
+  // stream `GET /issues/{n}/events` follows the SESSION GATE rather than being
+  // shut fleet-wide — 200 carrying each labeled/unlabeled name and timestamp,
+  // measured two-through-one-403 across three containers (+1); the quietest
+  // member of the shallow-checkout trap family is a WINDOWED `git log --grep`,
+  // which answers 0 results with exit 0 and no warning, so the reading drawn is
+  // "that commit never existed" (+1); and the response to
+  // `check-governed-merges`'s refusal is to deepen from a date BEFORE the
+  // window, never to enumerate past it, because a short list reads as
+  // COMPLIANCE (+1) = +3 exactly.
+  //
+  // ⚠️ The candidate set was larger than what landed, and the cut is the
+  // exception's own dedup condition doing its work rather than an author
+  // trimming: the authenticated 15,000 quota and the round-opening `rate_limit`
+  // read are already here, `/timeline` is already named twice (the
+  // queue-membership discriminant and the red-window row), "the gate forks per
+  // session, ⛔ never inherit another seat's 403" is already here, and the
+  // shallow clone's refusal-with-remedy is already the `check-governed-merges`
+  // row this increment appends to — that row carries the literal
+  // `git fetch --shallow-since=` spelling, so the dispatch's reading that this
+  // file holds ZERO lines on the shallow family was falsified on the tree before
+  // any line was written. Candidates 7 / landed 3 / already present 4 /
+  // refused 0. Nothing was paid in place: the fourth increment MEASURED zero
+  // line-neutral folds among this file's adjacent rule pairs, and re-wrap
+  // funding is refused per the 2026-08-17 rule in any case. Landed count,
+  // headroom 0, same convention.
+  ['.claude/skills/pm-dispatch/references/platform-readings.md', 422],
   // Per-operation REST/GraphQL/git channel mapping — which fleet operation has
   // a REST twin (each row executed in a real session, provenance date carried
   // per row), the handful that are GraphQL-only, and the queue-routing
@@ -1225,6 +1254,23 @@ export const CROSS_FILE_MOVES = new Map([
             + '逐条核实、去重计数(候选/落地/已有/拒收)、一事一行、不计重排」',
           date: '2026-09-09',
           delta: 17,
+        },
+        {
+          // The NINTH increment, under the same STANDING exception — the same
+          // words again, for the same reason: a record that quotes no ruling is
+          // RED and each record stands alone. The +3 is accounted for line by
+          // line beside this entry's ceiling above, and the exception's own
+          // conditions (per-item verification and the candidate / landed /
+          // already-present / refused counts) are carried by the raising PR's
+          // dedup table and the seat's ACCEPT.
+          ruling:
+            'the standing one-file exception for'
+            + ' `.claude/skills/pm-dispatch/references/platform-readings.md` — pm-dispatch'
+            + ' SKILL.md, verbatim and untranslated: 「唯一例外:`platform-readings.md`'
+            + ' 增量抬上限到落地行数,免决策卡,记 `ruledRaises` 引常设裁决。条件:席位验收评论'
+            + '逐条核实、去重计数(候选/落地/已有/拒收)、一事一行、不计重排」',
+          date: '2026-09-10',
+          delta: 3,
         },
       ],
       sources: [


### PR DESCRIPTION
Fixes #17308

Two measured container facts from the triage seat's handover, landed as terse rows in
`.claude/skills/pm-dispatch/references/platform-readings.md` — **deduplicated against what the
table already says**, which is why three lines land rather than the seven the readings offered.

## The rows, verbatim, with the section each landed in

**`## API 配额`** — inserted directly under the gate-open channel row (「门开会话实测通道宽于标签…」),
which is where its neighbours live:

```
- 标签事件流 `GET /issues/{n}/events` 归门态:200 带 labeled/unlabeled 名与时刻,三容器两通一 403。
```

**`## 读数陷阱`** — inserted inside trap ④'s shallow-checkout family, between the trap row
(「④:浅检出上的历史读数不可信…」) and its remedy row (「同族 `branch -r --contains` 零输出;先 `--deepen` 再判…」),
so the family's trap-then-remedy ordering survives:

```
- ④ 里最静默的是窗口式 `git log --grep`:回 0 结果、exit 0、无警告,读作该提交从不存在。
```

**`## 读数陷阱`** — inserted directly under the `check-governed-merges` row
(「`check-governed-merges` 浅克隆上拒答而非少报…补救 `git fetch --shallow-since=`。」), the row it extends:

```
- ⛔ 不越过该拒答自行枚举:短清单读作合规;加深日期取窗口起点之前,不猜深度。
```

Assumption C measured rather than assumed: the file has exactly six `##` sections and no
核验 / 树读数 section — the git/tree readings live in `## 读数陷阱`, so that is where two of the
three landed. Widest row: 117 bytes / 101 display columns, against the file's widest existing
bullet (114 columns) and the ratchet's 120-byte line cap. No table rows.

## 去重计数 — 候选 7 / 落地 3 / 已有 4 / 拒收 0

| # | Candidate reading | Verdict | Evidence on the tree |
|---|---|---|---|
| 1 | `issues/{n}/events` is readable, and what it returns | **landed** | zero hits for the endpoint anywhere in the file |
| 2 | `/timeline` is readable | 已有 | `:10`–`:11` (the queue-membership discriminant, with the full spelling) and `:133` (the red-window row) |
| 3 | `rate_limit` shows the authenticated 15000, not the anonymous 60 | 已有 | `:104` (it answers 200 regardless, so it cannot double as the probe), `:109` (proxy-and-credential egress, core 15000), `:147` (read it at round open) |
| 4 | The gate forks per container, so probe rather than inherit a 403 | 已有 | `:100`, `:101`, `:105` (「门态逐会话变…⛔ 不据他席、他日读数推本席」) |
| 5 | Windowed `git log --grep` answers 0 with exit 0 and no warning | **landed** | `:261` names `rev-list --count` truncation and `merge-base --is-ancestor`; the SILENT windowed zero is not there |
| 6 | `check-governed-merges` refuses rather than under-reporting, remedy `--shallow-since=` | 已有 | `:381` carries both, including the literal `--shallow-since=` spelling |
| 7 | ⛔ Never enumerate past that refusal — a short list reads as compliance | **landed** | not in the file; `:381` states a property of the guard, not the seat's disposition |

⚠️ **A dispatch premise was falsified on the tree before any line was written.** The dispatch (and
the claim comment's premise check) recorded that the file holds ZERO lines for `shallow`,
`history-horizon` or `--shallow-since`. It does not: `:261`/`:262` carry the shallow-checkout trap
family (spelled 浅检出) and `:381` carries the `check-governed-merges` refusal together with the
literal `git fetch --shallow-since=` remedy (spelled 浅克隆). The zero-hit list was an ASCII grep
against a table written in Chinese. Fact 2 therefore lands as a two-line residue appended to rows
that already exist, not as the fresh pair the grading assumed — which is the seat's own instruction
(「a duplicate row is a 拒收」) applied to the half it had measured as absent.

Fact 1's residue is smaller for the same reason: rows 3 and 4 above already carry the
authenticated quota and the per-seat probe rule, so the landed row states only what is missing —
the endpoint spelling, what a 200 carries, and the measured two-through-one-403 spread.

## Ratchet arithmetic

- `CEILINGS` row for `platform-readings.md`: **419 → 422**, the landed count, headroom 0, same
  convention as every entry above it. ⛔ No other ceiling moves.
- A **ninth `ruledRaises` record** on the cross-file-move declaration: `delta: 3`,
  `date: '2026-09-10'`, quoting the standing one-file exception from pm-dispatch SKILL.md
  verbatim and untranslated — the same words the eighth record quotes, quoted again rather than
  cross-referenced, because a record quoting no ruling is RED and each record stands alone.
- `was: 314` does not move. Records now sum 34 + 3 + 26 + 7 + 7 + 17 + 3 = **97**, so the move's
  own raise is 422 − 314 − 97 = **+11**, unchanged, against a net source decrease of 20. The gate
  prints exactly that:

```
✓ check-skill-line-ratchet: cross-file move into .claude/skills/pm-dispatch/references/platform-readings.md: +11 (314→422, less 97 lines of ordinary ruled raise) against a net source decrease of 20 (...); authorised by #14685 item 5 (comment 5520452691).
✓ check-skill-line-ratchet: .claude/skills/pm-dispatch/references/platform-readings.md is 422 lines (ceiling 422; headroom 0).
```

- Nothing was paid in place; no re-wrap funded anything (re-wrap funding is refused in any case).
  The accounting comment beside the ceiling names each landed line and each deduplicated candidate.

## Gates

Derived with `node scripts/pm/dispatch-gates.mjs --commands --repo objectstack-ai/objectstack`
(39 commands; change set read from the merge base by the script itself, not from a hand-written diff).
**38 of 39 run green**; the 39th is still running and is reported below rather than guessed at.

| Gate | Verdict |
|---|---|
| `pnpm -s check:pm-skill-ratchet` | exit 0 — `✓ ... is 422 lines (ceiling 422; headroom 0)` |
| `node scripts/pm/check-skill-line-ratchet.mjs --self-test` | exit 0 — `✓ check-skill-line-ratchet self-test: 157 cases pass.` |
| `pnpm -s check:skill-frame-sync` | exit 0 — `✓ 2 copies of the decision frame are structurally isomorphic across 2 files` |
| `pnpm -s check:skill-compatibility` | exit 0 — `✓ 11 SKILL.md file(s) reconciled against 80 workspace packages` |
| `pnpm -s check:pm-skill-id-lint` | exit 0 — `✓ check-skill-id-lint: 27 file(s) clean` (no card number in any skill file) |
| `pnpm -s check:nul-bytes` | exit 0 — `scanned 8150 text file(s) ... no raw ASCII control bytes` |
| `node scripts/pm/check-governed-merges.mjs --test` on both files | **exit 3 GOVERNED**, quoted below |
| the other 31 derived commands | exit 0 each |

```
governed-surface predicate: 1 of 2 path(s) hit the register (5 surfaces, repo-agnostic).
  ⛔  GOVERNED — a human merge is the review record for this PR (#9495 regime).
      No seat flips it ready, enqueues it, or arms auto-merge (AGENTS.md Prime Directive #14).
      One hit governs the whole PR — 「混合 diff 一条命中即整 PR 分叉」; proportion is not a question.
      .claude/** ×1 — the agent instruction tree (skills, agents, hooks, settings)
        - .claude/skills/pm-dispatch/references/platform-readings.md
  paths not on the register: scripts/pm/check-skill-line-ratchet.mjs
```

⚠️ Reading worth carrying: the dispatch stated `scripts/pm/**` is on the governed register. The
predicate says it is not — only `.claude/**` hit. The PR is governed either way (one hit governs
the whole diff), so nothing about the terminal changes; the wrong half of the premise is recorded
here rather than repeated.

`pnpm --filter @objectstack/lint run check:doc-formula-expressions` first exited **3 =
PREREQUISITE NOT MET** (`@objectstack/formula` and `@objectstack/lint` not built) — NOT MEASURED,
not a finding. Built both under the shared verify lock
(`VERDICT command-exit 0 · held the lock 2s · waited 0s`) and re-ran: exit 0.

No build and no package tests are owed: the diff touches no package. No changeset is owed either
— nothing published moves (`.claude/**` and `scripts/pm/**` are both outside every package's
`files[]`), so `skip-changeset` applies.

## 维护者速读(草稿)

**改了什么** — 平台事实表 `platform-readings.md` 加三行:① 标签事件流 `GET /issues/{n}/events`
在门开会话可读(回 200 带 labeled/unlabeled 的名与时刻,三个容器实测两通一 403);② 浅检出上
窗口式 `git log --grep` 回 0 结果、exit 0、无警告,读作该提交从不存在;③ 遇到
`check-governed-merges` 的拒答,正确处置是按窗口起点之前的日期加深,而不是自己去枚举。
配套把该文件的行数上限从 419 抬到 422(落地行数),并在棘轮脚本里记一条引常设裁决的 `ruledRaises`。

**为什么改** — 这两个事实这一班各自造成过一次错误读数。其一:有席位把「REST 403」当成整个机群的
属性继承下来,于是放弃了本可用的第二条回读通道;其二:一次调查据窗口式 `git log --grep` 的零结果
差点公开发布「该提交从不存在」的结论,而那个零只是提交落在浅检出的地平线以下。事实表就是给这类
读数兜底的地方 —— 写下来,下一个席位才 grep 得到。

**风险与代价(含回滚)** — 风险很低:改的是 agent 指令树里的只读事实表,不进任何发布包,不改运行时
行为。代价是三行预算(419 → 422),按常设裁决走,免决策卡。回滚 = revert 本 PR 一个提交,行数上限
随之回到 419,棘轮与其余门禁自动恢复绿。

**席位意见** —

**你要做的** — 治理面 PR,合并是人工的:请直接读上面三行中文原文是否准确、是否值得占三行预算,认可
就合并。⛔ 不需要席位翻转 ready、不需要入队、不需要挂 auto-merge。

## Acceptance notes

- **Scope held.** Two files touched, exactly the surface the claim named: the readings table plus
  its `CEILINGS` row and one `ruledRaises` record. Nothing in `SKILL.md`, `core-rules.md`,
  `lanes/hotcrm.md` (sibling dev's surface) or `skills/**`, `scripts/check-*.mjs`,
  `scripts/pm/dispatch-gates.mjs`, docs, `packages/**` (the other sibling's).
- **Mechanism assumption A held**: the ratchet's `ruledRaises` path accepts the raise and its
  `--self-test` stays green (157 cases) with the ninth record in place.
- **Mechanism assumption B held**: no card number appears in either edited file's prose;
  `check:pm-skill-id-lint` reports 27 files clean. The ruling is cited by its wording, as the
  eight records before it do.
- **Mechanism assumption C measured, and it decided placement** — see the section list above.
- noted, not filed: `:312`–`:315` (PR-body footer eaten with its rule line) and `:321`–`:323`
  (create-side appends a footer only when the sent tail is not already that block) are two
  readings of the same write path that a reader must reconcile by hand; both are hedged by
  `:316`/`:328` (「⛔ 不由任一条推其余,写后必回读」), so this is a legibility observation, not a
  defect, and it is outside this card. 承接者:无 — no queued card and no in-flight PR touches
  the footer block; it would sit unowned if filed.
- noted, not filed: the dispatch's zero-hit premise list and the claim comment's
  `Premise checks:` line were both drawn from an ASCII grep over a Chinese table. That is a PM-side
  measurement habit, not a repo defect, and it has no file to be fixed in. 承接者:无.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MoTv7pn338AZ71owsp19gQ)_