### PR TITLE
measure-test-shard-timings: fold a package's test:repo leg into its sample

### DIFF
--- a/scripts/measure-test-shard-timings.mjs
+++ b/scripts/measure-test-shard-timings.mjs
@@ -140,7 +140,17 @@ export function sliceOfCliArguments(args) {
   return null;
 }
 
-// Pull every genuinely-executed `test` task out of one parsed run summary.
+// The task names whose windows this file counts as a package's test cost.
+// #16550: since #16466, six packages (core, objectql, rest, runtime, spec,
+// types) split their suite into `test` and `test:repo` (the repo-scanning
+// tests, hashed on the wide inputs) -- TWO task records per package in the
+// same run summary, both genuinely part of the suite's cost. `ci.yml` runs
+// them together (`turbo run test test:repo`), so a package that has a
+// `test:repo` task always has it in the SAME summary as its `test` task.
+const SAMPLED_TASKS = ['test', 'test:repo'];
+
+// Pull every genuinely-executed `test` (and, for split packages, `test:repo`)
+// task out of one parsed run summary, folded per package into ONE window.
 //
 // The shape assertions are loud for the same reason the partitioner's are:
 // `--summarize` is stable but not contractual, and the failure this script can
@@ -152,6 +162,16 @@ export function sliceOfCliArguments(args) {
 // not need it (a shard runs exactly one slice, so its prediction follows from
 // the slice map, not from the summary), while buildDataset below cannot record
 // a correct weight without it.
+//
+// #16550: a package's `test` and `test:repo` legs are folded by SUMMING their
+// execution windows -- the whole-package cost is both halves together, not
+// either alone. The rejection rule composes across the fold rather than being
+// re-derived per leg: EVERY leg present for a package must be a cache MISS
+// with exit 0, or the WHOLE package is skipped -- one cached or failed leg is
+// exactly as disqualifying as a cached or failed `test` used to be on its own.
+// Recording one leg's seconds alone (because the other was cached or failed)
+// would write a partial suite's cost as the package's whole cost, a reading
+// worse than today's undercount by #16466's own defect this card fixes.
 export function samplesFromSummary(parsed, label) {
   const tasks = parsed?.tasks;
   if (!Array.isArray(tasks)) {
@@ -160,29 +180,63 @@ export function samplesFromSummary(parsed, label) {
         'is this a run summary at all?'
     );
   }
-  const samples = new Map();
-  const skippedCached = [];
-  const slices = new Map();
+  // One entry per package, holding whichever of its sampled tasks this
+  // summary carries (almost always just `test`; `test` + `test:repo` for a
+  // split package). Each leg is recorded as EITHER a seconds+cliArguments
+  // reading, OR a `cached`/`failed` flag -- never both -- so the fold below
+  // can tell "this leg disqualifies the package" from "this leg is a real
+  // measurement" without re-reading the raw task.
+  const legsByPackage = new Map();
   for (const task of tasks) {
-    if (task?.task !== 'test') continue;
+    const taskName = task?.task;
+    if (!SAMPLED_TASKS.includes(taskName)) continue;
     const name = task.package;
     if (typeof name !== 'string' || name.length === 0) {
-      throw new Error(`${label}: a test task carries no package name: ${JSON.stringify(task.taskId)}`);
+      throw new Error(`${label}: a ${taskName} task carries no package name: ${JSON.stringify(task.taskId)}`);
     }
+    if (!legsByPackage.has(name)) legsByPackage.set(name, new Map());
+    const legs = legsByPackage.get(name);
     if (task?.cache?.status !== 'MISS') {
-      skippedCached.push(name);
+      legs.set(taskName, { cached: true });
       continue;
     }
     const { startTime, endTime, exitCode } = task.execution ?? {};
     if (typeof startTime !== 'number' || typeof endTime !== 'number') {
-      throw new Error(`${label}: ${name}#test has no execution window to measure`);
+      throw new Error(`${label}: ${name}#${taskName} has no execution window to measure`);
     }
     // A failed suite stops early, so its duration is not this package's cost.
-    if (exitCode !== 0) continue;
+    if (exitCode !== 0) {
+      legs.set(taskName, { failed: true });
+      continue;
+    }
     const seconds = (endTime - startTime) / 1000;
-    if (!(seconds >= 0)) throw new Error(`${label}: ${name}#test measured ${seconds}s`);
+    if (!(seconds >= 0)) throw new Error(`${label}: ${name}#${taskName} measured ${seconds}s`);
+    legs.set(taskName, { seconds, cliArguments: task.cliArguments });
+  }
+
+  const samples = new Map();
+  const skippedCached = [];
+  const slices = new Map();
+  for (const [name, legs] of legsByPackage) {
+    const readings = [...legs.values()];
+    // Cache wins over failure when both are present: either alone already
+    // disqualifies the whole package, and `skippedCached` is what the merge
+    // rule in buildDataset() reads as the witness for carrying a prior weight
+    // forward -- a package skipped here for ANY reason including a failed
+    // sibling leg still needs that witness if one of its legs was a HIT.
+    if (readings.some((leg) => leg.cached)) {
+      skippedCached.push(name);
+      continue;
+    }
+    if (readings.some((leg) => leg.failed)) continue;
+    let seconds = 0;
+    let cliArguments;
+    for (const leg of readings) {
+      seconds += leg.seconds;
+      cliArguments ??= leg.cliArguments;
+    }
     samples.set(name, seconds);
-    const slice = sliceOfCliArguments(task.cliArguments);
+    const slice = sliceOfCliArguments(cliArguments);
     if (slice) slices.set(name, slice);
   }
   return { samples, skippedCached, slices };
@@ -425,7 +479,7 @@ export function buildDataset({ perSummary, fileCounts, provenance, carryFrom = n
 // must not red. A battery BELOW its floor means cases stopped running; the
 // remedy is to find what stopped registering, never to lower the number.
 const SELF_TEST_BATTERIES = Object.freeze({
-  'measure-test-shard-timings self-test': 50,
+  'measure-test-shard-timings self-test': 56,
 });
 
 // DELETING an entry silences that battery's floor exactly as effectively as
@@ -470,6 +524,13 @@ function selfTest() {
   const testTask = (pkg, start, end, status = 'MISS', exitCode = 0) => ({
     taskId: `${pkg}#test`,
     task: 'test',
+    package: pkg,
+    cache: { status },
+    execution: { startTime: start, endTime: end, exitCode },
+  });
+  const testRepoTask = (pkg, start, end, status = 'MISS', exitCode = 0) => ({
+    taskId: `${pkg}#test:repo`,
+    task: 'test:repo',
     package: pkg,
     cache: { status },
     execution: { startTime: start, endTime: end, exitCode },
@@ -523,6 +584,65 @@ function selfTest() {
   const failed = samplesFromSummary(summary([testTask('a', 0, 500, 'MISS', 1)]), 'f');
   check(() => {
     if (failed.samples.has('a')) throw new Error('exit: a failed suite was recorded as a duration');
+  });
+
+  // #16550: a two-task summary -- a split package's `test` and `test:repo`
+  // legs are SUMMED into one whole-package reading, not either leg alone. The
+  // un-split control (`ctl`, a plain `test`-only package in the SAME summary)
+  // rides alongside it and must read exactly as it always has -- the
+  // discriminating half of this case, since a probe that reads the same
+  // before and after the fold would not catch a fold that leaked onto
+  // packages it was never meant to touch.
+  const twoTask = samplesFromSummary(
+    summary([testTask('spec', 0, 400_000), testRepoTask('spec', 0, 53_900), testTask('ctl', 0, 12_000)]),
+    'f'
+  );
+  check(() => {
+    if (twoTask.samples.get('spec') !== 453.9) {
+      throw new Error(`test:repo fold: expected the sum 453.9, got ${twoTask.samples.get('spec')}`);
+    }
+  });
+  check(() => {
+    if (twoTask.samples.get('ctl') !== 12) {
+      throw new Error(`test:repo fold: the un-split control was disturbed (got ${twoTask.samples.get('ctl')})`);
+    }
+  });
+
+  // Either leg cached skips the WHOLE package -- recording the other leg's
+  // seconds alone would be a reading worse than the pre-#16550 undercount.
+  const repoCached = samplesFromSummary(
+    summary([testTask('spec', 0, 400_000), testRepoTask('spec', 0, 53_900, 'HIT')]),
+    'f'
+  );
+  check(() => {
+    if (repoCached.samples.has('spec')) {
+      throw new Error(`test:repo fold: a cached test:repo leg did not skip the whole package (got ${repoCached.samples.get('spec')})`);
+    }
+  });
+  check(() => {
+    if (!repoCached.skippedCached.includes('spec')) {
+      throw new Error('test:repo fold: a package with a cached test:repo leg was not reported as skipped');
+    }
+  });
+  const testCached = samplesFromSummary(
+    summary([testTask('spec', 0, 400_000, 'HIT'), testRepoTask('spec', 0, 53_900)]),
+    'f'
+  );
+  check(() => {
+    if (testCached.samples.has('spec')) {
+      throw new Error(`test:repo fold: a cached test leg did not skip the whole package (got ${testCached.samples.get('spec')})`);
+    }
+  });
+
+  // Either leg failed skips the WHOLE package, same as a lone `test` failure.
+  const repoFailed = samplesFromSummary(
+    summary([testTask('spec', 0, 400_000), testRepoTask('spec', 0, 53_900, 'MISS', 1)]),
+    'f'
+  );
+  check(() => {
+    if (repoFailed.samples.has('spec')) {
+      throw new Error('test:repo fold: a failed test:repo leg did not skip the whole package');
+    }
   });
 
   const threw = (fn) => {


### PR DESCRIPTION
Closes #16550

## What changed

`samplesFromSummary()` in `scripts/measure-test-shard-timings.mjs` kept only
`task.task === 'test'`, so the six packages `#16466` split into `test` +
`test:repo` (core, objectql, rest, runtime, spec, types) had their
`test:repo` execution window silently dropped from every future refresh.

`samplesFromSummary()` now folds a package's `test` and `test:repo` legs by
**summing** their execution windows into one whole-package reading. The
rejection rule composes across the fold rather than being re-derived per
leg: **every** leg present for a package must be `cache.status === 'MISS'`
and `exitCode === 0`, or the **whole package is skipped** — one cached or
failed leg is exactly as disqualifying as it was for a lone `test` task
before. The existing throw paths (no execution window, negative seconds, no
package name) apply per leg, so they still fire for either task name.

The partitioner (`scripts/partition-test-shards.mjs`) is untouched — it only
weighs packages, and both `--check-drift` and the shard's own
`turbo run test test:repo` already run/read both tasks for a package through
this same function.

## `--check-drift` self-consistency (boundary check)

Fed a synthetic two-leg summary for `@objectstack/spec`
(`test` 349.75s + `test:repo` 53.9s) against the *current, unrefreshed*
`scripts/test-shard-timings.json` (weight `403.65`, measured before the
split when both halves still lived inside one `test` task):

```
$ node scripts/partition-test-shards.mjs --check-drift <fixture> --label "issue-16550 two-leg fixture"
shard-timing-drift: OK -- issue-16550 two-leg fixture, 403.6s measured vs 403.6s predicted
across 1 package(s) = 1.00x (bound 1.5x).
```

Measured and predicted agree (1.00x) because `--check-drift` reads legs
through the same now-fixed `samplesFromSummary()` — before this change, only
the 349.75s `test` leg would have been read against the 403.65s prediction,
a 0.87x undershoot invisible to nobody watching for it today but exactly the
"measured and predicted shrink together" blind spot the card names once the
dataset is refreshed and predicted also starts under-counting.

## Dataset

`scripts/test-shard-timings.json` is **not** touched — this PR fixes the
generator only; "until the refresh the existing rows are right" per the
card. Refreshing is `#16464`'s scheduled workflow's job.

## Tests

- `node scripts/measure-test-shard-timings.mjs --self-test` — OK. Added a
  two-task-summary battery: the sum case, an un-split control riding in the
  *same* summary (proves the fold does not disturb ordinary packages —
  the discriminating leg, since a before/after-identical reading on that
  control alone would not catch a fold that leaked), either-leg-cached (both
  orderings), and either-leg-failed. Floor raised `50 -> 56` for the 6 new
  cases (#13799).
- `node scripts/partition-test-shards.mjs --self-test` — OK (71 measured
  packages, unaffected — it imports `samplesFromSummary` but its own fixtures
  are single-task).
- Scoped gate derivation: `node scripts/pm/dispatch-gates.mjs --commands`
  named 34 families for this diff (editing a gated tooling script with its
  own `--self-test` pulls in the self-test-wiring/declaration-mirror family).
  All 34 ran green under `scripts/pm/os-verify-lock.sh`; reconciled with
  `--ran` — 34 derived, 34 run, 0 NOT-MEASURED.
- `pnpm exec eslint scripts/measure-test-shard-timings.mjs --no-inline-config
  --format json` — 1 file checked, 0 errors, 0 warnings.
- `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]' scripts/measure-test-shard-timings.mjs`
  — no control bytes.

## Changeset

`skip-changeset` — measured, not assumed: `scripts/measure-test-shard-timings.mjs`
lives at the repo root, outside every package directory, and every
publishing package's `"files"` array is limited to `dist` / `README.md` /
`CHANGELOG.md` (checked across `packages/*/package.json`). No package
bundles or re-exports this script (`grep -rl measure-test-shard-timings`
outside `scripts/` returns nothing). Nothing published moves. Applying the
`skip-changeset` label on this PR now.

**Clause-②**: no

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012GKcPZbMoGq7WPzKLfRBTU

---
_Generated by [Claude Code](https://claude.ai/code/session_012GKcPZbMoGq7WPzKLfRBTU)_