### PR TITLE
spec(ui): constrain the object-grid / object-calendar sort value to the SortItem array

### DIFF
--- a/.changeset/object-block-sort-item-array.md
+++ b/.changeset/object-block-sort-item-array.md
@@ -1,0 +1,69 @@
+---
+"@objectstack/spec": minor
+---
+
+feat(spec)!: `object-grid` and `object-calendar` constrain the `sort` VALUE to the `SortItem` array — one sort orthography platform-wide reaches the last two unconstrained doors (#16553; objectui#8221, decision batch #77 option B)
+
+<!-- adr-0087: registered object-block-sort-item-array -->
+
+**BREAKING** accept-set change at two doors — `ComponentPropsMap['object-grid'].sort`
+and `ComponentPropsMap['object-calendar'].sort` — shipped as `minor` under the
+repo's launch-window convention for breaking changes; the migration prescription
+is registered under protocol major 18 as `object-block-sort-item-array`.
+
+One `sort` spelling platform-wide, the array (objectui#8221, decision batch #77,
+2026-09-07, maintainer verbatim 「其他同意」, option B; the consumer half is
+objectui PR #8758, which drops the legacy string arm from
+`convertSortToQueryParams`). Item 4 of that ruling is this release's subject:
+「`ComponentPropsMap` for `object-calendar` and `object-grid` constrains the
+`sort` value to the array shape (today it accepts anything), so the spec, the
+registrations and the helper agree; that is a pull-back to the declared contract,
+ordinary tier」.
+
+Until this release both doors declared `z.unknown()` — no orthography at all.
+Measured on `@objectstack/spec` 17.2.0 and re-measured on this tree before the
+change: an array, the legacy string clause and a bare NUMBER all returned
+`success: true`, while `bogusProp` was refused by name on the same call. So key
+checking was live and only the VALUE was unheld, and an author following
+objectui's own registrations (`plugin-grid/src/index.tsx:222` has published
+`type: 'array'` all along) and an author following the legacy string each got a
+silent success receipt for a different shape — while objectui's html tier
+answered `type-mismatch` on the second one. Both doors now declare
+`z.array(SortItemSchema)`, the array `ElementDataSourceSchema.sort`,
+`ListPageSchema.sort` and `element:record_picker`'s flat `sort` shorthand already
+carry: one shared schema, not a third copy.
+
+Sequenced measurement-first, as this family has to be. At the objectui pin this
+repo builds against (`53ded82b`) the string is still lowered —
+`ObjectGrid.tsx:1844-1851` carries an explicit `typeof === 'string'` arm onto
+`$orderby` beside the array arm, and `ObjectCalendar.tsx:431` hands `schema.sort`
+to `convertSortToQueryParams`, whose string arm is still present at
+`sort-query.ts:66-70`. This declaration therefore lands ahead of the pinned
+consumer, which the ruling permits explicitly — either order, since the
+registrations already declare the array — and the next pin bump carries the
+retirement in.
+
+**Migration** (`object-block-sort-item-array`): `sort: 'created_at desc'` becomes
+`sort: [{ field: 'created_at', order: 'desc' }]`; a bare field name
+`sort: 'created_at'` meant ascending and becomes
+`sort: [{ field: 'created_at', order: 'asc' }]` — `order` is required in
+`SortItemSchema`, so it is written out rather than omitted; a comma-separated
+clause becomes one array entry per key, in the same order. The string is refused
+at `sort` (`invalid_type`, expected array), as is a bare number; a misspelled or
+absent direction is refused at `sort.0.order`. Metadata AT REST is not rewritten
+and this disposition adds no D2 conversion — a stored page carrying a string
+`sort` keeps loading and still renders at the pinned `.objectui-sha`; what
+changes is that RE-SAVING it is refused at the `sort` door.
+
+**Not moved by this release.** `record:related_list.sort` keeps its declared
+string arm: that string is the `'field'` / `'-field'` dialect read by
+`RelatedList.normalizeSortSpec`, it never reaches `convertSortToQueryParams`, and
+retiring it was not ruled — objectui#8221's own implementing round narrowed it,
+established the dialect and reverted the narrowing byte-identically.
+`object-grid.defaultSort` is a different key, already retired by #11805. Zero
+authored `sort` values on either block exist in this repo (the two showcase pages
+that author `object-grid` declare none), so nothing in-tree was converted.
+
+Type aliases are unchanged: `SortItemSchema`'s input equals its infer, so neither
+block's parsed state moves for this key, and both already take the
+`…PropsParsed` route for `filter` (ADR-0122).

--- a/content/docs/references/ui/component.mdx
+++ b/content/docs/references/ui/component.mdx
@@ -312,7 +312,7 @@ Sort field and direction pair
 | **calendar** | `any` | optional | Calendar field config: `{ startDateField, endDateField?, titleField?, colorField?, allDayField? }` |
 | **defaultView** | `Enum<'month' \| 'week' \| 'day'>` | optional | Initial view mode |
 | **filter** | `{ field: string; operator: Enum<'equals' \| 'not_equals' \| 'contains' \| 'not_contains' \| 'icontains' \| …>; value?: string \| number \| boolean \| null \| (string \| number)[] }[]` | optional | Base query filter — the ViewFilterRule array form `[{ field, operator, value }, ...]`, the one filter orthography every `filter` door in this map shares. The MongoDB-style record form is refused — see migration `element-data-source-and-object-block-filter-rule-array` |
-| **sort** | `any` | optional | Sort for the fetched events |
+| **sort** | `{ field: string; order: Enum<'asc' \| 'desc'> }[]` | optional | Row order for the fetched events — the SortItem array form `[{ field, order }, ...]`, the one sort orthography every declared `sort` door on this platform shares; lowered to the wire `$orderby`. The legacy string clause (`name desc`) is refused — see migration `object-block-sort-item-array` |
 | **data** | `any[]` | optional | Pre-fetched records — skips the internal fetch |
 | **staticData** | `any[]` | optional | Static inline records |
 | **locale** | `string` | optional | Locale override for the calendar chrome |
