### PR TITLE
docs(agents): name the missing tool, not an absent sibling scripts/pm/

### DIFF
--- a/.claude/agents/os-dev.md
+++ b/.claude/agents/os-dev.md
@@ -146,7 +146,7 @@ model: opus
 - 派生答哪些门禁读你改的文件,不答哪些测试测这个脚本。
 - 跑同目录点名它的 `*.test.ts`,加同包 tests 下 `git grep` 该脚本文件名的全部命中。
 - 该脚本只住在 objectstack,答案只关于它所在的树:每次推导第一行(stderr)点名仓与 commit。
-- 读之前先核对;姊妹仓(objectui / cloud)没有 `scripts/pm/`。
+- 读之前先核对;姊妹仓未必有 `scripts/pm/dispatch-gates.mjs`:objectui 只有 `check-half-states.mjs`。
 - 把它们的路径喂进 objectstack 检出,得到的是 objectstack 的门禁族:形态完整、退出 0、全错。
 - 那边的清单从该仓自己的 `package.json` 与 `.github/workflows/` 手工推导。
 - 加 `--repo <owner>/<name>` 申报本次答案该属于哪个仓,不匹配即拒绝并同时点名两个仓。


### PR DESCRIPTION
Fixes #17244

One sentence in `.claude/agents/os-dev.md` — in the 本地验证范围 gate-derivation rules — stated that sibling repos have no `scripts/pm/`. objectui has one. The sentence is rewritten in place, net-zero, to name the missing **tool** instead of an absent directory, and to claim nothing about cloud.

## The line

Before (71 bytes):

```text
- 读之前先核对;姊妹仓(objectui / cloud)没有 `scripts/pm/`。
```

After (114 bytes; the corpus line cap is 120):

```text
- 读之前先核对;姊妹仓未必有 `scripts/pm/dispatch-gates.mjs`:objectui 只有 `check-half-states.mjs`。
```

- **Net-zero**: 403 lines before, 403 after. Ratchet verdict, verbatim: `✓ check-skill-line-ratchet: .claude/agents/os-dev.md is 403 lines (ceiling 403; headroom 0).` — no ceiling raise, headroom was and is zero.
- **The operative instruction is untouched.** The two bullets that follow it still say what they said: feeding a sibling's paths into an objectstack checkout yields objectstack's own gate families (complete-looking, exit 0, all wrong), and that repo's list is derived by hand from its own `package.json` and `.github/workflows/`. What changes is only the premise the reader carries into them.
- **cloud is no longer asserted, in either direction.** It is attached to no seat in this container, so the corrected sentence measures objectui and says nothing about cloud rather than generalising over it.
- Punctuation follows the corpus convention the ratchet pins (ASCII `;` and `:` in CJK prose, fullwidth 。), and the line carries no control bytes: `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]'` over the file returns no hits, `pnpm check:nul-bytes` exit 0.

## The measurement, re-verified at this branch tip

objectui `origin/main` is `a646262`; the shared objectui checkout at `/home/user/objectui` was read, never edited.

```console
$ git -C /home/user/objectui ls-tree --name-only origin/main scripts/pm/
scripts/pm/check-half-states.mjs

$ git -C /home/user/objectui ls-tree --name-only origin/main .github/workflows/ | grep half-state
.github/workflows/half-state-patrol.yml

$ git -C /home/user/objectui cat-file -e origin/main:scripts/pm/dispatch-gates.mjs; echo "exit=$?"
fatal: path 'scripts/pm/dispatch-gates.mjs' does not exist in 'origin/main'
exit=128
```

The control is the third command: the same reader, the same tree, the same channel, answering **absent** for a path that genuinely is not there — so the first command's answer is a reading and not a channel artefact.

In-repo corroboration, independent of the card — `scripts/pm/check-half-states.mjs` already carries this comment:

```text
// objectui's `scripts/pm/` holds this file alone.
```

The sweeper's own source and this measurement agree; only the dev-agent text disagreed.

## Gates

Derived on the real diff with `node scripts/pm/dispatch-gates.mjs --commands --repo objectstack-ai/objectstack` (the tool takes its change set from the merge base itself). 17 derived families, **17 run, 0 UNRUN, 0 NOT-MEASURED** — reconciled with `--ran`, exit codes recorded per line and captured before any pipe:

`✓ dispatch-gates --ran: 17 derived famil(ies) accounted for — 17 run, 0 NOT-MEASURED (a DERIVED zero — all 17 recorded an exit code and none of them is 3).`

