### PR TITLE
check:keyed-text-bounds: skip tmp/, move scaffold test's temp root under node_modules

### DIFF
--- a/packages/cli/test/init-scaffold-authoring-rules.test.ts
+++ b/packages/cli/test/init-scaffold-authoring-rules.test.ts
@@ -30,11 +30,16 @@
  * (`writeTemplateSrcFiles`) and checked through the command's own self-test
  * (`validateScaffold`), so neither half can drift from what `init` really does.
  *
- * Temp projects are created under this package's git-ignored `tmp/` (not
- * `os.tmpdir()`) because the rendered config imports `@objectstack/spec`,
- * which only resolves where Node can walk up into this package's
- * `node_modules`. Keeping them out of `test/` also keeps generated `.ts` away
- * from any glob that collects sources.
+ * Temp projects are created under this package's own `node_modules` (not
+ * `os.tmpdir()`, and not this package's `tmp/`) because the rendered config
+ * imports `@objectstack/spec`, which only resolves where Node can walk up
+ * into this package's `node_modules` -- the same reasoning
+ * `generate-scaffold-validates.test.ts` documents for its own materialized
+ * scaffolds. `node_modules` is git-ignored and already excluded from every
+ * source-walking gate, so a run killed before `afterAll` runs (a timeout, the
+ * container's foreground cap, `ctrl-c`) leaves inert litter behind instead of
+ * files a repo-wide scan can trip over. Keeping them out of `test/` also
+ * keeps generated `.ts` away from any glob that collects sources.
  */
 
 import { describe, it, expect, afterAll } from 'vitest';
@@ -46,7 +51,7 @@ import { TEMPLATES, sanitizeNamespace, writeTemplateSrcFiles } from '../src/comm
 import { validateScaffold, SCAFFOLD_RULE_COMMAND } from '../src/utils/scaffold-validate.js';
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
-const TMP_ROOT = path.resolve(HERE, '../tmp');
+const TMP_ROOT = path.resolve(HERE, '../node_modules/.init-scaffold-authoring-rules');
 const PROJECT_NAME = 'my-app';
 
 const roots: string[] = [];

--- a/scripts/check-keyed-text-bounds.mjs
+++ b/scripts/check-keyed-text-bounds.mjs
@@ -359,6 +359,7 @@ const MIN_KEYED_TEXT_COLUMNS = 140;
 
 const SKIP_DIRS = new Set([
   '.git', 'node_modules', 'dist', 'build', 'coverage', '.turbo', '.next', '.cache', '.changeset',
+  'tmp',
 ]);
 
 /** Where shipped object declarations are discovered. */


### PR DESCRIPTION
Closes #16195

## What changed

**Shape 1** — `check:keyed-text-bounds`'s walk (`scripts/check-keyed-text-bounds.mjs`) now skips `tmp/` directories, the same way it already skips `node_modules`, `dist`, `build`, etc. I added `'tmp'` to the existing `SKIP_DIRS` set rather than reading `.gitignore`: `SKIP_DIRS` is already the walk's one filter point and already carries this exact family of "build/tooling litter, not source" directories (`node_modules`, `dist`, `build`, `coverage`, `.turbo`, `.next`, `.cache`, `.changeset`) — `tmp/` is the same kind of entry, not a new mechanism. Reading `.gitignore` would add a second, more powerful exclusion mechanism (glob/negation semantics) for one directory name, and risks silently widening the walk's exclusions to patterns nobody has reviewed against this gate's population.

**`:376` design note check** — the walk is deliberately "the whole repository minus `SKIP_DIRS`", specifically so a boundary-scoped sweep (narrowing the walk to `ROOT_DIR_WATCH_HINTS`) can't reopen the hole this gate exists to close. Adding one more literal to `SKIP_DIRS` keeps that sentence true: the walk is still repo-wide minus `SKIP_DIRS`, just with one more skip entry — nothing about the population's boundary-scoping changed.

**Shape 3** — `packages/cli/test/init-scaffold-authoring-rules.test.ts`'s scaffold temp root moved from this package's git-ignored `tmp/` to under this package's own `node_modules/` (`node_modules/.init-scaffold-authoring-rules/`), matching the placement `generate-scaffold-validates.test.ts` already documents and uses for the same reason (`@objectstack/spec` resolution needs the temp project under `packages/cli` so Node can walk up into its `node_modules`). `node_modules` is already in `SKIP_DIRS` regardless of this PR, so this closes the leftover-after-a-killed-run failure mode more robustly than shape 1 alone would for this one test. The `afterAll` cleanup logic (`roots` array, unchanged) already targets whatever `TMP_ROOT` resolves to, so no separate cleanup-path edit was needed beyond the constant itself.

**Shape 2 is intentionally NOT done here** (per triage/dispatch: out of this card's scope). See "Shape 2" below.

## Acceptance legs (reproduced on `origin/main` `d57611dfd3` before, and on this branch after, the fix)

**Before fix** (repro, not committed): an `os init`-shaped `.object.ts` written under `packages/cli/tmp/…/src/objects/my_app_item.object.ts` →
```
check:keyed-text-bounds: 1 declaration(s) this scan cannot classify
  packages/cli/tmp/full-plugin-repro/src/objects/my_app_item.object.ts:1
    no object declaration recognised in a `.object.ts` file.
```
exit 2.

**Leg 1 — ignored tree ⇒ exit 0.** Same file, same content, under `packages/cli/tmp/` after the fix:
```
✓ check:keyed-text-bounds: 112 *.object.ts files under packages/** + apps/** + examples/** (walk is repo-wide; 0 outside), …
```
exit 0.

**Leg 2 — anti-overfix control, tracked directory ⇒ still exit 2.** The identical file copied into a tracked directory (`packages/cli/src/tracked-repro-objects/my_app_item.object.ts`) still produces:
```
check:keyed-text-bounds: 1 declaration(s) this scan cannot classify
  packages/cli/src/tracked-repro-objects/my_app_item.object.ts:1
    no object declaration recognised in a `.object.ts` file.
```
exit 2. The refusal is unchanged for tracked, unrecognised shapes — only the walked population moved.

Both repro trees were removed before committing; neither leg's files are part of this diff.

## Shape 2 (out of scope here)

Per the card: the platform's gate (112/112 recognised files are the `ObjectSchema.create({…})` factory shape) and `os init`'s own emitter (a plain, annotated `Data.ServiceObject` object literal) disagree about how a `.object.ts` may be written, and that's a decision, not a side effect of this cleanup. I looked for a standing ruling on which shape is authorised and did not find one framed as such, but did find real evidence on both sides:
- `content/docs/data-modeling/schema-design.mdx` states the factory shape as "the" pattern for every object definition; `packages/create-objectstack`'s own bundled template also uses it — a second, independent official scaffolder agreeing with the gate.
- `content/docs/deployment/cli.mdx:1323` documents `os init`/`os g` emitting the `Data.*`-typed literal as current, undeprecated behaviour, and `packages/cli/src/commands/init.ts`'s `TEMPLATES` is actively kept in sync for version policy (`scripts/sync-scaffold-emission-policy.mjs`), i.e. treated as maintained source of truth, not legacy.

Filed as #17418 (unlabelled, for triage), since I could read the disagreement clearly but not its resolution.

## Changeset reading

Both changed files were measured against their package's published `files[]`, not guessed:
- `scripts/check-keyed-text-bounds.mjs` lives at the monorepo root, which is `"private": true` (`@objectstack/spec-monorepo`) and is never published; it isn't referenced from any workspace package's `files[]`.
- `packages/cli/test/init-scaffold-authoring-rules.test.ts` — `packages/cli`'s `package.json` `files` is `["dist", "README.md", "CHANGELOG.md"]`; `test/**` is not included.

Neither changed path ships in any published artifact ⇒ **no changeset owed**. The `skip-changeset` label has been applied to this PR.

## Tests run

- `node scripts/check-keyed-text-bounds.mjs` — exit 0 on the clean tree (112 files, 148/148 bounded, matches pre-change baseline).
- `node scripts/check-keyed-text-bounds.mjs --self-test` — PASS (0 failures), 17 cases.
- `pnpm --filter @objectstack/cli exec vitest run --project unit test/init-scaffold-authoring-rules.test.ts` — 6/6 passed (after building the package's dependency closure, `pnpm --filter '@objectstack/cli^...' build`, 58 workspace projects, exit 0).
- Repro/anti-overfix legs above, run manually against the gate script; files removed before commit.
- Gate union derived from `node scripts/pm/dispatch-gates.mjs --commands` for this diff's changed paths (67 commands): 63 passed cleanly on the first pass; `check:query-options-erasure` was only slow in the batch (90s cap) and passes cleanly (exit 0) standalone — 64/67 verified green. `check:dual-build-cjs-loads` and `check:type-check-debt` both refuse with `PREREQUISITE NOT MET` (exit 3) because they read built output across the *whole* monorepo, unrelated to either changed file — outside this diff's package-scoped local validation, left to CI. `check:pm-dispatch-gates` (the `dispatch-gates` tool's own self-test, unrelated to either changed file — `scripts/pm/**` is untouched here) ran every visible assertion green (no `✗` observed) but did not finish inside two long timeouts (90s then 580s); recorded as NOT MEASURED to completion rather than claimed as a pass.

**Clause-②**: no


---
_Generated by [Claude Code](https://claude.ai/code/session_012GKcPZbMoGq7WPzKLfRBTU)_