### PR TITLE
fix(cli): `os register` requires a name, and the request-side `as any` that hid the mismatch is gone

### DIFF
--- a/.changeset/cli-register-requires-name.md
+++ b/.changeset/cli-register-requires-name.md
@@ -1,0 +1,16 @@
+---
+"@objectstack/cli": patch
+---
+
+fix(cli): `os register` requires a name, and the request-side `as any` that hid the mismatch is gone (#16932)
+
+`os register` prompted **"Name (optional)"**, typed its own payload with `name?`, and guarded `email` and `password` but not `name` — three places agreeing the field was optional. The route it actually posts to does not agree: on a fresh environment (no human user yet, so the audience gate's bootstrap bypass admits the request and the route's own validation is the only judge left), `POST /api/v1/auth/sign-up/email` answers `400 VALIDATION_ERROR` — `[body.name] Invalid input: expected string, received undefined`. The same run with a name supplied answers `200` and creates the account.
+
+So the first-use path failed on exactly the answer the prompt invited, and `RegisterRequestSchema`'s required `name` was right all along.
+
+- the prompt now reads `Name: `;
+- an empty answer is refused by the CLI itself (`Name is required`), beside the existing `Email is required` / `Password is required` guards, before any request goes out;
+- the payload is annotated with the declared `RegisterRequest` instead of a hand-written twin;
+- the `as any` at the call site is removed, so the next divergence between this command and the declared request type is a compile error rather than a `400` a user meets on their first command.
+
+No behaviour change for anyone already passing a name, by flag or at the prompt.

--- a/packages/cli/src/commands/register.ts
+++ b/packages/cli/src/commands/register.ts
@@ -4,6 +4,7 @@ import { Command, Flags } from '@oclif/core';
 import { printHeader, printSuccess, printError, printKV, emitJson, errorCodeFields } from '../utils/format.js';
 import { writeAuthConfig } from '../utils/auth-config.js';
 import { ObjectStackClient } from '@objectstack/client';
+import type { RegisterRequest } from '@objectstack/client';
 import * as readline from 'node:readline/promises';
 import { stdin as input, stdout as output } from 'node:process';
 
@@ -112,7 +113,7 @@ export default class Register extends Command {
         email = await rl.question('Email: ');
       }
       if (!name) {
-        name = await rl.question('Name (optional): ');
+        name = await rl.question('Name: ');
       }
       rl.close();
       if (!password) {
@@ -120,12 +121,12 @@ export default class Register extends Command {
       }
 
       if (!email) throw new Error('Email is required');
+      if (!name) throw new Error('Name is required');
       if (!password) throw new Error('Password is required');
 
       const client = new ObjectStackClient({ baseUrl: flags.url });
-      const registerPayload: { email: string; password: string; name?: string } = { email, password };
-      if (name) registerPayload.name = name;
-      const response = await client.auth.register(registerPayload as any);
+      const registerPayload: RegisterRequest = { email, password, name };
+      const response = await client.auth.register(registerPayload);
 
       const token = response.data?.token ?? (response as any).token;
       const user = response.data?.user ?? (response as any).user;

--- a/packages/cli/test/register-requires-name.test.ts
+++ b/packages/cli/test/register-requires-name.test.ts
@@ -92,7 +92,7 @@ async function runRegister(argv: string[]): Promise<{ output: string; threw: unk
 }
 
 describe('os register — the prompt, the payload and the route agree about `name`', () => {
-  let exitCode: number | undefined;
+  let exitCode: typeof process.exitCode;
 
   beforeEach(() => {
     answers = [];

--- a/packages/cli/test/register-requires-name.test.ts
+++ b/packages/cli/test/register-requires-name.test.ts
@@ -1,0 +1,166 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * `os register` and the door it actually knocks on must agree about `name`.
+ *
+ * MEASURED, not inferred (a fresh showcase environment with no human user yet,
+ * so the audience gate's bootstrap bypass admits the sign-up and the only
+ * judge left is the route's own validation):
+ *
+ *   empty Name answer -> POST /api/v1/auth/sign-up/email
+ *                        400 VALIDATION_ERROR
+ *                        "[body.name] Invalid input: expected string, received undefined"
+ *   same run, name supplied (positive control, same environment, same route)
+ *                     -> 200, account created
+ *
+ * So the route REQUIRES `name`, `RegisterRequestSchema` declares it correctly,
+ * and the command was advertising a field as "(optional)" that the first-use
+ * path cannot omit. The request-side `as any` at the call site is what kept
+ * that disagreement off the compiler: with it gone the payload is annotated
+ * with the declared `RegisterRequest`, so a future divergence is a type error
+ * instead of a runtime 400 a user meets on their first command.
+ *
+ * Both halves are pinned here, and neither is optional:
+ *
+ *   REFUSAL     — an empty answer is refused by the CLI, BEFORE any request is
+ *                 made (the route was never called). A test that only asserted
+ *                 "it fails" would pass just as well on the pre-fix command,
+ *                 which also failed — one HTTP round trip later, with the
+ *                 server's field-path message instead of the CLI's own.
+ *   PRESERVATION— when a name IS supplied, the wire body is exactly the three
+ *                 declared members. This is what stops the refusal from being
+ *                 "fixed" by sending an empty string, which the route's
+ *                 `z.string()` accepts and which would create an account whose
+ *                 display name is blank.
+ *
+ * The prompt text is pinned alongside them: the false promise lived in that
+ * string, and nothing else in the tree carries it.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import Register from '../src/commands/register.js';
+
+/** Answers handed to `rl.question`, in prompt order. */
+let answers: string[] = [];
+/** Every prompt string the command actually asked. */
+let asked: string[] = [];
+
+vi.mock('node:readline/promises', () => ({
+  createInterface: () => ({
+    question: async (prompt: string) => {
+      asked.push(prompt);
+      return answers.shift() ?? '';
+    },
+    close: () => {},
+  }),
+}));
+
+vi.mock('../src/utils/auth-config.js', () => ({
+  writeAuthConfig: vi.fn(async () => {}),
+}));
+
+const URL_FLAG = 'http://route.test';
+const EMAIL = 'first-run@example.com';
+const PASSWORD = 'Passw0rd123';
+
+/** A `fetch` stub that records its calls and answers like the real route. */
+function stubFetch(): ReturnType<typeof vi.fn> {
+  const impl = vi.fn(async (_url: string, _init?: RequestInit) => ({
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    headers: { get: () => null },
+    json: async () => ({ token: 'tok_1', user: { id: 'usr_1', email: EMAIL } }),
+  }) as any);
+  vi.stubGlobal('fetch', impl);
+  return impl;
+}
+
+/** Run the command, capturing everything it printed. */
+async function runRegister(argv: string[]): Promise<{ output: string; threw: unknown }> {
+  const lines: string[] = [];
+  const capture = (...args: unknown[]) => { lines.push(args.map(String).join(' ')); };
+  vi.spyOn(console, 'log').mockImplementation(capture);
+  vi.spyOn(console, 'error').mockImplementation(capture);
+  let threw: unknown;
+  try {
+    await Register.run(argv);
+  } catch (error) {
+    threw = error;
+  }
+  return { output: lines.join('\n'), threw };
+}
+
+describe('os register — the prompt, the payload and the route agree about `name`', () => {
+  let exitCode: number | undefined;
+
+  beforeEach(() => {
+    answers = [];
+    asked = [];
+    exitCode = process.exitCode;
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    // oclif's default `catch` sets process.exitCode on the refusal case; leaving
+    // it set would fail the whole vitest run on a suite that passed.
+    process.exitCode = exitCode;
+  });
+
+  it('refuses an empty name WITHOUT calling the route', async () => {
+    const fetchImpl = stubFetch();
+    answers = ['']; // the Name prompt, answered with a bare Enter
+
+    const { output, threw } = await runRegister([
+      '--url', URL_FLAG, '--email', EMAIL, '--password', PASSWORD,
+    ]);
+
+    expect(threw).toBeDefined();
+    expect(output).toContain('Name is required');
+    // The half that distinguishes this fix from the defect: no request went out.
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('no longer advertises the field as optional', async () => {
+    stubFetch();
+    answers = ['Jane Doe'];
+
+    await runRegister(['--url', URL_FLAG, '--email', EMAIL, '--password', PASSWORD]);
+
+    expect(asked).toContain('Name: ');
+    expect(asked.join('\n')).not.toMatch(/optional/i);
+  });
+
+  it('sends exactly the declared request members when a name is supplied', async () => {
+    const fetchImpl = stubFetch();
+    answers = ['Jane Doe'];
+
+    const { threw } = await runRegister([
+      '--url', URL_FLAG, '--email', EMAIL, '--password', PASSWORD,
+    ]);
+
+    expect(threw).toBeUndefined();
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchImpl.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(`${URL_FLAG}/api/v1/auth/sign-up/email`);
+    expect(init.method).toBe('POST');
+    expect(JSON.parse(String(init.body))).toEqual({
+      email: EMAIL,
+      password: PASSWORD,
+      name: 'Jane Doe',
+    });
+  });
+
+  it('accepts the name from the flag without prompting for it', async () => {
+    const fetchImpl = stubFetch();
+
+    await runRegister([
+      '--url', URL_FLAG, '--email', EMAIL, '--password', PASSWORD, '--name', 'Flagged Name',
+    ]);
+
+    expect(asked).toEqual([]);
+    const [, init] = fetchImpl.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(String(init.body)).name).toBe('Flagged Name');
+  });
+});


### PR DESCRIPTION
Fixes #16932

The card turned on a measurement nobody had taken: does the live route refuse a sign-up with no `name`, or accept it? It refuses. So the fix is the CLI's, `packages/spec` is untouched, and the whole card ships here.

## The measurement

Driving the real command against a real route, not reading better-auth's source.

A showcase app booted `--fresh --no-seed-admin` on a random high port, so the environment carries **no human user yet**. That matters: the audience gate refuses self-registration under the default `invite_only` posture (the first attempt, against a seeded environment, came back `403 SELF_REGISTRATION_CLOSED` and measured the gate rather than the route). With no human user the bootstrap bypass admits the request, and the route's own validation is the only judge left.

**Leg 1 — empty answer at the Name prompt:**

```
$ printf '\n' | os register --url http://localhost:38619 \
    --email measure-empty-name@example.com --password Passw0rd123 --json
Name (optional): ERROR HTTP request failed
  {"method":"POST","url":"http://localhost:38619/api/v1/auth/sign-up/email","status":400,
   "error":{"message":"[body.name] Invalid input: expected string, received undefined",
            "code":"VALIDATION_ERROR"}}
{ "success": false,
  "error": "[body.name] Invalid input: expected string, received undefined",
  "code": "VALIDATION_ERROR", "httpStatus": 400 }
exit 1
```

**Leg 2 — positive control, same environment, same route, same run, name supplied:**

```
$ printf 'Jane Doe\n' | os register --url http://localhost:38619 \
    --email measure-with-name@example.com --password Passw0rd123 --json
{ "success": true, "email": "measure-with-name@example.com", "userId": "0LTwRn6I7O6YC2n3VabQssWNi1ugxjg5" }
exit 0
```

⇒ **The route REQUIRES `name`.** The 400 is attributable to `name` and nothing else about the environment. `RegisterRequestSchema`'s required `name` describes the door correctly — the card's neighbouring-line control (`image` on the next line carries `.optional()` and `name` does not) reads as deliberate because it is. `os register` failed on exactly the answer its own prompt invited, on the first door of the first-use experience.

## What changed, all in `packages/cli/src/commands/register.ts`

The command disagreed with the route in four places; all four now agree.

| | before | after |
|:--|:--|:--|
| prompt | `Name (optional): ` — a false promise | `Name: ` |
| guard set | `email`, `password` — no `name` | `name` guarded beside them |
| payload type | a local twin, `name?: string` | the declared `RegisterRequest` |
| call site | `client.auth.register(payload as any)` | no cast |

The cast is the card's real subject and comes out under either branch. With it gone the next divergence between this command and the declared request type is a compile error instead of a `400` a user meets on their first command.

## The predicted compiler answer, verified — and it differs in wording

Dropping the cast on the **unmodified** command (mutation proven on disk, restored byte-identical to `HEAD` afterwards) yields exactly one error:

```
src/commands/register.ts(128,51): error TS2345: Argument of type
  '{ email: string; password: string; name?: string | undefined; }' is not assignable to parameter of type
  '{ email: string; password: string; name: string; image?: string | undefined; }'.
```

Same code, same call site, same declaration as the card predicted. The sub-message differs: the card quoted the *"Property 'name' is missing"* form, which is what a bare object literal produces — the form PR #16926 fixed in `packages/client/README.md`. Here the payload is a named variable annotated `name?: string`, so tsc reports the assignability failure on the optional member instead. The declaration has not moved; the two carriers just differ in shape.

⭐ And **exactly one** error, not two. The #5543 precedent the card cites (a cast also hiding genuinely misspelled keys) did not repeat here — nothing else was under the cast.

## Tests

`packages/cli/test/register-requires-name.test.ts` (unit tier — no spawn, no kernel), four cases, pinning both halves:

- **refusal** — an empty answer is refused by the CLI itself and `fetch` is **never called**. The "route was never called" half is what distinguishes the fix from the defect: the pre-fix command also failed, one HTTP round trip later.
- **prompt** — the question asked is `Name: ` and no prompt matches `/optional/i`.
- **preservation** — with a name supplied the wire body is exactly `{ email, password, name }` to `POST .../api/v1/auth/sign-up/email`. This is what stops the refusal being "fixed" by sending an empty string, which the route's `z.string()` accepts and which would create an account with a blank display name.
- **flag path** — `--name` is taken without prompting.

**Reverse verification** (fix committed first; pre-fix source restored tree-only from the base commit, proven on disk, then restored byte-identical to `HEAD`):

```
Tests  2 failed | 2 passed (4)
  FAIL  refuses an empty name WITHOUT calling the route
        AssertionError: expected undefined to be defined
  FAIL  no longer advertises the field as optional
        AssertionError: expected [ 'Name (optional): ' ] to include 'Name: '
```

The two defect pins go red. The two preservation pins stay green on both sides **by construction** — the pre-fix command also sent all three members once a name was supplied — and that is what they are for; they are not evidence about the defect and are not claimed as such.

## Verification

| what | result |
|:--|:--|
| `dispatch-gates --commands` (derived from the real change set, `--repo` asserted) | 62 families, **62 run, 62 exit 0**; reconciled with `--ran` carrying exit codes: 62 accounted, 0 NOT-MEASURED, 0 UNRUN |
| `pnpm check:type-check-debt` | first run **exit 3 = PREREQUISITE NOT MET** (tsc OOM under `--max-old-space-size=4096`; not a pass and not a finding). Re-run at the CI-shaped ceiling the script pins, `--max-old-space-size=6144`: **exit 0** |
| the 5 artifact-roster families whose roster sits under a path of mine, plus `check:cli-examples-parity` | all exit 0 |
| `pnpm --filter '@objectstack/cli^...' build` | exit 0 |
| `pnpm --filter @objectstack/cli typecheck` | exit 0 (source layer and `check:test-typecheck`) |
| `packages/cli` unit tier | **193 files / 2671 tests passed**; the integration tier is declared to CI — the diff touches no integration-layer file, no spawn entry point and no driver/kernel boot path |
| `pnpm lint` (whole repo, `eslint . --no-inline-config`) | exit 0 over **6558 files**, 0 errors, 0 warnings — the full scan, not a narrowed one; both changed files are in the linted set |

## Acceptance notes

- **The measurement's own container side effect.** A successful `os register` writes `~/.objectstack/credentials.json`. Leg 2 therefore overwrote whatever that shared-container file held. Ephemeral dev state, but worth knowing before anyone drives this command as a measurement again.
- **`response as any` on the two lines below the call site stays.** `(response as any).token` / `.user` read the raw wire keys beside the normalized `data.*` envelope, and `@objectstack/client`'s `register` deliberately serves both — its TSDoc says the raw keys "are kept alongside for callers written against the wire". That is a declared compatibility read on the **response** seam, not the request-side mismatch this card is about, so it is out of scope here. *noted, not filed* — it is neither a reproducible defect nor a contract violation, and the successor is whoever next works the `SessionResponse` envelope on the client seam; naming no one, there is no queued PR it belongs to today.
- **Nothing else in the tree carried the false promise.** `Name (optional)` had exactly one occurrence repo-wide, and the two docs pages that show `os register` (`content/docs/permissions/authentication.mdx`, `content/docs/deployment/cli.mdx`) never called the field optional — so no docs change rides along.
- **Coordinates re-derived by symbol.** Every line number the card and the dispatch quote still held at the base commit `ba9f0299`: `register.ts` `:115` / `:122-123` / `:126` / `:128`, `auth.zod.ts` `:93-98`, and the instrument control (9 `export const` in `auth.zod.ts`). None had moved.
- **`packages/spec` was not edited.** The measurement landed on the CLI half, so the declaration half never came up; the `packages/spec` half of the card has nothing left in it.

Clause-②: no — re-declared from the delivered diff. Nothing published is narrowed and nothing is widened: no export, type or schema changes, no published request member becomes optional. `@objectstack/cli`'s behaviour changes only in that an input the route already refused is now refused locally with a clear message; no input that previously worked stops working.

A `patch` changeset ships with it (`@objectstack/cli` publishes `dist`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01DapQyvYrFb1MxSYe7BL2nt)_