| family | exit |
|:---|:---|
| `node scripts/check-closing-keyword-parity.mjs` (and `--self-test`) | 0 |
| `node scripts/check-comment-mask-corpus.mjs` | 0 |
| `node scripts/pm/check-governed-queue-guard.mjs --self-test` | 0 |
| `pnpm --filter @objectstack/lint run check:doc-formula-expressions` | 0 |
| `pnpm check:agent-model-declared` | 0 |
| `pnpm check:agent-test-spelling` | 0 |
| `pnpm check:doc-authoring` | 0 |
| `pnpm check:driver-memory-census` | 0 |
| `pnpm check:nul-bytes` | 0 |
| `pnpm check:partof-closing-keyword` | 0 |
| `pnpm check:pm-governed-merges` | 0 |
| `pnpm check:pm-skill-id-lint` | 0 |
| `pnpm check:pm-skill-ratchet` | 0 |
| `pnpm check:refd-timer-probe` | 0 |
| `pnpm check:skill-frame-sync` | 0 |
| `pnpm check:watch-hint-literal` | 0 |

`check:pm-governed-prose` was run beyond the derived set (exit 0); the derivation scores it silent because its population is a tracked roster, not this path. `check:doc-formula-expressions` first refused with `PREREQUISITE NOT MET` (exit 3, explicitly **not** a finding) until `@objectstack/formula` and `@objectstack/lint` were built — that build ran through `scripts/pm/os-verify-lock.sh` (`VERDICT command-exit 0 · held the lock 170s · waited 0s`) and the gate then exited 0.

Repo-wide scans (`pnpm lint` and the wide-population families the derivation names) are CI's run, not this card's.

## Acceptance notes

- Nothing filed. The one sentence was the whole surface; no defect, contract violation or metadata-authoring trap surfaced beside it.
- Noted, not filed: `姊妹仓` is now used in this file without an in-file enumeration of which repos it covers (it was enumerated only inside the false half). Not a gap — AGENTS.md Prime Directive #11 defines the term repo-wide, naming objectui and cloud. Carrier: the skills lane's next os-dev.md edit, if it ever wants the term localised; nobody owes it today.
- Assumption A (PM's) holds: `git grep -n '姊妹仓' -- .claude/agents/os-dev.md` hits exactly two lines — the worktree-per-repo rule and this one. One rewrite closes the whole claim.
- Assumption B (PM's) holds: no twin outside this file. The `scripts/pm/` claims under `.claude/skills/pm-dispatch/` are about *this* repo's tree or about the derivation answering only its own tree (`references/platform-readings.md`, `references/true-green.md`), and `references/lanes/hotcrm.md`'s sibling-repo patrol-carrier clause is consistent with the corrected sentence. Nothing was edited outside the declared surface.
- Assumption C (PM's) holds with one correction to the expected set: the derivation returns the skill-file families it predicted **plus** several this card also owes — closing-keyword parity, the comment-mask corpus, the governed-queue-guard self-test, doc-formula-expressions, agent-test-spelling, doc-authoring, driver-memory-census, partof-closing-keyword, refd-timer-probe and watch-hint-literal. All were run.
- `skip-changeset` is measured, not assumed: `.claude/**` is on the fast track — nothing under it is published by any package's `files[]`, so this diff moves nothing that ships.

## 维护者速读(草稿)

**改了什么** — `.claude/agents/os-dev.md` 里的一句话,原地改写、行数不变(403 → 403)。原句说「姊妹仓(objectui / cloud)没有 `scripts/pm/`」,改成「姊妹仓未必有 `scripts/pm/dispatch-gates.mjs`:objectui 只有 `check-half-states.mjs`」。全 PR 只动这一行。

**为什么改** — 原句是错的,不是过时:objectui 的 `main` 上确实有 `scripts/pm/`,里面躺着 `check-half-states.mjs`,还挂着一个每天跑四次的 `half-state-patrol.yml`。缺的只是 `dispatch-gates.mjs` 这一个工具。开发 agent 读到「没有 `scripts/pm/`」,就会带着一个自信的「没有」去做判断——而这一班里已经有一次派发词把同样的前提写进了受管文件的草稿,差一行就被版本化进 `.claude/`。改法是点名缺的那个工具,而不是宣称目录不存在;同时把没人实测过的 cloud 从这句话里摘出去(本容器没有 cloud 的座位,不实测就不表态)。真正的操作指令没动:姊妹仓没有 `dispatch-gates.mjs`,门禁族仍然从该仓自己的 `package.json` 与 `.github/workflows/` 手推。

**风险与代价(含回滚)** — 风险极低:纯操作性文本一行,无代码、无发布面、无 changeset。代价是这句话现在对 cloud 不再表态,想知道 cloud 有没有 `scripts/pm/` 的人得自己去测——这是把未实测的断言换成沉默,不是信息丢失。回滚成本一个 revert:单文件单行,行数与 ratchet 天花板都不动(403/403,headroom 0,未抬上限)。

**席位意见** — (留空,待复核席填写)

**你要做的** — 人工合并本 draft PR(`.claude/**` 属受管面,只能由维护者手动合并;没有别的动作)。

---
_Generated by [Claude Code](https://claude.ai/code/session_01YKEjmbYNvYWJvWGSWx26zK)_