@@ -327,6 +327,15 @@ View filter rule
 | **field** | `string` | ✅ | Field name to filter on |
 | **operator** | `Enum<'equals' \| 'not_equals' \| 'contains' \| 'not_contains' \| 'icontains' \| …>` | ✅ | Filter operator |
 | **value** | `string \| number \| boolean \| null \| (string \| number)[]` | optional | Filter value. The accepted SHAPE depends on the operator: `in` / `not_in` take an array (any length, including []), `between` takes exactly [min, max], every other operator takes a scalar. The unary operators (is_empty / is_not_empty / is_null / is_not_null) take their direction from the operator name and ignore this key. |
+
+### Nested Shape: `ObjectCalendarProps.sort[number]`
+
+Sort field and direction pair
+
+| Property | Type | Required | Description |
+| :--- | :--- | :--- | :--- |
+| **field** | `string` | ✅ | Field name to sort by |
+| **order** | `Enum<'asc' \| 'desc'>` | ✅ | Sort direction |
 
 
 ---
@@ -393,7 +402,7 @@ View filter rule
 | **fields** | `any[]` | optional | Field list fallback used when `columns` is absent |
 | **filter** | `{ field: string; operator: Enum<'equals' \| 'not_equals' \| 'contains' \| 'not_contains' \| 'icontains' \| …>; value?: string \| number \| boolean \| null \| (string \| number)[] }[]` | optional | Base query filter — the ViewFilterRule array form `[{ field, operator, value }, ...]`, the one filter orthography every `filter` door in this map shares; lowered to the wire `$filter`. THE key, singular — not the plural misspelling. The MongoDB-style record form is refused — see migration `element-data-source-and-object-block-filter-rule-array` |
 | **defaultFilters** | `any` | optional | Legacy base-filter fallback, read only when `filter` is absent. Prefer `filter` |
-| **sort** | `any` | optional | Initial sort (array of `{ field, order }`) |
+| **sort** | `{ field: string; order: Enum<'asc' \| 'desc'> }[]` | optional | Initial row order — the SortItem array form `[{ field, order }, ...]`, the one sort orthography every declared `sort` door on this platform shares; lowered to the wire `$orderby`. The legacy string clause (`name desc`) is refused — see migration `object-block-sort-item-array` |
 | **defaultSort** | `never` | optional | [REMOVED] `object-grid` property `defaultSort` was removed in @objectstack/spec 17 (ADR-0049) — it was the legacy second spelling of `sort`: a single `{ field, order }` pair read only when `sort` was absent, so one intent had two spellings and a grid authoring both silently ignored this one. Rename the key to `sort` and wrap the value in an array (`defaultSort: { field, order }` becomes `sort: [{ field, order }]`); the pair itself is unchanged. Run `os migrate meta --from 17` to list the mechanical edits for existing sources; apply them by hand. |
 | **pagination** | `any` | optional | Pagination config (`{ pageSize, pageSizeOptions, … }`); its presence enables paging |
 | **pageSize** | `number` | optional | Flat page-size shorthand; `pagination.pageSize` wins when both are set |
@@ -433,6 +442,15 @@ View filter rule
 | **field** | `string` | ✅ | Field name to filter on |
 | **operator** | `Enum<'equals' \| 'not_equals' \| 'contains' \| 'not_contains' \| 'icontains' \| …>` | ✅ | Filter operator |
 | **value** | `string \| number \| boolean \| null \| (string \| number)[]` | optional | Filter value. The accepted SHAPE depends on the operator: `in` / `not_in` take an array (any length, including []), `between` takes exactly [min, max], every other operator takes a scalar. The unary operators (is_empty / is_not_empty / is_null / is_not_null) take their direction from the operator name and ignore this key. |
+
+### Nested Shape: `ObjectGridProps.sort[number]`
+
+Sort field and direction pair
+
+| Property | Type | Required | Description |
+| :--- | :--- | :--- | :--- |
+| **field** | `string` | ✅ | Field name to sort by |
+| **order** | `Enum<'asc' \| 'desc'>` | ✅ | Sort direction |
 
 ### Nested Shape: `ObjectGridProps.data[provider='object']`
 

