### PR TITLE
platform-checklist: point automation.json's ExecutionStatus mention at its declaring source

### DIFF
--- a/docs/qa/platform-checklist/areas/automation.json
+++ b/docs/qa/platform-checklist/areas/automation.json
@@ -426,7 +426,7 @@
         {
           "clause": "suspending types (screen, wait, approval, approval_revise — and subflow/map when the child pauses) park the run status=paused and resume to completed",
           "oracle": "api",
-          "verify": "run detail shows status paused while parked and completed after the screen resume / timer elapse / approval decision / resubmit (ExecutionStatus vocabulary: pending|running|paused|completed|failed|cancelled|timed_out|retrying)",
+          "verify": "run detail shows status paused while parked and completed after the screen resume / timer elapse / approval decision / resubmit (see the ExecutionStatus vocabulary declared in packages/spec/src/automation/execution.zod.ts)",
           "evidence": "before/after run-detail reads per suspending type"
         },
         {


### PR DESCRIPTION
Closes #16424

**Clause-②**: no

## What changed

`docs/qa/platform-checklist/areas/automation.json` line 429, inside the "suspending types park the run" clause's `verify` string, hand-copied the `ExecutionStatus` vocabulary as eight pipe-separated members and was missing `refused` (added by #14945, `packages/spec/src/automation/execution.zod.ts:39`). Per the PM ruling on this card, the repair points at the declaring source instead of retyping a fresh (now nine-member) list — retyping would re-arm the identical trap the moment a tenth member lands.

**Before:**
```
"verify": "run detail shows status paused while parked and completed after the screen resume / timer elapse / approval decision / resubmit (ExecutionStatus vocabulary: pending|running|paused|completed|failed|cancelled|timed_out|retrying)",
```

**After:**
```
"verify": "run detail shows status paused while parked and completed after the screen resume / timer elapse / approval decision / resubmit (see the ExecutionStatus vocabulary declared in packages/spec/src/automation/execution.zod.ts)",
```

No member count or fresh member list was minted anywhere in the change.

## Probe — member enumeration gone from the line

Probe: `grep -coE '[a-z_]+(\|[a-z_]+){3,}'` against line 429 of the file.

| | reading |
|---|---|
| before (positive control) | `1` |
| after | `0` |

The rest of the `verify` string (everything outside the parenthetical) is byte-identical before/after — `git diff` shows a single-line, single-hunk change.

## Scope

Only `docs/qa/platform-checklist/areas/automation.json` was touched, per the card's explicit scope note. Out-of-scope sites named by the card — `packages/spec/src/automation/execution.test.ts`'s deliberate eight-member prefix pin, `AUTOMATION_RESULT_STATUSES`, plugin-approvals' `TERMINAL_RUN_STATUSES`, and the generated docs under `content/docs/references/` — were not touched.

A light sweep of `docs/qa/platform-checklist/**` for other self-declared "the X vocabulary: a|b|c" style enumerations found several similar member lists (`records-forms.json`, `approvals.json`, `automation.json:587`, `studio-authoring.json`, `i18n.json`, `identity-auth.json`) — but every one of them already names its declaring source file alongside the member list, unlike this line's original sourceless form. None reproduce this defect class as-is, so none are filed as new cards.

## Gates — `docs/qa/platform-checklist/**` gate family

```
$ pnpm check:platform-checklist
✓ checklist-select self-test: 17 cases pass.
✓ check-platform-checklist --self-test: 176 assertions ... [pass]
check-platform-checklist: OK — 15 areas, 264 items (264 active); coverage: 35 kinds mapped, 1 waived;
traps: 19 documented, 19 in use; provisioning: 5 area recipes, 8 item references resolved
(1 area-qualified), 5/5 recipes referenced; meta-URL spelling: 19 `call` strings scanned against
34 folded spellings; source citations: 20 family files carry no `file:line` pin; symbol anchors:
631/631 resolved against 307 cited sources, 17 file floors held.
os-verify-lock: VERDICT command-exit 0 · held the lock 6s · waited 0s
```
Exit 0, ran under the shared verify lock (`os-verify-lock.sh`).

## Changeset

Measured, not assumed: no workspace package's `package.json` `files[]` entry names `docs/`, `qa/`, or `checklist` (checked every `packages/*` and `apps/*` manifest); `docs/qa/` is not itself a publishable workspace package. Nothing published moves ⇒ `skip-changeset`. The `skip-changeset` label is applied to this PR (see report if it failed to apply).

---
_Generated by [Claude Code](https://claude.ai/code/session_012GKcPZbMoGq7WPzKLfRBTU)_