### PR TITLE
docs(agents): a PR declaring clause-② grades its changeset at least minor

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1040,7 +1040,8 @@ registry? Add it to `OPEN_CAPABILITY_REGISTRIES` in the same PR that fixes it.
 3. **Add a changeset for anything that publishes.** Feature, functional improvement or fix — run `pnpm changeset`
    (or add a `.changeset/*.md` entry) describing it before committing. A bug fix in a released package takes a
    **`patch`** changeset — never none, and ⛔ never `skip-changeset`: that label is for a diff that publishes
-   nothing from any released package.
+   nothing from any released package. A PR that declares `Clause-②: yes` takes at least **`minor`** instead —
+   the widening it declares is what makes it more than a patch, whatever else the diff fixes.
    **Breaking changesets must carry their migration.** If the change removes or renames anything an author can write (a
    spec key, an export, a config field), the changeset body must state the FROM → TO mapping and the one-line fix —
    this text ships to consumers as `CHANGELOG.md` inside the npm package and is what an upgrading agent greps after the

--- a/scripts/pm/check-skill-line-ratchet.mjs
+++ b/scripts/pm/check-skill-line-ratchet.mjs
@@ -1066,7 +1066,24 @@ export const CEILINGS = new Map([
   // option A; recorded by the director on #16851 comment 5617189215, which also
   // rules the net budget of 6). AGENTS.md is not a CROSS_FILE_MOVES destination,
   // so no `ruledRaises` record applies. Landed count, headroom 0, same convention.
-  ['AGENTS.md', 1074],
+  //
+  // 1074 → 1075 (card #16973): the Post-Task Checklist's changeset rule gains the
+  // ruled exception — a bug fix in a released package takes `patch` UNLESS the PR
+  // declares `Clause-②: yes`, in which case at least `minor`. Until this line the
+  // two live authorities disagreed on the same PR — this item's sentence and the
+  // maintainer's own level ruling — and an author could satisfy either and cite it;
+  // the LEVEL axis of check-changeset-no-major.mjs has judged it the second way
+  // since #16055, so the text is being brought to the gate, not the gate to the
+  // text. +1 line against the ruled budget of 2, and forced: the item's paragraph
+  // measures 543 bytes of prose, which four lines cannot hold under the 120-byte
+  // rule above (4 × 120 = 480), so there is no lossless rewrap at any width.
+  // Maintainer ruling, verbatim and untranslated: 「其他同意」 (decision batch #111
+  // item 3, 2026-09-10, on analysis 5615846581 option A, forward-only; recorded by
+  // the director on #16973 comment 5617188486, which also rules the net budget of 2
+  // and holds the gate's LEVEL axis unchanged). AGENTS.md is not a CROSS_FILE_MOVES
+  // destination, so no `ruledRaises` record applies. Landed count, headroom 0, same
+  // convention.
+  ['AGENTS.md', 1075],
   // #9965: root CLAUDE.md is the other repo-root instruction file — same read
   // path (every seat session), same governance (Prime Directive #14). It is
   // structurally growth-prone in the way the ratchet is built for: it exists to


### PR DESCRIPTION
Fixes #16973

The Post-Task Checklist's changeset rule now carries the ruled exception: a bug fix in a released package takes a `patch` changeset **unless the PR declares clause ② as `yes`**, in which case the changeset takes at least `minor`.

Ruling — the maintainer's 「其他同意」 on decision batch #111 item 3 (option A of the director's analysis 5615846581), executed by the director in comment 5617188486, verbatim and untranslated:

> 「`Clause-②: yes` 的 PR，changeset 级别至少 `minor`（裁决 #15294 为准）；AGENTS.md:1035「A bug fix in a released package takes a `patch` changeset」补一句例外：「…unless the PR declares `Clause-②: yes`, in which case the changeset takes at least `minor`」（措辞由 skills 席起草、您亲合时定稿）。门 `check-changeset-no-major.mjs` 的 LEVEL 轴不动（它已按 A 判）。回溯：分诊 5595827965 实测 #16650 随 17.4.0 minor 发出，⛔ 无需重评重发；其余六张 `not-measured` 不在本裁决内。⛔ 不裁 B / C。」

Forward-only: #16650 is not re-graded and not re-released — triage 5595827965 measured its entry shipping inside the `17.4.0` **minor** — and the gate's LEVEL axis is untouched.

## The sentence — before / after

**Before** — `AGENTS.md` :1040–:1043, 4 lines, 374 bytes:

```text
3. **Add a changeset for anything that publishes.** Feature, functional improvement or fix — run `pnpm changeset`
   (or add a `.changeset/*.md` entry) describing it before committing. A bug fix in a released package takes a
   **`patch`** changeset — never none, and ⛔ never `skip-changeset`: that label is for a diff that publishes
   nothing from any released package.
```

**After** — :1040–:1044, 5 lines, 543 bytes (the last two lines are the diff; the first three are unchanged):

```text
3. **Add a changeset for anything that publishes.** Feature, functional improvement or fix — run `pnpm changeset`
   (or add a `.changeset/*.md` entry) describing it before committing. A bug fix in a released package takes a
   **`patch`** changeset — never none, and ⛔ never `skip-changeset`: that label is for a diff that publishes
   nothing from any released package. A PR that declares `Clause-②: yes` takes at least **`minor`** instead —
   the widening it declares is what makes it more than a patch, whatever else the diff fixes.
```

| reading | before | after |
|---|---|---|
| `AGENTS.md` total lines | 1074 | 1075 |
| ratchet ceiling (`CEILINGS`) | 1074 | 1075 |
| the checklist item's paragraph | 4 lines / 374 bytes | 5 lines / 543 bytes |
| the one edited line (:1043) | 37 bytes | 113 bytes |
| the one added line (:1044) | — | 93 bytes |
| longest line in the paragraph | 115 bytes | 115 bytes (cap 120) |

**Why the line cannot be re-wrapped away.** The ceilinged-file rule caps a line at 120 bytes, so four lines hold at most 480; the paragraph now measures 543, and `ceil(543 / 120) = 5`. Net growth is **+1 line**, inside the ruled budget of 2.

**What is untouched.** 「never none, and ⛔ never `skip-changeset`: that label is for a diff that publishes nothing from any released package」 is byte-identical — it is a context line in the diff, and the exception attaches after it. Neither `scripts/check-changeset-no-major.mjs` nor § 3 (landed with PR #17398) is touched, and no other file is.

## The ratchet raise

`scripts/pm/check-skill-line-ratchet.mjs`: `['AGENTS.md', 1074]` → `['AGENTS.md', 1075]`, in the map's own ledger-comment form — the shape the `1068 → 1074` entry PR #17398 added established: a comment block above the constant, carrying the raise's arithmetic, the reason it cannot be paid in place, and the ruling verbatim (「其他同意」, decision batch #111 item 3, on analysis 5615846581 option A, recorded on #16973 comment 5617188486). `AGENTS.md` is not a `CROSS_FILE_MOVES` destination, so no `ruledRaises` record applies. Landed count, headroom 0, same convention.

## What the gate already does — confirmed, not assumed

`scripts/check-changeset-no-major.mjs` :814–:815 states the LEVEL axis's predicate in its own words:

```text
//     A PR that declares clause-② `yes` must grade AT LEAST ONE package whose
//     `packages/**/src/**` it moves at `minor` or above.
```

So the text is being brought to the gate, not the gate to the text — which is what makes this edit forward-safe rather than a new obligation. One grain note for the record (⛔ not a gap filed here, and ⛔ not a change to the axis, which the ruling holds fixed): the gate's predicate is **existential** — at least one moved package graded `minor`+ — while the sentence is about the changeset the PR writes. The gate names that residual itself (`discharged`), and the two agree exactly on a single-package PR.

## Verification

| check | reading |
|---|---|
| derived families | `dispatch-gates --commands` on the real diff ⇒ 37; all 37 run |
| reconciliation | `dispatch-gates --ran` ⇒ 37 derived / 37 run / **0 NOT-MEASURED** / 0 UNRUN, each line carrying an exit code captured before any pipe |
| named families | `check:pm-skill-ratchet`, `check:pm-skill-id-lint`, `check:pm-governed-prose`, `check:nul-bytes` — exit 0 |
| `check:pm-dispatch-gates` | detached, awaited with `tail --pid`, exit read from the redirected log: `GATE_EXIT=0` (1678 self-test cases) |
| governed-surface test | `check-governed-merges.mjs --test AGENTS.md scripts/pm/check-skill-line-ratchet.mjs` ⇒ **GOVERNED** (`AGENTS.md` ×1) |
| `skip-changeset` | measured: 70 published packages, none lists `AGENTS.md` or `scripts/` in `files[]`; positive control `packages/spec` lists ten real entries |

## Landing

Governed surface (`AGENTS.md`) ⇒ **draft only**. ⛔ No seat flips it ready, enqueues it or arms auto-merge; the maintainer merges it by hand (Prime Directive #14).

## 维护者速读(草稿)

**改了什么。** `AGENTS.md` 收尾清单第 3 条那句「修 bug 就是 `patch`」后面补了一句例外:PR 如果声明了走契约复核(clause ② 那一行写 `yes`),changeset 级别就至少 `minor`。一句话,净增 1 行;顺带把 ratchet 的上限 1074 抬到 1075,并在它自己的台账注释里记下您的裁决。

**为什么改。** 之前两条都还生效的权威文本对同一个 PR 给出不同答案:这一条说 `patch`,您 9 月 4 日的裁决说「纯加法式扩大公开面至少 `minor`」。作者读哪条都能自圆其说,谁被抓到取决于门禁看得见看不见——门禁刚修好,下一张同形状的 PR 会被当场拦下。现在文本和门禁说的是同一件事。

**风险与代价(含回滚)。** 只改文字,不改任何门禁谓词、不改 #16650、不重发任何版本。代价是保守声明 `yes` 的 PR 版本级别会偏高一点;实测 69 个包同一 `fixed` 组、由当期最高 changeset 定版,所以几乎不改变实际发布结果。回滚 = revert 本 PR 两个文件(上限跟着退回 1074),零迁移、零消费者影响。

**席位意见。**

**你要做的。** 一个动作:人工合并本 draft PR。

---
_Generated by [Claude Code](https://claude.ai/code/session_01YKEjmbYNvYWJvWGSWx26zK)_