### PR TITLE
fix(scripts): drop the stale "five" from the balancing-pins banner

### DIFF
--- a/scripts/partition-test-shards.mjs
+++ b/scripts/partition-test-shards.mjs
@@ -820,7 +820,7 @@ function selfTest() {
   // Everything above pins that the split is a correct, deterministic, total
   // cover of its input. None of it noticed that the six bins it produced ran
   // 5.0/6.2/6.3/13.6/6.3/9.0 minutes, because a perfectly-balanced split of the
-  // WRONG quantity satisfies every one of those assertions. These five pin the
+  // WRONG quantity satisfies every one of those assertions. These pin the
   // quantity and the outcome.
   battery('the balancing pins (#10472)');
 


### PR DESCRIPTION
Closes #15208

**Clause-②**: no

## What changed

`scripts/partition-test-shards.mjs`, the banner comment above the balancing-pins battery, `:823` (text-located; the card's line number was from a stale commit):

**Before**
```
  // WRONG quantity satisfies every one of those assertions. These five pin the
  // quantity and the outcome.
```

**After**
```
  // WRONG quantity satisfies every one of those assertions. These pin the
  // quantity and the outcome.
```

Only the word `five` was removed. The sentence now matches the shape of the
sibling banner already in this file at `:1082` ("These pin the one
comparison that can tell a good dataset from a rotted one."), which carries
no quantity word — the model the card pointed at, not touched here.

## Pin count — unchanged, six, none touched

The six numbered pins under this banner (`battery('the balancing pins
(#10472)')`) are exactly:
1. weight is TIME, not file count
2. committed dataset meets the acceptance bound at CI's shard count
3. the bound is REACHABLE at this shard count
4. the shard count is spelled in ci.yml too
5. an unmeasured package is ESTIMATED, never silently free
6. END-TO-END: the weight a REAL RUN gives a REAL package is its measured one

No pin was added, removed, or reordered. This is a comment-only fix with
zero behaviour change.

## Probe — quantity word on the sentence, with positive control

Probe: `grep -noP '(?<=These )(\w+)(?= pin the)' scripts/partition-test-shards.mjs`

- **Before** (positive control, run against the pre-fix text): `823:five` — 1 match.
- **After** (post-fix): no output — 0 matches.

`node scripts/partition-test-shards.mjs --self-test` still passes:
```
partition-test-shards: self-test OK (71 measured packages -> 72 shard items, 6 shards, max/mean 1.00x <= 1.3x, floor 404s, bins 672/672/672/671/672/671s)
```
confirming zero behaviour change.

## Changeset

`skip-changeset` — measured, not assumed: this repo's root package
(`@objectstack/spec-monorepo`, which owns `scripts/`) is `"private": true`
and never publishes, and independently the edit is comment-only prose in a
script, which is one of the standard skip-changeset fast channels. `skip-changeset`
label requested on this PR.

## Local gates run

- `node scripts/partition-test-shards.mjs --self-test` — pass (shown above).
- `node scripts/check-nul-bytes.mjs` — pass.
- `node scripts/check-self-test-wired.mjs` — pass.
- `node scripts/check-scripts-symbol-anchors.mjs` — pass.
- `pnpm check:entry-guard` — pass.
- `pnpm check:parse-guard` — pass.


---
_Generated by [Claude Code](https://claude.ai/code/session_012GKcPZbMoGq7WPzKLfRBTU)_