### PR TITLE
docs(spec): spell the FieldReference @example as a same-table comparand

### DIFF
--- a/.changeset/spicy-pears-count.md
+++ b/.changeset/spicy-pears-count.md
@@ -1,0 +1,7 @@
+---
+'@objectstack/spec': patch
+---
+
+Correct `FieldReferenceSchema`'s first TSDoc `@example`: a `{ $field }` comparand names a column of the SAME row, never a relation path.
+
+The example spelled its comparand as `{ "$eq": { "$field": "order.owner_id" } }` and captioned it as a join ON clause, while the same docblock's "Execution support" prose states that a dotted path is refused by SQL push-down with `INVALID_FILTER` (HTTP 400). Copied as written it does not fail at the schema door — both spellings parse — so it fails later and quietly: the in-memory evaluator answers `false` for a flat row, and SQL push-down refuses. The ON clause it advertised no longer exists either; `query.joins` was removed and related records are read through `expand`. The example is now the same-table cross-field comparison both execution paths compile, and the docblock header no longer advertises a join surface. `@objectstack/spec` publishes `src/**/*.zod.ts`, so this docblock ships to authors and to IDE hover.

--- a/packages/spec/src/data/filter.test.ts
+++ b/packages/spec/src/data/filter.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import {
   FilterConditionSchema,
   QueryFilterSchema,
@@ -1832,5 +1835,94 @@ describe('FieldReferenceSchema.addDays (#14104)', () => {
       expect(firstIssue(result)?.path).toEqual(['$in', 0]);
       expect(firstIssue(result)?.message).toContain('$in member at index 0');
     });
+  });
+});
+
+// ============================================================================
+// [#16923] The docblock @examples are RUNNABLE, and same-table
+// ============================================================================
+
+/**
+ * [#16923] `FieldReferenceSchema`'s FIRST `@example` used to spell its `$field`
+ * comparand as the RELATION path `order.owner_id`, captioned as a join ON
+ * clause — while the same block's "Execution support" prose says a dotted path
+ * is refused by SQL push-down with `INVALID_FILTER`, and while `query.joins`
+ * (the only ON clause this protocol ever had) was removed in #4286. The
+ * example was the wrong half, established by RUNNING it rather than reading
+ * it: the schema door admits either spelling, so nothing here can be pinned by
+ * `safeParse` alone — the memory evaluator answers `false` for the dotted
+ * spelling on a flat row and the SQL compiler refuses it
+ * (`sql-driver-cross-field-reference.test.ts`, "a dotted relation path").
+ *
+ * These pins hold the docblock to its own prose from two directions:
+ *
+ * - The `FieldReferenceSchema` block's examples PARSE, on both the
+ *   documentation copy and the enforced copy — an example nobody can run is
+ *   how the previous one drifted.
+ * - No `@example` ANYWHERE in `filter.zod.ts` spells a `$field` value as a
+ *   path. The probe is on the CLAIM (what does an example say a comparand
+ *   looks like), not on one spelling: it is case-insensitive, quote-agnostic,
+ *   and refuses `.` and `/` alike, so a slash-separated or unbackticked
+ *   respelling trips it too.
+ */
+describe('filter.zod.ts docblock @examples (#16923)', () => {
+  const HERE = dirname(fileURLToPath(import.meta.url));
+  const SOURCE = readFileSync(resolve(HERE, 'filter.zod.ts'), 'utf8');
+
+  /**
+   * Every `@example` body in the file, as the raw comment text following the
+   * tag. An example body ends at the blank continuation line (` *`) that this
+   * file's convention puts after every one, or at the end of the docblock —
+   * so the body is the caption and the payload, never the prose after it.
+   */
+  function exampleBlocks(source: string): string[] {
+    return source
+      .split('@example')
+      .slice(1)
+      .map((rest) => rest.split(/^[ \t]*\*[ \t]*$|\*\//m)[0]);
+  }
+
+  /** The JSON payload lines of one `@example` body — the lines that are the example. */
+  function payloads(block: string): string[] {
+    return block
+      .split('\n')
+      .map((line) => line.replace(/^\s*\*\s?/, '').trim())
+      .filter((line) => line.startsWith('{'));
+  }
+
+  /** Every `$field` VALUE inside a chunk of example text, any quote style, any case. */
+  function fieldValues(text: string): string[] {
+    return [...text.matchAll(/["']?\$field["']?\s*:\s*["']([^"']*)["']/gi)].map((m) => m[1]);
+  }
+
+  const blocks = exampleBlocks(SOURCE);
+
+  it('lit control — the file really has @example blocks carrying $field values', () => {
+    // A zero below must mean "no path spellings", never "nothing was read".
+    expect(blocks.length).toBeGreaterThan(1);
+    expect(fieldValues(blocks.join('\n')).length).toBeGreaterThan(1);
+    // Dark control — a spelling that is not in the file returns nothing.
+    expect(fieldValues('{ "$fieldd": "order.owner_id" }')).toEqual([]);
+  });
+
+  it('the FieldReferenceSchema block\'s examples parse — documentation copy AND enforced copy', () => {
+    const block = SOURCE.slice(0, SOURCE.indexOf('export const FieldReferenceSchema'));
+    const examples = exampleBlocks(block).flatMap(payloads);
+    expect(examples.length).toBeGreaterThanOrEqual(2);
+    for (const line of examples) {
+      const value: unknown = JSON.parse(line);
+      expect(ComparisonOperatorSchema.safeParse(value).success, line).toBe(true);
+      expect(FieldOperatorsSchema.safeParse(value).success, line).toBe(true);
+      // …and the whole thing is a legal condition on a field, which is where an
+      // author copies it to.
+      expect(FilterConditionSchema.safeParse({ amount: value }).success, line).toBe(true);
+    }
+  });
+
+  it('no @example in the file spells a $field comparand as a path (dot OR slash)', () => {
+    const offenders = blocks
+      .flatMap((block) => fieldValues(block).map((value) => ({ block: block.trim().slice(0, 80), value })))
+      .filter(({ value }) => /[./]/.test(value));
+    expect(offenders, 'a $field comparand is a column of the SAME row').toEqual([]);
   });
 });

--- a/packages/spec/src/data/filter.zod.ts
+++ b/packages/spec/src/data/filter.zod.ts
@@ -29,12 +29,17 @@ import { bareDateRangePresetComparandMessage, isDateRangePresetName } from './da
 
 /**
  * Field Reference
- * Represents a reference to another field/column instead of a literal value.
- * Used for joins (ON clause) and cross-field comparisons.
+ * Represents a reference to another COLUMN OF THE SAME ROW instead of a
+ * literal value. Used for cross-field comparisons. There is no ON clause to
+ * write one into: `query.joins` was removed (#4286, ADR-0049) and related
+ * records are read through `expand`, so a reference naming a relation path
+ * (`order.owner_id`) is not a join — it is the dotted spelling "Execution
+ * support" below says SQL push-down refuses with `INVALID_FILTER`.
  *
  * @example
- * // user.id = order.owner_id
- * { "$eq": { "$field": "order.owner_id" } }
+ * // amount > budget — a SAME-TABLE cross-field comparison, the shape both
+ * // execution paths compile (`cross-field-conformance-cases.ts` pins the rows)
+ * { "$gt": { "$field": "budget" } }
  *
  * @example
  * // completed_at <= due_date + grace_days  (#14104 — a SAME-TABLE offset


### PR DESCRIPTION
Fixes #16923

Clause-②: no — the diff moves no accept set. `FieldReferenceSchema` is byte-identical; only its TSDoc `@example` and the sentence above it changed, plus a new pin. Measured against the actual diff, not asserted at dispatch time: `pnpm --filter @objectstack/spec run check:api-surface`, `check:authorable-surface`, `check:spec-changes` and `check:generated` all exit 0 with no regeneration, and the generated reference page `content/docs/references/data/filter.mdx` is untouched (it republishes `describe()` text, never `@example` blocks).

Authored in Claude Code session `session_01MkQhmuuJAVDjmeWNixwDDH`, dispatched by the `domain:spec` execution seat.

## Which half was wrong, and how that was established

The card records a contradiction inside one TSDoc block: the FIRST `@example` spelled its `{ $field }` comparand as the relation path `order.owner_id`, captioned as a join ON clause, while the same block's "Execution support" prose says a dotted path is refused by SQL push-down with `INVALID_FILTER` (HTTP 400).

Reading the source cannot say which half is wrong, and **neither can `safeParse` alone** — this is the honest reading, and it is the opposite of what the card's class-(a) framing suggests. `$field` is `z.string()`: **both spellings parse, before and after**. The schema door is not the door that refuses. Three runtime readings settle it instead, and all three convict the example:

1. **The surface the caption names does not exist.** `query.joins` — the only ON clause this protocol ever had — was removed (#4286, ADR-0049). A query carrying the example's caption is refused by `QuerySchema` with a prescription pointing at `expand`.
2. **In memory it fails silently.** On a flat row (what a table stores) the dotted reference resolves to nothing and the predicate answers `false` — no error, no refusal, just a lost row. The same-table spelling answers `true`.
3. **On SQL push-down it is refused by name.** Pinned in `@objectstack/driver-sql`, `src/sql-driver-cross-field-reference.test.ts` → "a dotted relation path" → `400 INVALID_FILTER`, log fragment `dotted path`. Re-run on this branch: `Tests 1 passed | 47 skipped`.

So the prose is right and the example was wrong — and the header sentence that made it look right ("Used for joins (ON clause) and cross-field comparisons") was advertising a retired surface. Both are corrected; the schema shape is not touched.

## Before / after — the example run exactly as the file spells it

Extracted from `packages/spec/src/data/filter.zod.ts` at each revision and executed, verbatim:

```text
===== BEFORE — FieldReferenceSchema, FIRST @example =====
header : Represents a reference to another field/column instead of a literal value. Used for joins (ON clause) and cross-field comparisons.
caption: // user.id = order.owner_id
example: { "$eq": { "$field": "order.owner_id" } }

[1] schema door — does the example parse?
    FieldReferenceSchema.safeParse(comparand) -> true
    ComparisonOperatorSchema.safeParse(example) -> true
    FilterConditionSchema.safeParse({ amount: example }) -> true

[2] the caption's surface — is there an ON clause to write it into?
    QuerySchema.safeParse({ object, joins:[{ on: example }] }) -> false
    refusal (first 180 chars): `query.joins` was removed in @objectstack/spec 17 (ADR-0049) — no engine or driver ever read it: a query carrying `joins` behaved exactly as if the key were absent, while its name …

[3] in-memory evaluation against a flat row (the shape a table stores)
    row = {"id":"r1","amount":120,"budget":100,"owner_id":"u1","user_id":"u1"}
    $field names "order.owner_id"; row has that column? false
    matchesFilterCondition(row, { amount: example }) -> false

[4] SQL push-down: pinned in @objectstack/driver-sql
    src/sql-driver-cross-field-reference.test.ts, "a dotted relation path"
    { amount: { $gt: { $field: 'a.b' } } } -> 400 INVALID_FILTER (log fragment "dotted path")
    a same-table reference compiles: cross-field-conformance-cases.ts, { amount: { $gt: { $field: 'budget' } } }
```

```text
===== AFTER — FieldReferenceSchema, FIRST @example =====
header : Represents a reference to another COLUMN OF THE SAME ROW instead of a literal value. Used for cross-field comparisons. There is no ON clause to
caption: // amount > budget — a SAME-TABLE cross-field comparison, the shape both
caption: // execution paths compile (`cross-field-conformance-cases.ts` pins the rows)
example: { "$gt": { "$field": "budget" } }

[1] schema door — does the example parse?
    FieldReferenceSchema.safeParse(comparand) -> true
    ComparisonOperatorSchema.safeParse(example) -> true
    FilterConditionSchema.safeParse({ amount: example }) -> true

[2] the caption's surface — is there an ON clause to write it into?
    QuerySchema.safeParse({ object, joins:[{ on: example }] }) -> false
    refusal (first 180 chars): `query.joins` was removed in @objectstack/spec 17 (ADR-0049) — no engine or driver ever read it: a query carrying `joins` behaved exactly as if the key were absent, while its name …

[3] in-memory evaluation against a flat row (the shape a table stores)
    row = {"id":"r1","amount":120,"budget":100,"owner_id":"u1","user_id":"u1"}
    $field names "budget"; row has that column? true
    matchesFilterCondition(row, { amount: example }) -> true

[4] SQL push-down: pinned in @objectstack/driver-sql
    src/sql-driver-cross-field-reference.test.ts, "a dotted relation path"
    { amount: { $gt: { $field: 'a.b' } } } -> 400 INVALID_FILTER (log fragment "dotted path")
    a same-table reference compiles: cross-field-conformance-cases.ts, { amount: { $gt: { $field: 'budget' } } }
```

Line `[2]` is a control, not a claim about the fix: the join surface is gone in BOTH states. What changed is that the example no longer advertises it.

## The pin, and the ablation that proves it can fail

`packages/spec/src/data/filter.test.ts` gains three assertions that hold the docblock to its own prose:

- **lit and dark controls** — the extractor really finds `@example` blocks carrying `$field` values (12 blocks, 3 values), and a fabricated key (`$fieldd`) finds none. A zero below therefore means "no path spellings", never "nothing was read".
- **the block's examples parse** on the documentation copy (`ComparisonOperatorSchema`), the enforced copy (`FieldOperatorsSchema`) and as a whole condition (`FilterConditionSchema`) — an example nobody runs is how this one drifted.
- **no `@example` anywhere in the file spells a `$field` value as a path.** The probe is on the CLAIM, not on one spelling: case-insensitive, quote-agnostic, and it refuses `.` and `/` alike, so a slash-separated or unbackticked respelling trips it too.

Ablation — the pre-fix example put back byte-for-byte, on-disk arrival proved before the run, restored after:

```text
== HEAD blob: 0783f9256ddfbfc4eedf88153e48179dfb441f17
== pre-mutation on-disk hash: 0783f9256ddfbfc4eedf88153e48179dfb441f17
-- injected text present (expect >0): 3
-- deleted text absent  (expect 0):  0
== mutated on-disk hash: e1d4dc6c36da4c6aa0f33c114163809ca92fd930
== MUTATED RUN EXIT=1
     × no @example in the file spells a $field comparand as a path (dot OR slash) 13ms
 FAIL  src/data/filter.test.ts > filter.zod.ts docblock @examples (#16923) > no @example in the file spells a $field comparand as a path (dot OR slash)
AssertionError: a $field comparand is a column of the SAME row: expected [ { …(2) } ] to deeply equal []
 Test Files  1 failed (1)
      Tests  1 failed | 156 passed (157)
== restored on-disk hash: 0783f9256ddfbfc4eedf88153e48179dfb441f17  (HEAD blob 0783f9256ddfbfc4eedf88153e48179dfb441f17)
== git diff HEAD empty for target? []
```

The injected-text count is 3 LINES, not 3 occurrences — `grep -c` counts lines, and the mutated block puts `order.owner_id` on the prose line, the caption line and the payload line.

## Site sweep — probed on the claim, not on one spelling

`order.owner_id` was never the search key. The sweep asked: does any surface say a `$field` comparand may be a path? Regex `\$field["']?\s*[:=]\s*["'][ident][./][path]`, case-insensitive, over the whole tree minus `node_modules` and `.git`, then triaged by hand.

| surface | verdict |
| :--- | :--- |
| `packages/spec/src/data/filter.zod.ts:37` | the card's site — **fixed here**. The only `@example` in the file naming a path. |
| `content/docs/protocol/objectql/query-syntax.mdx` | correct already: every `$field` example is same-table, and `:513` states dotted is refused. `order.owner_id` returns 0 hits. |
| `content/docs/references/data/filter.mdx` | generated, and it republishes `describe()` text only — no `@example` reaches it. `order.owner_id` returns 0 hits. **Not regenerated: nothing moved it** (`check:generated` exit 0). |
| `skills/objectstack-query/{SKILL.md,rules/filters.md}` | correct already — "two columns of the same row", example `actual_cost: { $gt: { $field: 'budget' } }`. |
| driver / analytics / runtime / formula tests, `cross-field-conformance-cases.ts` | dotted paths appear as **pinned refusals** and as `addDays` dot-path cases the ruling admits. Correct as written; not touched. |
| `packages/spec/src/data/query.test.ts:632` | a dotted `$field` inside a `joins[]` payload asserted to be REFUSED. Correct as written. |
| `docs/audits/2026-06-handwritten-docs-accuracy-followups.md:85,350` | a dated audit record, not an instruction to authors. Left as the record it is. |
| `packages/drivers/driver-*/CHANGELOG.md` | released history. Never rewritten. |

**How complete is this, honestly.** It is complete for the spelling class the regex names — a `$field` key immediately assigned a quoted value containing `.` or `/`, any quote style, any case. It is **not** provably complete for prose that describes a relation-path comparand without writing one; that class has no mechanical key, and I triaged it by reading every author-facing surface the count table surfaced rather than by proving a negative. The two docs pages the card names are **not** the whole set, and I do not claim my set is either — what I claim is that the pin now fails on any future `@example` in `filter.zod.ts` that reintroduces the shape.

## Gates

Run locally on this head, exits captured before any pipe:

| command | exit |
| :--- | :--- |
| `pnpm --filter @objectstack/spec build && typecheck && test` | 0 — **471 files, 13269 tests passed** |
| `pnpm --filter @objectstack/spec exec vitest run src/data/filter.test.ts` | 0 — 157 passed |
| `pnpm --filter @objectstack/driver-sql exec vitest run src/sql-driver-cross-field-reference.test.ts -t 'a dotted relation path'` | 0 — 1 passed, 47 skipped |
| `check:docs` · `check:yaml-examples` · `check:authorable-surface` · `check:generated` · `check:spec-changes` · `check:migration-registry` · `check:upgrade-guide` · `check:liveness` (all `--filter @objectstack/spec`) | 0 |
| `check:api-surface` · `check:strictness-ledger` · `check:variant-docs` · `check:skill-refs` · `check:llms-txt` (`--filter @objectstack/spec`) | 0 |
| `check-spec-docblock-symbol-anchors.mjs` · `check:nul-bytes` · `check:cross-package-test-inputs` · `check:test-source-alias` · `check:published-files` · `check:doc-authoring` · `check:tier-file-adoption` · `check:type-check-coverage` · `check:changeset-gate-self-tests` | 0 |
| `check-empty-changeset --base origin/main` · `check-changeset-no-major --base origin/main` · `check-closing-keyword-parity` · `check-comment-mask-adoption` · `docs-audit/check-affected-docs.mjs` | 0 |
| `pnpm check:type-check-debt` | **3 — NOT MEASURED, not red.** `PREREQUISITE NOT MET`: `--re-measure` needs 25 workspace dependencies built. Its `--self-test` and the `check:type-check-coverage` half both passed. Left to CI, which builds the closure first. |

`node scripts/pm/dispatch-gates.mjs --commands --repo objectstack-ai/objectstack` derives **81** runnable commands for this change set (plus 46 artifact-roster families, 11 wide-population families and 5 path-scheduled CI jobs it explicitly declines to place). The families above are the ones this diff can actually move; the remainder is **declared to CI**, which runs the whole farm.

**Lint, narrowed and declared.** `pnpm lint` is `eslint . --no-inline-config`, a whole-repo run CI owns. Narrowed here to the diff's two source files, with the three readings that make a narrowing a measurement rather than a skip:

1. **Population, read from ESLint's own config** (`ESLint#isPathIgnored` over `git ls-files`): 6486 lintable files, 0 ignored. Lit control: `filter.zod.ts` → not ignored. Dark control: `node_modules/eslint/lib/api.js` → ignored.
2. **Files linted, read from `--format json`**: 2. Both 0 errors, 0 warnings; eslint exit 0.
3. **Invariance for the 6484 untouched files**: this repo runs one `eslint.config.mjs`, which **never enables type-aware linting for any file** — no `parserOptions.project`, no typed `@typescript-eslint` rules (stated and independently measured at `eslint.config.mjs:326-329`). This diff changes no config file, so the ruleset applied to every untouched file is byte-identical and no verdict on one can depend on my two files' contents.

Every gate figure above and the `git rev-parse --short HEAD` cited in the report were taken on the final commit of this branch.

## 验收备注

- The changeset is a `patch` on `@objectstack/spec`: `files[]` includes `src/**/*.zod.ts`, so this docblock is published bytes and reaches authors and IDE hover. `filter.test.ts` is not published.
- The corrected example deliberately reuses the `amount > budget` shape that `cross-field-conformance-cases.ts` already compiles and pins on both execution paths, so the example has a live backing rather than a second unpinned spelling.
- The new header prose still contains the string `order.owner_id`, once, framed as the refused spelling. That is deliberate — a reader who already copied the old example needs to find the correction by searching for what they copied — and the new pin scans `@example` bodies only, so the refusal framing does not trip it.
- The card offered three routes and asked for a judgement about the join surface. Measurement closed it rather than a judgement: route (c) — "keep it, label the memory-only context" — is falsified, because the dotted spelling does not work in memory on a flat row either; it answers `false`. Routes (a) and (b) were both taken, because the header framing is what made the dotted example look correct.
- Out of scope, noted, not filed: `packages/spec/src/ui/dataset.zod.ts:80` and `dataset.form.ts:39` already say "you never write an ON clause", which is the sentence `filter.zod.ts` contradicted until this PR. They are correct; no carrier and no defect. Recorded so the next reader of this block knows the two surfaces now agree.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MkQhmuuJAVDjmeWNixwDDH)_