### PR TITLE
fix(spec): give the `permissions` alias table's `hosts` entry its own, true justification

### DIFF
--- a/.changeset/permissions-alias-hosts-justification.md
+++ b/.changeset/permissions-alias-hosts-justification.md
@@ -1,0 +1,13 @@
+---
+'@objectstack/spec': patch
+---
+
+Correct the `permissions` alias table's justification for `hosts`, and pin the two aliases nothing measured.
+
+`PluginPermissionsSchema` (`kernel/manifest.zod.ts`) curates three aliases — `filesystem` and `paths` point at `fs`, `hosts` points at `network`. The block's only comment said edit distance cannot reach any of them, and it sat directly above all three. That is true of the two `fs` entries and false of `hosts`.
+
+The fallback budget is `Math.max(2, Math.floor(key.length / 3))` (`shared/suggestions.zod.ts`), so a 5-character key gets 2, and `hosts` differs from the declared `hooks` by exactly 2. Measured against the real `findClosestMatches` with the alias table out of the picture: `filesystem` and `paths` return nothing, `hosts` returns `hooks`. So without the alias an author writing `hosts` is answered ``Did you mean `hosts` → `hooks`?`` — pointed at lifecycle hooks on the one block that also grants network access.
+
+The alias is therefore better justified than the comment claimed: it overrules a confident wrong suggestion rather than filling a silent gap. Only the justification moves — the alias stays, the declared keys, the strictness and the union are untouched, and no message an author reads changes.
+
+`hosts` is also the only one of the three whose absence would be invisible, since it is the only one that changes a live suggestion, so `manifest-unknown-keys.test.ts` now pins both it and `paths` alongside the `filesystem` pin that was already there, asserting the offending key and the rename — and, for `hosts`, that `hooks` is not what comes back.

