### PR TITLE
skills(pm-dispatch): the lane table carries non-gate scripts/pm and the three devx paths; lane files point at it

### DIFF
--- a/.claude/skills/pm-dispatch/SKILL.md
+++ b/.claude/skills/pm-dispatch/SKILL.md
@@ -244,8 +244,8 @@ PM 的工作是循环:选卡 → 认领 → 派发 → 收集 → 复核 → 报
 |:--|:--|
 | `domain:engine` | `packages/objectql`、`packages/core`、`packages/formula`(CEL / `matches-filter` / RLS 谓词求值)、`plugin-pinyin-search`;`packages/metadata*`、`packages/platform-objects`;`packages/drivers/driver-*`;退役标签 `domain:engine-core` / `domain:metadata` / `domain:drivers` 只退出流通,GitHub 标签对象保留 |
 | `domain:services` | `packages/services/*`、`packages/connectors/*`、`packages/triggers/*`、`plugin-approvals`、`plugin-webhooks`、`plugin-email`、`plugin-reports`、`embedder-openai`、`knowledge-*`;`plugin-auth`、`plugin-security`、`plugin-sharing`、`plugin-audit`;退役标签 `domain:identity` 同上只退流通 |
-| `domain:devx` | `packages/sdui-parser`、`content/docs/**`、`apps/docs`;`packages/lint`、`scripts/`(门禁类)、`.github/workflows/`(门禁接线);三者与 spec 相交的面按锚定规则的例外归 `domain:spec`,门禁再按 SUBJECT:治理 agent 指令面/governed 面的归 skills,治理代码/文档质量的归本域 |
-| `domain:skills` | governed 面全量(含本文件;统一定义见「governed 面统一定义」行);governed 面的治理执行文件:`.github/CODEOWNERS` + SUBJECT 是 governed 面本身的门禁/审计(现为 `scripts/pm/check-governed-merges.mjs`) |
+| `domain:devx` | `sdui-parser`、`content/docs/**`、`apps/docs`、`.githooks/`、`docker/README.md`、`examples/**` 仅测试基建面;`packages/lint`、`scripts/`(门禁类)、`.github/workflows/`(接线)三者与 spec 相交面按锚定规则例外归 `domain:spec`,门禁按 SUBJECT:governed 面归 skills,代码/文档质量归本域 |
+| `domain:skills` | governed 面全量(含本文件;统一定义见「governed 面统一定义」行);非门禁的 `scripts/pm/**`(PM 循环工具);governed 面的治理执行文件:`.github/CODEOWNERS` + SUBJECT 是 governed 面本身的门禁/审计(现为 `scripts/pm/check-governed-merges.mjs`) |
 | `domain:spec` | `packages/spec` 整包:schema 形状、`contracts/**`、退役行为半边、strictness 台账;describe/JSDoc/墓碑散文/错误 guidance 与 alias 表;`packages/spec/scripts/**`、`packages/spec/docs/**` 及按锚定规则的例外归本域的工具链(域边界枚举与席内分派见 `references/lanes/spec.md`) |
 | `domain:cli` | `packages/cli`、`runtime`、`verify`、`packages/qa`、`types`、`packages/rest`、`packages/mcp`、`packages/observability`、`packages/client*`、`cloud-connection`、`create-objectstack`、`packages/adapters/*`、`plugin-hono-server`、`plugin-dev` |
 | (无固定归属,按落点分诊) | `packages/apps/*`、`packages/console`(dist 由脚本生成 ⛔ 不手改;UI 缺陷走 `repo:objectui`)、`examples/*`(归它演练的子系统)、`docs/audits/**` |

--- a/.claude/skills/pm-dispatch/references/lanes/devx.md
+++ b/.claude/skills/pm-dispatch/references/lanes/devx.md
@@ -4,9 +4,7 @@
 
 ## 范围
 
