### PR TITLE
Pin check-test-source-alias's codeOnly projection with a literal-brace fixture

### DIFF
--- a/scripts/check-test-source-alias.mjs
+++ b/scripts/check-test-source-alias.mjs
@@ -2412,6 +2412,29 @@ function buildFixtureTree() {
       "it('y', async () => boot({ dir: '.' }));\n",
   });
 
+  // (26) THE `codeOnly` PROJECTION ITSELF, PINNED (#16299). A `}` sitting
+  // inside a template literal — content `maskCommentsAndLiterals` blanks and a
+  // scanner that merely strips comments does not. Read literally, that stray
+  // `}` closes the `it()` callback's REAL opening brace early, right there
+  // inside the template, before the dynamic `import()` two lines down — so an
+  // under-masked `codeOnly` reports zero function-body ranges reaching the
+  // import and the violation goes SILENT, the same failure mode fixture (25)
+  // pins for the brace scanner's backward walk. Correctly masked, the
+  // template's interior is blanked (delimiters survive, content does not), the
+  // callback's true closing brace is what pairs with its opener, and the
+  // import is reported CLOCKED like any other. This is the shape #16299 named:
+  // the module-scope-vs-CLOCKED verdict hinges on a brace living inside a
+  // string or template, which is the exact content `codeOnly` exists to erase.
+  fixture(root, 'packages/clocked-literal-brace', {
+    'package.json': ARTIFACT_MANIFEST('@fx/clocked-literal-brace'),
+    'src/thing.test.ts':
+      "import { it } from 'vitest';\n" +
+      "it('y', async () => {\n" +
+      '  const label = `already closed }`;\n' +
+      "  await import('@fx/core');\n" +
+      '});\n',
+  });
+
   return root;
 }
 
