### PR TITLE
docs(spec): record which calendar axis the #13817 guard gates — and which door carries the other

### DIFF
--- a/.changeset/listview-calendar-type-axis-scope-16577.md
+++ b/.changeset/listview-calendar-type-axis-scope-16577.md
@@ -1,0 +1,16 @@
+---
+"@objectstack/spec": patch
+---
+
+docs(spec): record which axis the list-view calendar guard gates — and which it does not (#16577)
+
+`checkListViewCalendarVisualization` gates ONE way of asking for a calendar: `appearance.allowedVisualizations` includes `'calendar'`. A view can also ask for one by BEING one — `type: 'calendar'` — and that axis parses CLEAN at all three doors (`ListViewSchema`, `ObjectListViewSchema`, `VIEW_METADATA_MEMBERS.listOverlay`). The disposition was correct but undocumented, so it read as an oversight rather than a decision.
+
+**No behaviour changes.** Every parse verdict at every door is byte-identical before and after; the diff is a TSDoc block on the exported check (which ships in `dist/*.d.ts` and in `src/**/*.zod.ts`) plus pins in `view.test.ts`.
+
+What the docblock now records, all of it measured rather than inferred:
+
+- The `type:` axis is **not unwatched**. It is carried by `checkViewCompleteness`'s `VIEW_BINDING_BLOCKS` (`kernel/functional-completeness.ts`) at **warning** severity, under the same ADR-0078 §1 rubric this file's `page` note already cites — refuse what renders NOTHING, warn what degrades. The two doors have complementary coverage: the completeness check reads `type` only and is blind to `allowedVisualizations`; this check reads `allowedVisualizations` only and is blind to `type`.
+- `viewType` is **not** a second spelling of `type`. The two authoring doors refuse it as an unknown key; the `.strip()`ed overlay write door (`PUT /api/v1/meta/view`) DROPS it, so the view parses as the defaulted `type: 'grid'` — an author who spells it reaches a grid, never a calendar.
+
+⛔ Escalating the `type:` axis to a parse refusal is deliberately NOT done here: it would refuse a shape 17.3.0 accepts, which is a published-surface narrowing and belongs to a ruling — the same disposition the `timeline` scope pin has stated since #13817.

--- a/packages/spec/src/ui/view.test.ts
+++ b/packages/spec/src/ui/view.test.ts
@@ -52,6 +52,11 @@ import {
   originFileOf,
   originOf,
 } from '../../scripts/lib/export-origins-testkit';
+
+// [#16577] The door that carries the `type: '<layout>'` axis these view
+// schemas deliberately leave open — imported so the two-door split is asserted
+// from the side that can see both.
+import { checkViewCompleteness } from '../kernel/functional-completeness';
 describe('HttpMethodSubsetSchema', () => {
   it('should accept valid HTTP methods', () => {
     const methods = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'] as const;
@@ -3870,16 +3875,24 @@ describe("ListViewSchema — the `page` view type (#13216)", () => {
 // requires `calendar.startDateField` (ruled on #13748, option A; spec half)
 // ============================================================================
 
-describe("ListViewSchema — calendar in `appearance.allowedVisualizations` requires the `calendar:` block (#13817)", () => {
-  /** Walk `invalid_union` wrappers and return every issue, nested arms included. */
-  const flattenUnionIssues = (issues: z.ZodIssue[]): z.ZodIssue[] =>
-    issues.flatMap((i) => {
-      const nested = (i as unknown as { errors?: z.ZodIssue[][] }).errors;
-      return i.code === 'invalid_union' && Array.isArray(nested)
-        ? [i, ...flattenUnionIssues(nested.flat())]
-        : [i];
-    });
+/**
+ * Walk `invalid_union` wrappers and return every issue, nested arms included.
+ *
+ * Module-scoped (#16577) because two blocks need it: the #13817 refusals below
+ * and the `type: 'calendar'` scope pins further down. At the overlay door the
+ * union wraps a SHAPE failure in `invalid_union` with the per-arm truth nested
+ * one level down, so a search that reads only the top level finds nothing and
+ * reports it as "no such issue" rather than "issue is one level down".
+ */
+const flattenUnionIssues = (issues: z.ZodIssue[]): z.ZodIssue[] =>
+  issues.flatMap((i) => {
+    const nested = (i as unknown as { errors?: z.ZodIssue[][] }).errors;
+    return i.code === 'invalid_union' && Array.isArray(nested)
+      ? [i, ...flattenUnionIssues(nested.flat())]
+      : [i];
+  });
 
+describe("ListViewSchema — calendar in `appearance.allowedVisualizations` requires the `calendar:` block (#13817)", () => {
   // The same three doors the page-mount check runs at — the check is attached
   // at three separate points for the same zod-4 reason, and a missing
   // re-attachment is invisible (the door keeps accepting, which reads as "no
@@ -3954,5 +3967,114 @@ describe("ListViewSchema — calendar in `appearance.allowedVisualizations` requ
       appearance: { allowedVisualizations: ['grid', 'timeline'] },
     });
     expect(r.success).toBe(true);
+  });
+});
+
+// ============================================================================
+// [#16577] The OTHER route to a calendar — `type: 'calendar'`. SCOPE PIN.
+//
+// #13817 gates ONE axis: `appearance.allowedVisualizations` includes
+// `'calendar'`. A view can also ask for a calendar by BEING one —
+// `type: 'calendar'` — and that axis is deliberately NOT gated here. The
+// disposition was undocumented and therefore unreadable as a decision; these
+// pins make it one, exactly as the `timeline` scope pin above does for the
+// other visualizations.
+//
+// ## Measured, at every door, before this block was written
+//
+// | body                                         | 3 schema doors | `checkViewCompleteness` |
+// |----------------------------------------------|----------------|-------------------------|
+// | `allowedVisualizations: ['calendar']`, no blk | REFUSED        | no finding              |
+// | `type: 'calendar'`, no `calendar:` block      | CLEAN          | **warning**             |
+//
+// So the axis is not unwatched — the two axes are carried by two doors with
+// complementary coverage, at two severities. The door that decides
+// `type: 'calendar'` is `checkViewCompleteness`'s `VIEW_BINDING_BLOCKS`
+// (`packages/spec/src/kernel/functional-completeness.ts`), which warns rather
+// than refuses under the ADR-0078 §1 rubric this file's `page` note already
+// cites: refuse what renders NOTHING, warn what degrades.
+//
+// ⛔ Whether that severity should be escalated for `calendar` is NOT ruled
+// here. #13748's own ruling says extensions of this guard are separate
+// findings to measure first, not riders — the same sentence the `timeline`
+// scope pin above records. Escalating would REFUSE a shape 17.3.0 accepts, so
+// it is a published-surface narrowing and belongs to a ruling, not to a pin.
+// ============================================================================
+
+describe("ListViewSchema — the `type: 'calendar'` axis is NOT gated by the #13817 check (#16577)", () => {
+  describe.each(viewDoorsCarryingPageMountCheck)('%s', (_label, parse) => {
+    it("ACCEPTS `type: 'calendar'` with no `calendar:` block — the axis #13817 does not gate", () => {
+      const r = parse({ type: 'calendar', columns: ['name'] });
+      expect(r.success, r.success === false ? JSON.stringify((r as unknown as { error: z.ZodError }).error.issues) : '').toBe(true);
+    });
+
+    // The asymmetry is the BLOCK schema's, not the guard's: writing the block
+    // is what makes `startDateField` required. Omitting the block skips that
+    // schema entirely, which is why the two rows above differ.
+    it("REFUSES `type: 'calendar'` + `calendar: {}` at `calendar.startDateField` — CalendarConfigSchema's own required key", () => {
+      const r = parse({ type: 'calendar', columns: ['name'], calendar: {} });
+      expect(r.success).toBe(false);
+      const flat = flattenUnionIssues((r as { error: z.ZodError }).error.issues);
+      const issue = flat.find((i) => i.path.join('.').endsWith('calendar.startDateField'));
+      expect(issue, JSON.stringify((r as { error: z.ZodError }).error.issues)).toBeDefined();
+    });
+  });
+
+  // The door that DOES carry this axis, named here so the split above is
+  // readable from either side. A change of severity there fails this pin.
+  it('is carried by `checkViewCompleteness` instead — at WARNING severity', () => {
+    const findings = checkViewCompleteness({ type: 'calendar', columns: ['name'] });
+    expect(findings).toHaveLength(1);
+    expect(findings[0]!.severity).toBe('warning');
+    expect(findings[0]!.path).toBe('calendar');
+  });
+
+  // The complement, and the reason neither door is redundant: the completeness
+  // check reads `type` only, so the axis #13817 gates is invisible to it.
+  it('and `checkViewCompleteness` does NOT see the allowedVisualizations axis', () => {
+    expect(checkViewCompleteness({
+      type: 'grid',
+      columns: ['name'],
+      appearance: { allowedVisualizations: ['grid', 'calendar'] },
+    })).toEqual([]);
+  });
+});
+
+// ============================================================================
+// [#16577] `viewType` is NOT a second spelling of `type` — measured, pinned.
+//
+// The finding that opened #16577 cited `viewType: 'calendar'` as a second way
+// in. At the spec's doors it is not one, and the two authoring doors and the
+// runtime write door disagree about HOW it fails — which is the part worth
+// pinning, because one of the two is a silent downgrade.
+// ============================================================================
+
+describe('ListViewSchema — `viewType` is not a spelling of `type` (#16577)', () => {
+  it('is an UNKNOWN key at the two authoring doors — refused, not aliased', () => {
+    for (const [label, parse] of [
+      ['ListViewSchema', (b: Record<string, unknown>) => ListViewSchema.safeParse(b)],
+      ['ObjectListViewSchema', (b: Record<string, unknown>) => ObjectListViewSchema.safeParse(b)],
+    ] as const) {
+      const r = parse({ viewType: 'calendar', columns: ['name'] });
+      expect(r.success, label).toBe(false);
+      const issue = (r as { error: z.ZodError }).error.issues.find((i) => i.code === 'unrecognized_keys');
+      expect(issue, `${label}: ${JSON.stringify((r as { error: z.ZodError }).error.issues)}`).toBeDefined();
+    }
+  });
+
+  // ⚠️ The overlay door is `PUT /api/v1/meta/view` — the only door a Studio
+  // tenant or an MCP/AI author has — and it is `.strip()`ed by design (it
+  // carries Studio's round-trip keys). So `viewType` is DROPPED there and the
+  // view parses as the defaulted `type: 'grid'`: an author who spells the
+  // retired alias gets a 200 and a grid, never a calendar. Pinned because the
+  // finding assumed the opposite, and because accepted-and-ignored is the
+  // failure mode this file's `VIEW_HISTORY` exists to record.
+  it("is STRIPPED at the overlay write door, leaving the defaulted `type: 'grid'`", () => {
+    const r = VIEW_METADATA_MEMBERS.listOverlay.safeParse({
+      object: 'crm_lead', viewKind: 'list', viewType: 'calendar', columns: ['name'],
+    });
+    expect(r.success).toBe(true);
+    expect((r as { data: Record<string, unknown> }).data).not.toHaveProperty('viewType');
+    expect((r as { data: { type?: unknown } }).data.type).toBe('grid');
   });
 });

--- a/packages/spec/src/ui/view.zod.ts
+++ b/packages/spec/src/ui/view.zod.ts
@@ -1746,6 +1746,27 @@ const VIEW_CALENDAR_ALLOWED_NEEDS_START_DATE =
  * another visualization has the same shape is a separate finding to measure
  * first, not a rider here (the #13748 ruling says so in those words).
  *
+ * ⚠️ [#16577] Scope, the OTHER axis: this check reads
+ * `appearance.allowedVisualizations` and NOT `type`. A view that asks for a
+ * calendar by BEING one — `type: 'calendar'` with no `calendar:` block —
+ * parses CLEAN at all three doors, measured. That is not an unwatched shape:
+ * it is the axis `checkViewCompleteness`'s `VIEW_BINDING_BLOCKS`
+ * (`../kernel/functional-completeness.ts`) carries, at WARNING, under the same
+ * ADR-0078 §1 rubric the `page` note above cites — refuse what renders
+ * NOTHING, warn what degrades. The two axes are covered by two doors with
+ * complementary coverage: the completeness check reads `type` only and is
+ * blind to `allowedVisualizations`, this check reads `allowedVisualizations`
+ * only and is blind to `type`. ⛔ Escalating the `type` axis to a refusal is
+ * NOT ruled: it would refuse a shape 17.3.0 accepts, so it is a
+ * published-surface narrowing and a separate finding — the same disposition
+ * the `timeline` sentence above states. Both halves are pinned in
+ * `view.test.ts`, so a change to either is a deliberate edit.
+ *
+ * ⚠️ [#16577] `viewType` is NOT a second spelling of `type` at any of these
+ * doors: the two authoring doors refuse it as an unknown key, and the
+ * `.strip()`ed overlay door DROPS it, so the view parses as the defaulted
+ * `type: 'grid'` — an author who spells it reaches a grid, never a calendar.
+ *
  * Attached with `.superRefine` at the same three doors as
  * {@link checkListViewPageMount}, for the same zod-4 reason (refinements block
  * `.omit()`/key-overwriting `.extend()`, so derived shapes re-attach): the


### PR DESCRIPTION
Part of #16577 — the card asks a question it explicitly declines to rule, and this PR answers it with measurements and pins the disposition **without** ruling it. #16577 stays open for the ruling.

Clause-②: no — measured, not declared. Every parse verdict at all three doors is byte-identical before and after this diff (transcripts below), and the ablation further down proves that probe is a real discriminator rather than a probe both sides happen to pass.

## What the card claimed, and what parsing actually says

Measured by parsing, at `ListViewSchema` · `ObjectListViewSchema` · `VIEW_METADATA_MEMBERS.listOverlay`, against this branch's build. Overlay bodies carry the required `object` / `viewKind` identity. Every fixture was confirmed to parse at zero issues in its control form first, so no refusal below arrived alongside an `unrecognized_keys`.

| body | ListViewSchema | ObjectListViewSchema | listOverlay |
|---|---|---|---|
| `{ type: 'grid', columns: ['name'] }` (control) | CLEAN | CLEAN | CLEAN |
| `type: 'calendar'` + `calendar: { startDateField }` (control) | CLEAN | CLEAN | CLEAN |
| **`type: 'calendar'`, no `calendar:` block** | **CLEAN** | **CLEAN** | **CLEAN** |
| `type: 'calendar'` + `calendar: {}` | REFUSED `invalid_type@[calendar.startDateField]` | same | same |
| **`viewType: 'calendar'`** | **REFUSED `unrecognized_keys`** | **REFUSED `unrecognized_keys`** | **CLEAN** |
| `allowedVisualizations: ['calendar']`, no block | REFUSED `custom@[calendar]` | same | same |
| `type: 'calendar'` + `allowedVisualizations: ['calendar']` | REFUSED `custom@[calendar]` | same | same |

Three of the card's premises move:

1. **CONFIRMED** — `type: 'calendar'` with no `calendar:` block parses CLEAN at all three doors.
2. **FALSIFIED** — `viewType: 'calendar'` is not a second spelling here. The two authoring doors refuse it as an unknown key. The overlay write door is `.strip()`ed by design, so it is **DROPPED**: the parsed body comes back as `{"type":"grid","columns":["name"],"object":"task","viewKind":"list"}`. An author who spells the retired alias reaches a **grid**, never a calendar — the opposite of the consequence the card assumed.
3. **REFRAMED** — *"the guard does not watch it"* is true of the guard and false of the platform.

## The door that actually decides — named, as the claim comment asked

⚠️ A probe both sides pass is not a discriminator. The schema door is **not** the door that decides `type: 'calendar'`. This one is:

```
=== checkViewCompleteness (@objectstack/lint validate-functional-completeness) ===
{ type: 'grid', columns: ['name'] }                             no finding
{ type: 'calendar', columns:['name'], calendar:{startDateField}} no finding
{ type: 'calendar', columns: ['name'] }        warning:view/layout-without-binding@[calendar]
{ type: 'calendar', columns:['name'], calendar:{} }             no finding
{ viewType: 'calendar', columns: ['name'] }                     no finding
{ appearance:{allowedVisualizations:['calendar']} }             no finding
```

So the two axes are carried by **two doors with complementary coverage, at two severities**: `checkViewCompleteness`'s `VIEW_BINDING_BLOCKS` reads `type` only and is blind to `allowedVisualizations`; `checkListViewCalendarVisualization` reads `allowedVisualizations` only and is blind to `type`. That split is not an accident — it is the ADR-0078 §1 rubric this file's own `page` note already cites: refuse what renders NOTHING, warn what degrades.

## Which of the three failure-fix routes — route 3, and why 1 and 2 were unavailable

⛔ First delete the construct that permits the error; then make the correct form the only spelling; only then add a check. Stated plainly rather than dressed up: **this PR adds no check at all, because none of the three routes is open without a ruling.**

- **Route 1** has no construct to delete. Nothing here *permits* an error — what makes `type: 'calendar'` accepting is the ABSENCE of a relation, and the only route-1-shaped fix (a discriminated union on `type` that binds each type-specific block) is refused in this file's own words: *"tolerating a stale optional block is this schema's standing disposition, and narrowing it is a separate decision about every view type, not a rider on this one."*
- **Route 2** has nothing to re-spell. `type: 'calendar'` **is** the correct and only spelling for asking for a calendar; there is no incorrect form to eliminate.
- **Route 3** — extending the guard to the `type:` axis — is available, is a one-line change, and is **deliberately not taken here**: see the fence below.

What ships instead is the measurement made permanent: a docblock on the exported check that records which axis it gates and which door carries the other, plus pins at all three doors so a change to either is a deliberate edit rather than a silent drift.

## The fence — why route 3 is not taken in this PR

The card says outright: *"what is worth deciding is whether the guard's coverage should match the ways a calendar can actually be requested, or whether `allowedVisualizations` is deliberately the only gated axis and `type:` is meant to be handled by the renderer's refusal. ⛔ This card does not rule that."*

Three measured facts bear on that ruling, and all three point the same way:

1. **#13748's own ruling forbids the rider.** This file quotes it: *"Whether `timeline` or another visualization has the same shape is a separate finding to measure first, not a rider here (the #13748 ruling says so in those words)."* The `type:` axis is exactly such a separate finding. There is even a scope pin standing in `view.test.ts` for the timeline case.
2. **The rationale that justified escalating the OTHER axis has been deleted downstream.** #13817's docblock escalates because *"a date guessed by the renderer lands every record without that field on 'today', a plausible-looking, fully wrong screen. The renderer's own refusal screen was unreachable because the synthesized config always looked complete."* Read on objectui `main` at `3fbdd4a2d`: `plugin-list`'s `case 'calendar':` now spreads `startDateField` / `endDateField` only when declared (objectui#7029 deleted the `'start_date'` / `'end_date'` floors, and says so in the comment above them), and `ObjectCalendar`'s `getCalendarConfig` returns `null` with no block, reaching the **"Calendar configuration required. Please specify startDateField and titleField."** screen. Nothing is guessed, nothing is silent. Under the ADR-0078 §1 rubric — refuse what renders nothing *while reporting success*, warn what degrades — a shape that is loud at the authoring door AND loud at the render door is a warning-class shape.
3. **Escalating narrows a published surface.** Ablation, below: it turns two PRE-EXISTING pins red, one of them named *"keeps every pre-existing view type accepting exactly as before"*.

⇒ Ruling it here would be guessing at a contract decision the card reserved. Reported as `needs_decision`; #16577 stays open.

## Ablation — the escalation, measured both ways

The mutation is route 3 applied: the guard's predicate becomes `allowedVisualizations includes 'calendar'` OR `type === 'calendar'`.

On-disk proof before reading any result — anchor line `1 → 0`, injected marker `0 → 1`, blob hash `0927443b…` → `01bbd00a…`. Restore leg: `git checkout HEAD -- PATH` (HEAD named explicitly, never a bare `--`, so the restore does not take the mutation back out of the index), then `git diff HEAD` empty and the on-disk hash back to `0927443b7bd4e566cfb0e289c1a7ff13e7a69026`, byte-identical to the HEAD blob. Both legs under a `trap … EXIT INT TERM` with an absolute repo root. No `dist/` is involved: `view.test.ts` imports `./view.zod` relatively, so the run resolves to source.

**Mutated run — 5 failed, 815 passed (8 files):**

- `ListViewSchema > should accept all list view types` — pre-existing
- `ListViewSchema — the page view type (#13216) > keeps every pre-existing view type accepting exactly as before` — pre-existing
- the three new door pins (`ListViewSchema`, `ObjectListViewSchema`, flattened overlay)

**Restored run — 469 files, 13220 tests, all pass.**

⇒ The pins bite; the escalation is a narrowing on a published surface, and it would be `Clause-②: yes` with `needs:contract-review`. This PR is neither.

**Blast radius, for whoever rules it:** every authored `type: 'calendar'` view in this repo already carries a `calendar:` block — `examples/app-crm/src/views/activity.view.ts`, `examples/app-showcase/src/ui/views/task.view.ts`, `content/docs/ui/views.mdx`. Lit control: 23 occurrences of the literal across 10 files; dark control `type: 'calendarium'`: 0. So inside this repo the escalation would break test fixtures only, not one example or doc snippet.

## Changeset — required, and measured rather than assumed

Not `skip-changeset`. `@objectstack/spec`'s `files[]` publishes both `dist` and `src/**/*.zod.ts`, so a docblock-only edit to `view.zod.ts` moves published bytes twice over. Measured after the build: the added prose greps in `dist/view.zod-jHu6dKeF.d.ts` and `.d.mts` (2 files); positive control, a sentence from the same pre-existing docblock, hits the same 2; dark control 0. Patch bump, documentation-only.

## Verification

- `pnpm --filter @objectstack/spec test` — **469 files / 13220 tests, all pass**
- `pnpm --filter @objectstack/spec typecheck` — green (`tsc --noEmit` + `check:scripts-typecheck` + `check:test-typecheck`)
- `pnpm lint` — the **whole repo**, `eslint . --no-inline-config`, exit 0. Not narrowed, so no narrowing evidence is owed.
- `pnpm --filter @objectstack/spec build` — green, and re-run after the edit (the first five spec gates refused a stale build with exit 1 until it was; all green on re-run)
- Gate families derived with `scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack`, re-derived after the changeset existed (5 more families appeared and were run), then reconciled with `--ran` carrying exit codes: **81 derived, 78 run green, 3 NOT MEASURED, 0 unrun.**
- The 3 NOT MEASURED are `check:dual-build-cjs-loads`, `check:lean-entry-closure`, `check:type-check-debt` — each exited **3, PREREQUISITE NOT MET**, all three asking for a whole-workspace build. ⛔ Declared to CI, not silently skipped; exit 3 is neither a pass nor a failure.
- Run at `a3b57f3a80`. The 46 artifact-roster families, the 11 wide-population families and the 5 path-scheduled CI jobs are outside the derived total and are CI's.

## Out of scope, filed

#17445 — `VIEW_BINDING_BLOCKS`'s calendar row, and the warning it prints, assert a renderer fallback objectui#7029 deleted. Same route as this card, different door and different file, so it is filed rather than ridden in here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MkQhmuuJAVDjmeWNixwDDH)_