### PR TITLE
docs(spec): assert an `@example` caption has a block beneath it

### DIFF
--- a/.changeset/example-caption-fence-assertion.md
+++ b/.changeset/example-caption-fence-assertion.md
@@ -1,0 +1,30 @@
+---
+"@objectstack/spec": patch
+---
+
+The reference-docs renderer now refuses an `@example CAPTION` with no code block beneath it,
+instead of publishing an orphaned caption.
+
+`@example CAPTION` is declared to be *the caption of the fence beneath it*, and the renderer
+acts on that reading: it promotes the tag into a bold lead-in on the assumption that a fence
+follows. Nothing asserted that one did. When a module header captioned a listing and wrote its
+rows as bare prose, the promotion still fired and the rows below collapsed into a single run-on
+paragraph — consecutive non-blank lines are one markdown paragraph, and the docs site loads no
+`remark-breaks`. Two customer-facing reference pages shipped that way.
+
+The assumption is now a precondition the generator checks before it emits anything. A module
+description whose caption has no block under it fails the docs build with a message naming the
+caption and the source-side fix, the way the renderer already refuses a heading it cannot
+renumber. Deliberately a refusal in the generator rather than a separate gate: it makes the
+wrong page impossible instead of detecting it afterwards, and it is scoped to the population
+the renderer actually renders — module doc blocks — rather than to every `@example` line in the
+package.
+
+⛔ The check never asks whether a run of prose is "really" a table. Shape-sniffing is exactly
+what this renderer refuses to do, and what an author writes instead of a fence is not knowable
+from the text. It asks only the question the contract already states: is there a block beneath
+the caption? An author who wants those words as ordinary prose writes them without the tag.
+
+Both code kinds satisfy it. An indented block reaches the page as a fence — the render loop
+re-emits it as one — so a caption above one captions a fence by the time a reader sees it. All
+twelve captions in the corpus are fenced today and are unaffected; no schema behavior changes.

