### PR TITLE
docs(agents): scope the force-push ban to shared branches, with five unshared criteria

### DIFF
--- a/.claude/agents/os-dev.md
+++ b/.claude/agents/os-dev.md
@@ -280,7 +280,7 @@ model: opus
 - ⛔ 不写否定式的关单句,它照样关掉点名的卡:解析器无视否定,只匹配关键词 + `#<n>`。
 - 关键词是 `fix/fixes/fixed/close/closes/closed` 与 `resolve/resolves/resolved`;让它们远离其它卡号。
 - 写 `#<n> is not addressed here`、`out of scope: #<n>` 或 `#<n> remains open`。
-- 卡片关系只在 PR 正文声明:commit ⛔ 不带卡片 trailer(`check:partof-closing-keyword` RULE 2 阻断)。
+- 卡片关系只在 PR 正文声明一次:commit ⛔ 不带卡片 trailer,其 trailer pair 一律 model-free。
 - 标题与散文用英文(见 AGENTS.md);引用的中文裁决保持原文不译,改写引文就是改写裁决。
 - 受管面(见 AGENTS.md)PR 正文带 `## 维护者速读(草稿)` 节,中文、业务角度,席位意见留空。
 - 五段固定:改了什么/为什么改/风险与代价(含回滚)/席位意见/你要做的;席位定稿成评论。

--- a/.claude/agents/os-dev.md
+++ b/.claude/agents/os-dev.md
@@ -65,7 +65,7 @@ model: opus
    - 就地修欠两样:认领申报的文件面同轮增补;PR 正文点名该修复并附证据。
    - 优先扩展一个守卫关掉整个类;任一条不成立 ⇒ 回默认:无 assignee 立单、列出、不碰。
    - 本轮改动令其变假或触碰的已发布缺陷必修;其余立卡并记明已发布面,PR 照常落地。
-4. ⛔ 永不编辑 `content/docs/releases/`、force-push、推 `main`、合并任何东西。
+4. ⛔ 永不编辑 `content/docs/releases/`、推 `main`、合并任何东西;force-push 只按 AGENTS.md §3。
    - 用户可见的改动需要 `.changeset/*.md`。
 5. **Contract-first。** 修复若诱使你在消费端加宽容回退(`??` 别名、宽松解析),缺陷在上游。
    - 去生产者或 spec 修,或返回 `needs_decision`。

--- a/.claude/agents/os-dev.md
+++ b/.claude/agents/os-dev.md
@@ -280,7 +280,7 @@ model: opus
 - ⛔ 不写否定式的关单句,它照样关掉点名的卡:解析器无视否定,只匹配关键词 + `#<n>`。
 - 关键词是 `fix/fixes/fixed/close/closes/closed` 与 `resolve/resolves/resolved`;让它们远离其它卡号。
 - 写 `#<n> is not addressed here`、`out of scope: #<n>` 或 `#<n> remains open`。
-- 卡片关系只在 PR 正文声明一次:commit ⛔ 不带卡片 trailer,其 trailer pair 一律 model-free。
+- 卡片关系只在 PR 正文声明:commit ⛔ 不带卡片 trailer(`check:partof-closing-keyword` RULE 2 阻断)。
 - 标题与散文用英文(见 AGENTS.md);引用的中文裁决保持原文不译,改写引文就是改写裁决。
 - 受管面(见 AGENTS.md)PR 正文带 `## 维护者速读(草稿)` 节,中文、业务角度,席位意见留空。
 - 五段固定:改了什么/为什么改/风险与代价(含回滚)/席位意见/你要做的;席位定稿成评论。

--- a/.claude/skills/pm-dispatch/references/dispatch-runbook.md
+++ b/.claude/skills/pm-dispatch/references/dispatch-runbook.md
@@ -119,7 +119,7 @@
 - 二、派发词必带自驱条款:云会话回合一结束即停摆等 poke。
 - ⛔ 不为提问或中期汇报结束回合;开放选择按裁决与评估轴自裁,记入终报 `open_questions`。
 - 合法回合终点只有两个:推送完成加终报,或硬阻塞详报。
