### PR TITLE
fix(spec): PageSchema's rejection guidance stops prescribing `assignedProfiles` as a page gate

### DIFF
--- a/.changeset/page-guidance-stops-prescribing-assignedprofiles.md
+++ b/.changeset/page-guidance-stops-prescribing-assignedprofiles.md
@@ -1,0 +1,13 @@
+---
+"@objectstack/spec": minor
+---
+
+fix(spec): `PageSchema`'s rejection guidance stops prescribing `assignedProfiles` as a page gate (#16929)
+
+The two wrong-layer prescriptions `PageSchema` hands an author at parse time both ended by pointing at `assignedProfiles`: the `visibleWhen` pointer said "or gate the page with `assignedProfiles`", and the `permissions` pointer said "reach it through `assignedProfiles`". Neither is true. `assignedProfiles` gates nothing.
+
+Measured 2026-09-10 on `origin/main` `e1eee43beb` and objectui `3fbdd4a2d`: `assignedProfiles` has **zero readers** in this repo — every one of its 25 matching files is a declaration, a generated artifact, prose, a `CHANGELOG`, the liveness ledger, or this schema's own round-trip test — and **zero readers** in objectui, whose three hits are a docs table row and two type/zod declarations. Lit controls in the same sweeps (`visibleWhen` 308 files, `PageSchema` 94 files in objectui; `visibleWhen` 168 files here) prove the instrument fired; a fabricated dark control read 0 in both. The key is also named for the concept **ADR-0090 D2** removed, which `security/permission.zod.ts` states to authors three times over.
+
+Prescribing it was Prime Directive #10's exact prohibition — advertising a capability the runtime does not deliver — delivered to the author in the error that is supposed to be teaching them the correct spelling. Both prescriptions now say only what the platform actually does: put `visibleWhen` on the component inside a region, and gate the DATA a page shows with the object's permission sets.
+
+**Nothing about what `PageSchema` accepts changes.** `assignedProfiles` remains an authorable key with its declaration untouched, and the `profiles:` / `assignedTo:` alias entries are untouched. Both channels edited here fire only from the `unrecognized_keys` path, so every key involved is rejected before this change and rejected after it, with identical `issue.code` and identical `path` — only the human-readable text moves. The key's own disposition (keep, rename, or remove) needs a ruling and stays open on #16929.