--- a/packages/spec/src/migrations/entries/semantic/18.object-block-sort-item-array.ts
+++ b/packages/spec/src/migrations/entries/semantic/18.object-block-sort-item-array.ts
@@ -1,0 +1,74 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+import type { SemanticMigration } from '../../types.js';
+
+export const entry: SemanticMigration = {
+  id: 'object-block-sort-item-array',
+  surface:
+    'The `sort` prop of `object-grid` and `object-calendar` in `ComponentPropsMap` '
+    + '(the FORM: the accept-anything `z.unknown()` at both block doors, vs the '
+    + '`SortItem` array `[{ field, order }, ...]`)',
+  replacement:
+    '`z.array(SortItemSchema)` at both doors — the array `ElementDataSourceSchema.sort`, '
+    + '`ListPageSchema.sort` and `element:record_picker`\'s flat `sort` shorthand already '
+    + 'carry. The legacy OData-ish clause `sort: \'created_at desc\'` becomes '
+    + '`sort: [{ field: \'created_at\', order: \'desc\' }]`; a bare field name '
+    + '`sort: \'created_at\'` meant ascending and becomes '
+    + '`sort: [{ field: \'created_at\', order: \'asc\' }]` — `order` is required in '
+    + '`SortItemSchema`, so it is written out rather than omitted. A comma-separated '
+    + 'clause becomes one array entry per key, in the same order. `record:related_list` '
+    + 'is NOT moved by this entry: its string is the `\'field\'` / `\'-field\'` dialect '
+    + 'read by `RelatedList.normalizeSortSpec`, which never reaches '
+    + '`convertSortToQueryParams`, and retiring it was not ruled. '
+    + '`object-grid.defaultSort` is a different key, retired separately by the '
+    + '`ui__ObjectGridProps__defaultSort` entry.',
+  reason:
+    'One `sort` spelling platform-wide, the array (objectui#8221, decision batch #77, '
+    + '2026-09-07, maintainer verbatim 「其他同意」, option B; the consumer half is '
+    + 'objectui PR #8758, which drops the string arm from `convertSortToQueryParams`). '
+    + 'Item 4 of that ruling is this entry\'s subject: 「`ComponentPropsMap` for '
+    + '`object-calendar` and `object-grid` constrains the `sort` value to the array shape '
+    + '(today it accepts anything), so the spec, the registrations and the helper agree; '
+    + 'that is a pull-back to the declared contract, ordinary tier」. The `z.unknown()` at '
+    + 'both doors was a read-point record (#7751), the same vintage as the `filter` doors '
+    + 'the `element-data-source-and-object-block-filter-rule-array` entry moved, and not an '
+    + 'exception to the ruling: measured on `@objectstack/spec` 17.2.0 an array, a string '
+    + 'and a bare NUMBER all returned `success: true` while `bogusProp` was refused by name '
+    + 'on the same call, so key checking was live and only the VALUE was unheld. Meanwhile '
+    + 'objectui\'s own html tier has published `type: \'array\'` for the grid all along '
+    + '(`plugin-grid/src/index.tsx:222`) and answered `type-mismatch` on the string — a '
+    + 'spelling `@object-ui/core` implemented, the docs taught and the validator refused, '
+    + 'which is what made this a ruling rather than a mechanical widening. '
+    + 'Sequenced measurement-first: at the objectui pin this repo builds against '
+    + '(`53ded82b`) the string is still lowered — `ObjectGrid.tsx:1844-1851` carries an '
+    + 'explicit `typeof === \'string\'` arm onto `$orderby`, and `ObjectCalendar.tsx:431` '
+    + 'hands `schema.sort` to `convertSortToQueryParams`, whose string arm is still present '
+    + 'at `sort-query.ts:66-70`. So this declaration lands AHEAD of the pinned consumer, '
+    + 'which the ruling permits explicitly (either order; the registrations already declare '
+    + 'the array). The in-repo sweep found ZERO authored `sort` on either block — the two '
+    + 'showcase pages that author `object-grid` (`command-center.page.ts`, '
+    + '`my-work.page.ts`) declare none — with the same grep shape finding 40+ string `sort` '
+    + 'values at OTHER doors (view definitions, ObjectQL `query.sort`) as the control that '
+    + 'the sweep fires; so this entry carries the prescription for authors outside the repo. '
+    + '⚠️ Metadata AT REST is deliberately NOT rewritten and this disposition adds no D2 '
+    + 'conversion: `os migrate meta --stored` replays D2 conversions only, and the read path '
+    + 'does not re-validate stored rows (`applyConversionsToStoredItem` replays the chain '
+    + 'without validating, by its own contract), so a stored page carrying a string `sort` '
+    + 'keeps loading and is still rendered by objectui at the pinned `.objectui-sha`. What '
+    + 'changes is that RE-SAVING it is refused at the `sort` door, on its next save and not '
+    + 'before. ADR-0049, ADR-0087.',
+  acceptanceCriteria:
+    '`ComponentPropsMap[\'object-grid\' | \'object-calendar\'].safeParse({ objectName, '
+    + 'sort: [{ field: \'created_at\', order: \'desc\' }] })` succeeds and the parsed `sort` '
+    + 'is that same array, equal value-for-value to '
+    + '`ElementDataSourceSchema.parse({ object, sort: <that array> }).sort`. The legacy '
+    + 'string clause is refused at the `sort` path on both doors (`invalid_type`, expected '
+    + 'array), and so is a bare number; a misspelled or ABSENT direction is refused at '
+    + '`sort.0.order` (`invalid_value` — `order` is a required enum, so both take one '
+    + 'verdict) and a missing field at `sort.0.field` (`invalid_type`). An undeclared key '
+    + 'is still refused BY NAME on the same call (`unrecognized_keys` naming it), the '
+    + 'control that makes those refusals verdicts rather than a schema reporting nothing. '
+    + 'No `sort` door in `ComponentPropsMap` accepts a string except `record:related_list`, '
+    + 'which is the one deliberate exception. At runtime each block orders exactly as the '
+    + 'array orders — the same `$orderby` the string lowered to.',
+};