-- `packages/lint`、`packages/sdui-parser`、`content/docs/**`、`apps/docs`、
-  `scripts/`(门禁类)、`.github/workflows/`(门禁接线)、`.githooks/`、
-  `examples/**` 测试基建面、`docker/README.md`。
+- 本席路径面全量在 SKILL.md 域车道表 `domain:devx` 行,⛔ 不另抄。
 - objectui 的本域面同辖:`.github/`、`scripts/`、构建与发布管线、门禁工具。
 - 边界:守护 skills 的门禁脚本在 `scripts/` 下时归本席,判据是被改文件的路径。
 - SUBJECT 例外与 spec 三面切分在 SKILL.md 域车道表;`.claude/workflows/` 不是 `.claude/skills/`。

--- a/.claude/skills/pm-dispatch/references/lanes/skills.md
+++ b/.claude/skills/pm-dispatch/references/lanes/skills.md
@@ -5,7 +5,7 @@
 ## 范围
 
 - 两个技能根:`.claude/skills/**`(含 pm-dispatch 本体)与 `skills/**`(发布目录,恒英文)。
-- `scripts/pm/**` PM 循环工具;指令架构文件:根 `AGENTS.md` 与根 `CLAUDE.md`。
+- PM 循环工具与指令架构文件的归属见 SKILL.md 域车道表 `domain:skills` 行,⛔ 不另抄。
 - 受管面的治理执行文件:`.github/CODEOWNERS` 治理路由半边。
 - 同含 SUBJECT 是受管面本身的门禁与审计脚本。
 - 全量判据在 SKILL.md 域车道表;受管面统一定义见 SKILL.md 〈复核〉,⛔ 不另抄。

