### PR TITLE
Pin COMPOUND_ANCHOR_LEDGER's docblock counts to the table

### DIFF
--- a/scripts/pm/dispatch-gates.mjs
+++ b/scripts/pm/dispatch-gates.mjs
@@ -4172,18 +4172,21 @@ const BARE_ENTRY_POINT_NAME = 'selfTest';
  *
  * ## The census, re-derived on this tree
  *
- * 209 code-position matches over the tracked JS/TS corpus. 187 are the bare
- * `selfTest`; the remaining 22 carry compound names over 21 distinct spellings,
- * and they are the rows below. Fifteen are genuine self-test batteries — the
- * anchor firing on them is the anchor working. SEVEN are production code:
+ * 252 code-position matches over the tracked JS/TS corpus. 223 are the bare
+ * `selfTest`; the remaining 29 carry compound names over 26 distinct spellings,
+ * and they are the rows below. Nineteen are genuine self-test batteries — the
+ * anchor firing on them is the anchor working. TEN are production code:
  *
- *   scripts/check-self-test-wired.mjs            carriesSelfTest
+ *   scripts/check-self-test-wired.mjs             carriesSelfTest
  *   scripts/check-self-test-workflow-commands.mjs runSelfTest
- *   scripts/check-step-collectors.mjs            selfTestTargets
- *   scripts/check-step-collectors.mjs            selfTestDiscoveries
- *   scripts/measure-self-test-floor.mjs          selfTestDefs
- *   scripts/pm/dispatch-gates.mjs                selfTestOnlyCallables
- *   scripts/pm/dispatch-gates.mjs                maskSelfTests
+ *   scripts/check-step-collectors.mjs             selfTestTargets
+ *   scripts/check-step-collectors.mjs             selfTestDiscoveries
+ *   scripts/measure-durability-swallow-family.mjs selfTestMode
+ *   scripts/measure-self-test-floor.mjs           selfTestDefs
+ *   scripts/pm/dispatch-gates.mjs                 selfTestOnlyCallables
+ *   scripts/pm/dispatch-gates.mjs                 maskSelfTests
+ *   scripts/pm/dispatch-gates.mjs                 selfTestCaseLines
+ *   scripts/pm/dispatch-gates.mjs                 selfTestOnlyInvocation
  *
  * Every one of them is a gate that REASONS ABOUT self-tests, which is why they
  * cluster: a tool that finds, spawns, counts or masks other scripts' self-tests
@@ -4192,16 +4195,17 @@ const BARE_ENTRY_POINT_NAME = 'selfTest';
  *
  * ## What it costs today: nothing, MEASURED, and that is the whole point
  *
- * Neutralising each of the seven one at a time and re-extracting moves no hint
- * in any of the four files. The claim is therefore live rather than recalled —
+ * Neutralising each of the ten one at a time and re-extracting moves no hint
+ * in any of the six files. The claim is therefore live rather than recalled —
  * and it is exactly the kind of claim that stops being true without anything
  * going red, which is what the pin in this module's self-test exists to catch.
  *
- * The same measurement over the fifteen genuine rows is NOT zero, and that
- * asymmetry is what makes the classification load-bearing rather than
- * decorative: `fixtureSelfTest` drops `packages/spec/spec-changes.json` and
- * `prePushIsArmedSelfTest` drops `.githooks/pre-push`, both fixture paths in
- * `scripts/check-regen-pending.mjs`, both correctly refused. So "no
+ * The same measurement, redone over the table's current nineteen genuine rows,
+ * is still NOT zero, and that asymmetry is what makes the classification
+ * load-bearing rather than decorative: `fixtureSelfTest` drops
+ * `packages/spec/spec-changes.json` and `prePushIsArmedSelfTest` drops
+ * `.githooks/pre-push`, both fixture paths in `scripts/check-regen-pending.mjs`,
+ * both correctly refused. So "no
  * compound-name match may contribute a hint" is FALSE as a blanket invariant;
  * the invariant holds only over the accidental half, and only a classification
  * can name that half.
@@ -4219,14 +4223,14 @@ const BARE_ENTRY_POINT_NAME = 'selfTest';
  *     that excludes the accidental one also unmasks a real self-test battery and
  *     readmits its fixture paths as hints — the fabricated-lead family this
  *     whole masker exists to refuse, traded for a silence that costs nothing.