--- a/packages/spec/src/migrations/registry.ts
+++ b/packages/spec/src/migrations/registry.ts
@@ -8703,6 +8703,76 @@ const step18: MigrationStep = {
         + 'before and after.',
     },
     {
+      id: 'object-block-sort-item-array',
+      surface:
+        'The `sort` prop of `object-grid` and `object-calendar` in `ComponentPropsMap` '
+        + '(the FORM: the accept-anything `z.unknown()` at both block doors, vs the '
+        + '`SortItem` array `[{ field, order }, ...]`)',
+      replacement:
+        '`z.array(SortItemSchema)` at both doors — the array `ElementDataSourceSchema.sort`, '
+        + '`ListPageSchema.sort` and `element:record_picker`\'s flat `sort` shorthand already '
+        + 'carry. The legacy OData-ish clause `sort: \'created_at desc\'` becomes '
+        + '`sort: [{ field: \'created_at\', order: \'desc\' }]`; a bare field name '
+        + '`sort: \'created_at\'` meant ascending and becomes '
+        + '`sort: [{ field: \'created_at\', order: \'asc\' }]` — `order` is required in '
+        + '`SortItemSchema`, so it is written out rather than omitted. A comma-separated '
+        + 'clause becomes one array entry per key, in the same order. `record:related_list` '
+        + 'is NOT moved by this entry: its string is the `\'field\'` / `\'-field\'` dialect '
+        + 'read by `RelatedList.normalizeSortSpec`, which never reaches '
+        + '`convertSortToQueryParams`, and retiring it was not ruled. '
+        + '`object-grid.defaultSort` is a different key, retired separately by the '
+        + '`ui__ObjectGridProps__defaultSort` entry.',
+      reason:
+        'One `sort` spelling platform-wide, the array (objectui#8221, decision batch #77, '
+        + '2026-09-07, maintainer verbatim 「其他同意」, option B; the consumer half is '
+        + 'objectui PR #8758, which drops the string arm from `convertSortToQueryParams`). '
+        + 'Item 4 of that ruling is this entry\'s subject: 「`ComponentPropsMap` for '
+        + '`object-calendar` and `object-grid` constrains the `sort` value to the array shape '
+        + '(today it accepts anything), so the spec, the registrations and the helper agree; '
+        + 'that is a pull-back to the declared contract, ordinary tier」. The `z.unknown()` at '
+        + 'both doors was a read-point record (#7751), the same vintage as the `filter` doors '
+        + 'the `element-data-source-and-object-block-filter-rule-array` entry moved, and not an '
+        + 'exception to the ruling: measured on `@objectstack/spec` 17.2.0 an array, a string '
+        + 'and a bare NUMBER all returned `success: true` while `bogusProp` was refused by name '
+        + 'on the same call, so key checking was live and only the VALUE was unheld. Meanwhile '
+        + 'objectui\'s own html tier has published `type: \'array\'` for the grid all along '
+        + '(`plugin-grid/src/index.tsx:222`) and answered `type-mismatch` on the string — a '
+        + 'spelling `@object-ui/core` implemented, the docs taught and the validator refused, '
+        + 'which is what made this a ruling rather than a mechanical widening. '
+        + 'Sequenced measurement-first: at the objectui pin this repo builds against '
+        + '(`53ded82b`) the string is still lowered — `ObjectGrid.tsx:1844-1851` carries an '
+        + 'explicit `typeof === \'string\'` arm onto `$orderby`, and `ObjectCalendar.tsx:431` '
+        + 'hands `schema.sort` to `convertSortToQueryParams`, whose string arm is still present '
+        + 'at `sort-query.ts:66-70`. So this declaration lands AHEAD of the pinned consumer, '
+        + 'which the ruling permits explicitly (either order; the registrations already declare '
+        + 'the array). The in-repo sweep found ZERO authored `sort` on either block — the two '
+        + 'showcase pages that author `object-grid` (`command-center.page.ts`, '
+        + '`my-work.page.ts`) declare none — with the same grep shape finding 40+ string `sort` '
+        + 'values at OTHER doors (view definitions, ObjectQL `query.sort`) as the control that '
+        + 'the sweep fires; so this entry carries the prescription for authors outside the repo. '
+        + '⚠️ Metadata AT REST is deliberately NOT rewritten and this disposition adds no D2 '
+        + 'conversion: `os migrate meta --stored` replays D2 conversions only, and the read path '
+        + 'does not re-validate stored rows (`applyConversionsToStoredItem` replays the chain '
+        + 'without validating, by its own contract), so a stored page carrying a string `sort` '
+        + 'keeps loading and is still rendered by objectui at the pinned `.objectui-sha`. What '
+        + 'changes is that RE-SAVING it is refused at the `sort` door, on its next save and not '
+        + 'before. ADR-0049, ADR-0087.',
+      acceptanceCriteria:
+        '`ComponentPropsMap[\'object-grid\' | \'object-calendar\'].safeParse({ objectName, '
+        + 'sort: [{ field: \'created_at\', order: \'desc\' }] })` succeeds and the parsed `sort` '
+        + 'is that same array, equal value-for-value to '
+        + '`ElementDataSourceSchema.parse({ object, sort: <that array> }).sort`. The legacy '
+        + 'string clause is refused at the `sort` path on both doors (`invalid_type`, expected '
+        + 'array), and so is a bare number; a misspelled or ABSENT direction is refused at '
+        + '`sort.0.order` (`invalid_value` — `order` is a required enum, so both take one '
+        + 'verdict) and a missing field at `sort.0.field` (`invalid_type`). An undeclared key '
+        + 'is still refused BY NAME on the same call (`unrecognized_keys` naming it), the '
+        + 'control that makes those refusals verdicts rather than a schema reporting nothing. '
+        + 'No `sort` door in `ComponentPropsMap` accepts a string except `record:related_list`, '
+        + 'which is the one deliberate exception. At runtime each block orders exactly as the '
+        + 'array orders — the same `$orderby` the string lowered to.',
+    },
+    {
       id: 'object-grid-data-view-data-converged',
       surface:
         "`object-grid` component props — `data` (the KIND: bare array `z.array(z.unknown())` "

--- a/packages/spec/src/ui/component.test.ts
+++ b/packages/spec/src/ui/component.test.ts
@@ -2007,6 +2007,108 @@ describe('the four `object-*` `filter` doors — one filter orthography platform
   });
 });
 