--- a/packages/spec/src/kernel/manifest-unknown-keys.test.ts
+++ b/packages/spec/src/kernel/manifest-unknown-keys.test.ts
@@ -387,6 +387,24 @@ describe('#16328 — the `permissions` union door names the surface and the rena
   // the `devPlugins[]` guard above.
   const near = () => ({ ...legal(), permissions: { services: ['object'], hoooks: ['x'] } });
 
+  /**
+   * The object arm's own `unrecognized_keys` issue, carried inside the union
+   * issue at `['permissions']` — the shape the first pin below measures raw.
+   */
+  const permissionsRefusal = (result: ReturnType<typeof ManifestSchema.safeParse>) => {
+    if (result.success) throw new Error('expected the manifest to be refused');
+    const union = result.error.issues.find((i) => i.code === 'invalid_union') as
+      | { path: (string | number)[]; errors: Array<Array<{ code: string; keys?: string[] }>> }
+      | undefined;
+    expect(union, 'the refusal is a union issue at `permissions`').toBeDefined();
+    expect(union!.path).toEqual(['permissions']);
+    const nested = union!.errors.flat().find((i) => i.code === 'unrecognized_keys') as
+      | { code: string; keys: string[] }
+      | undefined;
+    expect(nested, 'the named refusal is carried inside the union issue').toBeDefined();
+    return nested!;
+  };
+
   it('the author reads the key, the surface and the rename — through `formatZodError`', () => {
     const result = ManifestSchema.safeParse(near());
     expect(result.success).toBe(false);
@@ -443,6 +461,38 @@ describe('#16328 — the `permissions` union door names the surface and the rena
     expect(result.success).toBe(false);
     if (result.success) return;
     expect(formatZodError(result.error)).toContain('Did you mean `filesystem` → `fs`?');
+  });
+
+  it('`paths` reaches `fs` too — the second half of the same unreachable pair', () => {
+    // `paths` is 5 characters, so the fallback budget is
+    // `Math.max(2, Math.floor(5 / 3))` = 2, and its nearest declared key is 4
+    // edits away (`hooks` and `fs` tie). Nothing to overrule; the entry buys a
+    // suggestion where the fallback offers none.
+    const result = ManifestSchema.safeParse({ ...legal(), permissions: { paths: ['/tmp'] } });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    const nested = permissionsRefusal(result);
+    expect(nested.keys).toEqual(['paths']);
+    expect(formatZodError(result.error)).toContain('Did you mean `paths` → `fs`?');
+  });
+
+  it('`hosts` overrules a LIVE wrong suggestion — without the alias the fallback answers `hooks`', () => {
+    // The one alias of the three whose absence would be invisible: it does not
+    // fill a silent gap, it overrides a confident wrong answer. `hosts` is 5
+    // characters, so the budget is `Math.max(2, Math.floor(5 / 3))` = 2, and
+    // `hosts` differs from the declared `hooks` by exactly 2 — so the bare
+    // fallback reaches `hooks` and sends the author to lifecycle hooks on the
+    // one block that also grants network access. Dropping the alias line makes
+    // the assertion below read ``Did you mean `hosts` → `hooks`?``, which is
+    // why the negative half is asserted and not only the positive one.
+    const result = ManifestSchema.safeParse({ ...legal(), permissions: { hosts: ['api.acme.com'] } });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    const nested = permissionsRefusal(result);
+    expect(nested.keys).toEqual(['hosts']);
+    const rendered = formatZodError(result.error);
+    expect(rendered, 'the curated target is offered').toContain('Did you mean `hosts` → `network`?');
+    expect(rendered, 'the reachable wrong answer is not').not.toContain('`hosts` → `hooks`');
   });
 
   it('the five doors that already named their key are untouched by this change', () => {

--- a/packages/spec/src/kernel/manifest.zod.ts
+++ b/packages/spec/src/kernel/manifest.zod.ts
@@ -48,11 +48,19 @@ export const PluginPermissionsSchema = strictObject({
     + 'and this block decides which services, hooks, network hosts and filesystem paths the '
     + 'plugin may touch. The declared keys are `services`, `hooks`, `network` and `fs`.',
   aliases: {
-    // Edit distance cannot reach a two-letter abbreviation from the word it
-    // abbreviates, and `fs` is the one key here an author is most likely to
-    // spell out in full.
+    // These two are the unreachable case: edit distance cannot reach a
+    // two-letter abbreviation from the word it abbreviates, and `fs` is the
+    // one key here an author is most likely to spell out in full.
     filesystem: 'fs',
     paths: 'fs',
+    // `hosts` is the opposite case, and the stronger reason to curate an
+    // entry: it IS within budget of `hooks`. The fallback budget is
+    // `Math.max(2, Math.floor(key.length / 3))` (`shared/suggestions.zod.ts`),
+    // so a 5-character key gets 2, and `hosts`/`hooks` differ by exactly 2.
+    // Without this line the fallback answers `hosts` -> `hooks`, pointing the
+    // author at lifecycle hooks on the one block that also grants network
+    // access. This alias overrides a confident WRONG suggestion rather than
+    // filling a silent gap, and `manifest-unknown-keys.test.ts` pins that.
     hosts: 'network',
   },
 }, {


### PR DESCRIPTION
Fixes #16859

The `permissions` alias table curates three entries. Its only comment said edit distance cannot reach any of them, and it sat directly above all three. That is true of the two `fs` entries and **false for `hosts`** — which is the more interesting way round: `hosts` is reachable, the fallback answers it `hooks`, and the alias exists to overrule that. Only the justification moves. The alias stays, the accept set does not move, and no message an author reads changes.

## Correction 1 is deliberately NOT here

The card's first correction was the changeset sentence. That window has shut: the changeset was consumed and the sentence is published verbatim at `packages/spec/CHANGELOG.md:3407`. Verified on this branch — `.changeset/permissions-block-named-refusal.md` is gone and the line reads:

> Three spelled-out near-misses that edit distance cannot reach are curated as aliases: `filesystem` and `paths` point at `fs`, and `hosts` points at `network`.

A shipped changelog entry is a record of what was said, not a document to correct — the same principle as never editing `content/docs/releases/` in a code PR. `CHANGELOG.md` is untouched by this PR, no erratum was added, and the disposition is a report to the maintainer, not an edit.

## The fork the triage left open: answered, with controls

Triage asked whether any **source** comment repeats the false justification, searched `packages/spec/src` for the phrase, found five occurrences and none about the permissions aliases — so the card was left on a fork whose other branch was "closes as `not_planned`".

Re-run here, on this branch, probing the claim rather than a spelling:

| probe | matched |
|:---|:---|
| case-**sensitive** `edit distance cannot reach` over `packages/spec/src` | **10 occurrences**, in `shared/strict-object.ts` (x2), `ui/chart.zod.ts` (x2), `automation/state-machine.test.ts`, `automation/builtin-node-config.test.ts`, `data/driver/turso.zod.ts`, `data/default-value-shape.ts`, `data/object-strictness-batch20.test.ts`, `data/object.zod.ts`. **`kernel/manifest.zod.ts` is not among them.** |
| case-**insensitive**, same phrase, same tree | **14 occurrences** — the same ten plus `shared/suggestions.zod.ts:331`, `data/authoring-key-lint.ts:82`, `data/default-value-shape.test.ts:139` and **`kernel/manifest.zod.ts:51`** |
| LIT control — `aliases` in `kernel/manifest.zod.ts` | 1 occurrence (reads greater than zero, so the probe reaches the file) |
| DARK control — a fabricated token over the same tree | 0 occurrences, exit 1 |
| claim-level sweep — `edit[- ]?distance`, case-insensitive, every tracked file | 209 occurrences across 88 files; the only source site that repeats the claim beside the permissions alias table is `kernel/manifest.zod.ts:51` |

The comment capitalises it: **`Edit` distance cannot reach**. The triage's lowercase probe could not match it. So the "none of them about the permissions aliases" reading was a letter-case artifact, the `not_planned` branch does not apply, and correction 2 is real. Counts above are **occurrences** (`grep -o | wc -l`), not lines.

## The arithmetic, re-derived here rather than relayed

`shared/suggestions.zod.ts:461` sets the budget:

```ts
const maxDistance = Math.max(2, Math.floor(key.length / 3));
```

Derived independently and then cross-checked against the repo's own `findClosestMatches` (built `dist`), with the alias table out of the picture and the declared keys `services` / `hooks` / `network` / `fs`:

| key | length | budget | distances to the declared keys | nearest | reachable | real `findClosestMatches` |
|:---|---:|---:|:---|:---|:---|:---|
| `hosts` | 5 | `max(2, 1)` = **2** | `hooks`:2 `fs`:4 `services`:7 `network`:7 | `hooks` @ 2 | **YES** | `["hooks"]` |
| `filesystem` | 10 | `max(2, 3)` = **3** | `services`:8 `fs`:8 `hooks`:9 `network`:9 | 8 | no | `[]` |
| `paths` | 5 | `max(2, 1)` = **2** | `hooks`:4 `fs`:4 `network`:6 `services`:7 | 4 | no | `[]` |

So the sentence is right about two of three. `hosts` is the one entry that overrides a **confident wrong** suggestion — pointing the author at lifecycle hooks on the one block that also grants network access — rather than filling a silent gap. Removing the alias would be the opposite of the fix, and nothing here does.

## Ablation — the two-sided proof

`hosts` is the only one of the three that changes a **live** suggestion, so it is the only one whose absence is currently invisible. Mutation and restore are proven on disk by blob hash and marker count, never by an editor's exit code, and the restore is trapped with absolute paths.

```text
HEAD blob            : 5be325e1a0f35f6845d03f945f1d276cda9f228b
on-disk blob (before): 5be325e1a0f35f6845d03f945f1d276cda9f228b
marker count BEFORE  : 1 occurrence
   -- delete the line `hosts: 'network',` --
marker count AFTER   : 0 occurrences
on-disk blob (after) : 5dbf88108b32258abdc2111d0ba6da7d7fa01866
MUTATION PROVEN ON DISK (blob changed, marker gone)

ablated vitest exit  : 1
 ✓ `paths` reaches `fs` too -- the second half of the same unreachable pair
 × `hosts` overrules a LIVE wrong suggestion -- without the alias the fallback answers `hooks`
      Tests  1 failed | 26 passed (27)

  the message the ablated tree produces:
  permissions: Unrecognized key(s) on the `permissions` block of this package
  manifest: `hosts`. Did you mean `hosts` → `hooks`? ...

-- restore ran; on-disk blob: 5be325e1a0f35f6845d03f945f1d276cda9f228b
```

Restore proven by state, not by exit code: `git diff HEAD` empty (0 bytes), `git status --porcelain` empty, on-disk blob equal to the HEAD blob.

Two notes on what the ablation establishes. It turns **exactly one** test red — the new `hosts` pin — and leaves 26 green, so the pin fails for its own reason and not as collateral. And the flip happened with **no rebuild** against a `dist` that still carried the alias, which is the proof that this suite resolves the schema through `src` (relative imports) and that no stale `dist` could have produced a false green here.

## Gates

Derived with `node scripts/pm/dispatch-gates.mjs --commands --repo objectstack-ai/objectstack` (change set taken by the tool itself from the merge base, three-dot), then reconciled with `--ran` carrying each recorded exit code.

**82 derived families — 80 run green, 2 NOT MEASURED.** The tool's own verdict: `82 derived famil(ies) accounted for — 80 run, 2 NOT-MEASURED (2 DERIVED from a recorded exit 3)`.

The two, both `PREREQUISITE NOT MET` (exit 3 — neither a pass nor a finding; nothing was measured), each refusing because it reads built output the whole workspace has to produce:

- `pnpm check:dual-build-cjs-loads` — "this gate reads built output, and some package has no dist/"
- `pnpm check:type-check-debt` — `--re-measure` refuses with 31 workspace dependencies unbuilt, because a number measured without the closure is a different world

Both are left to CI, which checks out fresh and builds. `check:doc-formula-expressions` and `check:lean-entry-closure` also refused at first for the same reason; a targeted `turbo run build --filter=@objectstack/formula --filter=@objectstack/lint --filter=@objectstack/objectql` cleared them and both then ran **green**, which is what the reconciliation above records.

Beyond the derived list:

| run | result |
|:---|:---|
| `pnpm --filter @objectstack/spec build` | exit 0 (34/34 declaration files present) |
| `pnpm --filter @objectstack/spec check:generated` | exit 0 — **all 15 generated artifacts up to date** |
| `pnpm --filter @objectstack/spec typecheck` | exit 0, including `check:test-typecheck` over `tsconfig.test.json`, so the new pins are compiled |
| `pnpm --filter @objectstack/spec test` | exit 0 — **471 files / 13253 tests passed** |
| repo-wide `eslint . --no-inline-config` | exit 0 over the **full** population, 76s — no narrowing was needed, so none is declared |
| `pnpm check:nul-bytes` plus a manual control-character sweep of the three touched files | exit 0 / no matches |

Exit codes were captured before any pipe (`cmd > log 2>&1; EXIT=$?`) throughout.

Heavy runs went through `scripts/pm/os-verify-lock.sh` on a stable slot; every verdict above is read from its `VERDICT command-exit` line, never from a bare `$?`.

Clause-②: no — `node scripts/pm/check-widening-tells.mjs --declaration no --diff` exits 0: of the three changed files, one is judged against a declared surface with no widening tell (`kernel/manifest.zod.ts`) and two are NOT MEASURED by construction (a changeset declares no surface; a test file declares no contract). Read directly: the diff moves a code comment inside the `aliases` option and adds two test pins. No alias value, declared key, shape or strictness changes; `check:api-surface` and `check:authorable-surface` are green, and the file's pre-existing six-door regression pin still passes, so no message an author reads moves either.

## 验收备注

- `docs/audits/2026-07-unknown-key-strictness-ledger.md:141` describes `aliases` as "semantic near-misses edit distance cannot reach", the same universal this card falsifies — the `hosts` entry shows the facility also serves the override role. One line, in a doc, not an example that fails when copied, so it is noted rather than filed. Carrier: the next author adding a strictness-ledger row, a file this diff's own `check:strictness-ledger` gate already reads.
- `packages/spec/CHANGELOG.md:3407` carries the false sentence and is deliberately untouched, per the paragraph above. Carrier: the maintainer, as accepted history.

_Generated by [Claude Code](https://claude.ai/code/session_01MkQhmuuJAVDjmeWNixwDDH)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01MkQhmuuJAVDjmeWNixwDDH)_