### PR TITLE
docs(site): drop the count-based claims from the homepage

### DIFF
--- a/apps/docs/app/[lang]/page.tsx
+++ b/apps/docs/app/[lang]/page.tsx
@@ -33,7 +33,7 @@ const mono = IBM_Plex_Mono({
 
 const HOME_TITLE = 'Metadata framework for AI-written apps';
 const HOME_DESCRIPTION =
-  'ObjectStack turns the whole app — data model, UI, workflows, permissions — into typed metadata: a complete CRM in under 150k tokens, one context window.';
+  'ObjectStack turns the whole app — data model, UI, workflows, permissions — into typed metadata that fits in a single context window.';
 
 /**
  * The homepage's metadata. Its social card is the shared hero cover,
@@ -140,7 +140,7 @@ const VOCABULARY: { tag: string; title: string; copy: string }[] = [
 const GATES: { title: string; copy: string }[] = [
   { title: 'Typed', copy: 'Strict TypeScript + Zod — shape errors die in the editor, seconds after the agent writes them.' },
   { title: 'Validated', copy: 'os validate rejects metadata that would fail silently at runtime — before it ships.' },
-  { title: 'Reviewed', copy: 'You approve a small readable diff in the Console — not fifty thousand lines of glue.' },
+  { title: 'Reviewed', copy: 'You approve a small readable diff in the Console — not a pile of generated glue.' },
   { title: 'Governed', copy: 'Permissions and audit are enforced by the runtime on every call. Even a wrong app stays inside the fence.' },
 ];
 
@@ -219,8 +219,8 @@ export default function HomePage() {
           </h1>
           <p className="mx-auto mt-6 max-w-2xl text-lg text-fd-muted-foreground text-pretty">
             ObjectStack turns the whole app — data model, UI, workflows, permissions — into
-            typed metadata: a complete CRM in under 150k tokens, one context window. Agents
-            read it whole, reason it whole, refactor it whole.
+            typed metadata that fits in a single context window. Agents read it whole, reason
+            it whole, refactor it whole.
           </p>
           <div className="mt-8 flex flex-wrap items-center justify-center gap-3">
             <Link
@@ -291,20 +291,14 @@ export default function HomePage() {
           </figure>
         </section>
 
-        {/* ── the claim the video makes, in prose ──────────────── */}
+        {/* ── what that metadata is, in prose ──────────────────── */}
         <section className="relative mx-auto w-full max-w-5xl px-6 pt-12 md:pt-14">
-          <div className="grid gap-8 md:grid-cols-2">
-            <p className="text-lg text-fd-muted-foreground text-pretty">
-              The business logic alone — every object, workflow and permission — is under 100k
-              tokens; the UI adds just 50k more.
-            </p>
-            <p className="text-base text-fd-muted-foreground text-pretty">
-              That metadata is your business ontology — an open, versioned definition you own.
-              Strict TypeScript, Zod schemas, and a validation gate catch the agent&apos;s mistakes
-              at authoring time, and the runtime derives the database, REST API, UI, and MCP
-              server — permissions and audit enforced on every call.
-            </p>
-          </div>
+          <p className="text-base text-fd-muted-foreground text-pretty">
+            That metadata is your business ontology — an open, versioned definition you own.
+            Strict TypeScript, Zod schemas, and a validation gate catch the agent&apos;s mistakes
+            at authoring time, and the runtime derives the database, REST API, UI, and MCP
+            server — permissions and audit enforced on every call.
+          </p>
         </section>
 
         {/* ── 01 · the loop ────────────────────────────────────── */}
@@ -439,18 +433,6 @@ export default function HomePage() {
                 </div>
               </div>
             ))}
-          </div>
-          <div
-            className="mt-8 flex flex-wrap items-center gap-x-3 gap-y-2 text-[13px] text-fd-muted-foreground"
-            style={{ fontFamily: 'var(--l-mono)' }}
-          >
-            <span>1,600+ typed schemas</span>
-            <span aria-hidden className="text-fd-border">|</span>
-            <span>5 database drivers</span>
-            <span aria-hidden className="text-fd-border">|</span>
-            <span>7 framework adapters</span>
-            <span aria-hidden className="text-fd-border">|</span>
-            <span>MCP built-in</span>
           </div>
           <Link
             href="/docs"


### PR DESCRIPTION
Fixes #17351

Applies the maintainer's ruling to the homepage, in the maintainer's own words:

> 建议首页也是非必要不强调数字，省的一直要改。

(given 2026-09-10, after the same ruling was applied to `README.md`: 「数量 相关的统计都去掉」)

## What changed — `apps/docs/app/[lang]/page.tsx`, and nothing else

The five sites the card names, in order:

1. **`HOME_DESCRIPTION`** — now "…into typed metadata that fits in a single context window." It feeds `metadata.description`, `openGraph.description`, `twitter.description` **and** the JSON-LD `SoftwareSourceCode.description` via `homeGraph()`, so all four move together, which is what the file's own comments require.
2. **The hero paragraph** — the same first sentence, verbatim, followed by the unchanged "Agents read it whole, reason it whole, refactor it whole." The description and the hero still say the same thing, in the same relationship they had before: the description **is** the hero's opening sentence.
3. **The two-column prose section** — the token-budget paragraph ("under 100k tokens; the UI adds just 50k more") is deleted. The ontology paragraph becomes the section's single full-width `<p>`; the `<section>` wrapper and its padding are untouched, so vertical rhythm is unchanged.
4. **The count strip** — `1,600+ typed schemas | 5 database drivers | 7 framework adapters | MCP built-in` is deleted outright, not replaced with a number-free strip. The "Browse the full vocabulary in the docs" link that follows is the section's exit, and it already carries its own `mt-8`.
5. **`GATES[2].copy`** — "not a pile of generated glue".

