### PR TITLE
Derive four self-test verdict counts from their battery ledger

### DIFF
--- a/scripts/check-init-service-contract.mjs
+++ b/scripts/check-init-service-contract.mjs
@@ -974,7 +974,15 @@ function selfTest() {
     process.exit(1);
   }
 
-  console.log('✓ self-test: 19 cases');
+  // The verdict DERIVES its number from `batterySeen` — the very ledger the floor
+  // above just evaluated — so the printed count and the floor can never disagree.
+  // What "cases" counts here is BATTERIES that actually ran (the named
+  // scenarios), not `assert(` call sites: the floor above guarantees
+  // `batterySeen.size` equals `declaredBatteries.length` by this point, so
+  // reading it off the runtime ledger rather than the static roster is a
+  // distinction without a difference — and it is the ledger, not the roster,
+  // that a stopped-running battery would actually shrink (#16664).
+  console.log(`✓ self-test: ${batterySeen.size} cases`);
 
   return SELF_TEST_VERDICT;
 }

--- a/scripts/check-kernel-hook-pairs.mjs
+++ b/scripts/check-kernel-hook-pairs.mjs
@@ -557,7 +557,15 @@ function selfTest() {
     }
     assert(!floorBreached, floorMessages.join('\n     '));
 
-    console.log('✓ self-test: 10 cases');
+    // The verdict DERIVES its number from `batterySeen` — the very ledger the
+    // floor above just evaluated — so the printed count and the floor can never
+    // disagree. What "cases" counts here is BATTERIES that actually ran (the
+    // named scenarios), not `check(` call sites: the floor above guarantees
+    // `batterySeen.size` equals `declaredBatteries.length` by this point, so
+    // reading it off the runtime ledger rather than the static roster is a
+    // distinction without a difference — and it is the ledger, not the roster,
+    // that a stopped-running battery would actually shrink (#16664).
+    console.log(`✓ self-test: ${batterySeen.size} cases`);
 
     return SELF_TEST_VERDICT;
 }

--- a/scripts/check-quick-reference-counts.mjs
+++ b/scripts/check-quick-reference-counts.mjs
@@ -925,7 +925,15 @@ function selfTest() {
     for (const f of failures) console.error(f);
     process.exit(1);
   }
-  console.log('✓ check-quick-reference-counts self-test: 22 cases pass.');
+  // The verdict DERIVES its number from `batterySeen` — the very ledger the
+  // floor above just evaluated — so the printed count and the floor can never
+  // disagree. What "cases" counts here is BATTERIES that actually ran (the
+  // named scenarios), not `expect(` call sites: the floor above guarantees
+  // `batterySeen.size` equals `declaredBatteries.length` by this point, so
+  // reading it off the runtime ledger rather than the static roster is a
+  // distinction without a difference — and it is the ledger, not the roster,
+  // that a stopped-running battery would actually shrink (#16664).
+  console.log(`✓ check-quick-reference-counts self-test: ${batterySeen.size} cases pass.`);
   selfTestReachedVerdict = true;
 }
 

--- a/scripts/check-spec-parsed-alias.mjs
+++ b/scripts/check-spec-parsed-alias.mjs
@@ -558,7 +558,18 @@ export type Iso0 = Assert<Eq< z.input< typeof M0.ColourSchema >, z.infer< typeof
     for (const f of failures) console.error('  - ' + f);
     process.exit(1);
   }
-  console.log('check-spec-parsed-alias --self-test: 18 assertions passed');
+  // The verdict DERIVES its number from `batterySeen` — the very ledger the
+  // floor above just evaluated — so the printed count and the floor can never
+  // disagree, and a block that stops running shrinks the number instead of
+  // leaving a transcribed literal standing (#16664). Unlike the other three
+  // files in this class, this roster holds a SINGLE battery, and what it
+  // counts is assertions that actually RAN this run (every `check(` call), not
+  // `check(` call sites in the source — those are two different facts, and
+  // only the first one is measured here. Summing the whole ledger is exact
+  // because reaching this line means every battery that registered is a
+  // declared one — the set difference above reds otherwise.
+  const assertionsRun = [...batterySeen.values()].reduce((total, count) => total + count, 0);
+  console.log(`check-spec-parsed-alias --self-test: ${assertionsRun} assertions passed`);
 
   return SELF_TEST_VERDICT;
 }


### PR DESCRIPTION
**Clause-②**: no

Closes #16664

## What

Four self-test verdict lines printed a transcribed literal count that nothing
derived. All four already carry the identical `SELF_TEST_BATTERIES` +
`batterySeen` ledger (the shape PR #16669 read from for `check-wildcard-fallthrough.mjs`,
`Fixes #15231`). Each verdict now reads its number off that ledger instead.

`scripts/measure-self-test-floor.mjs:1891` is untouched — its number is a
citation of another gate's historical output, not a live verdict line, and the
card is explicit that it is not an instance.

## Per-file before / after

### `scripts/check-init-service-contract.mjs`
- before: `console.log('✓ self-test: 19 cases');`
- after: `` console.log(`✓ self-test: ${batterySeen.size} cases`); ``
- source: `batterySeen.size` — the roster here has 19 named batteries and the
  printed number has always meant "batteries that ran", not raw `assert(`
  call sites (measured: `batterySeen.size` = 19, `sum(batterySeen.values())` = 26 — the
  printed literal matches the former, not the latter).

### `scripts/check-kernel-hook-pairs.mjs`
- before: `console.log('✓ self-test: 10 cases');`
- after: `` console.log(`✓ self-test: ${batterySeen.size} cases`); ``
- source: `batterySeen.size` (measured: size = 10, sum = 16 — printed literal
  matches size).