--- a/packages/spec/src/ui/page.zod.ts
+++ b/packages/spec/src/ui/page.zod.ts
@@ -655,8 +655,25 @@ export const PageSchema = lazySchema(() => strictObject({
     route: '`route` is not a page key — a page is routed by its `name` (lowercase snake_case). Rename the page rather than declaring a path.',
     path: '`path` is not a page key — a page is routed by its `name` (lowercase snake_case).',
     url: '`url` is not a page key — a page is routed by its `name`. To link OUT to an address, use a navigation node on the app.',
-    visibleWhen: 'page-level conditional rendering does not exist — put `visibleWhen` on the COMPONENT inside a region, or gate the page with `assignedProfiles`',
-    permissions: 'a page is not permission-gated by a field — reach it through `assignedProfiles`, and gate the DATA it shows with the object\'s permission sets (which is what actually protects the records)',
+    // ⛔ Neither prescription below may name `assignedProfiles` as the way to gate
+    // a page. The key is still authorable on this schema — nothing here changes what
+    // the schema accepts — but it gates NOTHING, so prescribing it handed the author
+    // a capability the runtime does not deliver, at parse time, which is Prime
+    // Directive #10's exact prohibition. Measured 2026-09-10: zero readers in this
+    // repo (every hit is a declaration, a generated artifact, prose, or this
+    // schema's own round-trip test) and zero readers in objectui at `3fbdd4a2d`
+    // (three hits — a docs table row, `packages/types/src/layout.ts` and
+    // `packages/types/src/zod/layout.zod.ts` — every one a declaration; lit controls
+    // `visibleWhen` 308 files and `PageSchema` 94 files prove the instrument fired).
+    // `liveness/page.json` still grades it `live` on the strength of an objectui
+    // bridge at `react/src/spec-bridge/bridges/page.ts` — a path that does not exist
+    // in that repo, while two sibling citations in the same ledger file resolve.
+    // It is also named for the concept ADR-0090 D2 removed, which
+    // `security/permission.zod.ts` states to authors three times over.
+    // ⛔ The key's own disposition (keep / rename / remove) needs a ruling and is
+    // tracked in #16929; this correction deliberately does not pre-empt it.
+    visibleWhen: 'page-level conditional rendering does not exist — put `visibleWhen` on the COMPONENT inside a region',
+    permissions: 'a page is not permission-gated by a field — gate the DATA it shows with the object\'s permission sets (which is what actually protects the records)',
   },
 }, {
   name: SnakeCaseIdentifierSchema.describe('Page unique name (lowercase snake_case)'),


### PR DESCRIPTION
Part of #16929 — and deliberately only part of it. See "Why this is `Part of`, not a closing keyword" below; the card's central question is NOT answered here and the card must stay open.

Clause-②: yes — declared at dispatch on the card's shape. This PR carries `needs:contract-review` and does not enqueue without an at-tier verdict. See "Clause-② reading" below: the measurement says this **diff** moves no accept set, but re-declaring that is the seat's act, not the implementing lane's.

Authored by Claude Code in session `session_01MkQhmuuJAVDjmeWNixwDDH`, dispatched by the `domain:spec` execution seat.

## What this PR changes

Two strings, in `packages/spec/src/ui/page.zod.ts`. Both are `guidance` prescriptions — the text `PageSchema` hands an author when it **rejects** a wrong-layer key — and both ended by pointing at `assignedProfiles`:

- `visibleWhen` said "…or gate the page with `assignedProfiles`"
- `permissions` said "…reach it through `assignedProfiles`, and gate the DATA it shows…"

Neither is true. `assignedProfiles` gates nothing. Prescribing it is Prime Directive #10's exact prohibition — advertising a capability the runtime does not deliver — delivered at parse time, inside the error whose whole job is to teach the correct spelling. Both prescriptions now state only what the platform actually does.

**Nothing else is touched.** The `assignedProfiles` declaration, the `profiles:` / `assignedTo:` alias entries, `page.form.ts`, the four locale bundles and the liveness ledger are all left exactly as they are.

## What the key does today

`assignedProfiles: z.array(z.string()).optional()` on the published `PageSchema` — untyped strings, no `.describe()`. It is accepted, stored, round-tripped, and read by nobody.

## What the alias map actually does — the card's mechanism, re-measured

This is the finding that reframes the whole card. `aliases` on `strictObject` does **not** accept a key and rewrite it. `strict-object.ts` says so in its own words: *"an alias runs only from the `unrecognized_keys` path, so a declared key can never reach it"*. An alias only decorates the **rejection message** with a "Did you mean" rename.

Runtime probe against the built `dist`, before and after this diff, with a lit control (a key known to be accepted) and a dark control (a fabricated key):

| Probe | Authored key | `success` | What came back |
|---|---|---|---|
| A (the claim) | `profiles:` | **false** | `unrecognized_keys` — "Did you mean `profiles` → `assignedProfiles`?" |
| B | `assignedTo:` | **false** | `unrecognized_keys` — "Did you mean `assignedTo` → `assignedProfiles`?" |
| C (lit control) | `assignedProfiles:` | **true** | parses; value preserved |
| D (dark control) | `grobnicators:` | **false** | `unrecognized_keys`, no rename offered |
| E | `visibleWhen:` | false | the prescription under edit |
| F | `permissions:` | false | the prescription under edit |

C accepting and D offering no rename together prove the instrument fired and that the rename in A and B is the alias table's doing.

**Therefore: `profiles` and `assignedTo` are NOT in `PageSchema`'s accept set.** They are refused today and would be refused with the alias entries deleted. The card's title says the alias map "corrects an authored `profiles:` into it" — the *effect* is real (the author is steered into retired vocabulary) but the *mechanism* is a suggestion in a rejection, not an acceptance. Contrast the real thing two hundred lines away: ADR-0089's `visibility` → `visibleWhen` on a page **component** genuinely is accept-and-rewrite (`page.test.ts:1150`).

## Consumer census — every probe with what it matched

⭐ A count is not a reading until you look at what it matched. Every absence below carries a lit and a dark control.

**This repo, `origin/main` `e1eee43beb`** — `assignedProfiles` case-insensitive: **25 files**. Every one classified by hand:

- generated docs under `content/docs/references/` (8 rows) and one hand-written docs table row
- `docs/adr/0010` — a 2022-era open question, prose
- `docs/audits/2026-06-pageschema-property-liveness.md` and `…-security-identity-…` — two prior audits that **already list it as zero-consumer**
- three `CHANGELOG.md` files (release-owned)
- `packages/metadata-protocol/src/protocol.ts:11818` — the comment the card quotes
- four `*.metadata-forms.generated.ts` locale bundles
- `authorable-surface.base.json` + `authorable-surface/ui.json` — generated baselines
- `liveness/page.json`, `liveness/view.json` — the ledger
- `packages/spec/src/api/protocol.zod.ts`, `ui/view.zod.ts` — prose
- `packages/spec/src/ui/page.form.ts` — the form field
- `packages/spec/src/ui/page.zod.ts` — the declaration, the aliases, the two strings
- `packages/spec/src/ui/page.test.ts` — the schema's own round-trip assertion

**Readers: zero.** Controls: `visibleWhen` 168 files (lit), fabricated `assignedGrobnicators` 0 files (dark), snake-case `assigned_profiles` 0 files.

**objectui, `origin/main` `3fbdd4a2d`** (read-only; this repo's PR touches nothing there) — `assignedProfiles` case-insensitive: **3 files**, each inspected:

- `content/docs/api/schema-reference.md:140` — a docs table row
- `packages/types/src/layout.ts:795` — a TypeScript declaration
- `packages/types/src/zod/layout.zod.ts:459` — a zod declaration

**Readers: zero.** Controls: `visibleWhen` 308 files (lit), `PageSchema` 94 files (lit), fabricated term 0 files (dark), `assigned_profiles` 0 files. This confirms triage's reading at `42ddd7f71` one day later and at a moved head (the `layout.ts` line number shifted 829 to 795 — same claim, different line).

**cloud** — NOT MEASURED. The repository is not present in this container, so there is no instrument to fire. This is an absence of measurement, not a measurement of absence.

## Three prose claims this falsifies

1. `packages/metadata-protocol/src/protocol.ts:11818` — the key *"is enforced where it is enforced now, at page render"*. Page render is objectui's; objectui does not read it. **False.** (Already falsified by triage; re-measured here at a newer head.)
2. `packages/spec/liveness/page.json` grades `assignedProfiles` **`live`**, on the strength of *"objectui bridges it (`react/src/spec-bridge/bridges/page.ts`)"*. **That path does not exist in objectui, and neither does any `spec-bridge` directory.** Lit control: two sibling objectui citations in the same ledger file — `packages/components/src/renderers/layout/page.tsx` and `packages/app-shell/src/views/PageView.tsx` — both resolve. So the ledger can cite objectui correctly; this entry does not.
3. `packages/spec/liveness/view.json:125` leans on the same claim: a `type: 'page'` view is safe because *"the page keeps its own audience gate (`page.assignedProfiles`)"*. That gate does not exist.

Claims 1 and 3 are **out of this PR's declared file face** and are filed below rather than fixed here.

## The options, and which move the accept set

| | Option | Moves the published accept set? | Blast radius | Whose call |
|---|---|---|---|---|
| **A** | Remove `assignedProfiles` | **YES — narrows.** A page authoring it validates today, refused after | ADR-0087 conversion + `retiredKey` tombstone, both authorable-surface baselines, liveness ledger, `page.form.ts`, four locale bundles, docs, plus objectui's two declarations cross-repo | **Maintainer.** Fenced |
| **B** | Rename the key | **YES — both directions.** Old spelling refused, new one accepted | A's, plus the new key's own declared-versus-enforced question | **Maintainer.** Fenced |
| **C** | Retarget or delete the `profiles:` / `assignedTo:` aliases | **NO — measured.** Both keys are refused before and after; only the rejection text moves | two lines in one file | Fenced by the dispatch order's literal words. ⭐ The measurement above reframes this: it is **not** an accept-set change, so the premise the fence rests on does not hold for it. Re-grading it is the seat's act, not mine |
| **D** | Stop the two `guidance` prescriptions naming `assignedProfiles` | **NO — measured byte-identical** | two strings in one file | ⇒ **TAKEN HERE** |
| **E** | Actually build page-level profile gating | YES — new capability | new feature | **Maintainer only.** Triage already routed this to the human floor |

## Why option D moves no accept set — the reverse verification

Both channels this PR edits fire only from the `unrecognized_keys` path, so every key involved is refused before and after. Proven, not asserted: the probe table above was run against the built `dist` **before** the edit and **again after a full rebuild**, and diffed. The complete difference between the two runs is two lines — the E and F message texts. Probes A, B, C and D are byte-identical across the rebuild, including C's accepted parse, its parsed key list and its preserved value.

`pnpm --filter @objectstack/spec check:generated` reports all 15 generated artifacts up to date, `check:authorable-surface` among them — the published accept set did not move.

## Why this is `Part of`, not a closing keyword

The dispatch order asked for a closing keyword on this card. I am not writing one, and this is flagged rather than done silently.

The order's own fence says removing or retiring the key is the maintainer's floor and that a round returning the options table is a complete round. That is the round this is. The card's central question — what happens to `assignedProfiles` — is **unanswered**, and options A, B and E all need a ruling nobody has given. A closing keyword would shut the card the moment this merges and delete the decision item from the open set.

**What is left on #16929:** the disposition of the key itself (A / B / E), and the re-grading of option C now that it is measured to be message-only.

## Clause-② reading

Declared `yes` at dispatch, on the card's shape, before a diff existed. The measurement is now in: **this diff moves no accept set** — proven byte-identical above. Per the claim comment, if the round's measurement shows that, *the seat re-declares, not the dev*. So the declaration stands as `yes` here, `needs:contract-review` is applied, and the re-grading is handed to the seat with the evidence.

The changeset grades `@objectstack/spec` **minor**, satisfying the level rule that applies with `Clause-②: yes`.

## Verification

Run at `origin/main` merge-base `e1eee43beb`; the numbers below come from the branch head.

- `pnpm --filter @objectstack/spec build` — exit 0
- `pnpm --filter @objectstack/spec check:generated` — exit 0; **all 15 generated artifacts up to date**, including `check:authorable-surface`, `check:api-surface` and `check:docs`
- `pnpm --filter @objectstack/spec typecheck` — exit 0
- `pnpm --filter @objectstack/spec test` — exit 0, **472 files / 13275 tests passed**, including `alias-integrity.test.ts` and `strict-object.test.ts`, the two suites that audit these very tables
- `eslint . --no-inline-config` over the whole repo — exit 0, **6491 files received, 0 errors, 0 warnings** (full union, not a narrowing)
- `node scripts/pm/dispatch-gates.mjs --ran … --repo objectstack-ai/objectstack` — **76 derived families, all 76 accounted for: 74 run, 0 unrun, 2 NOT MEASURED**

The two NOT MEASURED are `check:dual-build-cjs-loads` and `check:lean-entry-closure`, both **exit 3, PREREQUISITE NOT MET** — they read built output for packages this worktree never built. Exit 3 is neither pass nor failure; CI's Build Core supplies what they need. `check:react-declaration-parity` was run properly with `MANIFEST` set from the checked-in root manifest, exit 0, no new declaration divergence versus baseline.

## Acceptance notes — noted, not filed

- **`scripts/gen:authorable-surface-base` / `authorable-surface.base.json`** was not touched and its `baseRev` may lag; `check:authorable-surface` is green, which is the assertion that counts.
- **AGENTS.md's paragraph on `check:react-declaration-parity`** says the gate "exits 1 with no usable manifest" and that the manifest comes only from a real browser over objectui. The gate's own refusal text now contradicts that: a copy IS checked in at the repo root and it prints the exact complete local invocation, adding *"do not report it as EXTERNAL_INPUT_REQUIRED or NOT MEASURED"*. AGENTS.md is a governed surface and out of this lane; carrier: the `domain:spec` seat, or whichever lane next edits that paragraph.
- **`page.form.ts` was deliberately not touched.** Its `helpText: 'Profiles that can access this page'` describes the key itself, and editing it would touch four locale bundles and editorialise on a key whose fate is undecided. It belongs with the ruling, not ahead of it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MkQhmuuJAVDjmeWNixwDDH)_