@@ -2443,7 +2466,7 @@ const SELF_TEST_BATTERIES = Object.freeze({
   'the canary (#8020)': 14,
   'the cross-boundary walk (#8351)': 7,
   'the latent half (#9674)': 8,
-  'the clocked-window rule (#10126)': 10,
+  'the clocked-window rule (#10126)': 12,
   'the import clause is bounded to ONE statement (#12555)': 11,
   'the declared population must stay READABLE by the dispatch deriver': 11,
   'the declaration must still BE the workspace (#11510)': 22,
@@ -2816,6 +2839,22 @@ function selfTest() {
     expect(
       clockedIn('packages/clocked-typed-signature/src/thing.test.ts:6').length === 1,
       'a helper whose multi-line signature ends `}): Promise< { … } > {` was read as not a function body — a SILENT exemption',
+    );
+
+    // …and the `codeOnly` projection itself (#16299): a `}` sitting inside a
+    // template literal, positioned to close the real callback's brace EARLY if
+    // read as code rather than masked as content. Under-masking here does not
+    // fabricate a finding — it does the opposite, and silently: the dynamic
+    // import falls outside every reported range and never reaches `clocked` at
+    // all. `commentsOnly` (which still feeds the import regex) is unaffected —
+    // only `codeOnly`'s brace count decides this verdict.
+    expect(
+      clockedIn('packages/clocked-literal-brace/src/thing.test.ts:4').length === 1,
+      'a `}` inside a template literal closed the real function body early — the dynamic import went unreported',
+    );
+    expect(
+      clockedIn('packages/clocked-literal-brace/src/thing.test.ts:4').every((f) => f.includes("import('@fx/core')")),
+      'the clocked-window finding for the literal-brace fixture lost or renamed its specifier',
     );
 
     // ── the import clause is bounded to ONE statement (#12555) ────────────


### PR DESCRIPTION
Fixes #16299

**Clause-②**: no

## What

Adds fixture (26) to `check-test-source-alias.mjs`'s `--self-test`: a dynamic
`import('@fx/core')` inside an `it()` callback, preceded by a template
literal whose interior contains a stray `` ` }` `` character. This pins the
`codeOnly` half of `maskedProjections` — the projection `functionBodyRanges`
reads to decide module-scope vs CLOCKED — which #16299 measured as pinned by
nothing.

Why this shape: `functionBodyRanges` walks `codeOnly` character by character,
pushing a frame on every `{` and popping (closing a range) on every `}`. Under
correct masking, `maskCommentsAndLiterals` blanks the template's interior
(delimiters survive, content does not), so the stray `}` never reaches the
scanner and the callback's real closing brace is what pairs with its real
opener — the import lands inside `[open, close]` and is reported CLOCKED.
Under an under-masking `codeOnly` (either ablation below), the literal `}`
is read as real code: it pops the callback's frame early, right there inside
the template, *before* the dynamic import two lines down. The range this
scanner records is `[open, thatEarlyClose]`, the import falls outside it, and
the violation goes silently unreported — the same "silent exemption" failure
mode fixture (25) already pins for the brace scanner's backward walk, but for
the forward brace-count instead.

Two assertions added to the existing "the clocked-window rule (#10126)"
battery (floor raised 10 → 12 per #13799): the fixture's one CLOCKED finding
is reported, at the correct line, naming the correct specifier.

## Ablation proof (temporary, not committed)

Both directions #16299 named, applied to `scripts/js-comment-mask.mjs`'s
`maskCommentsAndLiterals`, then reverted:

| ablation | `--self-test` before revert |
|:--|:--|
| `flags[k] = comment[k]` (degrades to `maskComments`) | **RED** — `a \`}\` inside a template literal closed the real function body early — the dynamic import went unreported` |
| `return source` (identity — blanks nothing) | **RED** — same failure |

After each ablation: `git checkout HEAD -- scripts/js-comment-mask.mjs`,
confirmed via `git status --short` / `git diff --stat` (both empty) and
`git hash-object scripts/js-comment-mask.mjs` matching the pre-ablation
`HEAD` blob hash (`7956343dd85bdef8924372cb2cdec45fcd54501d`) both times.

Un-ablated, after revert: `node scripts/check-test-source-alias.mjs
--self-test` → `check-test-source-alias --self-test OK` (exit 0), and the
plain run's output is byte-identical to the pre-change baseline
(`check-test-source-alias OK — 73 packages with tests scanned; 61 registered
as still resolving a workspace dep through \`dist/\`; 49 published
subpath(s) resolved through every alias table.`) — the reverse control: the
new fixture is green un-ablated, red under both ablations.

`scripts/js-comment-mask.mjs` was never committed to — it is a shared file
and #16299 states it is only touched by the ablation, which is reverted.

## Scope

Only `scripts/check-test-source-alias.mjs` changed (fixture + 2 assertions +
floor bump). No change to `scripts/js-comment-mask.mjs` (shared, out of
scope). Not re-proving #15776's conversion — that proof (6,204 files /
107,177,732 chars byte-for-byte, with a 6,174-file-distinguishing control)
already lives in that PR's body; this card supplies the pin this gate itself
lacked.

## Changeset

`skip-changeset`: `scripts/check-test-source-alias.mjs` is a root dev/tooling
script — it is not part of any published package's `files[]` (root package
`@objectstack/spec-monorepo` is `"private": true`; `grep -rl` for the file
across every `packages/*/package.json` `files` entry returns nothing), so
nothing published moves. Label applied to the PR.

## Local verification

- `node scripts/check-test-source-alias.mjs --self-test` and the plain run:
  both green, both before and after the ablation-and-revert cycle.
- `scripts/pm/dispatch-gates.mjs --commands` derived 32 commands for this
  diff (1 changed path, `scripts/check-test-source-alias.mjs`); run directly
  (not through turbo — none is a package build/test), all green so far
  (`pnpm check:pm-dispatch-gates` still running per its own documented
  detach-and-poll guidance for this container).
- No workspace package closure (①): the changed file is a root `scripts/`
  script, not part of any package. `pnpm turbo ls --affected` reports the
  full 80-package list for this diff, which is `turbo`'s documented blind
  spot for root-level, non-package changes (AGENTS.md: "仓根包不在 `turbo ls`
  里,根级套件整个在图外") rather than a real per-package signal, so ② is
  also N/A — no package's own `test`/`typecheck` is implicated.

---
_Generated by [Claude Code](https://claude.ai/code/session_012GKcPZbMoGq7WPzKLfRBTU)_