### `scripts/check-quick-reference-counts.mjs`
- before: `console.log('✓ check-quick-reference-counts self-test: 22 cases pass.');`
- after: `` console.log(`✓ check-quick-reference-counts self-test: ${batterySeen.size} cases pass.`); ``
- source: `batterySeen.size` (measured: size = 22, sum = 37 — printed literal
  matches size). This is the file the card names as the sharpest instance — a
  gate whose own subject is counts, printing an underived one about itself.

### `scripts/check-spec-parsed-alias.mjs`
- before: `console.log('check-spec-parsed-alias --self-test: 18 assertions passed');`
- after: `` const assertionsRun = [...batterySeen.values()].reduce((total, count) => total + count, 0);
  console.log(`check-spec-parsed-alias --self-test: ${assertionsRun} assertions passed`); ``
- source: `sum(batterySeen.values())`, **not** `batterySeen.size` — this file's
  roster is a single battery (`'check-spec-parsed-alias self-test': 18`), the
  line calls the number "assertions" rather than "cases", and the printed
  literal matches the sum of individual `check(...)` calls (measured: size =
  1, sum = 18 — the printed literal matches the sum). This is the exact shape
  PR #16669 landed for `check-wildcard-fallthrough.mjs`.

All four print byte-identical output to before the change — the counts were
accurate today, they were simply not derived (#15305 precedent: accurate by
coincidence is still the defect).

## Verification — both legs, per file

Each leg was run by temporarily mutating the file, observing `--self-test`
output, then reverting the mutation exactly (confirmed via `git diff` showing
zero residual change before moving to the next leg).

| file | leg 1 — add a case | leg 2 — unrelated edit |
|---|---|---|
| `check-init-service-contract.mjs` | added a 20th battery + assertion → `✓ self-test: 20 cases` | added an unrelated comment above `const ROOT = …` → stayed `✓ self-test: 19 cases` |
| `check-kernel-hook-pairs.mjs` | added an 11th battery + assertion → `✓ self-test: 11 cases` | added an unrelated comment above `function selfTest()` → stayed `✓ self-test: 10 cases` |
| `check-quick-reference-counts.mjs` | added a 23rd battery + assertion → `✓ check-quick-reference-counts self-test: 23 cases pass.` | added an unrelated comment above `function selfTest()` → stayed `✓ check-quick-reference-counts self-test: 22 cases pass.` |
| `check-spec-parsed-alias.mjs` | added one more `check(...)` call to the existing single battery (no roster change needed — the roster value is a floor, not an equality) → `check-spec-parsed-alias --self-test: 19 assertions passed` | added an unrelated comment above `function selfTest()` → stayed `check-spec-parsed-alias --self-test: 18 assertions passed` |

Leg 1 alone would not distinguish a derived number from one that just happens
to track additions by luck; leg 2 is the control that rules that out.

## Dropped out

None. All four files named on the card carry a live `SELF_TEST_BATTERIES` +
`batterySeen` registration to derive from.

## Out of scope, explicitly

- Not an assertion-floor change (#13799's axis) — the derived numbers are
  verdict counts, not floors, and none of the existing `SELF_TEST_BATTERY_FLOOR`
  constants were touched.
- No claim that any of the four was stale — all four printed the accurate
  number before this change; the defect was that nothing derived it.
- `check-wildcard-fallthrough.mjs` (#15231) and the file(s) under #16007 are
  untouched — out of this card's scope.
- `scripts/measure-self-test-floor.mjs:1891` is untouched — it is a citation
  of another gate's historical output, not a live verdict line.

## Changeset

`skip-changeset` — measured, not asserted. These four files live under root
`scripts/`, which is not inside any `pnpm-workspace.yaml` package glob
(`packages/*`, `packages/apps/*`, …, `apps/*`, `examples/*`); the only
`package.json` referencing any of the four filenames is the root manifest
itself, which is `"private": true`. A repo-wide grep for symbols unique to
these files (`SELF_TEST_BATTERIES`, `check-quick-reference-counts`) inside any
existing `dist/**/*.js` returned zero hits. Nothing published moves. Applying
the `skip-changeset` label on this PR (not just stating it here — #17352 is
the precedent for why the label itself is required).

## Local verification

`pnpm run check:nul-bytes` — pass (exit 0, this diff touches files so the gate
applies unconditionally).

Full command set derived via `node scripts/pm/dispatch-gates.mjs --commands
--repo objectstack-ai/objectstack` against this diff (35 commands: 17 `pnpm
check:*`, 18 direct `node scripts/**`) — all run, all exit 0 (captured before
any pipe), reconciled with `--ran`:
`✓ dispatch-gates --ran: 35 derived famil(ies) accounted for — 35 run, 0 NOT-MEASURED (a DERIVED zero — all 35 recorded an exit code and none of them is 3).`
Includes the four directly-matched gates for the touched files themselves:
`pnpm check:init-service-contract`, `pnpm check:kernel-hook-pairs`, `pnpm
check:quick-reference-counts`, `pnpm check:spec-parsed-alias`.

Root `scripts/` is outside every `turbo ls`-visible package dependency graph,
so leg ① (`pnpm --filter '<pkg>^...' build`) and leg ② (`pnpm --filter <pkg>
test/typecheck`) of the local verification scope are both empty for this
diff — there is no package these files belong to. The gate commands above are
the entire local verification surface for a root-`scripts/` change.

---
_Generated by [Claude Code](https://claude.ai/code/session_012GKcPZbMoGq7WPzKLfRBTU)_