--- a/packages/spec/scripts/file-description.test.ts
+++ b/packages/spec/scripts/file-description.test.ts
@@ -851,6 +851,122 @@ describe('renderFileDescription — #14455: a tag WITH a payload is rewritten, n
 });
 
 /**
+ * #16962 — the caption's fence is a PRECONDITION, and the generator asserts it.
+ *
+ * `EXAMPLE_CAPTION` promotes `@example CAPTION` to a bold lead-in because the
+ * contract says a fence follows. Nothing checked, and #15440 is what that cost:
+ * two module headers captioned a listing, wrote its rows as bare prose, and the
+ * rows reached two customer-facing reference pages as one run-on paragraph —
+ * consecutive non-blank lines are one markdown paragraph, and the docs site
+ * loads no `remark-breaks`.
+ *
+ * ⛔ The refusal is NOT a detector for "prose that is really a table". This
+ * module's own header rejects that shape-sniffing and so does the card. The
+ * question asked here is only the one the contract already states: is there a
+ * block beneath the caption? An author who wants those words as prose writes
+ * them without the tag.
+ */
+describe('renderFileDescription — #16962: a caption with no block beneath it is refused, not published', () => {
+  const ctx = { fromCategory: 'api', sourcePathToDocsRoute: () => null, sectionLevel: PAGE_SECTION_LEVEL };
+
+  const moduleBlock = (...body: string[]): string =>
+    ['/**', ...body.map(l => (l === '' ? ' *' : ` * ${l}`)), ' */', '', "import { z } from 'zod';", ''].join('\n');
+
+  it('refuses the #15440 shape — a caption over rows written as bare prose', () => {
+    // `api/automation-api` and `api/package-api`, reduced to the shape they
+    // shipped. Before the assertion this rendered `**Endpoints**` followed by
+    // one paragraph reading `GET /api/automation … POST /api/automation …`.
+    expect(() =>
+      renderFileDescription(
+        moduleBlock(
+          'Automation API Protocol',
+          '',
+          '@example Endpoints',
+          'GET /api/automation - list',
+          'POST /api/automation - create',
+        ),
+        ctx,
+      ),
+    ).toThrow(/`@example Endpoints` with no code block beneath it/);
+  });
+
+  it('names the source fix, because the source is where the fix goes', () => {
+    // The renderer cannot repair this and must not try — the same reason the
+    // heading-depth refusal points at the file header rather than clamping.
+    expect(() => renderFileDescription(moduleBlock('@example Endpoints', 'GET /api/x'), ctx)).toThrow(
+      /Fence the block in the source's own file header/,
+    );
+  });
+
+  it('refuses a caption that ends the block, with nothing at all beneath it', () => {
+    // The other orphan shape, and the one a "next line is not a fence" test
+    // written with an off-by-one would sail past.
+    expect(() => renderFileDescription(moduleBlock('Automation API Protocol', '', '@example Endpoints'), ctx)).toThrow(
+      /no code block beneath it/,
+    );
+  });
+
+  it('refuses a caption whose next block is another tag rather than a fence', () => {
+    // A run of tags is the arrangement `withTagBlocksSeparated` exists for, so
+    // the caption is followed by a blank line here whatever the source wrote.
+    // Skipping blanks must not be mistaken for finding a block.
+    expect(() =>
+      renderFileDescription(
+        moduleBlock('Automation API Protocol', '', '@example Endpoints', '@see https://example.invalid/api'),
+        ctx,
+      ),
+    ).toThrow(/no code block beneath it/);
+  });
+
+  it('accepts the fenced form — the twelve captions in the corpus keep rendering', () => {
+    const out = renderFileDescription(
+      moduleBlock('Automation API Protocol', '', '@example Endpoints', '```', 'GET /api/automation', '```'),
+      ctx,
+    );
+    expect(out).toContain('**Endpoints**\n```');
+  });
+
+  it('accepts a blank line between the caption and its fence', () => {
+    // Markdown puts the fence under the bold line either way, and the sources
+    // write both spellings — refusing this one would reject correct pages.
+    const out = renderFileDescription(
+      moduleBlock('@example Endpoints', '', '```', 'GET /api/automation', '```'),
+      ctx,
+    );
+    expect(out).toContain('**Endpoints**');
+    expect(out).toContain('GET /api/automation');
+  });
+
+  it('accepts an INDENTED block, which reaches the page as a fence anyway', () => {
+    // `data/date-macros` and `data/context-tokens` write examples this way and
+    // the render loop re-emits them fenced. Judged by KIND, so a caption above
+    // one captions a fence by the time a reader sees it.
+    const out = renderFileDescription(moduleBlock('@example Macros', '', '    value: 1'), ctx);
+    expect(out).toContain('**Macros**');
+    expect(out).toContain('```\nvalue: 1\n```');
+  });
+
+  it('ignores an `@example CAPTION` shown INSIDE a fence — that is an author illustrating the tag', () => {
+    // Judged on the same classification the rewrite is, so a header teaching the
+    // convention is not refused for demonstrating the broken form. A refusal
+    // written over raw text instead of over `kind` would reject this file's own
+    // documentation.
+    const out = renderFileDescription(
+      moduleBlock('How a module header captions an example:', '', '```md', '@example Endpoints', 'GET /api/x', '```'),
+      ctx,
+    );
+    expect(out).toContain('@example Endpoints');
+  });
+
+  it('ignores a mid-sentence mention, the same UNTRIMMED test the rewrite uses', () => {
+    // `MODULE_MARKER`'s rule, and the reason the two can share one pattern: only
+    // a line that OPENS with the tag is a tag.
+    const out = renderFileDescription(moduleBlock('Write `@example Foo` above a fence to caption it.'), ctx);
+    expect(out).toContain('@example Foo');
+  });
+});
+
+/**
  * #5553 — the block is rendered as the markdown it was written as.
  *
  * The renderer used to drop blank lines and join what was left with `\n\n`,

--- a/packages/spec/scripts/lib/file-description.ts
+++ b/packages/spec/scripts/lib/file-description.ts
@@ -502,11 +502,11 @@ const SKILL_EXAMPLE_MARKER = '<!-- os:check -->';
  * may be DROPPED is decided by whether it has a payload, and the tags that
  * reach a page do not answer alike: `@module` and a bare `@example` are their
  * own entire content, while `@example CAPTION` is the caption of the fence
- * beneath it and `@see` is a cross-reference — both rewritten instead
- * (`EXAMPLE_CAPTION`, and `renderProse`'s `See also: …`). A blanket line filter
- * cannot express that difference; it would take the caption off the page and
- * orphan its fence, and "no page loses non-tag prose" is this fix's acceptance
- * criterion. `@category` is the one payload-carrying tag that still renders as
+ * beneath it — asserted by `assertCaptionedBlocksAreFenced`, not merely assumed
+ * — and `@see` is a cross-reference; both rewritten instead (`EXAMPLE_CAPTION`,
+ * and `renderProse`'s `See also: …`). A blanket line filter cannot express that
+ * difference; it would take the caption off the page and orphan its fence, and
+ * "no page loses non-tag prose" is this fix's acceptance criterion. `@category` is the one payload-carrying tag that still renders as
  * nothing, and `CATEGORY_MARKER` carries the measurement that says why.
  *
  * Judged with the same UNTRIMMED `^@module\b` test `hasModuleMarker` selects
@@ -795,8 +795,70 @@ function mapProse(text: string, kinds: ProseRun['kind'][], fn: (plain: string) =
  * `@example` in a list item — and only ever shown prose, so an `@example` inside
  * a fence stays as the author wrote it. Held global-safe by `String#replace`,
  * which resets `lastIndex` around the call.
+ *
+ * ⚠️ "the block it captions" is a PRECONDITION, not an observation, and
+ * `assertCaptionedBlocksAreFenced` is what makes it one. Until it existed this
+ * comment promised a fence that nothing checked for, and two module headers
+ * captioned a listing whose rows were bare prose: the promotion still fired,
+ * and the rows below collapsed into one run-on paragraph on two customer-facing
+ * reference pages. The rewrite is unconditional BY DESIGN — it may stay that
+ * way precisely because the assertion runs before it.
  */
 const EXAMPLE_CAPTION = /^@example[ \t]+(\S.*)$/gm;
