### PR TITLE
fix(lint): hook write-set findings on a lowered hook point at hooks[i].handler

### DIFF
--- a/.changeset/hook-write-set-finding-path-lowered-handler.md
+++ b/.changeset/hook-write-set-finding-path-lowered-handler.md
@@ -1,0 +1,41 @@
+---
+"@objectstack/lint": patch
+"@objectstack/cli": patch
+---
+
+fix(lint): a hook write-set finding on a handler-authored hook reports `path: hooks[i].handler` — a key the author actually wrote — instead of the lowered `hooks[i].body.source` (#16546)
+
+`hook-api-update-readonly-field` / `hook-api-update-readonly-when-field`
+(`validate-readonly-hook-writes.ts`) and `hook-body-write-unknown-field` /
+`hook-body-write-unprovisioned-anchor` / `hook-body-source-unparseable`
+(`validate-hook-body-writes.ts`) all report their `path` against `hook.body`,
+because that is the shape they parse. For a hook authored as an inline
+`handler: async (ctx) => { … }` (39 of 39 hooks in the reference app),
+`hooks[i].body` is not something the author wrote at all — `lowerCallables`
+mints it from the handler before `os build` / `os lint` hand the stack to
+these rules (#16095). The reported `path` therefore named a key that does not
+exist in the author's own source file; grepping for `body.source` there finds
+nothing.
+
+**What changed.** `lowerCallables` now records, per `lowerCallables()` call,
+which `hooks[*].handler` ref strings got their `body` minted this way (as
+opposed to a `body` the author wrote directly). The CLI's four lowering doors
+(`os build`, `os lint`, `os validate`, `os init`/`dev`'s scaffold validation)
+pass that set through `runAuthoringRules`'s `ctx.loweredHookRefs`, and the two
+hook write-set rules use it to redirect a finding on a lowered hook to
+`path: hooks[i].handler` — the key that replaced the function the author
+wrote — with a message suffix ("judged on the metadata body lowered from the
+inline handler") explaining why. A hook whose `body` the author wrote directly
+is unaffected: `path` stays `hooks[i].body.source`, unchanged.
+
+**No verdict changed.** Which hooks are flagged, at what severity, and why is
+untouched — #13653 and #4271 are unmoved by a word. Only the location a
+finding points at, and the wording explaining it, are different. `os build`
+and `os lint` continue to report the identical `path` and message for the
+same hook (#16095's "one implementation, both commands agree" — now including
+this).
+
+No `--json` field was added or removed: `path` and `message` keep their
+existing shape (string), and this is a within-type value correction for the
+one subclass whose old value could never be resolved against the author's
+source in the first place.

--- a/packages/cli/src/commands/compile.ts
+++ b/packages/cli/src/commands/compile.ts
@@ -416,6 +416,10 @@ export default class Compile extends Command {
         normalized: authoringRuleUnionStack(normalized as Record<string, unknown>),
         parsed: authoringRuleUnionStack(result.data as Record<string, unknown>),
         sduiManifest: resolveSduiManifest(),
+        // [#16546] Ref strings, not hook indices — survive the union fold and
+        // the per-package re-slice below unchanged (see `LoweringResult.
+        // loweredHookRefs`'s header for why an index would not).
+        loweredHookRefs: lowering.loweredHookRefs,
       });
       const { errors: ruleErrors, advisories } = splitBySeverity(findings);
       ruleAdvisories = advisories;
@@ -489,6 +493,7 @@ export default class Compile extends Command {
             normalized: asStack,
             parsed: asStack,
             sduiManifest: resolveSduiManifest(),
+            loweredHookRefs: lowering.loweredHookRefs,
           }).filter((f) => !alreadyReported.has(findingKey(f)));
           for (const f of pkgFindings) alreadyReported.add(findingKey(f));
           const split = splitBySeverity(pkgFindings);

--- a/packages/cli/src/commands/lint.ts
+++ b/packages/cli/src/commands/lint.ts
@@ -511,11 +511,15 @@ export function lintConfig(config: any, opts: LintConfigOptions = {}): LintIssue
   //     the family stays silent on it and `checkHookBodyLowering` is what
   //     reports it, so no verdict is ever given about a body that was not
   //     produced. Nothing here touches what `os build` accepts (#13838).
-  const { lowered } = lowerCallables(config as Record<string, unknown>);
+  const { lowered, loweredHookRefs } = lowerCallables(config as Record<string, unknown>);
   for (const f of runAuthoringRules('lint', {
     normalized: config,
     parsed: lowered,
     sduiManifest: opts.sduiManifest,
+    // [#16546] Same ref set `os build` computes from the same normalized
+    // input — what lets `validateReadonlyHookWrites` / `validateHookBodyWrites`
+    // report `hooks[i].handler` here byte-identically to `os build`.
+    loweredHookRefs,
   })) {
     issues.push({
       severity: f.severity === 'info' ? 'suggestion' : f.severity,

--- a/packages/cli/src/commands/validate.ts
+++ b/packages/cli/src/commands/validate.ts
@@ -260,8 +260,8 @@ export default class Validate extends Command {
       //     own contract decision (`compile.ts` records why the key is
       //     build's alone). No step line is printed either: the text face is
       //     byte-for-byte what it was, and the docs transcripts stay true.
-      const { lowered } = lowerCallables(normalized as Record<string, unknown>);
-      const result = ObjectStackDefinitionSchema.safeParse(lowered);
+      const lowering = lowerCallables(normalized as Record<string, unknown>);
+      const result = ObjectStackDefinitionSchema.safeParse(lowering.lowered);
 
       if (!result.success) {
         if (flags.json) {
@@ -304,6 +304,9 @@ export default class Validate extends Command {
         normalized: normalized as Record<string, unknown>,
         parsed: result.data as Record<string, unknown>,
         sduiManifest: resolveSduiManifest(),
+        // [#16546] Same ref set `os build` / `os lint` compute — keeps this
+        // door's hook write-set findings at the same `path` as the other two.
+        loweredHookRefs: lowering.loweredHookRefs,
       });
       const { errors: ruleErrors, advisories } = splitBySeverity(findings);
       ruleAdvisories = advisories;

--- a/packages/cli/src/utils/lower-callables.ts
+++ b/packages/cli/src/utils/lower-callables.ts
@@ -59,6 +59,29 @@ export interface LoweringResult {
   bodyExtracted: number;
   /** Per-extraction failures (still emit handler ref + bundle, but warn). */
   bodyExtractionWarnings: BodyExtractionWarning[];
+  /**
+   * [#16546] The `hooks[*].handler` ref strings whose `body` was minted HERE
+   * — extracted from the author's inline `handler` function — as opposed to a
+   * `body` the author wrote directly. A ref lands here if and only if this
+   * call set `hook.body`, so the set is empty whenever every hook already
+   * carried its own `body`.
+   *
+   * A ref, not a hook index: `register`'s `taken`/`refByFn` maps are shared
+   * across the whole walk (top level AND every ADR-0130 D4 package body, see
+   * `lowerBody`'s header), so a ref is unique for this whole call and
+   * survives unchanged through a Zod parse (`handler` is an ordinary
+   * string field) — an index would not: `authoringRuleUnionStack` folds
+   * package hooks into a new top-level array with its OWN numbering, and a
+   * hook index recorded against this call's `hooks[i]` would silently
+   * address a different hook once folded.
+   *
+   * Consumed by `validateReadonlyHookWrites` / `validateHookBodyWrites`
+   * (`@objectstack/lint`) via `AuthoringRuleContext.loweredHookRefs`, to
+   * report `path: hooks[i].handler` — a key that exists in the author's
+   * source — instead of `hooks[i].body.source`, a key this function minted
+   * and the author never wrote.
+   */
+  loweredHookRefs: ReadonlySet<string>;
 }
 
 type AnyFn = (...args: unknown[]) => unknown;
@@ -83,6 +106,7 @@ export function lowerCallables(input: Record<string, unknown>): LoweringResult {
   const functions: Record<string, AnyFn> = {};
   const taken = new Set<string>();
   const warnings: BodyExtractionWarning[] = [];
+  const loweredHookRefs = new Set<string>();
   let bodyExtracted = 0;
 
   // Try to extract a metadata-only body from a callable. Returns null if the
@@ -170,7 +194,12 @@ export function lowerCallables(input: Record<string, unknown>): LoweringResult {
           // Extract metadata body unless the user already provided one.
           if (!hook.body) {
             const body = tryExtractBody(hook.handler as AnyFn, `hook '${name}'`);
-            if (body) hook.body = body;
+            if (body) {
+              hook.body = body;
+              // [#16546] This ref's `body` was minted here, not authored — the
+              // marker the two hook write-set rules redirect their `path` on.
+              loweredHookRefs.add(ref);
+            }
           }
           hook.handler = ref;
         }
@@ -296,6 +325,7 @@ export function lowerCallables(input: Record<string, unknown>): LoweringResult {
     count: Object.keys(functions).length,
     bodyExtracted,
     bodyExtractionWarnings: warnings,
+    loweredHookRefs,
   };
 }
 

--- a/packages/cli/src/utils/scaffold-validate.ts
+++ b/packages/cli/src/utils/scaffold-validate.ts
@@ -88,6 +88,9 @@ export function runScaffoldAuthoringRules(config: unknown): ScaffoldRuleReport {
     normalized: normalized as Record<string, unknown>,
     parsed: result.data as Record<string, unknown>,
     sduiManifest: resolveSduiManifest(),
+    // [#16546] Same ref set the other three doors compute — keeps this
+    // door's hook write-set findings at the same `path` as they are.
+    loweredHookRefs: lowering.loweredHookRefs,
   });
   const { errors, advisories } = splitBySeverity(findings);
 

--- a/packages/cli/test/lint-hook-rules-reach-handler-hooks.test.ts
+++ b/packages/cli/test/lint-hook-rules-reach-handler-hooks.test.ts
@@ -78,16 +78,25 @@ describe('#16095 — INTAKE: a handler-authored hook reaches the readonly family
     expect(findings).toHaveLength(1);
     expect(findings[0].severity).toBe('error');
     expect(findings[0].message).toContain('is_escalated');
-    // The finding is reported on the LOWERED body — the same path `os build`
-    // reports it on for the same hook, so the two commands agree word for word.
-    expect(findings[0].path).toBe('hooks[0].body.source');
+    // [#16546] `body.source` is a key this author never wrote — the body was
+    // MINTED here from their inline `handler`, so the finding points at the
+    // key they actually wrote instead, with a suffix saying why. `os build`
+    // reports the identical `path` and message suffix for the same hook (see
+    // the e2e sibling's parity assertion), so the two commands still agree
+    // word for word — just no longer on the wrong word.
+    expect(findings[0].path).toBe('hooks[0].handler');
+    expect(findings[0].message).toContain('judged on the metadata body lowered from the inline handler');
   });
 
-  it('CONTROL — the identical statement as an explicit `body` fires the same finding', () => {
+  it('CONTROL — the identical statement as an explicit `body` fires the same finding, path UNCHANGED', () => {
+    // [#16546] Non-regression control: this hook's `body` is author-written,
+    // not lowered from a `handler` — `hooks[0].body.source` names a key that
+    // is really there, and the fix must never move it.
     const findings = rulesOf(bodyHook('escalate', WRITE_READONLY_SOURCE), READONLY_RULE);
     expect(findings).toHaveLength(1);
     expect(findings[0].severity).toBe('error');
     expect(findings[0].path).toBe('hooks[0].body.source');
+    expect(findings[0].message).not.toContain('judged on the metadata body lowered from the inline handler');
   });
 
   it('RED — `hook-api-update-readonly-when-field` (warning) fires on an inline handler too', () => {
@@ -99,6 +108,8 @@ describe('#16095 — INTAKE: a handler-authored hook reaches the readonly family
     );
     expect(findings).toHaveLength(1);
     expect(findings[0].severity).toBe('warning');
+    // [#16546] Same fix, this rule's other finding id.
+    expect(findings[0].path).toBe('hooks[0].handler');
   });
 
   it('RED — `hook-body-write-unknown-field` fires on an inline handler writing an undeclared field', () => {
@@ -111,6 +122,9 @@ describe('#16095 — INTAKE: a handler-authored hook reaches the readonly family
     expect(findings).toHaveLength(1);
     expect(findings[0].severity).toBe('warning');
     expect(findings[0].message).toContain('is_escalatd');
+    // [#16546] The sibling validator (`validate-hook-body-writes.ts`) gets the
+    // same fix — same `ctx.loweredHookRefs`, same shared `hookBodyFindingLocation`.
+    expect(findings[0].path).toBe('hooks[0].handler');
   });
 });
 
@@ -227,16 +241,21 @@ describe('#16095 — door: `runScaffoldAuthoringRules` (reached, and not one of 
   };
 
   it('INTAKE — the handler-authored hook IS judged here (it lowers before it parses)', () => {
-    expect(
-      familyOf(
-        handlerHook('escalate', async (ctx: any) => {
-          await ctx.api.object('crm_case').update({ id: ctx.input.id, is_escalated: true });
-        }),
-      ),
-    ).toHaveLength(1);
+    const findings = familyOf(
+      handlerHook('escalate', async (ctx: any) => {
+        await ctx.api.object('crm_case').update({ id: ctx.input.id, is_escalated: true });
+      }),
+    );
+    expect(findings).toHaveLength(1);
+    // [#16546] This door also gets `ctx.loweredHookRefs` (`scaffold-validate.ts`
+    // hands it through the same as `os build` / `os lint` do), so it must not
+    // be the one door still pointing at the un-authored `body.source` key.
+    expect(findings[0].path).toBe('hooks[0].handler');
   });
 
-  it('CONTROL — the identical statement as an explicit `body` fires the same finding', () => {
-    expect(familyOf(bodyHook('escalate_body', WRITE_READONLY_SOURCE))).toHaveLength(1);
+  it('CONTROL — the identical statement as an explicit `body` fires the same finding, path UNCHANGED', () => {
+    const findings = familyOf(bodyHook('escalate_body', WRITE_READONLY_SOURCE));
+    expect(findings).toHaveLength(1);
+    expect(findings[0].path).toBe('hooks[0].body.source');
   });
 });

--- a/packages/cli/test/lower-callables.test.ts
+++ b/packages/cli/test/lower-callables.test.ts
@@ -101,6 +101,47 @@ describe('lowerCallables', () => {
     });
     expect(out.bodyExtracted).toBe(1);
     expect((out.lowered.hooks as any[])[0].body).toBeDefined();
+    // [#16546] The ref this hook was minted under (its own name here, no
+    // collision) is recorded as body-from-handler — what the two hook
+    // write-set rules read to redirect their finding's `path`.
+    expect((out.lowered.hooks as any[])[0].handler).toBe('contained_hook');
+    expect(out.loweredHookRefs.has('contained_hook')).toBe(true);
+    expect(out.loweredHookRefs.size).toBe(1);
+  });
+
+  it('[#16546] does NOT mark the ref when body extraction fails — no body was minted to misreport', () => {
+    const handler = (ctx: any) => {
+      ctx.record.slug = moduleHelper(ctx.record.name);
+    };
+    const out = lowerCallables({
+      hooks: [{ name: 'slugify_hook_2', handler, events: ['beforeInsert'], object: 'doc' }],
+    });
+    expect(out.bodyExtracted).toBe(0);
+    expect(out.loweredHookRefs.size).toBe(0);
+  });
+
+  it('[#16546] does NOT mark the ref when the hook already carries an author-written `body`', () => {
+    // `lowerCallables` never extracts over an existing `body` (`if (!hook.body)`)
+    // — the `handler` is still lowered to a ref for bundling, but the body
+    // judged by the write-set rules is the one the author wrote, so its `path`
+    // must stay `body.source`.
+    const handler = (ctx: any) => {
+      ctx.record.id = Math.round(Number(ctx.record.raw));
+    };
+    const out = lowerCallables({
+      hooks: [
+        {
+          name: 'authored_body_hook',
+          handler,
+          events: ['beforeInsert'],
+          object: 'doc',
+          body: { language: 'js', source: 'ctx.record.id = 1;' },
+        },
+      ],
+    });
+    expect((out.lowered.hooks as any[])[0].handler).toBe('authored_body_hook');
+    expect((out.lowered.hooks as any[])[0].body).toEqual({ language: 'js', source: 'ctx.record.id = 1;' });
+    expect(out.loweredHookRefs.size).toBe(0);
   });
 
   it('produces a JSON-serializable lowered shape', () => {

--- a/packages/lint/src/authoring-rules.ts
+++ b/packages/lint/src/authoring-rules.ts
@@ -299,6 +299,22 @@ export interface AuthoringRuleContext {
    * argument.
    */
   runtimeWriteType?: string;
+  /**
+   * [#16546] `hooks[*].handler` ref strings whose metadata `body` was minted
+   * by `lowerCallables` from the author's inline `handler` function, rather
+   * than authored directly. Set by the CLI commands that lower before they
+   * run this registry (`os build`, `os lint`, `os validate`, scaffold
+   * validate — `lowerCallables`'s own return value, unchanged); ABSENT on the
+   * runtime publish gate, which never receives a `handler` function to lower.
+   *
+   * Read by `validateReadonlyHookWrites` / `validateHookBodyWrites`
+   * (`@objectstack/lint`) through the reference-integrity suite, to report
+   * `path: hooks[i].handler` — the key the author actually wrote — instead of
+   * `hooks[i].body.source`, a key this stack's `body` did not come from the
+   * author for. Absent or not naming a hook's ref means "this hook's `body`
+   * is author-written", and both validators keep reporting `body.source`.
+   */
+  loweredHookRefs?: ReadonlySet<string>;
 }
 
 export interface AuthoringRule {
@@ -1623,7 +1639,7 @@ export function authoringRulesFor(command: AuthoringCommand): readonly Authoring
  */
 export function runAuthoringRules(command: AuthoringCommand, run: AuthoringRuleRun): AuthoringFinding[] {
   const findings: AuthoringFinding[] = [];
-  const ctx: AuthoringRuleContext = { sduiManifest: run.sduiManifest };
+  const ctx: AuthoringRuleContext = { sduiManifest: run.sduiManifest, loweredHookRefs: run.loweredHookRefs };
   for (const rule of authoringRulesFor(command)) {
     const stack = rule.input === 'normalized' ? run.normalized : (run.parsed ?? run.normalized);
     findings.push(...rule.run(stack, ctx));

--- a/packages/lint/src/reference-integrity-suite.ts
+++ b/packages/lint/src/reference-integrity-suite.ts
@@ -179,7 +179,12 @@ export interface ReferenceIntegrityRule {
    * {@link validateReferenceIntegrity}).
    */
   runtimeTypes?: readonly string[];
-  run: (stack: Record<string, unknown>) => ReferenceIntegrityFinding[];
+  /**
+   * `ctx` is the same {@link ReferenceIntegrityRunOptions} `validateReferenceIntegrity`
+   * received — optional because most members read only `stack`; the two hook
+   * write-set members (#16546) read `ctx.loweredHookRefs`.
+   */
+  run: (stack: Record<string, unknown>, ctx?: ReferenceIntegrityRunOptions) => ReferenceIntegrityFinding[];
 }
 
 /** The runtime snapshot types a member judges when it declares none. */
@@ -404,7 +409,7 @@ export const REFERENCE_INTEGRITY_RULES: readonly ReferenceIntegrityRule[] = [
   // declared fields — the write-side counterpart of validateFlowTemplatePaths'
   // read-side membership (#4271). Lazy: only a hook that actually carries a
   // `language:'js'` body loads the TypeScript parser.
-  { name: 'validateHookBodyWrites', run: validateHookBodyWrites },
+  { name: 'validateHookBodyWrites', run: (stack, ctx) => validateHookBodyWrites(stack, ctx) },
   // The same check on the other surface that carries a `HookBodySchema` body:
   // action bodies, run by the same sandbox. Only the `ctx.api` write family
   // carries over — an action's `ctx.input` is its params bag, not a record
@@ -454,7 +459,7 @@ export const REFERENCE_INTEGRITY_RULES: readonly ReferenceIntegrityRule[] = [
   // `readonly` field is CORRECT and widely used, because the strip drops only
   // caller-supplied values (#5591) — so the rule keys on the write CHANNEL,
   // and both directions are pinned in its tests.
-  { name: 'validateReadonlyHookWrites', run: validateReadonlyHookWrites },
+  { name: 'validateReadonlyHookWrites', run: (stack, ctx) => validateReadonlyHookWrites(stack, ctx) },
   // [#13770] The THIRD write surface, and the one place the family's answer
   // differs. An action body's `ctx.api` is `createContext({ ...ec, isSystem:
   // true })` — elevated by design (#3914) — so the engine's STATIC readonly
@@ -524,6 +529,15 @@ export interface ReferenceIntegrityRunOptions {
    * caller, which run all members unconditionally.
    */
   runtimeWriteType?: string;
+  /**
+   * [#16546] `hooks[*].handler` ref strings whose metadata `body` was minted
+   * by `lowerCallables` from the author's inline `handler` function — spells
+   * the same key as `AuthoringRuleContext.loweredHookRefs` (see this
+   * interface's own header on why the two types stay separate). Read by
+   * `validateReadonlyHookWrites` / `validateHookBodyWrites` to redirect their
+   * `path` at the key the author actually wrote.
+   */
+  loweredHookRefs?: ReadonlySet<string>;
 }
 
 /**
@@ -545,7 +559,7 @@ export function validateReferenceIntegrity(
   for (const rule of REFERENCE_INTEGRITY_RULES) {
     if (writeType !== undefined
       && !(rule.runtimeTypes ?? DEFAULT_MEMBER_RUNTIME_TYPES).includes(writeType)) continue;
-    findings.push(...rule.run(stack));
+    findings.push(...rule.run(stack, options));
   }
   return findings;
 }

--- a/packages/lint/src/validate-hook-body-writes.test.ts
+++ b/packages/lint/src/validate-hook-body-writes.test.ts
@@ -5,6 +5,7 @@ import {
   validateHookBodyWrites,
   extractHookBodyWrites,
   extractHookBodyWriteSet,
+  hookBodyFindingLocation,
   HOOK_BODY_WRITE_PATTERNS,
   HOOK_BODY_WRITE_PATTERN_IDS,
   HOOK_BODY_WRITE_EXCLUSIONS,
@@ -659,5 +660,50 @@ describe('an unparseable hook body is reported, not scored clean (#10653)', () =
         `parseable body gained a parse failure:\n${source}`,
       ).toBeUndefined();
     }
+  });
+});
+
+// [#16546] `hooks[i].body.source` names a key the author never wrote when the
+// body was minted by `lowerCallables` from an inline `handler` function.
+describe('hookBodyFindingLocation / validateHookBodyWrites — #16546: path redirect for a lowered hook', () => {
+  it('hookBodyFindingLocation: `handler` ref present in ctx.loweredHookRefs redirects path, with suffix', () => {
+    const loc = hookBodyFindingLocation({ handler: 'normalize_deal' }, 0, {
+      loweredHookRefs: new Set(['normalize_deal']),
+    });
+    expect(loc.path).toBe('hooks[0].handler');
+    expect(loc.messageSuffix).toContain('judged on the metadata body lowered from the inline handler');
+  });
+
+  it('hookBodyFindingLocation: absent ctx, non-string handler, or an unmarked ref all keep body.source', () => {
+    expect(hookBodyFindingLocation({}, 2, undefined).path).toBe('hooks[2].body.source');
+    expect(hookBodyFindingLocation({ handler: 'x' }, 2, {}).path).toBe('hooks[2].body.source');
+    expect(hookBodyFindingLocation({ handler: 'x' }, 2, { loweredHookRefs: new Set(['y']) }).path).toBe(
+      'hooks[2].body.source',
+    );
+    // Not lowered at all — no ref, still the author's own key.
+    expect(hookBodyFindingLocation({}, 2, { loweredHookRefs: new Set(['x']) }).path).toBe('hooks[2].body.source');
+  });
+
+  it('validateHookBodyWrites reports `hooks[0].handler` + suffix on a lowered hook, verdict unchanged', () => {
+    const findings = validateHookBodyWrites(
+      stackWith('ctx.input.discont_total = 0;', { handler: 'normalize_deal' }),
+      { loweredHookRefs: new Set(['normalize_deal']) },
+    );
+    expect(findings).toHaveLength(1);
+    // [3] Same rule, same severity, same message content — only path + suffix move.
+    expect(findings[0].rule).toBe(HOOK_BODY_WRITE_UNKNOWN_FIELD);
+    expect(findings[0].severity).toBe('warning');
+    expect(findings[0].message).toContain('discont_total');
+    expect(findings[0].path).toBe('hooks[0].handler');
+    expect(findings[0].message).toContain('(judged on the metadata body lowered from the inline handler)');
+  });
+
+  it('CONTROL — the identical hook keeps `hooks[0].body.source` with no ctx (author-written body)', () => {
+    // [4] Non-regression control: this is the standing shape every other test
+    // in this file already exercises — the fix must never move it.
+    const findings = validateHookBodyWrites(stackWith('ctx.input.discont_total = 0;'));
+    expect(findings).toHaveLength(1);
+    expect(findings[0].path).toBe('hooks[0].body.source');
+    expect(findings[0].message).not.toContain('lowered from the inline handler');
   });
 });

--- a/packages/lint/src/validate-hook-body-writes.ts
+++ b/packages/lint/src/validate-hook-body-writes.ts
@@ -414,6 +414,40 @@ type AnyRec = Record<string, unknown>;
 const isRec = (v: unknown): v is AnyRec => !!v && typeof v === 'object' && !Array.isArray(v);
 
 /**
+ * [#16546] `path` + message suffix for a hook write-set finding — the
+ * location half shared by BOTH hook write-set rules
+ * (`validateHookBodyWrites` here and `validateReadonlyHookWrites`), so `os
+ * build` and `os lint` — which feed this registry the same
+ * `ctx.loweredHookRefs` for the same hook (`AuthoringRuleContext`,
+ * `@objectstack/lint`) — cannot report it two ways. That parity is #16095's
+ * own rule restated one layer down: one implementation, not two call sites
+ * that happen to agree today.
+ *
+ * `hooks[i].body.source` is a key this stack's `body` did not come from the
+ * author for whenever `lowerCallables` minted it from an inline `handler`
+ * function (`hook.handler` is then the ref string it registered that
+ * function under, named in `ctx.loweredHookRefs`) — an author grepping their
+ * source for `body.source` finds nothing. `hooks[i].handler` is: on a
+ * lowered hook it is the STRING that replaced the function the author wrote,
+ * literally the key `handler:` under which they wrote it. On a hook whose
+ * `body` the author wrote directly (`ctx` absent, or the ref unmarked),
+ * `hooks[i].body.source` remains the correct answer and is unchanged.
+ */
+export function hookBodyFindingLocation(
+  hook: AnyRec,
+  hookIndex: number,
+  ctx: { loweredHookRefs?: ReadonlySet<string> } | undefined,
+): { path: string; messageSuffix: string } {
+  const loweredFromHandler = typeof hook.handler === 'string' && !!ctx?.loweredHookRefs?.has(hook.handler);
+  return loweredFromHandler
+    ? {
+        path: `hooks[${hookIndex}].handler`,
+        messageSuffix: ' (judged on the metadata body lowered from the inline handler)',
+      }
+    : { path: `hooks[${hookIndex}].body.source`, messageSuffix: '' };
+}
+
+/**
  * object name → its declared field names (both `fields` authoring shapes).
  *
  * Exported for `validate-action-body-writes.ts` only (see
@@ -779,7 +813,10 @@ export function extractHookBodyWriteSet(source: string): ExtractedHookBodyWriteS
  * on it; the refusal itself is reported by `os lint`'s `hook-body/*` rules and
  * by `os build`'s warn-and-bundle line, never guessed at here.
  */
-export function validateHookBodyWrites(stack: AnyRec): HookBodyWriteFinding[] {
+export function validateHookBodyWrites(
+  stack: AnyRec,
+  ctx?: { loweredHookRefs?: ReadonlySet<string> },
+): HookBodyWriteFinding[] {
   const findings: HookBodyWriteFinding[] = [];
   const hooks = recordsOf(stack.hooks);
   if (hooks.length === 0) return findings;
@@ -803,15 +840,17 @@ export function validateHookBodyWrites(stack: AnyRec): HookBodyWriteFinding[] {
     // read" rather than "nothing written".
     const extracted = extractHookBodyWriteSet(source);
     const hookName = typeof hook.name === 'string' && hook.name ? hook.name : `#${hookIndex}`;
+    const loc = hookBodyFindingLocation(hook, hookIndex, ctx);
     if (extracted.parseFailure) {
       findings.push({
         severity: 'warning',
         rule: HOOK_BODY_SOURCE_UNPARSEABLE,
         where: `hook "${hookName}" › body`,
-        path: `hooks[${hookIndex}].body.source`,
+        path: loc.path,
         message:
           `L2 body did not parse (${describeParseFailure(extracted.parseFailure)}), so its write set was ` +
-          `read from a partially recovered tree — an undeclared field write in the unread part is not reported.`,
+          `read from a partially recovered tree — an undeclared field write in the unread part is not ` +
+          `reported.${loc.messageSuffix}`,
         hint: PARSE_FAILURE_HINT,
       });
     }
@@ -839,7 +878,7 @@ export function validateHookBodyWrites(stack: AnyRec): HookBodyWriteFinding[] {
       targets.length > 0 && !targets.includes('*') && targetSets.every((s) => s !== undefined);
 
     const where = `hook "${hookName}" › body`;
-    const path = `hooks[${hookIndex}].body.source`;
+    const path = loc.path;
     const reported = new Set<string>();
 
     for (const w of writes) {
@@ -870,7 +909,8 @@ export function validateHookBodyWrites(stack: AnyRec): HookBodyWriteFinding[] {
             path,
             message:
               `body writes '${w.field}' to its input, and ${unprovisionedAnchorCause(anchorObj, w.field)} — ` +
-              unprovisionedAnchorWriteConsequence(),
+              unprovisionedAnchorWriteConsequence() +
+              loc.messageSuffix,
             hint: unprovisionedAnchorHint(anchorObj, w.field),
           });
           continue;
@@ -895,7 +935,8 @@ export function validateHookBodyWrites(stack: AnyRec): HookBodyWriteFinding[] {
             // authors and operators who cannot resolve a tracker number.
             `clean and the value is copied back onto the record payload unfiltered, so the write is then ` +
             `REFUSED at run time — INVALID_FIELD / 400, identically on every driver (#4271). The ` +
-            `record is never written, and the refusal names the field far from the body that wrote it.`,
+            `record is never written, and the refusal names the field far from the body that wrote it.` +
+            loc.messageSuffix,
           hint: fixHint(w.field, unionCandidates(targetSets)),
         });
       } else {
@@ -916,7 +957,8 @@ export function validateHookBodyWrites(stack: AnyRec): HookBodyWriteFinding[] {
             path,
             message:
               `body calls ctx.api.object('${w.object}').${w.method ?? 'update'}(…) writing '${w.field}', and ` +
-              `${unprovisionedAnchorCause(w.object, w.field)} — ${unprovisionedAnchorWriteConsequence()}`,
+              `${unprovisionedAnchorCause(w.object, w.field)} — ${unprovisionedAnchorWriteConsequence()}` +
+              loc.messageSuffix,
             hint: unprovisionedAnchorHint(w.object, w.field),
           });
           continue;
@@ -940,7 +982,8 @@ export function validateHookBodyWrites(stack: AnyRec): HookBodyWriteFinding[] {
             `engine, so the payload arrives as an ordinary CALLER write and the declared-field door ` +
             `REFUSES it at run time — INVALID_FIELD / 400, identically on every driver (#4271), before ` +
             `any statement is built. The nested write lands nothing, and the refusal escapes the body ` +
-            `and fails the operation that triggered the hook.`,
+            `and fails the operation that triggered the hook.` +
+            loc.messageSuffix,
           hint: fixHint(w.field, [...known]),
         });
       }

--- a/packages/lint/src/validate-readonly-hook-writes.test.ts
+++ b/packages/lint/src/validate-readonly-hook-writes.test.ts
@@ -696,3 +696,48 @@ describe('READONLY_HOOK_WRITE_PATTERN_IDS - ledger partition', () => {
     }
   });
 });
+
+// [#16546] `hooks[i].body.source` names a key the author never wrote when the
+// body was minted by `lowerCallables` from an inline `handler` function — this
+// rule redirects `path` (plus a message suffix) to `hooks[i].handler`, the key
+// that replaced it, when `ctx.loweredHookRefs` names this hook's ref.
+describe('validateReadonlyHookWrites - #16546: path redirect for a lowered hook', () => {
+  const loweredStack = () =>
+    crmStack("await ctx.api.object('crm_account').update({ id: accountId, last_activity_date: now });");
+
+  it('reports `hooks[i].handler` plus the suffix when this hook’s ref is in ctx.loweredHookRefs', () => {
+    const stack = loweredStack();
+    // The lowered shape: `handler` is the ref string `lowerCallables` minted,
+    // beside the `body` it extracted from the function it replaced.
+    (stack.hooks[0] as Record<string, unknown>).handler = 'touch_account';
+    const findings = validateReadonlyHookWrites(stack, { loweredHookRefs: new Set(['touch_account']) });
+    expect(findings).toHaveLength(1);
+    expect(findings[0].path).toBe('hooks[0].handler');
+    expect(findings[0].message).toContain('(judged on the metadata body lowered from the inline handler)');
+    // [3] Only the location and the wording move — the verdict does not.
+    expect(findings[0].rule).toBe(HOOK_API_UPDATE_READONLY_FIELD);
+    expect(findings[0].severity).toBe('error');
+    expect(findings[0].where).toBe('hook "touch_account" > body');
+  });
+
+  it('CONTROL — the identical hook keeps `hooks[i].body.source` when ctx is absent (author-written body)', () => {
+    // [4] Non-regression control: same stack, no `ctx` at all — the standing
+    // shape every OTHER test in this file exercises. Path must not move.
+    const findings = validateReadonlyHookWrites(loweredStack());
+    expect(findings).toHaveLength(1);
+    expect(findings[0].path).toBe('hooks[0].body.source');
+    expect(findings[0].message).not.toContain('lowered from the inline handler');
+  });
+
+  it('CONTROL — a `handler` ref NOT named in ctx.loweredHookRefs keeps `hooks[i].body.source`', () => {
+    // A hook can carry a string `handler` (a bundle reference, #16095) without
+    // its `body` having been minted from a function THIS run lowered — e.g. a
+    // second `runAuthoringRules` call over an already-lowered stack. Only
+    // membership in the set redirects the path, never `handler`'s mere presence.
+    const stack = loweredStack();
+    (stack.hooks[0] as Record<string, unknown>).handler = 'touch_account';
+    const findings = validateReadonlyHookWrites(stack, { loweredHookRefs: new Set(['some_other_hook']) });
+    expect(findings).toHaveLength(1);
+    expect(findings[0].path).toBe('hooks[0].body.source');
+  });
+});

--- a/packages/lint/src/validate-readonly-hook-writes.ts
+++ b/packages/lint/src/validate-readonly-hook-writes.ts
@@ -163,6 +163,7 @@
 
 import {
   extractHookBodyWriteSet,
+  hookBodyFindingLocation,
   type BodyWritePatternExclusion,
 } from './validate-hook-body-writes.js';
 import { buildReadonlyIndex, buildInsertStripExemptObjects } from './validate-readonly-flow-writes.js';
@@ -346,7 +347,10 @@ function isRec(v: unknown): v is AnyRec {
  * on it; the refusal itself is reported by `os lint`'s `hook-body/*` rules and
  * by `os build`'s warn-and-bundle line, never guessed at here.
  */
-export function validateReadonlyHookWrites(stack: AnyRec): ReadonlyHookWriteFinding[] {
+export function validateReadonlyHookWrites(
+  stack: AnyRec,
+  ctx?: { loweredHookRefs?: ReadonlySet<string> },
+): ReadonlyHookWriteFinding[] {
   const findings: ReadonlyHookWriteFinding[] = [];
   const hooks = recordsOf(stack.hooks);
   if (hooks.length === 0) return findings;
@@ -394,7 +398,8 @@ export function validateReadonlyHookWrites(stack: AnyRec): ReadonlyHookWriteFind
 
     const hookName = typeof hook.name === 'string' && hook.name ? hook.name : `#${hookIndex}`;
     const where = `hook "${hookName}" > body`;
-    const path = `hooks[${hookIndex}].body.source`;
+    const loc = hookBodyFindingLocation(hook, hookIndex, ctx);
+    const path = loc.path;
     const reported = new Set<string>();
 
     for (const w of writes) {
@@ -436,7 +441,7 @@ export function validateReadonlyHookWrites(stack: AnyRec): ReadonlyHookWriteFind
           // The static-`readonly` write-path strip is #2948 on UPDATE and, since
           // the 2026-09-03 ruling, #14147 on INSERT; the ids stay here, out of
           // the message an author reads and cannot resolve.
-          message: isCreate
+          message: (isCreate
             ? `body writes field '${w.field}' through ${call}, and object '${objectName}' declares it ` +
               `readonly:true. A hook's ctx.api is a ScopedContext over the TRIGGERING operation's context, so ` +
               `on every non-system trigger the engine strips readonly keys from that INSERT payload exactly ` +
@@ -445,7 +450,7 @@ export function validateReadonlyHookWrites(stack: AnyRec): ReadonlyHookWriteFind
             : `body writes field '${w.field}' through ${call}, and object '${objectName}' declares it ` +
               `readonly:true. A hook's ctx.api is a ScopedContext over the TRIGGERING operation's context, so ` +
               `on every non-system trigger the engine strips readonly keys from that UPDATE payload - ` +
-              `the write never lands, while the call still returns success.`,
+              `the write never lands, while the call still returns success.`) + loc.messageSuffix,
           hint: isCreate
             ? `Seeding a readonly column at create time is a SYSTEM act. To keep writing it from here, ` +
               `declare runAs: 'system' on this hook: the strip skips a system context, so the write lands, ` +
@@ -475,7 +480,7 @@ export function validateReadonlyHookWrites(stack: AnyRec): ReadonlyHookWriteFind
           message:
             `body writes field '${w.field}' through ${call}, and object '${objectName}' declares it ` +
             `readonlyWhen. On records whose predicate is TRUE that UPDATE strips the field, so this ` +
-            `write may silently not land depending on the record's state.`,
+            `write may silently not land depending on the record's state.` + loc.messageSuffix,
           hint:
             `Either confirm this call only targets records whose readonlyWhen predicate is FALSE, or ` +
             `derive '${w.field}' in a beforeUpdate hook on '${objectName}' - a hook-derived value is not ` +


### PR DESCRIPTION
Closes #16546

## What changed

`lowerCallables` now records, per call, which `hooks[*].handler` ref strings
had their `body` **minted here** — extracted from the author's inline
`handler` function — as opposed to a `body` the author wrote directly
(`LoweringResult.loweredHookRefs`). The CLI's four lowering doors (`os build`
union run, `os build` per-package run, `os lint`, `os validate`, and `os
init`/`dev`'s scaffold validation) thread that set through
`runAuthoringRules`'s `ctx.loweredHookRefs` (`AuthoringRuleContext`,
`@objectstack/lint`).

`validateReadonlyHookWrites` and `validateHookBodyWrites`
(`packages/lint/src/validate-readonly-hook-writes.ts` /
`validate-hook-body-writes.ts`) share one new helper,
`hookBodyFindingLocation(hook, hookIndex, ctx)`, which both call before
pushing a finding: when the hook's ref is named in `ctx.loweredHookRefs` it
returns `path: hooks[i].handler` (the key that replaced the function the
author wrote) plus a message suffix — `" (judged on the metadata body
lowered from the inline handler)"` — otherwise it returns the unchanged
`hooks[i].body.source`. One implementation, so `os build` and `os lint`
cannot disagree about it (#16095's rule, applied one layer down).

## Why `path: hooks[i].handler`, not an index

The marker is a **ref string** (`hook.handler`'s value after lowering), not
a hook index. `lowerCallables`'s `taken`/`refByFn` registries are shared
across the whole walk (top level *and* every ADR-0130 D4 package body), so a
ref is unique for one `lowerCallables()` call and — because `handler` is an
ordinary string field — survives a Zod `safeParse` unchanged. An index would
not: `authoringRuleUnionStack` folds package hooks into a new top-level array
with its own numbering, and a per-call hook index recorded against the
pre-fold array would silently address a different hook post-fold.

## Acceptance evidence

### 1. The reported `path` names a key that exists in the author's source

Repro fixture (the card's own example):

```ts
hooks: [{
  name: 'escalate',
  object: 'crm_case',
  events: ['afterUpdate'],
  handler: async (ctx) => {
    await ctx.api.object('crm_case').update({ id: ctx.input.id, is_escalated: true });
  },
}],
```

`hooks[0].handler` is a real key in this source (`grep handler` finds it);
`hooks[0].body.source` — the old `path` — is not.

### 2. `os build` and `os lint` agree, verified on the built CLI (not just unit tests)

`os lint --json`:

```json
{
  "severity": "error",
  "rule": "hook-api-update-readonly-field",
  "message": "hook \"escalate\" > body: body writes field 'is_escalated' through ctx.api.object('crm_case').update(...), and object 'crm_case' declares it readonly:true. A hook's ctx.api is a ScopedContext over the TRIGGERING operation's context, so on every non-system trigger the engine strips readonly keys from that UPDATE payload - the write never lands, while the call still returns success. (judged on the metadata body lowered from the inline handler)",
  "path": "hooks[0].handler",
  "fix": "If automation is meant to maintain 'is_escalated', stamp it on the record's OWN hook - ctx.input.is_escalated = ... in beforeInsert/beforeUpdate survives the strip, and is the recommended shape. To keep writing it CROSS-OBJECT from here, declare runAs: 'system' on this hook: the strip skips a system context, so the write lands, and the triggering user is still stamped on the record. Note that ctx.api.sudo() is NOT an option from a body: sudo() lives on the in-process ScopedContext and is not marshalled into the sandbox, so calling it here is a TypeError at run time. Otherwise drop readonly:true from 'is_escalated'."
}
```

`os build --json`:

```json
{
  "severity": "error",
  "rule": "hook-api-update-readonly-field",
  "where": "hook \"escalate\" > body",
  "path": "hooks[0].handler",
  "message": "body writes field 'is_escalated' through ctx.api.object('crm_case').update(...), and object 'crm_case' declares it readonly:true. A hook's ctx.api is a ScopedContext over the TRIGGERING operation's context, so on every non-system trigger the engine strips readonly keys from that UPDATE payload - the write never lands, while the call still returns success. (judged on the metadata body lowered from the inline handler)",
  "hint": "If automation is meant to maintain 'is_escalated', stamp it on the record's OWN hook - ctx.input.is_escalated = ... in beforeInsert/beforeUpdate survives the strip, and is the recommended shape. To keep writing it CROSS-OBJECT from here, declare runAs: 'system' on this hook: the strip skips a system context, so the write lands, and the triggering user is still stamped on the record. Note that ctx.api.sudo() is NOT an option from a body: sudo() lives on the in-process ScopedContext and is not marshalled into the sandbox, so calling it here is a TypeError at run time. Otherwise drop readonly:true from 'is_escalated'."
}
```

`rule` / `path` / `message` / `hint`↔`fix` are identical between the two
commands (lint's `message` is `${where}: ${message}` and `fix` is build's
`hint` — that envelope difference predates this change, per #16095). Both
runs made against the built CLI (`node bin/run.js …`), exit code 1 on both.

### 3. Verdict unchanged

`HOOK_API_UPDATE_READONLY_FIELD` / `HOOK_API_UPDATE_READONLY_WHEN_FIELD`
(#13653) and `HOOK_BODY_WRITE_UNKNOWN_FIELD` /
`HOOK_BODY_WRITE_UNPROVISIONED_ANCHOR` (#4271) — which hooks are flagged, at
what severity, why — are byte-for-byte unchanged except for `path` and the
appended suffix. No branch of the judgement (the readonly strip channel
distinction, the `runAs: 'system'` exemption, the field-existence walk) was
touched.

### 4. Non-regression control (verified on the built CLI too)

The identical hook, authored with an explicit `body` instead of a `handler`,
keeps `path: hooks[0].body.source` on both `os lint` and `os build` —
unmoved. (`hooks[0].handler` reported `hook-api-update-readonly-field` for
the handler fixture above; the body-authored control below reports the
unchanged path for the same rule.)

```
$ node bin/run.js lint repro-control/objectstack.config.ts --json | … path
hooks[0].body.source
$ node bin/run.js build repro-control/objectstack.config.ts --json | … path
hooks[0].body.source
```

## `Clause-②`

**Clause-②**: no

`path`'s documented purpose — as this very card states it — is to name the
location responsible for a finding, so an author (or an editor/CI
integration reading it) can act on it. That purpose, and the field's shape
(a string on every `AuthoringFinding`), is unchanged: no key was added or
removed from `--json`, and `message`/`hint` keep their existing type too.
What changes is the **value** `path` carries for one previously-broken
subclass (a hook whose `body` never existed in the author's source at all)
— from a key that could never be resolved against the author's own file to
one that can. This is a correction toward the field's own already-declared
contract, not a widening of the accepted input set or the published
surface: no new field, no new accepted shape, no relaxed validation. A
consumer parsing `path` as "a locator into the author's source" gets a
*more* accurate answer than before for this subclass, never a differently
*shaped* one.

## Lane / spillover

The two validators and the `ctx.loweredHookRefs` plumbing through
`AuthoringRuleContext` / `runAuthoringRules` / the reference-integrity suite
are all in `packages/lint` — the assigned lane.

**Declared cross-domain spillover**: the marker's *source* —
`LoweringResult.loweredHookRefs` — lives in `packages/cli/src/utils/lower-callables.ts`, outside `packages/lint`. This was necessary: `lowerCallables`
is the only place that knows whether a given hook's `body` was minted from a
handler or authored directly, and duplicating that judgement inside
`packages/lint` would re-derive a fact `lowerCallables` already computed
(and could drift from it). Touched cli-side files, all wiring only (no new
lowering logic): `packages/cli/src/utils/lower-callables.ts`,
`src/commands/compile.ts`, `src/commands/lint.ts`, `src/commands/validate.ts`,
`src/utils/scaffold-validate.ts`, plus their tests.

## Tests

- `packages/lint/src/validate-readonly-hook-writes.test.ts` /
  `validate-hook-body-writes.test.ts`: new unit coverage for
  `hookBodyFindingLocation` and the two rules' redirect + non-regression
  control, direct (no CLI).
- `packages/cli/test/lower-callables.test.ts`: `loweredHookRefs` is set only
  when a body was actually minted from a handler (not on extraction failure,
  not when an author-written `body` already existed).
- `packages/cli/test/lint-hook-rules-reach-handler-hooks.test.ts`: updated
  the #16095 RED/CONTROL pins to assert the corrected `path` (and added one
  for the scaffold-validate door), verdict assertions untouched.
- `packages/cli/test/lint-hook-rules-reach-handler-hooks.e2e.test.ts`: not
  run locally — it is outside both the `unit` and `integration` vitest
  projects (a separate e2e suite spawning the real CLI); its assertions
  check rule ids / exit codes only, not `path`, so it is unaffected either
  way. Left to CI.

```
pnpm --filter @objectstack/lint exec vitest run \
  src/validate-hook-body-writes.test.ts src/validate-readonly-hook-writes.test.ts \
  src/reference-integrity-suite.test.ts src/authoring-rule-wiring.test.ts \
  src/authoring-rule-input-tier.test.ts
  → 5 test files, 179 tests, all passed

pnpm --filter @objectstack/cli exec vitest run --project unit \
  test/lower-callables.test.ts test/lint-hook-rules-reach-handler-hooks.test.ts
  → 2 test files, 21 tests, all passed

pnpm --filter @objectstack/lint --filter @objectstack/cli run typecheck
  → both packages: tsc --noEmit clean, check:test-typecheck clean (debt ledger unchanged)
```

`packages/cli`'s `integration` vitest tier was not run: this diff touches no
integration-layer files (no `bin/`, no spawn helper) per
`packages/cli/vitest-tiers.ts`'s own partition, so it is declared to CI.

## Build

`pnpm --filter '@objectstack/lint^...' build` — dependency-closure build,
exit 0 (covers `@objectstack/cli` and every other downstream consumer of
`@objectstack/lint`).

## Derived gate sweep

`node scripts/pm/dispatch-gates.mjs --commands` derived 63 gate families from
this diff. Ran all 63 (self-tests included): **60 passed (exit 0)**.

The remaining 3 read `PREREQUISITE NOT MET` (exit 3, per each gate's own
wording — *"NOT a pass and NOT a finding: nothing was measured"*), all for
the identical reason: they require a full `pnpm build` across the whole
workspace (studio, client-react, the connector packages, etc.), not just this
diff's dependency closure — squarely CI's job, not local scope:

- `check:dual-build-cjs-loads` — `no packages/apps/studio/dist`,
  `no packages/client-react/dist`, and 10 more unrelated packages.
- `check:i18n-coverage` — a partial lint round cannot judge the ratchet
  ("an unmeasured config is indistinguishable from a deleted one").
- `check:type-check-debt` — `--re-measure` needs `@objectstack/spec`'s
  built `.d.ts` resolved through the FULL workspace closure, not this
  diff's targeted one, or it "measures a different world" by its own
  wording.

None of the 3 name a file this diff touches. `NOT MEASURED`, left to CI.

## Changeset

`packages/lint` and `packages/cli` both publish `dist`
(`check:published-files` green) and this changes an exported function's
behaviour (`validateReadonlyHookWrites`, `validateHookBodyWrites`) plus a
published CLI command's `--json` output — a real shipped behaviour change,
not internal-only. `.changeset/hook-write-set-finding-path-lowered-handler.md`
bumps both `patch`.

## `skip-changeset`

Not applied — a changeset is owed and included (see above).


---
_Generated by [Claude Code](https://claude.ai/code/session_012GKcPZbMoGq7WPzKLfRBTU)_