--- a/scripts/pm/check-skill-line-ratchet.mjs
+++ b/scripts/pm/check-skill-line-ratchet.mjs
@@ -892,7 +892,7 @@ export const CEILINGS = new Map([
   // 「各条规则的出处叙事、事故复盘 根本不重要啊，不需要写入skills啊」) — provenance dates,
   // ruling citations and incident narrative left; every rule stayed. Landed count,
   // headroom 0, same convention (lowering is always legitimate).
-  ['.claude/skills/pm-dispatch/references/lanes/devx.md', 38],
+  ['.claude/skills/pm-dispatch/references/lanes/devx.md', 36],
   // Lowered 35 → 33 by the rules-only rewrite (maintainer 2026-09-04:
   // 「各条规则的出处叙事、事故复盘 根本不重要啊，不需要写入skills啊」) — provenance dates,
   // ruling citations and incident narrative left; every rule stayed. Landed count,


### PR DESCRIPTION
Fixes #17225

The 〈域车道〉 table in `.claude/skills/pm-dispatch/SKILL.md` is the declared 全量判据 (「全量判据在 SKILL.md 域车道表」), yet it answered for none of four paths the lane files stated: non-gate `scripts/pm/**` (stated only in `references/lanes/skills.md`), and `.githooks/`, `docker/README.md`, `examples/**` 测试基建面 (stated only in `references/lanes/devx.md`). This PR makes the table the one statement and turns the two lane-file statements into pointers at it — the discipline quoted on the card and its predecessor: one statement, pointers to it. No lane assignment changes: every routing written here is one the lane files already stated, and the 多仓协调 line 「`scripts/pm/**` 等住 objectstack 的全板工具链单写手恒为 objectstack 侧席」 already carried the `scripts/pm/**` half. Predecessor: #17222 (its PR #17226 landed at `d03c3c96`); this card is its successor, not a duplicate.

Governed surface (`.claude/**`) ⇒ draft only, human merge; `check-governed-merges.mjs --test` on the four paths answers GOVERNED (its own verdict line: 「3 of 4 path(s) hit the register … ⛔ GOVERNED」, exit 3).

## What changed (before → after, bytes)

Measured at `eb7406ca` (base) → `b5757749` (this PR's head). The two table rows and the two lane-file pointers stand as landed on `c8fdd0ce`; the patch-round commit `b5757749` touches only the ratchet map. Line numbers are the base tree's; the files sit under a line ratchet, so read the content, not the numbers.

**`.claude/skills/pm-dispatch/SKILL.md` — 812/812 lines (ceiling 812); widest table row 342/342 (the `domain:engine` row, unchanged).**

`domain:devx` row (:247), 330 B → 341 B (pin 342). Before:

```text
| `domain:devx` | `packages/sdui-parser`、`content/docs/**`、`apps/docs`;`packages/lint`、`scripts/`(门禁类)、`.github/workflows/`(门禁接线);三者与 spec 相交的面按锚定规则的例外归 `domain:spec`,门禁再按 SUBJECT:治理 agent 指令面/governed 面的归 skills,治理代码/文档质量的归本域 |
```

After:

```text
| `domain:devx` | `sdui-parser`、`content/docs/**`、`apps/docs`、`.githooks/`、`docker/README.md`、`examples/**` 仅测试基建面;`packages/lint`、`scripts/`(门禁类)、`.github/workflows/`(接线)三者与 spec 相交面按锚定规则例外归 `domain:spec`,门禁按 SUBJECT:governed 面归 skills,代码/文档质量归本域 |
```

Paid inside the row (+68 B of new paths against 12 B of headroom, so 57 B cut; no stated path lost, no pin raised): the repeated 「门禁」 qualifier on `.github/workflows/` (「门禁接线」→「接线」, the qualifier the dispatch named); `packages/sdui-parser` → `sdui-parser` (the table's own bare-name convention — `runtime`, `verify`, `types`, `plugin-*`; `packages/lint` keeps its prefix because the 锚定规则 exception line spells it so); 「;三者」→「三者」 as an appositive; 「相交的面」→「相交面」; 「的例外」→「例外」; 「再按」→「按」; and the SUBJECT sentence's two 「治理」 verbs plus 「agent 指令面/」, which is inside governed 面 by the table's own definition lines (「governed 面统一定义:… `.claude/**`(全量,含 agents/hooks/settings)…」 and 「governed 面同含 `AGENTS.md` + `CLAUDE.md`」), so the SUBJECT split is unchanged: governed 面 → skills, 代码/文档质量 → devx. `examples/**` carries 「仅测试基建面」 so it does not contradict the no-fixed-home row's `examples/*`(归它演练的子系统), which stays.

`domain:skills` row (:248), 254 B → 300 B — one clause inserted after the governed 面全量 clause: 「非门禁的 `scripts/pm/**`(PM 循环工具)」. Nothing else in the row moves; the 「governed 面统一定义」 reference stays verbatim. A `scripts/pm/` GATE keeps the devx row's SUBJECT split. After:

```text
| `domain:skills` | governed 面全量(含本文件;统一定义见「governed 面统一定义」行);非门禁的 `scripts/pm/**`(PM 循环工具);governed 面的治理执行文件:`.github/CODEOWNERS` + SUBJECT 是 governed 面本身的门禁/审计(现为 `scripts/pm/check-governed-merges.mjs`) |
```

**`references/lanes/skills.md` — 33/33 lines (ceiling 33).** :8, 90 B → 109 B (cap 120):

```text
before: - `scripts/pm/**` PM 循环工具;指令架构文件:根 `AGENTS.md` 与根 `CLAUDE.md`。
after:  - PM 循环工具与指令架构文件的归属见 SKILL.md 域车道表 `domain:skills` 行,⛔ 不另抄。
```

The root instruction files are covered by the table through 「governed 面同含 `AGENTS.md` + `CLAUDE.md`」, so the pointer drops no stated path.

**`references/lanes/devx.md` — 38 → 36 lines (ceiling 38 → 36 after the patch round; headroom 0).** The 范围 bullet at :7–:9 (79/78/55 B, one wrapped bullet) → one line, 83 B:

```text
before:
- `packages/lint`、`packages/sdui-parser`、`content/docs/**`、`apps/docs`、
  `scripts/`(门禁类)、`.github/workflows/`(门禁接线)、`.githooks/`、
  `examples/**` 测试基建面、`docker/README.md`。
after:
- 本席路径面全量在 SKILL.md 域车道表 `domain:devx` 行,⛔ 不另抄。
```

**`scripts/pm/check-skill-line-ratchet.mjs` — one token (patch round; the skills seat's answer A to the open question, surface widened by exactly this file).** The `lanes/devx.md` row of `CEILINGS`:

```text
before: ['.claude/skills/pm-dispatch/references/lanes/devx.md', 38],
after:  ['.claude/skills/pm-dispatch/references/lanes/devx.md', 36],
```

Reason: the file's count fell 38 → 36 when its three-line path bullet became one pointer line; the ratchet is shrink-only and its own text says lowering is always legitimate, so the ceiling is re-locked at the new count with headroom 0 instead of leaving two lines of growth budget nobody paid for. No ruling is needed to lower; nothing else in that file moves.

## Re-check (the card's commands), before → after

On `.claude/skills/pm-dispatch/SKILL.md`: `grep -c -- ".githooks"` 0 → 1 · `grep -c -- "docker/README"` 0 → 1 · `grep -c -- "scripts/pm/\*\*"` 1 → 2 (the new hit is the `domain:skills` row; the file-wide `grep -c "scripts/pm"` reads 15 → 15 because SKILL.md names many `scripts/pm/*` tools by file) · `grep -c -- "examples/"` 1 → 2 · control `grep -c "domain:spec"` 5 → 5.
On `references/lanes/skills.md`: `grep -c "scripts/pm"` 1 → 0. On `references/lanes/devx.md`: `.githooks` 1 → 0, `docker/README` 1 → 0, `examples/` 1 → 0.
The decision-frame block (:734–:752) is untouched: md5 `22f2339f0acb64cdb50c7adc9db681c3` before and after.

## Gates (all run at `b5757749`, the final head; exit codes captured before any pipe)

Derived with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack --commands` on the widened diff: 39 families (16 on the first head `c8fdd0ce`; the ratchet-script edit adds 23, `check:pm-dispatch-gates` among them); `--ran` reconciliation at `b5757749`: 「39 derived, 39 run, 0 NOT-MEASURED, 0 UNRUN」 with every recorded exit code. All exit 0, each gate's own verdict line read:

- `check:pm-skill-ratchet` — SKILL.md 「812 lines (ceiling 812; headroom 0)」, 「widest table row is 342 bytes (pin 342; headroom 0)」; lanes/skills.md 「33 lines (ceiling 33; headroom 0)」; lanes/devx.md 「36 lines (ceiling 36; headroom 0)」 (on `c8fdd0ce`, before the patch round, it read 「36 lines (ceiling 38; headroom 2)」).
- `check:skill-frame-sync` — 「the one declared copy of the decision frame is internally coherent」.
- `check:pm-skill-id-lint` — 「27 file(s) clean」. `check:pm-governed-prose` — 「2 instruction surface(s) name all 5 registered governed surfaces … and claim no others」. `check:nul-bytes` — 「OK (scanned 8179 text file(s) …)」.
- Derivation-added beyond the dispatch's list, all exit 0: `check-closing-keyword-parity` (+ `--self-test`), `check-comment-mask-corpus`, `check-governed-queue-guard --self-test`, `check:agent-test-spelling`, `check:doc-authoring`, `check:driver-memory-census`, `check:pm-governed-merges`, `check:refd-timer-probe`, `check:watch-hint-literal`, and `@objectstack/lint check:doc-formula-expressions` (first run exit 3 = its own PREREQUISITE NOT MET on an unbuilt worktree, NOT MEASURED by its own text; after `turbo run build --filter=@objectstack/formula --filter=@objectstack/lint` under the verify lock, VERDICT command-exit 0, the re-run exits 0: 「22 record-scoped formula example(s) … judged clean」).
- Patch-round additions (families that read the ratchet script), all exit 0: `check-reference-carrier-shape` (+ `--self-test`), `check-ci-filter-parity`, `check-declaration-mirrors` (+ `--self-test`), `check-scripts-symbol-anchors` (+ `--self-test`), `check-self-test-wired` (+ `--self-test`), `check-self-test-workflow-commands` (+ `--self-test`), `check-whole-set-label-write` (+ `--self-test`), `bare-root-worklist --self-test`, `report-test-timings --self-test`, `check:bash32-floor`, `check:cli-command-ids`, `check:cross-package-test-inputs`, `check:entry-guard`, `check:parse-guard`, `check:pnpm-filter-targets`, `check:ratchet-remedy-authority`.
- `check:pm-dispatch-gates` (dispatch-named on the first head, derived on the second) — 「dispatch-gates self-test: 1674 cases pass」, exit 0 on both heads (each run overran the foreground cap, was detached, and its verdict read from its redirected log).
- `check-governed-merges.mjs --test` on all four paths: 「3 of 4 path(s) hit the register … ⛔ GOVERNED」, exit 3 (expected; the ratchet script is not governed, `.claude/**` is).

`skip-changeset`: nothing published moves — three files live under `.claude/**` and the fourth under `scripts/pm/**`, neither of which any package's `files[]` ships.

## Deviations from the dispatch

1. `lanes/devx.md` lands at 36 lines, not the claim's 「38/38, net-zero」: the claim assumed the devx statement was one line; at `eb7406ca` it is a three-line wrapped bullet (:7–:9), and a pointer takes one line. Padding two lines to hold the count would be filler. Resolved on this branch by the patch round: the ceiling row was lowered to 36 (surface widened by exactly that file, answer A to the open question).
2. Zone 2 A held in direction but not in size: 12 B of headroom against +68 B of new paths meant 57 B of cuts inside the row, listed above; no path lost, pin not raised. The devx row's SUBJECT sentence is compressed, not byte-identical.
3. The gate derivation added nine families the dispatch did not name and omitted `check:pm-dispatch-gates`; all were run.

## Acceptance notes

- noted, not filed: `lanes/skills.md` :7 (`.claude/skills/**`, `skills/**`) and :9 (`.github/CODEOWNERS`) still restate paths the table carries (governed 面全量; the CODEOWNERS clause) — pre-existing and outside the declared surface; same discipline, not class (a)/(b)/(c). 承接者: the skills seat (the file's own lane), if a follow-up under the same discipline is wanted.
- noted, not filed: `lanes/devx.md` :11 states a path criterion for skills-guarding gates under `scripts/` while the table splits gates by SUBJECT; :12 defers the SUBJECT exception to the table, so the pair reads as default plus exception. 承接者: none needed.
- noted, not filed: SKILL.md's 「governed 面统一定义」 line spells three globs and the next line adds `AGENTS.md` + `CLAUDE.md`; one definition across two lines, matching the five-entry register (`check:pm-governed-prose` green). 承接者: none needed.

## 维护者速读(草稿)

**改了什么**:PM 技能里的「域车道表」现在自己写全了四条路径的归属:非门禁的 `scripts/pm/**`(PM 循环工具)归 skills 席;`.githooks/`、`docker/README.md`、`examples/**` 的测试基建面归 devx 席。两份车道岗位说明(skills、devx)里原来各自重复陈述的路径删掉,改成一句「见 SKILL.md 域车道表」的指针。SKILL.md 行数 812 不变,最宽表行 342 字节不变;devx 岗位说明由 38 行减到 36 行,其行数上限也在本 PR 内同步降到 36(棘轮只收不放)。

**为什么改**:表被声明为「全量判据」,但这四条路径只写在岗位说明里、表里没有;两处各说一套,分诊时该信哪一处没有答案。一处陈述、其余指向,是这条线上前两张卡已经定下的纪律。⛔ 本 PR 不改任何归属:写进表里的都是岗位说明与「多仓协调」行早已说了的。

**风险与代价(含回滚)**:纯协议文本,不碰代码、不发布任何包;风险是表行为了装下三条路径压缩了措辞(见正文 before/after),语义逐条对照过、门禁全绿。回滚 = revert 本 PR 的两个提交即可。无遗留:行数上限已随本 PR 一并收紧。

**席位意见**:(留空)

**你要做的**:人工合并本 draft PR(受管面,不走队列)。

---
_Generated by [Claude Code](https://claude.ai/code/session_01YKEjmbYNvYWJvWGSWx26zK)_