### PR TITLE
docs(protocol): plugin-spec package.json example prints the scaffolder's TypeScript floor

### DIFF
--- a/content/docs/protocol/kernel/plugin-spec.mdx
+++ b/content/docs/protocol/kernel/plugin-spec.mdx
@@ -705,7 +705,7 @@ Plugins are distributed as **NPM packages** for easy versioning and distribution
   
   "devDependencies": {
     "@objectstack/cli": "^2.0.0",
-    "typescript": "^5.0.0"
+    "typescript": "^5.3.0"
   },
   
   "keywords": [
@@ -720,6 +720,10 @@ Plugins are distributed as **NPM packages** for easy versioning and distribution
   }
 }
 ```
+
+The `typescript` floor above mirrors `SCAFFOLD_TYPESCRIPT_RANGE` in
+`packages/cli/src/commands/init.ts` — that constant, not this snippet, is the
+authority the scaffolders emit from.
 
 ### Publishing to NPM
 


### PR DESCRIPTION
Fixes #16756

## What changed

`content/docs/protocol/kernel/plugin-spec.mdx` line 708, in the "NPM Package"
distribution-format `package.json` example:

Before:
```
    "typescript": "^5.0.0"
```

After:
```
    "typescript": "^5.3.0"
```

...plus a new sentence immediately after the code fence:

> The `typescript` floor above mirrors `SCAFFOLD_TYPESCRIPT_RANGE` in
> `packages/cli/src/commands/init.ts` — that constant, not this snippet, is the
> authority the scaffolders emit from.

## Handling chosen, and why

Chose **print the scaffolder's current value + name the authority in the
adjacent sentence**, not "drop the range". The surrounding block is a
`devDependencies` example alongside `@objectstack/cli` — removing `typescript`
alone would leave that block looking incomplete (a real plugin `package.json`
declares both), where the sibling fix on the same class of finding
(#16763, `skills/objectstack-platform/SKILL.md`) also kept the key and
restamped the value. Printing the value plus naming
`packages/cli/src/commands/init.ts`'s `SCAFFOLD_TYPESCRIPT_RANGE` as the
authority satisfies acceptance clause 3 (no second drifting authority minted
silently) directly.

## Generated-page reading

**Not generated.** `scripts/regen-artifacts.mjs`'s routing table (the
`check:generated` ledger) only routes `content/docs/references/**` as a
generated tree; `content/docs/protocol/kernel/plugin-spec.mdx` is not listed
in it anywhere, and the file carries no generation marker. The only script
that emits scaffolder version pins into a tracked file
(`scripts/sync-scaffold-emission-policy.mjs`, `gen:scaffold-emission-policy`)
targets `packages/create-objectstack/src/templates/blank/package.json`, not
this doc page. Hand-editing the `.mdx` directly is correct here.

## Probe (measured on this checkout, before → after)

```
$ grep -c '\^5\.0\.0' content/docs/protocol/kernel/plugin-spec.mdx   # before this PR's commit
1
$ grep -c '\^5\.0\.0' content/docs/protocol/kernel/plugin-spec.mdx   # after
0
```
Positive control: the pre-edit probe read **1** (the line at old `:708`), confirming
the probe matches real content rather than a pattern that stopped matching
anything. Post-edit `git diff` for this file touches only lines 705-724 (the
`typescript` value and the four new prose lines) — nothing at or after `:758`
(#15952's `@objectstack/testing` section) was touched.

## `content/docs/**` gate family (39 commands derived by `dispatch-gates.mjs --commands`)

All 39 green (`exit 0`) on the final commit. 34 passed on the first pass; 5
initially reported `PREREQUISITE NOT MET` (packages not built — NOT MEASURED,
not a finding) and went green after building their declared prerequisites
(`@objectstack/formula`, `@objectstack/lint`, `@objectstack/spec`, and the
`@objectstack/client` → `@objectstack/client-react` closure via
`pnpm exec turbo run build --filter=@objectstack/client-react`):

- `check:doc-formula-expressions` — 0 → 0 after building formula+lint
- `check:doc-security-posture` — 0 → 0 after building formula+lint
- `check:docs` (spec) — 0 → 0 after building spec
- `check:docs-transcript-drift` — 0 → 0 after building lint
- `check:skill-examples` (spec) — 0 → 0 after building the client-react/client closure

Everything else (`check-ci-filter-parity`, `check-closing-keyword-parity` (+
self-test), `check-comment-mask-corpus`, `check-doc-frontmatter` (+
self-test), `check-doc-route-spelling --advisory` (+ self-test),
`check-docs-section-name` (+ self-test), `check-section-landing-index` (+
self-test), `report-test-timings --self-test`, `check:empty-state`,
`check:liveness`, `check:strictness-ledger`, `check:variant-docs`,
`check:yaml-examples`, `check:corpus-claim-drift`,
`check:cross-package-test-inputs`, `check:doc-anchors`, `check:doc-authoring`,
`check:docs-audit-scope`, `check:docs-redirects`, `check:docs-single-h1`,
`check:driver-memory-census`, `check:nul-bytes`,
`check:published-readme-links`, `check:react-page-adapter-contract`,
`check:refd-timer-probe`, `check:role-word`, `check:skill-identifier-liveness`,
`check:vendor-version-stamps`, `check:watch-hint-literal`) passed clean on the
first pass, no rebuild needed.

## Changeset

`skip-changeset` — measured, not assumed. `apps/docs` (the site that reads
`content/docs/**`) is `"private": true`; no published package's `files[]`
references `content/docs/**`; the only `.mdx`-touching gen script
(`sync-scaffold-emission-policy.mjs`) targets a different file. Nothing this
PR moves ships in an npm tarball. Applying the `skip-changeset` label on this
PR.

## Boundaries respected

Only `content/docs/protocol/kernel/plugin-spec.mdx` touched; nothing at/after
`:758` (#15952's territory); `skills/objectstack-platform/SKILL.md` and
`packages/create-objectstack/src/templates/blank/package.json` untouched; the
three `formats`-enum `typescript` hits under `content/docs/references/**`
untouched.

**Clause-②**: no

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012GKcPZbMoGq7WPzKLfRBTU

---
_Generated by [Claude Code](https://claude.ai/code/session_012GKcPZbMoGq7WPzKLfRBTU)_