One comment amended, because the edit falsified it: the section header above (3) read `{/* ── the claim the video makes, in prose ── */}` and that claim was the paragraph now deleted. It now reads `{/* ── what that metadata is, in prose ── */}`. The long comment above `metadata` and the two comments in `homeGraph()` describe how the description is shared — still true after the edit, so they are untouched.

## The "7 framework adapters" cell was also false

`packages/adapters/` on this tree holds exactly one adapter:

```
$ ls packages/adapters/
hono
```

Deleting the strip removes the false claim; it is not corrected in place, per the card.

## Evidence

The card's constraint grep, before and after, over the same file:

```
$ grep -nE '[0-9]+k|[0-9],[0-9]{3}\+|\b[0-9]+\+' 'apps/docs/app/[lang]/page.tsx'
# BEFORE (origin/main, 706ad0f) — 5 matches, all of them count claims:
36:  '…into typed metadata: a complete CRM in under 150k tokens, one context window.';
222:            typed metadata: a complete CRM in under 150k tokens, one context window. Agents
298:              The business logic alone — every object, workflow and permission — is under 100k
299:              tokens; the UI adds just 50k more.
447:            <span>1,600+ typed schemas</span>

# AFTER — no matches (exit 1).
```

A wider sweep for the same claims by literal spelling — `150k|100k|50k|1,600|N database|N framework|N typed` — also returns nothing.

**The rendered page, not just the source.** After `pnpm docs:build`, over `apps/docs/.next/server/app`:

```
$ grep -rl '150k tokens\|1,600+ typed schemas\|7 framework adapters\|fifty thousand lines\|50k more' apps/docs/.next/server/app
# exit 1, 0 files

$ grep -o 'ObjectStack turns the whole app[^"<]*' apps/docs/.next/server/app/en.html | sort -u
ObjectStack turns the whole app — … — into typed metadata that fits in a single context window.
ObjectStack turns the whole app — … — into typed metadata that fits in a single context window. Agents read it whole, reason it whole, refactor it whole.
```

The short form is the `<meta>` / OpenGraph / Twitter / JSON-LD description; the long form is the hero. Both moved, together.

## Gates

Derived in the worktree with `node scripts/pm/dispatch-gates.mjs --commands --repo objectstack-ai/objectstack` (no hand-written path list) at commit `dd66285`, then reconciled with `--ran`:

```
Run reconciliation — 27 derived, 27 run, 0 NOT-MEASURED, 0 UNRUN.
  EXIT CODES — all 27 accounted famil(ies) carry one, so the NOT-MEASURED count above is DERIVED from them.
✓ dispatch-gates --ran: 27 derived famil(ies) accounted for — 27 run, 0 NOT-MEASURED
```

All 27 exited 0. Plus, beyond the derivation:

| Command | Verdict |
|:---|:---|
| `pnpm --filter @objectstack/docs typecheck` | exit 0 (`fumadocs-mdx && next typegen && tsc --noEmit`) |
| `pnpm lint` (whole repo, **not** narrowed) | exit 0 — 6488 files linted, 0 errors, 0 warnings, 1m43s |
| `pnpm docs:build` under `bash scripts/pm/os-verify-lock.sh -c` | `VERDICT command-exit 0 · held the lock 173s (2m53s) · waited 0s` |

`pnpm lint` was run over the whole population rather than the changed file, so no narrowing needs proving. For the record, the population figure comes from eslint's own resolution (`--format json`, 6488 entries), and this repo's `eslint.config.mjs` never enables type-aware linting for any file (its own comment above `QUERY_OPTIONS_TEST_GLOBS` states and measures this) — so a one-file diff could not have moved an untouched file's verdict in any case.

**Not measured here, by design:** the CI job `[ci.yml · Build Docs]` runs 4 steps in CI's own shell that no local family names; the 49 artifact-roster families, the 11 wide-population families and the always-runs tail are outside the derived union. CI owns those.

## Changeset

None, and `skip-changeset` is on the PR. `apps/docs/package.json` is `"private": true` with no `files[]`, so this diff publishes nothing from any released package — confirmed against the repo's own gates rather than assumed: `pnpm check:published-files` and the 26 other derived gates are green with no changeset present, and `pr-automation.yml` reads the `skip-changeset` label live.

## Acceptance notes

Observed while working on this file; **not** changed here, and not filed:

- **The GitHub repository *description* field still carries "a complete CRM in under 150k tokens, one context window."** It is a repository setting, not a file in this repo, so no PR can reach it — it needs a hand edit in repo settings. The card already flags this for the maintainer. Carrier: the maintainer, not a PR.
- **`README.md` on this tree still carries all four count claims** (lines 10, 14, 144, 199 — `150k tokens`, `100k tokens; the UI adds just 50k more`, `fifty thousand lines of glue`, `1,600+ of them`). The card describes #17347 as having already landed that rewrite; on `origin/main` at `706ad0f` it has not. That is #17347's surface, not this card's, and the wording used for site (5) here is the wording that card specifies, so the two land consistent whichever order they merge in. Carrier: #17347.
- **Out of scope by the card, unchanged:** the nav links, the hero CTA row, and the `npx create-objectstack my-app` spelling in `STEPS[0].cmd` (which differs from the `npm create objectstack@latest` form used elsewhere). Carrier: none — noted only.
- **The card's predicted post-state for the constraint grep does not hold, in the safe direction.** It expected the grep to still show "the `01/02/03` section numerals and the `90 Seconds` video title". That regex cannot match either — `01` and `90` are followed by neither `k` nor `+` — so the correct post-state is zero matches, which is what we get. No match survived that the card did not name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016gFSzdPX4324QMRKCjccTc