- *   - **Special-casing this module's own path fixes two rows of seven.** The
- *     other five live in three other files, so the objection that a rename
+ *   - **Special-casing this module's own path fixes four rows of ten.** The
+ *     other six live in five other files, so the objection that a rename
  *     "fixes one instance and leaves the class" applies to it too, one file
  *     wider — and it would make the tool's self-scan differ from every other
  *     scan, which is a hazard of its own.
  *
- * ⇒ What ships is neither. The anchor keeps firing on all 22, the mask keeps
- * blanking all 22, and the cost of the seven accidental ones is MEASURED on
+ * ⇒ What ships is neither. The anchor keeps firing on all 29, the mask keeps
+ * blanking all 29, and the cost of the ten accidental ones is MEASURED on
  * every run instead of asserted in prose. Silence was the defect; the remedy is
  * noise on the day it starts costing something.
  *
@@ -4239,6 +4243,13 @@ const BARE_ENTRY_POINT_NAME = 'selfTest';
  * measures, and keeps measuring, that masking it costs no hint. ⛔ Do not
  * "repair" a red by renaming the function to dodge the anchor: the row is the
  * record, and the next accidental name is the one nobody will notice.
+ *
+ * The TOTAL / GENUINE / ACCIDENTAL counts stated above are pinned the same
+ * way (#15310): `--self-test` computes them fresh from this table and checks
+ * the docblock's own prose against that computation, never against a second
+ * hand-typed constant. Prose that drifts from the table reds there, instead
+ * of drifting further unnoticed the way it had — twice — by the time #15310
+ * measured it.
  */
 const COMPOUND_ANCHOR_LEDGER = [
   ['packages/lint/scripts/check-doc-formula-expressions.mjs', 'specSelfTest', false],
@@ -15506,6 +15517,73 @@ function selfTest() {
     const names = selfCensus.map((d) => d.name);
     t("this module's own masker is in the anchor's population", names.includes('maskSelfTests'));
     t('…and so is the reachability helper beside it', names.includes('selfTestOnlyCallables'));
+  }
+
+  // #15310 — the docblock above states this table's TOTAL / GENUINE /
+  // ACCIDENTAL composition in prose, and prose does not move when a row is
+  // added: three integers that agree with EACH OTHER while jointly
+  // disagreeing with the table is exactly the shape that let this drift twice
+  // without ever looking wrong. The declared numbers are read out of this
+  // module's own docblock text, never re-typed as a second constant here, and
+  // checked against a count taken fresh from COMPOUND_ANCHOR_LEDGER itself —
+  // so a row added without touching the docblock reds here, and an edit to
+  // any unrelated line changes neither side and stays green.
+  {
+    const ownSource = readFileSync(nodePath.join(ROOT, 'scripts/pm/dispatch-gates.mjs'), 'utf8');
+    const ledgerAt = ownSource.indexOf('const COMPOUND_ANCHOR_LEDGER = [');
+    const before = ledgerAt < 0 ? '' : ownSource.slice(0, ledgerAt);
+    const blockStart = before.lastIndexOf('/**');
+    const blockEnd = before.lastIndexOf('*/');
+    // Line-wrapped JSDoc prose carries a `\n * ` between words that happen to
+    // fall on a line break — flattened to single spaces so a future rewrap of
+    // this paragraph cannot itself make a true reading look false.
+    const prose =
+      blockStart < 0 || blockEnd < 0
+        ? ''
+        : ownSource
+            .slice(blockStart, blockEnd)
+            .replace(/\n[ \t]*\*[ \t]?/g, ' ')
+            .replace(/[ \t]+/g, ' ');
+
+    const total = COMPOUND_ANCHOR_LEDGER.length;
+    const genuine = COMPOUND_ANCHOR_LEDGER.filter(([, , accidental]) => !accidental).length;
+    const accidental = COMPOUND_ANCHOR_LEDGER.length - genuine;
+
+    // Only as wide as the words this docblock actually spells; extending it is
+    // a deliberate edit, not silent tolerance for a new spelling.
+    const NUMBER_WORDS = {
+      zero: 0, one: 1, two: 2, three: 3, four: 4, five: 5, six: 6, seven: 7, eight: 8, nine: 9,
+      ten: 10, eleven: 11, twelve: 12, thirteen: 13, fourteen: 14, fifteen: 15, sixteen: 16,
+      seventeen: 17, eighteen: 18, nineteen: 19, twenty: 20,
+    };
+    const asCount = (word) => (/^\d+$/.test(word) ? Number(word) : NUMBER_WORDS[String(word).toLowerCase()]);
+
+    const remaining = prose.match(/the remaining (\d+) carry compound names/);
+    const allFiring = prose.match(/keeps firing on all (\d+), the mask keeps blanking all (\d+)/);
+    const genuineLine = prose.match(/([A-Za-z]+) are genuine self-test batteries/);
+    const accidentalLine = prose.match(/([A-Za-z]+) are production code:/);
+
+    t(
+      'the docblock\'s TOTAL row count — "the remaining N carry compound names" and both "all N" claims — ' +
+        `agrees with the table (table: ${total}; declared: ` +
+        `${remaining ? remaining[1] : '<not found>'}/${allFiring ? allFiring[1] : '<not found>'}/` +
+        `${allFiring ? allFiring[2] : '<not found>'})`,
+      remaining !== null
+        && allFiring !== null
+        && Number(remaining[1]) === total
+        && Number(allFiring[1]) === total
+        && Number(allFiring[2]) === total,
+    );
+    t(
+      "the docblock's GENUINE count (\"N are genuine self-test batteries\") agrees with the table " +
+        `(table: ${genuine}; declared: ${genuineLine ? genuineLine[1] : '<not found>'})`,
+      genuineLine !== null && asCount(genuineLine[1]) === genuine,
+    );
+    t(
+      "the docblock's ACCIDENTAL count (\"N are production code:\") agrees with the table " +
+        `(table: ${accidental}; declared: ${accidentalLine ? accidentalLine[1] : '<not found>'})`,
+      accidentalLine !== null && asCount(accidentalLine[1]) === accidental,
+    );
   }
 
   // A population DECLARED for this very scanner is referenced by no executing

--- a/scripts/pm/dispatch-gates.mjs
+++ b/scripts/pm/dispatch-gates.mjs
@@ -15548,6 +15548,7 @@ function selfTest() {
     const total = COMPOUND_ANCHOR_LEDGER.length;
     const genuine = COMPOUND_ANCHOR_LEDGER.filter(([, , accidental]) => !accidental).length;
     const accidental = COMPOUND_ANCHOR_LEDGER.length - genuine;
+    const distinctSpellings = new Set(COMPOUND_ANCHOR_LEDGER.map(([, name]) => name)).size;
 
     // Only as wide as the words this docblock actually spells; extending it is
     // a deliberate edit, not silent tolerance for a new spelling.
@@ -15562,6 +15563,7 @@ function selfTest() {
     const allFiring = prose.match(/keeps firing on all (\d+), the mask keeps blanking all (\d+)/);
     const genuineLine = prose.match(/([A-Za-z]+) are genuine self-test batteries/);
     const accidentalLine = prose.match(/([A-Za-z]+) are production code:/);
+    const spellingsLine = prose.match(/over (\d+) distinct spellings/);
 
     t(
       'the docblock\'s TOTAL row count — "the remaining N carry compound names" and both "all N" claims — ' +
@@ -15583,6 +15585,17 @@ function selfTest() {
       "the docblock's ACCIDENTAL count (\"N are production code:\") agrees with the table " +
         `(table: ${accidental}; declared: ${accidentalLine ? accidentalLine[1] : '<not found>'})`,
       accidentalLine !== null && asCount(accidentalLine[1]) === accidental,
+    );
+    // Distinct NAMES, not rows: `runSelfTest` is a genuine entry point in one
+    // file and an accidental one in another, so it is one spelling occupying
+    // two rows — the same reason COMPOUND_ANCHOR_KEYS has to carry the file in
+    // its key. This is derivable from the table exactly like the three above,
+    // so it is pinned the same way rather than left as the one clause in this
+    // paragraph a future row could still drift without going red.
+    t(
+      "the docblock's distinct-spellings count (\"over N distinct spellings\") agrees with the table " +
+        `(table: ${distinctSpellings}; declared: ${spellingsLine ? spellingsLine[1] : '<not found>'})`,
+      spellingsLine !== null && Number(spellingsLine[1]) === distinctSpellings,
     );
   }
 


### PR DESCRIPTION
Fixes #15310

**Clause-②**: no

## What was wrong

`COMPOUND_ANCHOR_LEDGER`'s docblock in `scripts/pm/dispatch-gates.mjs` states the table's size and composition in prose, and the prose had drifted from the table — twice, per the card's own history (22/15/7 → 25/17/8 → 29/19/10 by the time this PR claimed the card).

## Re-measured on `origin/main` at claim time (`143c715a99`)

```
COMPOUND_ANCHOR_LEDGER — total 29, genuine (accidental: false) 19, accidental (true) 10
self-consistency: 19 + 10 = 29 ✓
control: rows matching neither bucket = 0 (both branches are exhaustive, so this isn't an undercount)
docblock prose (before this PR): "all 22" (×2), "fifteen genuine", "SEVEN … production code"
```

## The fix: pin the prose to the table

The docblock's TOTAL / GENUINE / ACCIDENTAL / **distinct-spellings** counts are asserted in `--self-test`, computed **from `COMPOUND_ANCHOR_LEDGER` itself** — never against a second hand-typed constant. The block reads this module's own source off disk, extracts the docblock's stated numbers by regex, and compares each against a count freshly derived from the ledger array. Four assertions now (added a fourth per review — see "Distinct spellings" below).

## Verification — all four pins, run against the real `--self-test`

Baseline (`origin/main` `143c715a99`, before this PR): `1674 cases pass`, exit 0.

After the fix (three pins): `1677 cases pass`, exit 0 — `table: 29; declared: 29/29/29`, `table: 19; declared: Nineteen`, `table: 10; declared: TEN`, all green.

After adding the fourth pin (this revision, head `358a0f82d1`): `1678 cases pass`, exit 0 — the distinct-spellings assertion reads `table: 26; declared: 26` and is green alongside the other three.

**Leg 2 — add a row without touching the prose ⇒ RED, still true with 4 pins.** Duplicated the first genuine ledger row as an extra array entry (same name, so distinct-spellings count is UNCHANGED — a useful negative case). Table becomes 30 total / 20 genuine / 10 accidental / still 26 distinct names; prose still says 29/Nineteen/TEN/26. Re-ran `--self-test`:
```
✗ the docblock's TOTAL row count — … agrees with the table (table: 30; declared: 29/29/29)
✗ the docblock's GENUINE count (…) agrees with the table (table: 20; declared: Nineteen)
✓ the docblock's ACCIDENTAL count (…) agrees with the table (table: 10; declared: TEN)
✓ the docblock's distinct-spellings count (…) agrees with the table (table: 26; declared: 26)
✗ dispatch-gates self-test: 2 of 1678 case(s) failed.
os-verify-lock: VERDICT command-exit 1 · held the lock 724s (12m04s)
```
TOTAL and GENUINE pins go red (30≠29, 20≠19); ACCIDENTAL and the new distinct-spellings pin correctly stay green (10=10, 26=26 — the duplicated row added no new spelling, only a new row). Reverted before commit; working tree confirmed clean against the fixed 4-pin state before pushing.

**Leg 3 — unrelated edit ⇒ NOT red.** Run in the prior revision with three pins (1677/1677 green after an unrelated trailing-comment edit). Not independently re-run with the fourth pin present in this revision — the fourth pin is extracted and compared by the identical mechanism as the other three (same `prose` string, same regex-then-compare shape), and the plain green 1678/1678 run right above it (no mutation at all) already shows it passing on the untouched tree. Flagging this rather than implying a rerun that didn't happen.

## (1) The neutralisation sentences — explicitly run, not inherited silently

Two sentences assert an experiment, not a description:
> "Neutralising each of the **ten** one at a time and re-extracting moves no hint in any of the **six** files."
> "The same measurement, **redone** over the table's current nineteen genuine rows, is still NOT zero"

I chose **(a): run it**, explicitly, rather than convert to a citation — the measurement is cheap (dispatch-gates.mjs's own `--self-test` already performs it as a live pin every run, over every row in `COMPOUND_ANCHOR_LEDGER`, and I had 4 green runs of it) but my first PR body never surfaced the per-row readings, which is the gap flagged. Ran a standalone script (importing this branch's real exported `compoundAnchorDecls`/`withoutAnchor`/`extractWatchHints`/`trackedFiles`/`COMPOUND_ANCHOR_KEYS` — no reimplementation) that neutralises every one of the 29 rows individually and reports each result:

```
accidental rows: 10 — all measured, all zero-drop:
  OK   scripts/check-self-test-wired.mjs :: carriesSelfTest
  OK   scripts/check-self-test-workflow-commands.mjs :: runSelfTest
  OK   scripts/check-step-collectors.mjs :: selfTestTargets
  OK   scripts/check-step-collectors.mjs :: selfTestDiscoveries
  OK   scripts/measure-durability-swallow-family.mjs :: selfTestMode
  OK   scripts/measure-self-test-floor.mjs :: selfTestDefs
  OK   scripts/pm/dispatch-gates.mjs :: selfTestOnlyCallables
  OK   scripts/pm/dispatch-gates.mjs :: maskSelfTests
  OK   scripts/pm/dispatch-gates.mjs :: selfTestCaseLines
  OK   scripts/pm/dispatch-gates.mjs :: selfTestOnlyInvocation
distinct files among accidental rows: 6 — scripts/check-self-test-wired.mjs, scripts/check-self-test-workflow-commands.mjs,
  scripts/check-step-collectors.mjs, scripts/measure-durability-swallow-family.mjs, scripts/measure-self-test-floor.mjs,
  scripts/pm/dispatch-gates.mjs

genuine rows: 19 — 3 show a nonzero drop (movers):
  MOVED scripts/check-platform-checklist.mjs :: selfTestSymbolAnchors ->
    ["packages/core/src/security/platform-admin.ts","areas/a.json","areas/b.json","areas/c.json"]
  MOVED scripts/check-regen-pending.mjs :: fixtureSelfTest -> ["packages/spec/spec-changes.json"]
  MOVED scripts/check-regen-pending.mjs :: prePushIsArmedSelfTest -> [".githooks/pre-push"]

SPECIMEN fixtureSelfTest: measured=true dropped=["packages/spec/spec-changes.json"]
SPECIMEN prePushIsArmedSelfTest: measured=true dropped=[".githooks/pre-push"]
```

Both sentences are true today, confirmed by fresh per-row measurement, not inherited: all ten accidental rows, across exactly six distinct files, individually neutralise with zero hint change; the genuine side is not zero (three movers, including the two positive-control specimens named in the docblock, both still dropping their original fixture paths). Text left as-is (the live-count wording was already correct); the readings above are the evidence that was missing from the first PR body.

## (2) Distinct spellings — now pinned; corpus census — measured, stated here

**"26 distinct spellings"** is derivable from the table (`new Set(COMPOUND_ANCHOR_LEDGER.map(row => row[1])).size`) and is now a fourth `--self-test` assertion, same shape as the other three: extracted from the docblock's `"over N distinct spellings"` clause, checked against the ledger.

**"252 code-position matches … 223 are the bare `selfTest`"** — these are **not** derivable from the table (they count the whole tracked JS/TS corpus, not just `COMPOUND_ANCHOR_LEDGER`'s rows) and are **not** pinned, per the review. I did measure them, freshly, on this branch's HEAD, reusing the module's own masking machinery (`trackedFiles`, `scanSource`/`maskComments` from `js-comment-mask.mjs`, the same `SELF_TEST_DECL` pattern) rather than guessing: 223 bare + 29 compound = 252 total, 26 distinct compound spellings — the compound share (29) matches the ledger exactly, which is itself a cross-check that the census and the table agree. Command: a standalone script walking `trackedFiles()` and classifying every `SELF_TEST_DECL` match as bare vs. compound (not committed — duplicates no shipped logic, exists only to produce this reading).

## Per-sentence: live count vs. citation (unchanged from prior revision, still holds)

- **"all N" / "the remaining N … N are genuine … N are production code … N distinct spellings"** — live counts, pinned (now four assertions).
- **"The same measurement over the fifteen genuine rows is NOT zero"** — was a citation of a specific past measurement; redone (see (1) above) and rewritten to "redone over the table's current nineteen genuine rows, is still NOT zero" since the redo confirmed it true today.
- **"Special-casing this module's own path fixes two rows of seven. The other five live in three other files"** — arithmetic inside an argument; re-derived to "four rows of ten … the other six live in five other files" from the current table. Conclusion (the objection still applies, "one file wider") unchanged.
- Left untouched, deliberately: the separate `SELF_TEST_DECL` docblock (~L3797) — different construct, already carries its own drift disclaimer, out of this card's boundary.

## Gate family (re-derived on the final head `358a0f82d1`)

`node scripts/pm/dispatch-gates.mjs --commands` on this revision names the identical 31-command family the first revision derived (diff confirmed byte-identical). All 31 exit 0 on this head: the other 30 were re-run directly (all green, seconds each); `pnpm check:pm-dispatch-gates` — the same `--self-test` this section already reports 3 fresh runs of on this exact diff (green/red/green) — was not run a 4th time as a duplicate of evidence already given above.

## Scope

Only `scripts/pm/dispatch-gates.mjs` changed — the docblock's prose and the self-test block (now four pinned assertions). No ledger data row was added, removed, or reclassified.

## Changeset

`skip-changeset` — `scripts/pm/**` is prose/tooling only, ships in no package's published `files[]`. Quick-channel per AGENTS.md; label applied.

---
_Generated by [Claude Code](https://claude.ai/code/session_012GKcPZbMoGq7WPzKLfRBTU)_
