### PR TITLE
Derive the dispatch-gates declaration case count in check-skill-compatibility-version's self-test

### DIFF
--- a/scripts/check-skill-compatibility-version.mjs
+++ b/scripts/check-skill-compatibility-version.mjs
@@ -777,7 +777,8 @@ function selfTest() {
   // state what it reads. If that refusal ever changes, this line moves with it.
   const unseeable = (r) => !r.includes('/') && !r.startsWith('.');
   const declFailures = [];
-  const decl = (label, ok) => { if (!ok) declFailures.push(label); };
+  let declCases = 0;
+  const decl = (label, ok) => { declCases += 1; if (!ok) declFailures.push(label); };
   decl('SKILLS_DIR is invisible to the derivation, which is why it needs a declaration at all',
     unseeable(SKILLS_DIR));
   decl('and it declares exactly that root, in the subtree spelling',
@@ -864,7 +865,7 @@ function selfTest() {
     console.error(`\n✗ check-skill-compatibility-version self-test: ${failed} failure(s) (cases and floor).`);
     process.exit(1);
   }
-  console.log(`\n✓ check-skill-compatibility-version self-test: ${cases.length} cases pass, plus 7 dispatch-gates declaration cases.`);
+  console.log(`\n✓ check-skill-compatibility-version self-test: ${cases.length} cases pass, plus ${declCases} dispatch-gates declaration cases.`);
   selfTestReachedVerdict = true;
 }
 


### PR DESCRIPTION
Closes #15291

## What changed

`check-skill-compatibility-version.mjs`'s self-test success line hand-transcribed
`plus 7 dispatch-gates declaration cases`, while the `declFailures` block it
describes registers only 6 `decl(...)` calls — a count accurate on the day it was
written, wrong the moment a 7th `decl()` is added or one is removed. Mirroring the
existing precedent in `check-skill-frame-sync.mjs` (`popCases` / `pop()`), `decl()`
now increments a `declCases` counter and the success line prints `${declCases}`
instead of the literal.

```diff
-  const decl = (label, ok) => { if (!ok) declFailures.push(label); };
+  let declCases = 0;
+  const decl = (label, ok) => { declCases += 1; if (!ok) declFailures.push(label); };
...
-  console.log(`\n✓ check-skill-compatibility-version self-test: ${cases.length} cases pass, plus 7 dispatch-gates declaration cases.`);
+  console.log(`\n✓ check-skill-compatibility-version self-test: ${cases.length} cases pass, plus ${declCases} dispatch-gates declaration cases.`);
```

## Before / after green line

Before (`origin/main` `572c33a2c4`):
```
✓ check-skill-compatibility-version self-test: 18 cases pass, plus 7 dispatch-gates declaration cases.
```

After (this PR):
```
✓ check-skill-compatibility-version self-test: 18 cases pass, plus 6 dispatch-gates declaration cases.
```

The line moving from `7` to `6` is the expected, correct behaviour change — the
`decl(...)` block really registers 6 cases today. This is exactly why the issue was
not folded into #15288 (batch 7a), whose proof depended on the self-test's success
line staying byte-identical to `main`.

## Verification — both legs

1. **Adding a `decl(...)` call moves the number.** A probe `decl('leg-1 probe: an
   added decl() call must move declCases', true);` appended after the existing
   block moved the printed count from 6 to 7:
   ```
   ✓ check-skill-compatibility-version self-test: 18 cases pass, plus 7 dispatch-gates declaration cases.
   ```
2. **An unrelated edit does not move the number.** Adding an unrelated comment line
   at the top of the file (outside `selfTest()`) left the printed count at 6:
   ```
   ✓ check-skill-compatibility-version self-test: 18 cases pass, plus 6 dispatch-gates declaration cases.
   ```
   Both probes were reverted before this commit; the working tree diff is exactly
   the two-line fix shown above (`git diff` confirmed clean before committing).

`decl(` count in the `declFailures` block on `origin/main` `572c33a2c4`: **6**
(lines 796, 798, 800, 808, 812, 817).

## Scope

Only `scripts/check-skill-compatibility-version.mjs` touched. `check-skill-frame-sync.mjs`
(the model for this fix) is untouched. This is not assertion-floor work (#13799) —
the derived value is not pinned as a floor, only printed.

**Clause-②**: no

---
_Generated by [Claude Code](https://claude.ai/code/session_012GKcPZbMoGq7WPzKLfRBTU)_