-- 三、交付通道:dev 自开 draft PR(`Fixes #<n>`,正文含验证记录)。
+- 三、交付通道:dev 自开 draft PR(`Fixes #<n>` 只写正文,`partof-closing-keyword` RULE 2,含验证记录)。
 - 终报以 issue 评论交付,带 `os-dev-report` 标记。
 - 未 attach 的姊妹仓够不着,跨仓跟进卡由 PM 代立。
 - trigger 定时会话维持降级通道:推送 outcome branch,终报走最后一条会话消息,PM 代开 draft PR。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -467,8 +467,14 @@ Even inside your own worktree, operate defensively:
    pays a rebuild lap per landing; and a breaking changeset's ADR-0087 disposition is base-relative, so a stacked card's
    two bases demand contradictory markers. A multi-card change uses a **trunk branch**: correct the trunk's disposition
    to `registered` before it merges, and pay the rebase laps. ⛔ No gate or merge-policy change is made for it.
-3. **Never `git push --force` / `--force-with-lease`, and never push `main`.** A
-   force-push can clobber a parallel agent's work; `main` is shared — land all via PR.
+3. **Never force-push a *shared* branch, and never push `main`.** A force-push can
+   clobber a parallel agent's work; `main` is shared — land all via PR. A branch is
+   unshared, and `--force-with-lease` allowed, only while ALL FIVE hold: ① it is named
+   `claude/issue-*`; ② this worktree created it; ③ nobody else has ever pushed it (the
+   author and committer sets of `git log origin/<branch>` are you alone); ④ no open PR
+   on it carries a reviewer or an approval (one does ⇒ a new branch and a fresh PR
+   instead); ⑤ the push spells `--force-with-lease=<branch>:<sha you last pushed>` —
+   ⛔ never bare `--force`. One criterion failing ⇒ the branch is shared.
 4. **Verify the current branch before every commit/push**
    (`git rev-parse --abbrev-ref HEAD`). HEAD may have been switched by another agent —
    if it isn't your feature branch, stop and re-checkout before pushing.