+describe('`object-grid` / `object-calendar` `sort` — one sort orthography, the array (objectui#8221, decision batch #77, option B)', () => {
+  const SORT_DOORS = ['object-grid', 'object-calendar'] as const;
+  const ARRAY_FORM = [{ field: 'created_at', order: 'desc' }];
+  /**
+   * The legacy OData-ish clause `convertSortToQueryParams` honours at the
+   * objectui pin `53ded82b` (`core/src/utils/sort-query.ts:66-70`) and that
+   * `ObjectGrid.tsx:1845-1846` puts on `$orderby` verbatim. Retired by the
+   * ruling; refused here.
+   */
+  const STRING_FORM = 'created_at desc';
+  type ParseResult = { success: boolean; data?: { sort?: unknown }; error?: { issues: Array<{ path: PropertyKey[]; code: string }> } };
+  type Door = { shape?: Record<string, unknown>; safeParse: (v: unknown) => ParseResult };
+  const door = (type: string) => ComponentPropsMap[type as keyof typeof ComponentPropsMap] as unknown as Door;
+  const issuesAtPath = (r: ParseResult, path: string) =>
+    r.success ? [] : r.error!.issues.filter((i) => i.path.join('.') === path);
+
+  it.each(SORT_DOORS)('%s accepts a SortItem[] and echoes it — the acceptance criterion', (type) => {
+    const r = door(type).safeParse({ objectName: 'showcase_task', sort: ARRAY_FORM });
+    expect(r.success).toBe(true);
+    expect(r.data!.sort).toEqual(ARRAY_FORM);
+  });
+
+  it.each(SORT_DOORS)('%s carries the REAL SortItemSchema, not a lookalike: the direction enum and the required pair are checked', (type) => {
+    // `z.unknown()` echoed every one of these back with `success: true`.
+    const spelledOut = door(type).safeParse({ objectName: 'showcase_task', sort: [{ field: 'created_at', order: 'descending' }] });
+    expect(issuesAtPath(spelledOut, 'sort.0.order').map((i) => i.code)).toEqual(['invalid_value']);
+    const noDirection = door(type).safeParse({ objectName: 'showcase_task', sort: [{ field: 'created_at' }] });
+    expect(issuesAtPath(noDirection, 'sort.0.order').map((i) => i.code)).toEqual(['invalid_type']);
+    const noField = door(type).safeParse({ objectName: 'showcase_task', sort: [{ order: 'asc' }] });
+    expect(issuesAtPath(noField, 'sort.0.field').map((i) => i.code)).toEqual(['invalid_type']);
+  });
+
+  it.each(SORT_DOORS)('%s REFUSES the legacy string clause at the `sort` path — the shape the ruling retires', (type) => {
+    // Reverse verification on the issue envelope: located at `sort`, kind
+    // named. Before this change the same value parsed with zero issues on
+    // both doors (the card's measurement on `@objectstack/spec` 17.2.0, and
+    // the ablation in the landing PR re-runs it against this tree).
+    const r = door(type).safeParse({ objectName: 'showcase_task', sort: STRING_FORM });
+    expect(r.success).toBe(false);
+    const atSort = issuesAtPath(r, 'sort');
+    expect(atSort).toHaveLength(1);
+    expect(atSort[0].code).toBe('invalid_type');
+    expect(atSort[0]).toMatchObject({ expected: 'array' });
+  });
+
+  it.each(SORT_DOORS)('%s REFUSES a bare number at `sort` — the other value `z.unknown()` receipted', (type) => {
+    const r = door(type).safeParse({ objectName: 'showcase_task', sort: 3 });
+    expect(issuesAtPath(r, 'sort').map((i) => i.code)).toEqual(['invalid_type']);
+  });
+
+  it.each(SORT_DOORS)('%s still refuses an undeclared key BY NAME on the same call — the control the card keeps', (type) => {
+    // The control that makes the three readings above verdicts rather than a
+    // schema that reports nothing: key checking was never the thing that was
+    // missing on these doors, the VALUE was.
+    const r = door(type).safeParse({ objectName: 'showcase_task', sort: ARRAY_FORM, bogusProp: 1 });
+    expect(r.success).toBe(false);
+    expect(issuesAtPath(r, 'sort')).toEqual([]);
+    const unrecognized = r.error!.issues.filter((i) => i.code === 'unrecognized_keys') as Array<{ keys?: string[] }>;
+    expect(unrecognized.flatMap((i) => i.keys ?? [])).toContain('bogusProp');
+  });
+
+  it('`sort` agrees with `dataSource.sort` and with the picker shorthand — one shape, four doors', () => {
+    // The map's own copies are the same import (`SortItemSchema`), so this
+    // asks the question the copies could not: do the doors AGREE, value for
+    // value, with the binding every data-bound element already carries.
+    const viaBinding = ElementDataSourceSchema.parse({ object: 'showcase_task', sort: ARRAY_FORM });
+    for (const type of [...SORT_DOORS, 'element:record_picker']) {
+      const value = type === 'element:record_picker'
+        ? { object: 'showcase_task', sort: ARRAY_FORM }
+        : { objectName: 'showcase_task', sort: ARRAY_FORM };
+      const r = door(type).safeParse(value);
+      expect([type, r.success]).toEqual([type, true]);
+      expect([type, r.data!.sort]).toEqual([type, viaBinding.sort]);
+      const refused = door(type).safeParse({ ...value, sort: STRING_FORM });
+      expect([type, issuesAtPath(refused, 'sort').map((i) => i.code)]).toEqual([type, ['invalid_type']]);
+    }
+  });
+
+  it('the census: no `sort` door in ComponentPropsMap takes a string except `record:related_list`, whose string is a DIFFERENT dialect and was not ruled', () => {
+    // Asked over the WHOLE map by shape rather than by the two names above, so
+    // a future entry declaring `sort` as `z.unknown()` is caught here by name.
+    // Guarded the same way as its `filter` twin: the doors pinned above must
+    // be found, or the shape read has gone wrong and the loop is vacuous.
+    const doors = (Object.entries(ComponentPropsMap) as Array<[string, unknown]>)
+      .filter(([, schema]) => {
+        const shape = (schema as Door).shape;
+        return !!shape && 'sort' in shape;
+      })
+      .map(([type]) => type);
+    expect(doors).toEqual(expect.arrayContaining([...SORT_DOORS, 'element:record_picker', 'record:related_list']));
+    const stringTakers = doors.filter((type) => issuesAtPath(door(type).safeParse({ sort: STRING_FORM }), 'sort').length === 0);
+    // ⚠️ `record:related_list` is the ONE deliberate exception and it is pinned
+    // as such, not tolerated: its string is the `'field'` / `'-field'` form
+    // read by `RelatedList.normalizeSortSpec`, a different dialect that never
+    // reaches `convertSortToQueryParams` — measured by objectui#8221's own
+    // implementing round, which narrowed it, established the dialect and then
+    // reverted the narrowing byte-identically. Retiring it was not ruled and
+    // would delete working, spec-legal behaviour.
+    expect(stringTakers).toEqual(['record:related_list']);
+  });
+});
+
 // ---------------------------------------------------------------------------
 // Interactive Elements — element:text_input
 // ---------------------------------------------------------------------------

--- a/packages/spec/src/ui/component.test.ts
+++ b/packages/spec/src/ui/component.test.ts
@@ -2033,8 +2033,11 @@ describe('`object-grid` / `object-calendar` `sort` — one sort orthography, the
     // `z.unknown()` echoed every one of these back with `success: true`.
     const spelledOut = door(type).safeParse({ objectName: 'showcase_task', sort: [{ field: 'created_at', order: 'descending' }] });
     expect(issuesAtPath(spelledOut, 'sort.0.order').map((i) => i.code)).toEqual(['invalid_value']);
+    // Same code as the misspelling above, and deliberately so: `order` is a
+    // required enum, so an ABSENT direction and a wrong one are one verdict at
+    // one path — the pair is what the schema asks for.
     const noDirection = door(type).safeParse({ objectName: 'showcase_task', sort: [{ field: 'created_at' }] });
-    expect(issuesAtPath(noDirection, 'sort.0.order').map((i) => i.code)).toEqual(['invalid_type']);
+    expect(issuesAtPath(noDirection, 'sort.0.order').map((i) => i.code)).toEqual(['invalid_value']);
     const noField = door(type).safeParse({ objectName: 'showcase_task', sort: [{ order: 'asc' }] });
     expect(issuesAtPath(noField, 'sort.0.field').map((i) => i.code)).toEqual(['invalid_type']);
   });