+
+/**
+ * The same pattern, per line and stateless — one source, so the two can never
+ * drift.
+ *
+ * Dropping `g` is what makes it safe to `.test()` in a loop: a `g` regex
+ * carries `lastIndex` between calls and would answer for every second caption.
+ * Dropping `m` costs nothing, because `^` and `$` against a single line mean
+ * exactly what they meant against a line of the block.
+ */
+const EXAMPLE_CAPTION_LINE = new RegExp(EXAMPLE_CAPTION.source);
+
+/**
+ * Refuse a caption with no block beneath it, rather than publishing one.
+ *
+ * `EXAMPLE_CAPTION` promotes `@example CAPTION` to a bold lead-in on the stated
+ * assumption that a fence follows. This asserts the assumption instead of
+ * trusting it — the generator makes the wrong page impossible, which is the
+ * same move `findModuleDocBlock` makes for block selection and the reason
+ * neither needs a detector bolted on beside it.
+ *
+ * ⛔ It never asks whether a run of prose is "really" a table. That is the
+ * shape-sniffing this module's own header rejects, and the thing an author
+ * writes instead of a fence is not knowable from the text. The question here is
+ * only the one the contract already states: is the next block a block? An
+ * author who wants the words as ordinary prose writes them without the tag.
+ *
+ * Both code kinds count. `indented` reaches the page as a fence — the render
+ * loop re-emits it as one — so a caption above an indented block captions a
+ * fence by the time a reader sees it, and refusing it would reject a form that
+ * renders correctly today.
+ *
+ * Blank lines between the caption and its block are skipped: `withTagBlocksSeparated`
+ * inserts one before every tag, the sources write their own, and markdown puts
+ * the fence under the bold line either way.
+ */
+function assertCaptionedBlocksAreFenced(lines: readonly string[], kind: readonly LineKind[]): void {
+  for (let i = 0; i < lines.length; i++) {
+    if (kind[i] !== 'prose' || !EXAMPLE_CAPTION_LINE.test(lines[i])) continue;
+
+    let next = i + 1;
+    while (next < lines.length && lines[next].trim() === '') next++;
+    if (next < lines.length && (kind[next] === 'fenced' || kind[next] === 'indented')) continue;
+
+    const caption = EXAMPLE_CAPTION_LINE.exec(lines[i])![1];
+    throw new Error(
+      `file-description: this module description writes \`@example ${caption}\` with no code block ` +
+        `beneath it. An \`@example CAPTION\` line is the caption OF the block below it and is published ` +
+        `as a bold lead-in on that assumption; with no fence there, the lines under it are consecutive ` +
+        `prose and markdown renders them as ONE run-on paragraph. Fence the block in the source's own ` +
+        `file header, or drop the tag and write the caption as ordinary prose.`,
+    );
+  }
+}
 
 /** One run of consecutive prose lines, rendered to MDX. */
 function renderProse(text: string, ctx: FileDescriptionContext): string {
@@ -901,6 +963,13 @@ export function renderFileDescription(source: string, ctx: FileDescriptionContex
     gutterless.filter((line, i) => !(markerKind[i] === 'prose' && isMarkerLine(line))),
   );
   const kind = classifyLines(lines);
+
+  // Before anything is emitted, and against that same classification: a caption
+  // whose block is missing is refused here rather than published (see
+  // `assertCaptionedBlocksAreFenced`). Ordered before the renumbering because a
+  // source this rejects should be told what is wrong with it, not handed a
+  // heading-depth error it did not cause.
+  assertCaptionedBlocksAreFenced(lines, kind);
 
   // Renumbered against the SAME classification the render loop below uses, so
   // the shift and the "this line is code" verdict can never disagree. Adding


### PR DESCRIPTION
Fixes #16962

Clause-②: no — the diff is a documentation-generator invariant plus its tests and a changeset. No schema, accept set, or published runtime surface is touched; `packages/spec/src/**` is untouched, and the assertion re-declared against the ACTUAL diff agrees with the claim comment's dispatch-time reading.

## The card's subject, and what turned out to be true

`@example CAPTION` is **declared** to be "the caption of the fence beneath it". `EXAMPLE_CAPTION` acts on that reading and promotes the tag into a bold lead-in. Nothing asserted the fence was there, and #15440 shipped two orphaned captions past that gap: the promotion still fired and the rows below collapsed into one run-on paragraph on two customer-facing pages.

Every premise re-measured on this branch at `origin/main` 59db8a02cb:

| premise | verdict |
|---|---|
| the contract sentence is at `file-description.ts` | HOLDS — in the `MODULE_MARKER` SCOPE paragraph |
| `EXAMPLE_CAPTION` is `/^@example[ \t]+(\S.*)$/gm` and rewrites to `**$1**` | HOLDS — line 799, unchanged |
| the universe is 199 `@example CAPTION` lines in `packages/spec/src` | HOLDS — 199, and `@example` partitions exactly 199 captioned / 199 bare / 398 total, zero overlap |
| confirmed damage is zero after #16961 | HOLDS — measured, not predicted |
| a gate over the 166 or 62 reading would be false-positive noise | HOLDS, **and understates it** — see below |

## The population the card could not name is 12, not 199

⭐ **`renderFileDescription` reads only the MODULE doc block.** `findModuleDocBlock` returns `null` for any block that documents a symbol, so property-level `@example` tags — the `@example 'support_case'` shape that made up the bulk of the card's 166 — never reach this renderer at all. Measured with the real `findModuleDocBlock` over all 1321 files: 456 carry a module block, and those blocks hold **12** `@example CAPTION` lines. All 12 are followed by a fence or an indented block. Orphans today: **0**.

Independent confirmation, arrived at separately: `EXAMPLE_CAPTION`'s own doc comment already says "Twelve module headers write a caption over a fence", and #15443's changeset says "12 lines across 10 pages".

Cross-check that the other 187 are outside the docs surface entirely: `@example` appears 6 times in all of `content/docs/references/`, and all 6 are email addresses (`j***@example.com`, `user@example.com`). Zero leaked tags. Lit control `Endpoints` = 6 files; dark control = 0.

⇒ The card asked for a predicate separating damage from harmless prose over a 166-line population. Scoped to what the renderer actually renders, **no such predicate is needed**: the population is 12, and the predicate is the contract itself.

## Which of the three failure-fix routes — the second

*First delete the construct that permits the error; then make the correct form the only spelling; only then add a check.*

**Route 1, delete the construct — rejected, with a measurement.** The construct is `EXAMPLE_CAPTION`'s unconditional promotion, and deleting it is the card's "Remove" end. It would regress #14455 (the literal text `@example Endpoints` returns to the page) and degrade **12 correct, live captions** to prevent a defect with **0** live instances.

**Route 2, make the correct form the only spelling — TAKEN.** `renderFileDescription` now refuses, before it emits anything, a prose-level `@example CAPTION` with no block beneath it. An unfenced caption fails the docs build, so the only spelling that can produce a page is the fenced one — the wrong page is not detected, it is impossible. This is the move the file already makes twice: `findModuleDocBlock` is written as what the generator will select "because a rule that makes the wrong page impossible needs no detector", and `withHeadingsAtSectionLevel` already refuses a heading it cannot renumber and names the source-side fix. The new refusal is the third instance of the same idiom.

**Route 3, add a check — NOT taken, and the difference is not cosmetic.** The card's "Enforce" end was a gate over `packages/spec` docblocks, which is what needs the predicate design and the controlled false-positive count. This PR adds **no gate script, no scan surface, and no new CI family**. The precondition lives inside the one function that publishes, is asked only of the 12 blocks that function renders, and asks only the question the contract already states.

⛔ It never asks whether a run of prose is "really" a table. That shape-sniffing is what this module's header rejects and what the card put out of scope. What an author writes instead of a fence is not knowable from the text; whether a block is there is.

Both code kinds satisfy it: an `indented` block is re-emitted as a fence by the render loop, so a caption above one captions a fence by the time a reader sees it. Judged on `classifyLines`' verdict rather than on raw text, so a header illustrating the tag inside a fence is not refused for demonstrating the broken form.

## Ablation — two-sided, proven on disk

Under `trap restore EXIT INT TERM` with absolute paths; restore is `git checkout HEAD -- packages/spec/scripts/lib/file-description.ts`.

```
HEAD blob:      4570a8aaec5cea439fa61a52e3f6e82b4323a16a
worktree blob:  4570a8aaec5cea439fa61a52e3f6e82b4323a16a
anchor count before mutation      = 1   (grep -cF, guards against a no-op edit)
LEG 1  delete the assertion call
anchor count after mutation       = 0   mutated blob 41d049a621f76ec15b05e5d876f6d74cfe8ef51e
MUTATED_RUN_EXIT=1        Tests  4 failed | 5 passed | 102 skipped
LEG 2  restore
anchor count after restore        = 1   restored blob 4570a8aaec... (matches HEAD: YES)
git diff HEAD empty: YES
RESTORED_RUN_EXIT=0       Tests  9 passed | 102 skipped
```

Exactly the four refusal cases go red and the five acceptance cases stay green — the direction a guard-deleting ablation must produce. No `dist` preflight applies: `file-description.test.ts` imports `./lib/file-description` by relative source path, so no build artifact sits in the resolution path.

## Verification

Run in the worktree, exit codes captured before any pipe.

| command | exit |
|---|---|
| `pnpm --filter @objectstack/spec exec vitest run scripts/file-description.test.ts` | **0** — 111 passed |
| the 9 new cases, by name filter, `--reporter=verbose` | **0** — 9 passed, each named |
| `pnpm --filter @objectstack/spec run check:docs` | **0** — 228 generated files in sync |
| `pnpm --filter @objectstack/spec run typecheck` | **0** |
| `pnpm check:nul-bytes` · `check:cross-package-test-inputs` · `check:test-source-alias` | **0** |
| `check-empty-changeset` · `check-changeset-no-major` · `check-changeset-fixed` | **0** |
| `pnpm check:published-files` · `check:doc-authoring` · `check:type-check-coverage` | **0** |
| `docs-audit/check-affected-docs.mjs` · `docs-audit/check-drift-comment.mjs` | **0** |
| `check:variant-docs` · `check:skill-refs` · `check:empty-state` | **0** |
| `pnpm check:type-check-debt` | **3 = NOT MEASURED** |

`check:docs` is the load-bearing one: it runs `renderFileDescription` over every source in the package, so the new precondition was asked of the whole live corpus and fired zero times, and the 228 generated files came back byte-identical. The assertion is additive — it refuses or passes through, and it changes no output.

`check:type-check-debt` exits **3**, which its own text defines as `PREREQUISITE NOT MET` — "NOT a pass and NOT a finding, nothing was measured". It needs the whole `./packages/*` build closure on disk. Left to CI. ⛔ Not read as green and ⛔ not read as red.

`check:docs` was **NOT MEASURED** on its first run too (exit 1, `packages/spec/json-schema is missing`); re-run after `pnpm --filter @objectstack/spec build`, which regenerates it. Not in MERGE state, so `gen:schema` had no stale anchor to roll back to.

**Type-check coverage, proven rather than assumed.** `tsconfig.test.json`'s `include` stops at `src`, so it does NOT reach these files; `scripts/**` is the sibling `tsconfig.scripts.json` program that `check:scripts-typecheck` invokes. `tsc -p tsconfig.scripts.json --listFiles` = exit 0 over 915 files, with the edited lib present (1), the edited test present (1), and a fabricated path absent (0).

**Declared narrowing.** `node scripts/pm/dispatch-gates.mjs --commands --repo objectstack-ai/objectstack` derives 59 runnable commands for these paths, re-derived after the changeset existed (which added the 6 changeset families, all run above). The families above were run; the remainder are left to CI, including every family the tool itself marks NOT MEASURED, the 46 artifact rosters, the 11 wide-population families, and the 5 path-scheduled CI jobs. Repo-wide scans (`pnpm lint`) are CI's run.

## 验收备注

Findings noted, not filed — neither has a carrier that would reach them.

- The card's derived predicates (166, 62) over-count for a reason one layer deeper than the card states: it is not only that two-line prose reads fine as a paragraph, it is that ~187 of the 199 sit in docblocks `renderFileDescription` never reads. This is a correction to the card's own analysis, delivered here and in the report rather than as a new issue — the card is the carrier, and it is about to be closed by this PR.
- `#16960`'s subject (`path:NNN` anchors in prose) and the third card the triage seat filed for the shared gap are unaffected by this change either way. This PR deliberately does not widen toward them; the routes stay separate exactly as triage ruled. `#16960 remains open` and is not addressed here.

Authored by Claude Code in session `session_01MkQhmuuJAVDjmeWNixwDDH`, dispatched by the `domain:spec` execution seat.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MkQhmuuJAVDjmeWNixwDDH)_