### PR TITLE
fix(spec): the one-day date-range presets prescribe a one-day window, and the table states its end-token convention

### DIFF
--- a/.changeset/date-range-preset-window-extent.md
+++ b/.changeset/date-range-preset-window-extent.md
@@ -1,0 +1,16 @@
+---
+"@objectstack/spec": patch
+---
+
+fix(spec): the date-range preset prescriptions now name a one-day window for the one-day presets (#17014)
+
+`DATE_RANGE_PRESET_MACRO_WINDOWS` maps each dashboard date-range preset to the `{date-macro}` window a refusal PRESCRIBES to an author who wrote the preset name as a bare filter comparand (`bareDateRangePresetComparandMessage`). Two of its thirteen entries prescribed a window wider than the preset they name — a filter that parses, runs and returns rows over the wrong range, with no second error to correct against.
+
+- **`yesterday`** was `['{yesterday}', '{today}']` — an end naming the day AFTER the window. The pair is written for `$between`, which is `$gte min` and `$lte max`, and a bare-day upper bound means "through that whole day", compiled half-open to `< nextUtcCalendarDay(max)` (ADR-0053 D-D). So the prescription resolved to `>= yesterday 00:00 AND < tomorrow 00:00`: yesterday **and** today. It is now `['{yesterday}', '{yesterday}']`.
+- **`today`** was `['{today}', null]`, the open `$gte`-only arm, so the prescribed filter had no upper bound at all and also selected every day after today on a column carrying future dates. It is now `['{today}', '{today}']`.
+
+Both entries now name their own last day, matching the convention the other eight closed entries already used and matching both executable mappings — objectui's `PRESET_RANGES` and `@objectstack/core`'s analytics date-range resolver, which independently spell `today` and `yesterday` as one-day windows.
+
+The convention that decides an end token was nowhere written down, which is what let one table carry two readings. It is now stated as a rule on the table: **`start` names the window's first calendar day and `end` names its last, inclusive — never the day the window stops before**, and `end: null` is the open arm reserved for exactly the three rolling `last_N_days` windows. Tests pin the resolved extent of every window against a frozen reference day and require a stated extent for every declared preset, so a preset added later cannot silently pick the other reading.
+
+No schema, type or export changes: the refused shapes and the vocabulary are exactly as before, and only the window text a refusal quotes back moves.

--- a/packages/spec/src/data/date-range-presets.test.ts
+++ b/packages/spec/src/data/date-range-presets.test.ts
@@ -6,8 +6,10 @@ import {
   DATE_RANGE_PRESET_MACRO_WINDOWS,
   bareDateRangePresetComparandMessage,
   isDateRangePresetName,
+  type DateRangePreset,
 } from './date-range-presets';
 import { DATE_MACRO_WRAPPED_RE, isDateMacroToken } from './date-macros.zod';
+import { nextUtcCalendarDay } from './calendar-day';
 
 describe('date-range preset vocabulary (#4614, re-homed by #8793)', () => {
   it('declares exactly the thirteen shipped preset names, in filter-bar order', () => {
@@ -75,6 +77,160 @@ describe('date-range preset vocabulary (#4614, re-homed by #8793)', () => {
     const window = bareDateRangePresetComparandMessage('this_week', '$lt');
     expect(window).toContain('{week_start}');
     expect(window).toContain('{week_end}');
+  });
+});
+
+/**
+ * A frozen reference day for the extent pins below — Wednesday 2026-07-15.
+ *
+ * Nothing here calls a resolver: the two tables state, independently, the two
+ * halves the prescription table has to connect. {@link TOKEN_DAY_ON_REFERENCE}
+ * says what each MACRO TOKEN denotes (read off `DATE_MACRO_DESCRIPTIONS` in
+ * `./date-macros.zod.ts` — "Monday 00:00 of this week", "Last day of this
+ * month", "Start of yesterday"). {@link EXPECTED_WINDOW_DAYS} says what each
+ * PRESET NAME denotes, which is decided by the name and by nothing else. The
+ * pin then asks whether `DATE_RANGE_PRESET_MACRO_WINDOWS` joins them, which is
+ * the only question it exists to answer — and the question a membership check
+ * over the token vocabulary cannot reach, because both a right and a wrong end
+ * token are perfectly good members (#17014).
+ */
+const REFERENCE_DAY = '2026-07-15'; // a Wednesday, mid-week / mid-month / mid-quarter
+
+/** What each token used by a CLOSED entry denotes on {@link REFERENCE_DAY}. */
+const TOKEN_DAY_ON_REFERENCE: Readonly<Record<string, string>> = {
+  '{today}': '2026-07-15',
+  '{yesterday}': '2026-07-14',
+  '{week_start}': '2026-07-13', // Monday of that week
+  '{week_end}': '2026-07-19', // Sunday of that week
+  '{last_week_start}': '2026-07-06',
+  '{last_week_end}': '2026-07-12',
+  '{month_start}': '2026-07-01',
+  '{month_end}': '2026-07-31',
+  '{last_month_start}': '2026-06-01',
+  '{last_month_end}': '2026-06-30',
+  '{quarter_start}': '2026-07-01',
+  '{quarter_end}': '2026-09-30',
+  '{last_quarter_start}': '2026-04-01',
+  '{last_quarter_end}': '2026-06-30',
+  '{year_start}': '2026-01-01',
+  '{year_end}': '2026-12-31',
+  '{last_year_start}': '2025-01-01',
+  '{last_year_end}': '2025-12-31',
+};
+
+/**
+ * The window each preset NAME denotes on {@link REFERENCE_DAY}, as
+ * `[firstDay, lastDay]` — or `null` for a ROLLING preset, whose upper bound is
+ * the resolver's clock rather than any calendar day.
+ *
+ * Every declared preset must appear here (the census is asserted below), so a
+ * preset added later cannot reach `main` without its author stating the days
+ * it covers — which is the point at which picking the wrong end convention
+ * becomes visible instead of silent.
+ */
+const EXPECTED_WINDOW_DAYS: Readonly<
+  Record<DateRangePreset, readonly [first: string, last: string] | null>
+> = {
+  today: ['2026-07-15', '2026-07-15'],
+  yesterday: ['2026-07-14', '2026-07-14'],
+  this_week: ['2026-07-13', '2026-07-19'],
+  last_week: ['2026-07-06', '2026-07-12'],
+  this_month: ['2026-07-01', '2026-07-31'],
+  last_month: ['2026-06-01', '2026-06-30'],
+  this_quarter: ['2026-07-01', '2026-09-30'],
+  last_quarter: ['2026-04-01', '2026-06-30'],
+  this_year: ['2026-01-01', '2026-12-31'],
+  last_year: ['2025-01-01', '2025-12-31'],
+  last_7_days: null,
+  last_30_days: null,
+  last_90_days: null,
+};
+
+const DAY_MS = 86_400_000;
+const midnightUtc = (day: string): number => Date.parse(`${day}T00:00:00.000Z`);
+
+/**
+ * How many whole days the prescribed `$between` pair actually selects, under
+ * the platform's own bare-day bound rule: `>= start 00:00` and, because a
+ * bare-day upper bound means "through that whole day",
+ * `< nextUtcCalendarDay(end) 00:00` (ADR-0053 D-D, `./calendar-day.ts`).
+ */
+function prescribedDayCount(startDay: string, endDay: string): number {
+  const exclusiveEnd = nextUtcCalendarDay(endDay);
+  expect(exclusiveEnd, `${endDay} must be a real calendar day`).not.toBeNull();
+  return (midnightUtc(exclusiveEnd!) - midnightUtc(startDay)) / DAY_MS;
+}
+
+describe('the prescribed window covers exactly the days the preset names (#17014)', () => {
+  it('states an expected window for every declared preset, and for nothing else', () => {
+    // The fence: a preset added to the vocabulary without a stated extent
+    // fails here rather than silently inheriting whichever end convention its
+    // author happened to reach for.
+    expect(Object.keys(EXPECTED_WINDOW_DAYS).sort()).toEqual([...DATE_RANGE_PRESETS].sort());
+  });
+
+  it('the open arm is exactly the three ROLLING last_N_days windows', () => {
+    // `end: null` is not a free choice — it says "this window has no calendar
+    // upper bound at all". A preset that names a period always closes, `today`
+    // included: `{ $gte: '{today}' }` also selects every day AFTER today on a
+    // column that carries future dates.
+    const open = DATE_RANGE_PRESETS.filter((p) => DATE_RANGE_PRESET_MACRO_WINDOWS[p][1] === null);
+    expect(open).toEqual(['last_7_days', 'last_30_days', 'last_90_days']);
+    for (const preset of DATE_RANGE_PRESETS) {
+      expect(
+        DATE_RANGE_PRESET_MACRO_WINDOWS[preset][1] === null,
+        `${preset}: the open arm and the rolling family must be the same set`,
+      ).toBe(EXPECTED_WINDOW_DAYS[preset] === null);
+    }
+  });
+
+  it('every closed entry names its FIRST day as start and its LAST day as end', () => {
+    for (const preset of DATE_RANGE_PRESETS) {
+      const expected = EXPECTED_WINDOW_DAYS[preset];
+      if (expected === null) continue;
+      const [start, end] = DATE_RANGE_PRESET_MACRO_WINDOWS[preset];
+      const startDay = TOKEN_DAY_ON_REFERENCE[start];
+      const endDay = TOKEN_DAY_ON_REFERENCE[end!];
+      expect(startDay, `${preset}: ${start} needs a denotation in TOKEN_DAY_ON_REFERENCE`).toBeTruthy();
+      expect(endDay, `${preset}: ${end} needs a denotation in TOKEN_DAY_ON_REFERENCE`).toBeTruthy();
+      expect(startDay, `${preset}: start must be the window's FIRST day`).toBe(expected[0]);
+      // ⭐ The convention, and the whole defect: an end naming the day AFTER
+      // the window resolves one day too wide, silently, on every backend.
+      expect(endDay, `${preset}: end must be the window's LAST day, never the day after`).toBe(expected[1]);
+    }
+  });
+
+  it('resolves the one-day presets to ONE day and the week presets to seven', () => {
+    // Stated as concrete counts rather than as a re-derivation of the table,
+    // because the defect was exactly a count: `['{yesterday}', '{today}']`
+    // prescribed `>= yesterday 00:00 AND < tomorrow 00:00` — two days for a
+    // one-day preset.
+    expect(prescribedDayCount('2026-07-14', TOKEN_DAY_ON_REFERENCE[DATE_RANGE_PRESET_MACRO_WINDOWS.yesterday[1]!])).toBe(1);
+    expect(prescribedDayCount('2026-07-15', TOKEN_DAY_ON_REFERENCE[DATE_RANGE_PRESET_MACRO_WINDOWS.today[1]!])).toBe(1);
+    expect(prescribedDayCount('2026-07-13', TOKEN_DAY_ON_REFERENCE[DATE_RANGE_PRESET_MACRO_WINDOWS.this_week[1]!])).toBe(7);
+    expect(prescribedDayCount('2026-07-06', TOKEN_DAY_ON_REFERENCE[DATE_RANGE_PRESET_MACRO_WINDOWS.last_week[1]!])).toBe(7);
+
+    // And the full census, so a period preset cannot drift either.
+    for (const preset of DATE_RANGE_PRESETS) {
+      const expected = EXPECTED_WINDOW_DAYS[preset];
+      if (expected === null) continue;
+      const end = DATE_RANGE_PRESET_MACRO_WINDOWS[preset][1]!;
+      expect(
+        prescribedDayCount(expected[0], TOKEN_DAY_ON_REFERENCE[end]),
+        `${preset}: prescribed extent must equal the named window`,
+      ).toBe(prescribedDayCount(expected[0], expected[1]));
+    }
+  });
+
+  it('the refusal prescribes a one-day window for a one-day preset', () => {
+    const yday = bareDateRangePresetComparandMessage('yesterday', '$gte');
+    expect(yday).toContain("{ $between: ['{yesterday}', '{yesterday}'] }");
+    // ⛔ The day AFTER the window must not appear in a prescription for it.
+    expect(yday).not.toContain("'{today}'");
+
+    const today = bareDateRangePresetComparandMessage('today', '$lte');
+    expect(today).toContain("{ $between: ['{today}', '{today}'] }");
+    expect(today).not.toContain("'{tomorrow}'");
   });
 });
 

--- a/packages/spec/src/data/date-range-presets.ts
+++ b/packages/spec/src/data/date-range-presets.ts
@@ -66,24 +66,59 @@ export function isDateRangePresetName(value: unknown): value is DateRangePreset 
 
 /**
  * The `{date-macro}` window each preset resolves to — `[start, end]`, in the
- * WRAPPED spelling a filter author writes; `end: null` means "now" (the
- * rolling `last_N_days` windows have no upper macro — the resolver's clock is
- * the bound).
+ * WRAPPED spelling a filter author writes.
  *
- * This exists for one purpose: PRESCRIPTION. When a preset name is refused as
- * a bare filter comparand (#8793), the refusal must name the spelling that
- * works — that is the difference between a dead end and a one-edit fix,
- * especially for an AI author whose correction loop only sees the error text.
+ * ## The convention, binding on every entry (#17014)
+ *
+ * **`start` names the FIRST calendar day the window contains; `end` names its
+ * LAST. Inclusive — never the day the window stops before.**
+ *
+ * That is the reading that makes the pair correct as the `$between` this table
+ * is written for. `$between` is `$gte min` ∧ `$lte max`, and a bare-day upper
+ * bound means "through that whole day", compiled half-open to
+ * `< nextUtcCalendarDay(max)` — the platform-wide rule stated in
+ * `./calendar-day.ts` (ADR-0053 D-D, #3777). So an inclusive last-day end
+ * covers its day to the final instant and stops there:
+ * `['{yesterday}', '{yesterday}']` is exactly yesterday, one day — and the
+ * degenerate single-day range is a shape `./temporal-conformance.ts` already
+ * pins across every driver.
+ *
+ * ⛔ The OTHER convention — an end naming the day the window STOPS BEFORE —
+ * is equally real and is used deliberately one package over
+ * (`@objectstack/core`'s `analytics-date-range.ts` states its ends that way
+ * and says so). It must never appear here. Both spellings parse, resolve, run
+ * and return rows; only the EXTENT differs, so nothing downstream can catch an
+ * entry that picked the wrong one, and a reader of a mixed table cannot tell
+ * which reading any single row intends.
+ *
+ * `end: null` is the open arm, and it is exactly the three ROLLING
+ * `last_N_days` windows: those have no calendar upper bound at all, so the
+ * resolver's clock is the bound and the prescription takes the `$gte`-only
+ * form. ⛔ A CALENDAR preset — one that names a period, `today` included —
+ * always closes on its own last day, because `$gte` alone also selects every
+ * day AFTER the window on a column that carries future dates.
+ *
+ * ## Why the table exists: PRESCRIPTION
+ *
+ * When a preset name is refused as a bare filter comparand (#8793), the
+ * refusal must name the spelling that works — that is the difference between
+ * a dead end and a one-edit fix, especially for an AI author whose correction
+ * loop only sees the error text. An author handed a prescription whose EXTENT
+ * is wrong gets a filter that parses, runs and returns rows over the wrong
+ * window, with no second error to correct against — which is why the
+ * convention above is a rule here and not a preference.
+ *
  * It is deliberately NOT a resolver: the console's own preset-to-bounds
  * lowering (objectui `dashboard-filters`) stays the executable mapping, and
- * `date-range-presets.test.ts` pins every token here as a member of the macro
- * vocabulary so the two cannot drift silently.
+ * `date-range-presets.test.ts` pins both the macro-vocabulary membership of
+ * every token here AND the resolved EXTENT of every window, so neither the
+ * spelling nor the convention can drift silently.
  */
 export const DATE_RANGE_PRESET_MACRO_WINDOWS: Readonly<
   Record<DateRangePreset, readonly [start: string, end: string | null]>
 > = {
-  today:        ['{today}', null],
-  yesterday:    ['{yesterday}', '{today}'],
+  today:        ['{today}', '{today}'],
+  yesterday:    ['{yesterday}', '{yesterday}'],
   this_week:    ['{week_start}', '{week_end}'],
   last_week:    ['{last_week_start}', '{last_week_end}'],
   this_month:   ['{month_start}', '{month_end}'],


### PR DESCRIPTION
Fixes #17014

`DATE_RANGE_PRESET_MACRO_WINDOWS` maps each dashboard date-range preset to the `{date-macro}` window a refusal **prescribes** to an author who wrote the preset name as a bare filter comparand. Two of its thirteen entries prescribed a window wider than the preset they name.

The real work here was the convention question, not the token edit: the table carried two readings of what an `end` token means and stated neither, so the outlier was invisible to every gate and to the next author. The convention is now written on the table and pinned by tests.

## Reproduction, verbatim

Both runs read the built `dist` (`pnpm --filter @objectstack/spec build`, exit 0 both times) and print the table entries plus the window each rendered refusal quotes back.

**Before** — at `47863f4fb` (`origin/main` at branch point; the card's own run was at `419facdde`, re-measured here):

```
yesterday window tokens: ["{yesterday}","{today}"]
today     window tokens: ["{today}",null]
this_week window tokens: ["{week_start}","{week_end}"]
prescription yesterday: { $between: ['{yesterday}', '{today}'] }
prescription today    : { $gte: '{today}' }
prescription this_week: { $between: ['{week_start}', '{week_end}'] }
```

**After** — this branch:

```
yesterday window tokens: ["{yesterday}","{yesterday}"]
today     window tokens: ["{today}","{today}"]
this_week window tokens: ["{week_start}","{week_end}"]
prescription yesterday: { $between: ['{yesterday}', '{yesterday}'] }
prescription today    : { $between: ['{today}', '{today}'] }
prescription this_week: { $between: ['{week_start}', '{week_end}'] }
```

## The mechanism, re-measured at head

The card's premise held. `$between` is `$gte min` and `$lte max`, and a bare-day upper bound means "through that whole day", compiled half-open to `< nextUtcCalendarDay(max)`. That rule is live and is stated inside this same directory — `packages/spec/src/data/calendar-day.ts` (ADR-0053 D-D), whose own table reads:

> | `$lte`, a `$between` max, a `dateRange` end | the WHOLE day -> compile `< nextUtcCalendarDay(day)` |

So `['{yesterday}', '{today}']` prescribed `>= yesterday 00:00 AND < tomorrow 00:00` — yesterday **and** today, two days for a one-day preset.

## Census of all thirteen entries against the convention

Read entry by entry, not grepped for a shape. Each `end` token's denotation is quoted from `DATE_MACRO_DESCRIPTIONS` in `date-macros.zod.ts`.

| preset | end token | what that token denotes | end = window's last day? |
|:--|:--|:--|:--|
| `today` | was `null`, now `{today}` | "Start of today" | ⛔ was OPEN -> ✅ fixed |
| `yesterday` | was `{today}`, now `{yesterday}` | "Start of yesterday" | ⛔ was the day AFTER -> ✅ fixed |
| `this_week` | `{week_end}` | "Sunday of this week" | ✅ |
| `last_week` | `{last_week_end}` | "Sunday of last week" | ✅ |
| `this_month` | `{month_end}` | "Last day of this month" | ✅ |
| `last_month` | `{last_month_end}` | "Last day of last month" | ✅ |
| `this_quarter` | `{quarter_end}` | "Last day of this quarter" | ✅ |
| `last_quarter` | `{last_quarter_end}` | "Last day of last quarter" | ✅ |
| `this_year` | `{year_end}` | "Dec 31 of this year" | ✅ |
| `last_year` | `{last_year_end}` | "Dec 31 of last year" | ✅ |
| `last_7_days` | `null` | rolling — no calendar upper bound | ✅ open arm, correct |
| `last_30_days` | `null` | rolling — no calendar upper bound | ✅ open arm, correct |
| `last_90_days` | `null` | rolling — no calendar upper bound | ✅ open arm, correct |

10 closed + 3 open = 13, the whole table.

### The second outlier, and the measurement that put it in scope

The card and the triage comment both read `today` as "takes the `$gte`-only arm and is unaffected". That premise did **not** survive re-measurement. Three independent readings say a `today` preset is a closed one-day window:

1. **This package's own conformance corpus.** `packages/spec/src/data/temporal-conformance.ts` states the case `{ at: { $between: ['{today}', '{today}'] } }`, annotated *"The 'today' preset degenerates to a single day"*, expecting rows `c_open`, `d_mid`, `e_late`. Two cases below, `{ at: { $gte: '{today}' } }` — which is exactly what the old entry prescribed — expects `c_open`, `d_mid`, `e_late`, **`f_next`, `g_eom`**. `f_next` is stamped the next midnight and `g_eom` three days later. The corpus therefore already measures the extra rows the prescription hands an author.
2. **The console's executable mapping**, which this table's TSDoc names as the authority: objectui `packages/core/src/utils/dashboard-filters.ts` has `today: { from: '{today}', to: '{today}' }` and `yesterday: { from: '{yesterday}', to: '{yesterday}' }`. All thirteen of its rows are closed.
3. **The analytics resolver** (`@objectstack/core`, `analytics-date-range.ts`) resolves `today` to `['today', 'tomorrow']` in stop-before spelling — one day — and reserves its own `null` arm for the three rolling presets only.

The old `today` entry's blast radius is larger than `yesterday`'s, not smaller: `$gte` alone has no upper bound, so on any column carrying future dates (a `close_date`, a scheduled-at) the prescription selects every day from today onward. Its own TSDoc justified the `null` arm only for "the rolling `last_N_days` windows"; `today` was riding along unstated. Closing it restores that sentence to exactly the set it describes.

## The convention, and where it is now written down

Written as a rule in the TSDoc of `DATE_RANGE_PRESET_MACRO_WINDOWS` itself, `packages/spec/src/data/date-range-presets.ts`:

> **`start` names the FIRST calendar day the window contains; `end` names its LAST. Inclusive — never the day the window stops before.**

with the reason (`$between` plus the ADR-0053 D-D bare-day rule), an explicit ban on the other convention, a pointer to where that other convention legitimately lives, and the rule that `end: null` is the open arm reserved for exactly the three rolling windows.

**A type-level fence was considered and declined, with the reason recorded here rather than silently.** The end tokens carry no shared spelling to constrain: eight are `*_end` forms, but the corrected single-day ends are `{today}` and `{yesterday}`, which are instant tokens. A template-literal type over `_end` would reject the very values this PR proves correct. What decides the question is what a token *denotes*, which lives in `DATE_MACRO_DESCRIPTIONS`, not in its spelling — so the fence is a test, and it is built to be one a new preset cannot walk past.

## Tests

`packages/spec/src/data/date-range-presets.test.ts` gains five cases under `the prescribed window covers exactly the days the preset names`. They avoid restating the table: one local table says what each **token** denotes on a frozen Wednesday (2026-07-15), a second says what each **preset name** denotes, and the pins ask whether the shipped table joins the two — computing the resolved extent through the real `nextUtcCalendarDay` from `./calendar-day.ts`.

- states an expected window for every declared preset, and for nothing else — **the fence**: a preset added later fails here until its author states the days it covers.
- the open arm is exactly the three ROLLING `last_N_days` windows.
- every closed entry names its FIRST day as start and its LAST day as end.
- resolves the one-day presets to ONE day and the week presets to seven, plus the full census.
- the refusal prescribes a one-day window for a one-day preset.

### Reverse verification (ablation)

The pre-fix values were restored on disk, the suite re-run, and the tree restored — a one-off proof, not a committed file.

On-disk proof of the mutation, before the run: injected `['{today}', null]` read 1, removed `['{today}', '{today}']` read 0, and the file's blob hash differed from its `HEAD` blob.

Result — `4 failed | 7 passed (11)`, exactly the four new cases, with the extent pin naming the defect as a count:

```
AssertionError: expected 2 to be 1 // Object.is equality
 ❯ src/data/date-range-presets.test.ts:208
```

Restore proof: `git diff HEAD` empty, and `git hash-object` on the file equal to its `HEAD` blob again.

## Gates

Derived from the real change set rather than from a remembered list — `node scripts/pm/dispatch-gates.mjs --commands --repo objectstack-ai/objectstack`, re-derived after the changeset existed (it named six families that only apply once one does).

**Ran, green — 77 of the 81 derived commands.** Every exit code was redirected to a file and read back from disk, never through a pipe. On top of them:

- `pnpm --filter @objectstack/spec check:generated` — exit 0, *"All 15 generated artifacts are up to date"*. Nothing needed regenerating: `check:docs`, `check:api-surface`, `check:authorable-surface`, `check:export-origins`, `check:declaration-map`, `check:migration-registry`, `check:spec-changes` and `check:upgrade-guide` are all current, which is the measured form of "no schema or export moved".
- `pnpm --filter @objectstack/spec test` — **471 files / 13256 tests passed**.
- `pnpm --filter @objectstack/spec typecheck` — exit 0, and its test layer really does reach the new cases rather than being assumed to: `tsc -p tsconfig.test.json --listFiles` lists `src/data/date-range-presets.test.ts` (1 hit, among 442 test files; a fabricated path reads 0).
- `pnpm --filter @objectstack/lint exec vitest run src/validate-preset-comparands.test.ts` — 17 passed. The `filter-preset-comparand` vocabulary consumer: it constrains nothing about this fix, because every window literal it asserts is `last_30_days` / `{30_days_ago}` — it uses `yesterday` only as an offending comparand, never as an expected window.
- `pnpm --filter @objectstack/core exec vitest run src/utils/analytics-date-range.test.ts` — 32 passed. This is the suite that pins the STARTS of this table against the resolver's; starts are untouched.
- `pnpm exec eslint . --no-inline-config --format json` — the **whole-repo scan**, run after the final commit at `ec57a80796`: exit 0 over **6481 files**, 0 errors, 0 warnings. No narrowing was needed, so none is claimed. (`eslint.config.mjs` enables no type-aware linting — no `parserOptions.project`, no typed rules — which is also why this diff could not have moved a verdict on a file it does not touch.)

**NOT MEASURED — 4.** Every one exited **3**, the code these gates reserve for `PREREQUISITE NOT MET`, in a worktree where only `@objectstack/spec` is built. ⛔ None of them is a finding, and none is red:

| command | what it refused on |
|:--|:--|
| `pnpm --filter @objectstack/lint run check:doc-formula-expressions` | "the workspace package `@objectstack/formula` is not built" |
| `pnpm check:dual-build-cjs-loads` | "this gate reads built output, and some package has no dist/" |
| `pnpm check:lean-entry-closure` | "this gate loads BUILT entry points, and some target is absent" |
| `pnpm check:type-check-debt` | only its `--re-measure` half — "31 workspace dependencies have no built type entry point on disk". Its coverage half printed `OK — 76/80 workspace packages type-checked`, and `pnpm check:type-check-coverage` ran separately and is green. |

Clearing those four needs the whole workspace built (`turbo run build --filter='./packages/*'`), which is CI's run on this PR, not this worktree's. **This narrowing is declared, not silent.**

The derivation tool also names, as outside its own 81, what no local invocation can cover: 46 artifact-roster families, 11 declared wide-population families, 5 families taking a value from the workflow, and 5 path-scheduled CI jobs (Test Core, Build Core, Temporal Conformance, and the two Dogfood jobs). Those are CI's.

## Clause ②

**`Clause-②: no`** — measured, not assumed, and it agrees with the seat's reading.

- No schema, type or export moves: `check:api-surface`, `check:export-origins` and `check:authorable-surface` are green with no regeneration. The exported const keeps its declared type; only two of its values change.
- The consumers were enumerated and read rather than counted. `@objectstack/lint`'s `validate-preset-comparands` and `packages/spec`'s `filter.zod.ts` both call `bareDateRangePresetComparandMessage`; neither pins a window literal for `today` or `yesterday` — the lint suite's message assertions are all on `last_30_days` and its `{30_days_ago}` window, and its own fixtures use `yesterday` only as an offending comparand, never as an expected window. `@objectstack/core`'s `analytics-date-range` pins that the window STARTS agree with this table; starts are untouched.
- Repo-wide, `{yesterday}` appears in only four places outside `dist`, and exactly one of them was the entry this PR edits.

Nothing is narrowed and nothing is widened: the set of shapes the refusal fires on is byte-identical, and only the window text a refusal quotes back moves.

## Acceptance notes — noted, not filed

- `packages/core/src/utils/analytics-date-range.ts` explains why it states its ends itself and ends with "so its ends are one day earlier for the eight period presets". After this PR the relationship holds for all **ten** calendar presets, so that enumeration now reads as "and the other two agree", which is no longer true. It is a comment-only correction and the file sits inside this card's declared do-not-touch fence (the #16322 resolver), so it is left for the reviewing `domain:spec` seat, which is the named carrier and reads that file as part of this review.

## Out-of-scope finding — filed

- `packages/spec/src/data/date-macros.zod.ts`'s module header still describes the pre-ADR-0053 upper-bound semantics: it says a `<=` against a `*_end` token "stops at midnight on the 31st" and tells the author to reach for a half-open `< {next_year_start}` instead. `calendar-day.ts`, one file over, states the opposite as the platform rule. Filed rather than folded in: it is a separate contract-text defect, and correcting a module header on a file of Zod schemas pulls in the `check:docs` / `gen:schema` regeneration surface this PR does not otherwise touch. Filed as **#17333** (no labels, no assignee, per the filing rule).

_Generated by [Claude Code](https://claude.ai/code/session_01MkQhmuuJAVDjmeWNixwDDH)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01MkQhmuuJAVDjmeWNixwDDH)_

---
_Generated by [Claude Code](https://claude.ai/code)_