--- a/packages/spec/src/ui/component.zod.ts
+++ b/packages/spec/src/ui/component.zod.ts
@@ -2523,7 +2523,7 @@ export const ObjectGridPropsSchema = lazySchema(() => strictObject({
    * array shape and not the string.
    */
   sort: z.array(SortItemSchema).optional()
-    .describe('Initial row order — the SortItem array form `[{ field, order }, ...]`, the one sort orthography every declared `sort` door on this platform shares; lowered to the wire `$orderby`. The legacy string clause (`name desc`) is refused — objectui#8221 decision batch #77, option B, retired it'),
+    .describe('Initial row order — the SortItem array form `[{ field, order }, ...]`, the one sort orthography every declared `sort` door on this platform shares; lowered to the wire `$orderby`. The legacy string clause (`name desc`) is refused — see migration `object-block-sort-item-array`'),
   /**
    * REMOVED (#11805, maintainer ruling 2026-08-25, decision-inbox batch 4:
    * 「#11805 退役 defaultSort,不需要major」 — the ADR-0049 enforce-or-remove
@@ -2892,7 +2892,7 @@ export const ObjectCalendarPropsSchema = lazySchema(() => strictObject({
    * no `sort` input at all, so nothing on the registry side moves.
    */
   sort: z.array(SortItemSchema).optional()
-    .describe('Row order for the fetched events — the SortItem array form `[{ field, order }, ...]`, the one sort orthography every declared `sort` door on this platform shares; lowered to the wire `$orderby`. The legacy string clause (`name desc`) is refused — objectui#8221 decision batch #77, option B, retired it'),
+    .describe('Row order for the fetched events — the SortItem array form `[{ field, order }, ...]`, the one sort orthography every declared `sort` door on this platform shares; lowered to the wire `$orderby`. The legacy string clause (`name desc`) is refused — see migration `object-block-sort-item-array`'),
   data: z.array(z.unknown()).optional().describe('Pre-fetched records — skips the internal fetch'),
   staticData: z.array(z.unknown()).optional().describe('Static inline records'),
   locale: z.string().optional().describe('Locale override for the calendar chrome'),

--- a/packages/spec/src/ui/component.zod.ts
+++ b/packages/spec/src/ui/component.zod.ts
@@ -2485,7 +2485,45 @@ export const ObjectGridPropsSchema = lazySchema(() => strictObject({
     .describe('Base query filter — the ViewFilterRule array form `[{ field, operator, value }, ...]`, the one filter orthography every `filter` door in this map shares; lowered to the wire `$filter`. THE key, singular — not the plural misspelling. The MongoDB-style record form is refused — see migration `element-data-source-and-object-block-filter-rule-array`'),
   defaultFilters: z.unknown().optional()
     .describe('Legacy base-filter fallback, read only when `filter` is absent. Prefer `filter`'),
-  sort: z.unknown().optional().describe('Initial sort (array of { field, order })'),
+  /**
+   * Initial row order — the `SortItem` ARRAY form, `[{ field, order }, ...]`,
+   * the one sort orthography every DECLARED `sort` door on this platform
+   * carries: `ElementDataSourceSchema.sort` and `ListPageSchema.sort`
+   * (page.zod.ts) and `element:record_picker`'s flat shorthand above. One
+   * shared schema rather than a third copy — all of them are
+   * `SortItemSchema`, already imported at the top of this file for the picker.
+   *
+   * objectui#8221, decision batch #77, 2026-09-07, maintainer verbatim
+   * 「其他同意」, option B: one `sort` spelling, the array; the legacy string
+   * clause is retired from `@object-ui/core`. Item 4 of that ruling is this
+   * declaration and `object-calendar`'s below — 「`ComponentPropsMap` for
+   * `object-calendar` and `object-grid` constrains the `sort` value to the
+   * array shape (today it accepts anything), so the spec, the registrations
+   * and the helper agree; that is a pull-back to the declared contract,
+   * ordinary tier」.
+   *
+   * The `z.unknown()` this door carried was a read-point record (#7751), the
+   * same vintage as its `filter` neighbour above and not an exception to the
+   * ruling: it receipted an array, a string and a bare NUMBER alike with
+   * `success: true`, while `plugin-grid/src/index.tsx:222` has published
+   * `type: 'array'` all along — so the html tier answered `type-mismatch` on a
+   * value this schema had just accepted.
+   *
+   * Sequenced measurement-first, as this family has to be. Measured at the
+   * objectui pin `53ded82b`: `ObjectGrid.tsx:1457` reads `schema.sort` and the
+   * fetch path at `:1844-1851` carries an explicit `typeof === 'string'` arm
+   * putting the clause on `$orderby` verbatim, beside the array arm that folds
+   * `[{ field, order }]` onto the same parameter. ⚠️ At THIS pin the string is
+   * therefore still lowered, and this door refuses a spelling the pinned
+   * renderer honours — the ruled sequence, not an oversight: objectui#8221's
+   * PR #8758 (merged 2026-09-09, after this pin) drops the string arm from
+   * `convertSortToQueryParams`, and the next pin bump carries it in. The array
+   * is the spelling both ends already agree on today; the header-arrow read at
+   * `:3998` hands `schemaSort` to `parseSchemaSort` as `TableSortItem[]`, the
+   * array shape and not the string.
+   */
+  sort: z.array(SortItemSchema).optional()
+    .describe('Initial row order — the SortItem array form `[{ field, order }, ...]`, the one sort orthography every declared `sort` door on this platform shares; lowered to the wire `$orderby`. The legacy string clause (`name desc`) is refused — objectui#8221 decision batch #77, option B, retired it'),
   /**
    * REMOVED (#11805, maintainer ruling 2026-08-25, decision-inbox batch 4:
    * 「#11805 退役 defaultSort,不需要major」 — the ADR-0049 enforce-or-remove
@@ -2836,7 +2874,25 @@ export const ObjectCalendarPropsSchema = lazySchema(() => strictObject({
    */
   filter: z.array(ViewFilterRuleSchema).optional()
     .describe('Base query filter — the ViewFilterRule array form `[{ field, operator, value }, ...]`, the one filter orthography every `filter` door in this map shares. The MongoDB-style record form is refused — see migration `element-data-source-and-object-block-filter-rule-array`'),
-  sort: z.unknown().optional().describe('Sort for the fetched events'),
+  /**
+   * Row order for the fetched events — the same `SortItem` ARRAY form
+   * `object-grid` declares above, and for the same ruling (objectui#8221,
+   * decision batch #77, option B; the `object-grid` entry carries the verbatim
+   * text). One sort orthography, one shared `SortItemSchema`.
+   *
+   * Measured at the objectui pin `53ded82b`: `ObjectCalendar.tsx:431` hands
+   * `schema.sort` to the shared sink `convertSortToQueryParams`
+   * (`core/src/utils/sort-query.ts`) as the fetch's `$orderby`. ⚠️ That sink
+   * still honours the legacy string clause at this pin — `sort-query.ts:66-70`
+   * — so, exactly as on `object-grid`, this declaration lands ahead of the
+   * consumer-side retirement (objectui#8221's PR #8758, merged 2026-09-09) and
+   * refuses a spelling the pinned helper still lowers. The array arm is
+   * unaffected: the sink folds `[{ field, order }]` into the field-direction
+   * map either way. Unlike the grid, `plugin-calendar/src/index.tsx` declares
+   * no `sort` input at all, so nothing on the registry side moves.
+   */
+  sort: z.array(SortItemSchema).optional()
+    .describe('Row order for the fetched events — the SortItem array form `[{ field, order }, ...]`, the one sort orthography every declared `sort` door on this platform shares; lowered to the wire `$orderby`. The legacy string clause (`name desc`) is refused — objectui#8221 decision batch #77, option B, retired it'),
   data: z.array(z.unknown()).optional().describe('Pre-fetched records — skips the internal fetch'),
   staticData: z.array(z.unknown()).optional().describe('Static inline records'),
   locale: z.string().optional().describe('Locale override for the calendar chrome'),


### PR DESCRIPTION
Fixes #16553

Clause-②: no — re-declared on the measured diff, not inherited from the dispatch. `z.unknown()` accepted every value; `z.array(SortItemSchema)` accepts a strict subset of them, so the accept set only shrinks. Nothing that parsed before this PR and is still authorable is newly refused by anything other than the ruled narrowing itself, and no value starts being accepted. Implemented by an `os-dev` seat in session `session_01MkQhmuuJAVDjmeWNixwDDH`.

## What changed

`ComponentPropsMap['object-grid'].sort` and `ComponentPropsMap['object-calendar'].sort` move from `z.unknown()` to `z.array(SortItemSchema)` — the same shared import `ElementDataSourceSchema.sort`, `ListPageSchema.sort` and `element:record_picker`'s flat `sort` shorthand already carry. One shared schema, not a third copy.

Also in the diff: the semantic migration entry `object-block-sort-item-array` under protocol major 18 (`registry.ts` is regenerated by `gen:migration-registry`, never hand-edited between the markers), the regenerated `content/docs/references/ui/component.mdx`, twelve pins in `component.test.ts`, and a `minor` changeset carrying the `**BREAKING**` accept-set declaration and the ADR-0087 disposition marker.

## The ruling this implements

objectui#8221, decision batch #77, 2026-09-07, maintainer verbatim 「其他同意」, option B: one `sort` spelling platform-wide, the array. Item 4 of that ruling is exactly this PR's subject, verbatim:

「`ComponentPropsMap` for `object-calendar` and `object-grid` constrains the `sort` value to the array shape (today it accepts anything), so the spec, the registrations and the helper agree; that is a pull-back to the declared contract, ordinary tier」

## What was measured, and what each probe matched

Every reading below was taken on this branch's own head, at `packages/spec/src/ui/component.zod.ts` as it stands on `origin/main` after PR #17342 and PR #17257 — no earlier reading of that file was reused.

**The card's premise holds.** Probing the two doors through the real map: an array, the legacy string clause `'created_at desc'` and a bare number all returned `success: true`, while `bogusProp` on the same call was refused by name (`unrecognized_keys`, `keys: ['bogusProp']`). So key checking was live and only the VALUE was unheld — the control that makes the three positive readings verdicts rather than a schema reporting nothing.

**`sort` and `filter` were NOT converged together — measured per block, not inferred by symmetry.** Enumerating `sort`-shaped key declarations in the file rather than searching by spelling, with a fabricated key as the dark control (0 hits):

- `object-grid` — `z.unknown()` (the door this PR moves)
- `object-calendar` — `z.unknown()` (the door this PR moves)
- `element:record_picker` — already `z.array(SortItemSchema)`
- `record:related_list` — `z.union([z.string(), z.array(...)])`, an explicitly declared string arm

`object-metric` and `object-kanban` carry `filter` but declare no `sort` key at all, so the "four `object-*` blocks" shape that holds for `filter` does not hold for `sort`. The four `filter` declarations and the two `element:*` doors were not touched.

**`record:related_list` is deliberately left alone.** Its string is the `'field'` / `'-field'` dialect read by `RelatedList.normalizeSortSpec`; it never reaches `convertSortToQueryParams`, and retiring it was not ruled. objectui#8221's own implementing round narrowed it, established the dialect, and reverted the narrowing byte-identically for that reason. The census pin in this PR asserts it is the ONE remaining `sort` door that takes a string, so the exception is pinned rather than tolerated.

**Sequenced measurement-first, and the sequence is stated rather than glossed.** At the objectui pin this repo builds against (`53ded82b`) the legacy string is STILL lowered:

- `plugin-grid/src/ObjectGrid.tsx:1457` reads `schema.sort`; `:1844-1851` carries an explicit `typeof === 'string'` arm putting the clause on `$orderby` verbatim, beside the array arm.
- `plugin-calendar/src/ObjectCalendar.tsx:431` hands `schema.sort` to `convertSortToQueryParams`, whose string arm is still present at `core/src/utils/sort-query.ts:66-70`.
- `plugin-grid/src/index.tsx:222` has published `{ name: 'sort', type: 'array' }` all along; `plugin-calendar/src/index.tsx` declares no `sort` input at all.

So this declaration lands AHEAD of the pinned consumer. The ruling permits that explicitly — either order, since the registrations already declare the array — and objectui PR #8758 (merged 2026-09-09, after this pin) drops the string arm from the helper. The next `.objectui-sha` bump carries the retirement in.

**In-repo authored `sort` on these blocks: zero.** The two showcase pages that author `object-grid` (`command-center.page.ts`, `my-work.page.ts`) declare no `sort`, and there is no `object-calendar` author in the tree. Lit control for the sweep: the same grep shape found 40+ string `sort` values at OTHER doors (view definitions, ObjectQL `query.sort`, lint fixtures) — none of them a block prop, none of them touched. So nothing in-tree needed converting, and the migration entry carries the prescription for authors outside the repo.

## Reverse verification (ablation)

Both `sort` declarations were reverted to `z.unknown().optional()` on disk and the pin file re-run; then restored. Predicted direction before the run: turns red.

- On-disk proof, before: 2 array-form declarations, 0 ablation markers. After the mutation: 0 array-form declarations, 2 ablation markers, and the worktree blob hash differed from the HEAD blob (`1de632a2…` to `ce92734b…`). The mutation reached the file.
- Result: `Tests 8 failed | 272 passed (280)`, exit 1. The eight are the string refusal, the bare-number refusal, the SortItemSchema-shape checks, the cross-door agreement and the census — on both doors.
- The four that stayed GREEN are the ones that must: the two "accepts a SortItem[] and echoes it" assertions (`z.unknown()` echoes an array too) and the two `bogusProp` controls (key checking was never the missing half). A pin set where every assertion moved would have meant the controls were not controls.
- Restore verified by state, not by exit code: `git diff HEAD` empty, and the worktree blob hash equals the HEAD blob hash byte-for-byte (`1de632a2b2d8dae1becae00e1f7db8354318404a`). The mutation script carried an `EXIT INT TERM` trap restoring through an absolute path with `git checkout HEAD --`, and treated an empty hash as a failure.

## Tests and gates

Run at head `b19b41eeec`. Exit codes captured before any pipe.

- `pnpm --filter @objectstack/spec build` — exit 0 (twice: once before the registry change, once after).
- `pnpm --filter @objectstack/spec typecheck` — exit 0 (`tsc --noEmit`, `check:scripts-typecheck`, `check:test-typecheck`; the test layer compiles, 54 files / 261 errors / 145 pinned signatures held).
- `pnpm --filter @objectstack/spec test` — exit 0, `Test Files 468 passed (468)`, `Tests 13202 passed (13202)`.
- `pnpm --filter @objectstack/lint test` — exit 0, `Test Files 103 passed (103)`, `Tests 3717 passed (3717)`. The closest real consumer of `ComponentPropsMap`.
- `pnpm exec turbo run typecheck` over the four downstream consumers that name `ObjectGridProps` / `ObjectCalendarProps` / `ComponentPropsMap` (`@objectstack/lint`, `@objectstack/mcp`, `@objectstack/platform-objects`, `@objectstack/example-showcase`) — exit 0, `Tasks: 65 successful, 65 total`. The narrowed published type breaks no consumer.
- `pnpm exec eslint . --no-inline-config --format json` — exit 0 over the WHOLE population, 6553 files linted, 0 errors, 0 warnings. Not a narrowed run: the repo-wide scan completed, so no narrowing argument is needed. Reading taken at this head.
- The derived gate family from `node scripts/pm/dispatch-gates.mjs --commands --repo objectstack-ai/objectstack` (re-derived after the changeset existed): 85 commands, all run. 83 exit 0. The two that did not are named below.

Two results that are NOT green and NOT red:

- `pnpm check:dual-build-cjs-loads` — exit **3**, `PREREQUISITE NOT MET`: it reads built output and eight packages have no `dist/` in this worktree. Its own text says "This is NOT a pass: nothing was measured." NOT MEASURED locally, declared to CI, which runs it after a full `pnpm build`.
- `pnpm --filter @objectstack/lint run check:doc-formula-expressions` — first run exit **3** for the same reason. Re-run after building `@objectstack/formula` and `@objectstack/lint`: exit 0. Reported as the second reading.

Two gates were red on a first run and are green now, both fixed in this diff rather than argued with:

- `check:doc-authoring` — refused `#8221` inside the two `.describe()` strings, which project into `content/docs/references/**` and the generated skill artifacts where an issue id resolves to nothing. Both describes now cite the migration id, which a reader can act on. Now exit 0 (15022 customer-facing strings clean).
- `check:docs` — `content/docs/references/ui/component.mdx` was out of date. Regenerated via `gen:schema` then `gen:docs`; now exit 0, 221 generated files in sync.

`check:react-declaration-parity` was run as CI runs it, with the checked-in root manifest — `MANIFEST="$PWD/sdui.manifest.json" pnpm --filter @objectstack/spec check:react-declaration-parity --baseline react-declaration-parity.baseline.json --strict` — exit 0, no new declaration divergence versus the accepted baseline. `object-grid`'s `sort` sits in "declared by both"; `object-calendar`'s is spec-only, which is correct because that registration declares no `sort` input.

## 验收备注

Observations found in passing. None is filed as a card — none meets the (a)/(b)/(c) bar, and each is recorded here with the carrier that will meet it.

- `component.zod.ts`'s `element:record_picker` `filter` docblock still says "the four `object-*` blocks declare `filter` as `z.unknown()`, no orthography at all". #15449 falsified that: all four now declare `z.array(ViewFilterRuleSchema)`. A stale comment, not a contract or code defect, and out of this card's defect class — untouched here. Carrier: the next PR that moves a `filter` door in this map, which will read that paragraph.
- `SortItemSchema` requires `order`, while `convertSortToQueryParams` deliberately treats an omitted `order` as ascending (its docblock states this as a fidelity improvement over the private copies it replaced). So the spec refuses `[{ field: 'x' }]` at every `sort` door while the pinned consumer would have honoured it. The refusal is LOUD, not a silent drop, and the spec is the contract, so this is downstream tolerance rather than a defect here. Carrier: whoever next revisits `SortItemSchema`'s optionality.
- objectui's contract review of PR #8758 recorded that a bare `object-grid` still honours the retired string spelling at runtime through the grid's private lowering, which that PR's ruling did not name. Already public on objectui#8221 and already judged there to be a separate card. Carrier: that thread; nothing to add from this side.
- This repo's `.objectui-sha` (`53ded82b`) predates objectui PR #8758, so the pinned consumer and this declaration disagree about the string for exactly as long as the pin sits where it is. That is the ruled sequence, not a defect. Carrier: the seat that next runs `objectui:refresh` and `pnpm sdui:manifest`.

Not flipped ready, not enqueued, no auto-merge armed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MkQhmuuJAVDjmeWNixwDDH)_