--- a/scripts/pm/check-skill-line-ratchet.mjs
+++ b/scripts/pm/check-skill-line-ratchet.mjs
@@ -1052,7 +1052,21 @@ export const CEILINGS = new Map([
   // bullet is already typeset at the surrounding block's 90-byte prose width, and
   // AGENTS.md is not a CROSS_FILE_MOVES destination, so no `ruledRaises` record
   // applies. Landed count, headroom 0, same convention.
-  ['AGENTS.md', 1068],
+  //
+  // 1068 → 1074 (card #16851): Multi-agent discipline §3 narrowed from an
+  // unconditional force-push ban to "never force-push a SHARED branch", plus the
+  // five criteria that make a branch provably unshared before `--force-with-lease`
+  // is allowed — the ban's own rationale (a parallel agent's work) was already
+  // scoped that way, and check-partof-closing-keyword RULE 2 can only be satisfied
+  // by rewriting a commit message, so the unconditional wording had already been
+  // broken once in practice. +6 lines, exactly the ruled budget: two lines cannot
+  // carry five criteria, and the item measures 0 lossless rewrap headroom at the
+  // list's ~90-byte prose width. Maintainer ruling, verbatim and untranslated:
+  // 「其他同意」 (decision batch #111 item 4, 2026-09-10, on analysis 5615846806
+  // option A; recorded by the director on #16851 comment 5617189215, which also
+  // rules the net budget of 6). AGENTS.md is not a CROSS_FILE_MOVES destination,
+  // so no `ruledRaises` record applies. Landed count, headroom 0, same convention.
+  ['AGENTS.md', 1074],
   // #9965: root CLAUDE.md is the other repo-root instruction file — same read
   // path (every seat session), same governance (Prime Directive #14). It is
   // structurally growth-prone in the way the ratchet is built for: it exists to


### PR DESCRIPTION
Fixes #16851

Executes ruling 5617189215 (the director recording the maintainer's 「其他同意」 on analysis 5615846806, option A): Multi-agent discipline §3 in `AGENTS.md` now bans force-pushing a **shared** branch instead of every force-push, and spells out the five criteria that make a branch provably unshared before `--force-with-lease` is allowed. Bare `--force` stays banned. Governed surface (`AGENTS.md`, `.claude/**`) — draft only, human merge. Four files change: `AGENTS.md`, the line ratchet's ceiling row, one line of `.claude/agents/os-dev.md` (its own force-push twin, now deferring to §3) and one line of the dispatch runbook (naming RULE 2 where a PM composes a dispatch). `scripts/check-partof-closing-keyword.mjs` is untouched.

## §3 before / after (`AGENTS.md`, found by content; :470–:471 at `eb7406ca`)

**Before** — 2 lines, 170 bytes (80 + 88, newlines included):

```text
3. **Never `git push --force` / `--force-with-lease`, and never push `main`.** A
   force-push can clobber a parallel agent's work; `main` is shared — land all via PR.
```

**After** — 8 lines, 689 bytes (82 / 85 / 88 / 90 / 88 / 84 / 88 / 76; every line under the 120-byte rule, typeset at the list's ~90-byte prose width). The file spells the placeholders in ③ and ⑤ with angle brackets; they are spelled as words here because the GitHub body sanitizer eats angle-bracket fragments:

```text
3. **Never force-push a *shared* branch, and never push `main`.** A force-push can
   clobber a parallel agent's work; `main` is shared — land all via PR. A branch is
   unshared, and `--force-with-lease` allowed, only while ALL FIVE hold: ① it is named
   `claude/issue-*`; ② this worktree created it; ③ nobody else has ever pushed it (the
   author and committer sets of `git log origin/BRANCH` are you alone); ④ no open PR
   on it carries a reviewer or an approval (one does ⇒ a new branch and a fresh PR
   instead); ⑤ the push spells `--force-with-lease=BRANCH:SHA-YOU-LAST-PUSHED` —
   ⛔ never bare `--force`. One criterion failing ⇒ the branch is shared.
```

Ruling text carried one-to-one: ① `claude/issue-*` name · ② created by this worktree · ③ author/committer set of `git log origin/BRANCH` is you alone · ④ no open PR with a reviewer or approval (else a new branch and PR) · ⑤ `--force-with-lease=BRANCH:SHA`, never bare `--force`. The existing rationale sentence is kept verbatim. Options B (RULE 2's gate) and C are not taken.

## Line ratchet — ruled raise, `AGENTS.md` 1068 → 1074

- `AGENTS.md` 1068 → 1074 lines, net +6 = exactly the ruled budget (「净增行数预算 6」, ruling 5617189215). Ceiling in `scripts/pm/check-skill-line-ratchet.mjs` moved 1068 → 1074 with a ledger comment in the map's own form (the ruling quoted verbatim and untranslated, 「其他同意」, with its comment id). `AGENTS.md` is not a `CROSS_FILE_MOVES` destination, so per the script header there is no `ruledRaises` record to write — the ordinary ruled raise is the ceiling constant plus the quoted ruling, which is what the last four AGENTS.md raises in that map did. Headroom 0 again by construction (`✓ check-skill-line-ratchet: AGENTS.md is 1074 lines (ceiling 1074; headroom 0)`).
- Why it cannot be paid in place: two lines cannot carry five criteria, and §3 had no lossless rewrap headroom (80 / 88-byte lines at the block's width).

## Patch round (skills seat: option A minus the gate file) — two net-zero, in-place lines

**1. `.claude/agents/os-dev.md` :68 — the dev definition's own unconditional force-push twin.** Zone 2 assumption A (only `AGENTS.md` :470–:471 states the rule; no twin in `CLAUDE.md`) held for those two files and was falsified for os-dev.md: `grep -n force .claude/agents/os-dev.md` → :68 (and :90, `git worktree remove --force`, unrelated). Left as it was, a dev reading os-dev.md first would still act on the stricter line under 「两条细则冲突 ⇒ 按更严的一条行动并立卡」 — the loop this card closes. Rewritten in place, 94 → 113 bytes, 403 → 403 lines:

```text
before  4. ⛔ 永不编辑 `content/docs/releases/`、force-push、推 `main`、合并任何东西。
after   4. ⛔ 永不编辑 `content/docs/releases/`、推 `main`、合并任何东西;force-push 只按 AGENTS.md §3。
```

**2. `.claude/skills/pm-dispatch/references/dispatch-runbook.md` :122 — RULE 2 named where a PM composes the dispatch.** The verification reading (at `eb7406ca`): `grep -n 'RULE 2\|partof-closing' .claude/agents/os-dev.md .claude/skills/pm-dispatch/references/*.md` → 0 hits; the rule's substance sits on os-dev.md :283 without the gate's name, and the runbook's delivery bullet said only `Fixes #N`. The delivery bullet is the line a PM writing a dispatch actually reads for the closing-keyword instruction, so it carries the name now — rewritten in place, 79 → 118 bytes (the `check:` prefix dropped to fit the 120-byte rule; the grep above hits on `partof-closing`), 241 → 241 lines; the angle-bracket placeholder is spelled `#N` here:

```text
before  - 三、交付通道:dev 自开 draft PR(`Fixes #N`,正文含验证记录)。
after   - 三、交付通道:dev 自开 draft PR(`Fixes #N` 只写正文,`partof-closing-keyword` RULE 2,含验证记录)。
```

**Why the gate file is not touched.** os-dev.md :283 is quoted verbatim by `RELATION_CONTRACT` in `scripts/check-partof-closing-keyword.mjs` (:505–:508), and that gate's self-test holds the quotation to the rules file mechanically — measured on the first round: an in-place rewrite of :283 at `0f2acde5` turned `check:partof-closing-keyword` red (`✗ every sentence inside the corner brackets is verbatim in the cited rules file`, 1 of 95). Naming RULE 2 on :283 therefore means editing the gate's citation in the same PR — a devx-lane gate the ruling says stays put (「RULE 2 门不动」). So :283 stays byte-identical to `origin/main` (`git diff eb7406ca -- .claude/agents/os-dev.md` shows only :68), the citation pin stands, and the gate stays 95/95.

## Hook measurement (conditional surface — does not apply)

- `.claude/hooks/*.sh`: `grep -rni force` hits only the word "enforce(s)/enforcement" (guard-governed-enqueue, guard-shared-stash, guard-process-kill, guard-main-checkout-bash headers). No hook reads a push.
- `.githooks/pre-push`: drains the ref list on stdin on purpose and runs only `check-regen-pending.mjs --pre-push`; `.githooks/pre-commit`: no `force` / `is-ancestor` / fast-forward mention.
- ⇒ Nothing mechanical enforced the old sentence; the rule was and stays text-enforced. No hook edit, none weakened.

## Other Zone 2 readings

- **A** holds for `AGENTS.md` and `CLAUDE.md`: `grep -n 'force-push\|force push\|--force' AGENTS.md` at `eb7406ca` → :470–:471 plus :362, which is turbo's build-cache `--force` (not a push rule); `CLAUDE.md` `grep -i force` → exit 1. Falsified for os-dev.md — fixed above.
- **C** falsified as to the tree (no in-repo text named RULE 2; `review-checklist.md` :8–:9 is body-side, RULE 1 / RULE 3 territory) — the runbook line above is now the in-tree carrier.
- **D**: no `ruledRaises` form for AGENTS.md; ceiling constant moved by exactly the net lines, ruling id carried here and in the ledger comment.
- Decision frame: SKILL.md :734–:752 at `eb7406ca` md5 `22f2339f0acb64cdb50c7adc9db681c3` — matches the dispatch.
- `node scripts/pm/check-governed-merges.mjs --test` over all four paths → exit 3, 「⛔ GOVERNED — a human merge is the review record」 (`.claude/**` ×2, `AGENTS.md` ×1).

## Verification

Commit under test: `a73fac30` (the §3 text and the ratchet ledger are unchanged since `17fa9213`; `0f2acde5` carried the later-reverted :283 line). Gates derived with `node scripts/pm/dispatch-gates.mjs --commands --repo objectstack-ai/objectstack` (no paths; change set from git off merge base `eb7406ca`): 4 paths → 43 commands. Each run with its exit captured before any pipe (`cmd > log 2>&1; EXIT=$?`); verdict lines quoted from the gates' own output.

| Gate (at `a73fac30`) | Exit | Verdict line (the gate's own) |
|---|---|---|
| `pnpm check:pm-skill-ratchet` | 0 | `✓ check-skill-line-ratchet self-test: 157 cases pass.` · `AGENTS.md is 1074 lines (ceiling 1074; headroom 0)` · `.claude/agents/os-dev.md is 403 lines (ceiling 403; headroom 0)` · `…/dispatch-runbook.md is 241 lines (ceiling 241; headroom 0)` — no over-length line reported |
| `pnpm check:pm-skill-id-lint` | 0 | `✓ check-skill-id-lint: 27 file(s) clean (pattern /#[0-9]{3,}/g).` |
| `pnpm check:partof-closing-keyword` | 0 | `✓ check-partof-closing-keyword self-test: 95 cases pass.` (:283 untouched) |
| `pnpm check:pm-governed-prose` | 0 | `✓ check-governed-prose: 2 instruction surface(s) name all 5 registered governed surfaces … and claim no others.` |
| `pnpm check:nul-bytes` | 0 | `check-nul-bytes: OK (scanned 8179 text file(s) … no raw ASCII control bytes).` |
| `pnpm check:skill-frame-sync` | 0 | `✓ check-skill-frame-sync: the one declared copy of the decision frame is internally coherent (.claude/skills/pm-dispatch/SKILL.md …)` |
| `pnpm check:agent-model-declared` | 0 | `✓ check-agent-model-declared: 1 agent definition(s) under .claude/agents/ all declare a model` |
| `pnpm check:doc-authoring` | 0 | `✓ doc authoring guard: 44 published skill files clean` · `15226 customer-facing string(s) across 878 spec sources clean` |
| `pnpm --filter @objectstack/lint run check:doc-formula-expressions` | 0 | after `@objectstack/formula` + `@objectstack/lint` were built under `scripts/pm/os-verify-lock.sh` (`VERDICT command-exit 0`, 4 tasks): `✓ … 9 @example(s) judged clean across 1321 packages/spec/src files` · `14 predicate(s) … judged clean` |
| `node scripts/pm/check-governed-queue-guard.mjs --self-test` | 0 | `✓ check-governed-queue-guard self-test: 144 cases pass` |
| `pnpm check:pm-dispatch-gates` — detached with `nohup` per its own header, exit code appended to the redirected log | 0 (`EXIT=0` read from the log) | `✓ dispatch-gates self-test: 1674 cases pass.` (11:34Z) |
| the other 31 derived commands (`check-*` scripts with their `--self-test`, and the `pnpm check:*` families the derivation lists) | 0 each | per-command logs, every one green |
| `node scripts/pm/dispatch-gates.mjs --ran` — 43 entries, all annotated `:: exit N` | 0 | `✓ dispatch-gates --ran: 43 derived famil(ies) accounted for — 43 run, 0 NOT-MEASURED (a DERIVED zero — all 43 recorded an exit code and none of them is 3).` |
| `node scripts/pm/check-governed-merges.mjs --test` (four paths) | 3 | `⛔ GOVERNED — a human merge is the review record for this PR (#9495 regime).` |

Earlier trees, for the record: at `17fa9213` (2 paths → 37 commands) 37/37 accounted, 36 with exit codes, all green; at `0f2acde5` (3 paths → 43) 40 green, `check:partof-closing-keyword` exit 1 (the citation pin — the finding above) and `check:doc-formula-expressions` exit 3 = PREREQUISITE NOT MET (nothing measured; green once built). The derivation reads three-dot against merge base `eb7406ca`; `origin/main` has advanced since the cut, with no visible commit touching the derived inputs.

No package builds or tests are owed: the diff touches no package (`packages/**` untouched), so ① and ② of the local verification scope are empty. `pnpm lint` (repo-wide eslint) is CI's run, not declared here. The ratchet script's own test suite is its `--self-test` (`check:pm-skill-ratchet` runs it first: 157 cases pass); no other test file names the script (`git grep -l check-skill-line-ratchet -- '*.test.*'` → none).

## Acceptance notes

- `skip-changeset`: nothing published moves — `AGENTS.md`, `.claude/**` and `scripts/pm/**` are on the fast lane (in no package's `files[]`).
- Not touched, by declaration: the changeset paragraph near :1035 (#16973 is queued behind this card on the same file and remains open); `SKILL.md` (#17225 in flight); RULE 2's gate and its citation of os-dev.md :283 (ruling: 「RULE 2 门不动」).
- The §3 text and the ratchet ledger are as accepted at `17fa9213`; the patch round added exactly the two in-place lines above.

## 维护者速读(草稿)

**改了什么**:`AGENTS.md` 多 agent 纪律第 3 条,从「任何情况下都不许 force-push」改为「不许 force-push **共享**分支」,并写死五条判据 —— 分支名 `claude/issue-*`、由本 worktree 创建、除自己外无人推送过、没有带评审人或批准的开放 PR、推送必须用 `--force-with-lease` 钉住自己最后推的 sha —— 五条全立才允许,裸 `--force` 仍然禁止。`AGENTS.md` 行数上限 1068 → 1074,恰为裁定的 6 行预算。另两处各改一行、行数不变:开发 agent 定义(`os-dev.md`)自己那句无条件的「永不 force-push」现在改为按 `AGENTS.md` 第 3 条办;派发运行手册的交付条目点名了把开发者逼进这个死角的门禁(`partof-closing-keyword` RULE 2),提醒关卡词只写在 PR 正文。门禁本身及其对 `os-dev.md` 的逐字引用一字未动。

**为什么改**:两条自己写的规矩互锁 —— 提交信息一旦带了卡号,唯一的改法是改写提交,而改写已推送的提交在旧规矩下绝对禁止。已经真的撞上一次,而且是靠违反旧规矩解决的:成文规则与实际做法已经分叉。本 PR 执行「其他同意」的裁决(方案 A),让规则、它自己的理由与实践三者对齐,并把开发 agent 定义里的同一句旧禁令一并收口,避免它比新第 3 条活得更久。

**风险与代价(含回滚)**:放宽了一条安全规则。误判「独占」的后果是清掉别人的工作,所以五条判据全部机械可判,其中 ③(`git log` 作者集合)和 ⑤(lease 钉 sha:只要别人在这期间推过,推送就被拒绝)是硬保护。门禁本身不动。回滚 = revert 本 PR 的三个提交,上限回到 1068。

**席位意见**:(留空,席位定稿成评论)

**你要做的**:人工合并本 draft PR。

---
_Generated by [Claude Code](https://claude.ai/code/session_01YKEjmbYNvYWJvWGSWx26zK)_


---
_Generated by [Claude Code](https://claude.ai/code)_