### PR TITLE
docs(spec): `ComponentPropsMap['object-grid'].exportOptions` names all five members the renderer reads

### DIFF
--- a/.changeset/17166-object-grid-export-options-describe-members.md
+++ b/.changeset/17166-object-grid-export-options-describe-members.md
@@ -1,0 +1,52 @@
+---
+'@objectstack/spec': patch
+---
+
+`ComponentPropsMap['object-grid'].exportOptions` names all five members the renderer reads, not two
+
+The entry is `z.unknown()`, so nothing about this key is parsed, refused or
+stripped: a member that does not exist draws no error and has no effect, and a
+member that does exist cannot be discovered from the schema. That makes the
+`.describe()` string the entire account of the key's shape rather than a summary
+of an enforced one — and it projects straight into
+`content/docs/references/ui/component.mdx`, which is what an author (or a
+generating model, ADR-0033) reads.
+
+It named two members, `formats` and `streaming`. The only renderer reads five.
+
+Measured at the `.objectui-sha` pin `53ded82bf7a494f54e344e19099dbf00854b8694`
+— objectui `packages/plugin-grid/src/ObjectGrid.tsx`, through the
+`schema.exportOptions` expression and the `exportConfig` local bound to it, with
+objectui's own scanner (`ObjectGrid.exportOptionsKeys.test.ts`, whose
+comment/string stripping is what stops a prose mention of a key being counted as
+a read): `formats` 2 read sites, `streaming` 2, `maxRecords` 1,
+`includeHeaders` 1, `fileNamePrefix` 1, and an absent-name control
+(`zzzNotAMember`) 0 on the same instrument — which is what makes those five
+counts readings rather than a matcher that matches anything. The same instrument
+answers the same five, with the same per-member counts, at objectui
+`3fbdd4a2dae1`, so the set is not an artefact of the pin's age.
+
+The three missing members are `maxRecords`, `includeHeaders` and
+`fileNamePrefix`. An author reading the old string learned that
+`exportOptions` takes `{ formats, streaming }` and had no way to reach the other
+three short of reading the renderer's source — the shape objectstack#8010
+closed for this same key one layer out, when `streaming` was read for releases
+while no schema declared it.
+
+⛔ The key is unchanged: it stays `z.unknown()` and no accept set moves in either
+direction. Giving `exportOptions` a real shape is a separate and much larger
+change with its own review requirements; this is the docs half only.
+
+The new list is not restated in prose that can drift on its own. A pin holds the
+describe string's member enumeration equal to the members
+`ListViewExportOptionsSchema` declares — the spec's own five-key declaration of
+this same authoring block, reached through `ListViewSchema.exportOptions`'s
+object branch and itself derived from that same read set. Both spellings reach
+one renderer, so narrowing or widening the declared block now reds the
+`z.unknown()` prose instead of leaving it quietly behind: the declared side has
+parse failures to catch drift, this side had nothing. The pin also records that
+the key is unvalidated today, so the day it grows an accept set is a deliberate
+decision rather than a silent one.
+
+`content/docs/references/ui/component.mdx` is regenerated from the string
+(`gen:schema` then `gen:docs`) and carries the same one-line change.

--- a/content/docs/references/ui/component.mdx
+++ b/content/docs/references/ui/component.mdx
@@ -428,7 +428,7 @@ Sort field and direction pair
 | **reorderableColumns** | `boolean` | optional | Allow column drag-reorder |
 | **frozenColumns** | `number` | optional | How many leading columns stay frozen (default 1) |
 | **showColumnTypeIcons** | `boolean` | optional | Show field-type icons in column headers |
-| **exportOptions** | `any` | optional | Export config (`{ formats, streaming }`) |
+| **exportOptions** | `any` | optional | Export config (`{ formats, maxRecords, includeHeaders, fileNamePrefix, streaming }`). Unvalidated here (`z.unknown()`), so this list is the whole account of the shape; `ListViewSchema.exportOptions` declares the same five members with their per-member contract |
 | **operations** | `any` | optional | Operation toggles (`{ export: false, … }`) |
 | **data** | `{ provider: 'object'; object: string } \| { provider: 'api'; read?: object; write?: object } \| { provider: 'value'; items: any[] } \| { provider: 'schema'; schemaId: string; schema?: Record<string, any> }` | optional | Data source binding (ViewDataSchema — discriminated on `provider`: object \| api \| value \| schema). Static inline rows live at `{ provider: 'value', items: [...] }`; the bare-array shortcut is refused — see migration `object-grid-data-view-data-converged` |
 | **staticData** | `any[]` | optional | Deprecated bare-array static-rows shortcut the renderer still reads. Prefer `data: { provider: 'value', items: [...] }` |

--- a/packages/spec/src/ui/component-object-grid-export-options-members.pin.test.ts
+++ b/packages/spec/src/ui/component-object-grid-export-options-members.pin.test.ts
@@ -1,0 +1,127 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * [#17166] `ComponentPropsMap['object-grid'].exportOptions`'s `.describe()` must
+ * name every member the renderer reads — because here the prose IS the shape.
+ *
+ * ## Why this key is different from its neighbours
+ *
+ * The entry is `z.unknown()`. Nothing is parsed, nothing is refused, nothing is
+ * stripped: an author who writes a member that does not exist gets no error and
+ * no effect, and an author who omits one that does exist has no way to discover
+ * it. So the `.describe()` string is not a SUMMARY of an enforced shape — it is
+ * the entire account of the shape that exists at this position, and it projects
+ * straight into `content/docs/references/ui/component.mdx`, which is what an
+ * author (or a generating model, ADR-0033) reads.
+ *
+ * Until #17166 that string named two members, `formats` and `streaming`, of the
+ * five the only renderer reads.
+ *
+ * ## What was measured, and on which tree
+ *
+ * Measured at the `.objectui-sha` pin `53ded82bf7a494f54e344e19099dbf00854b8694`
+ * — objectui `packages/plugin-grid/src/ObjectGrid.tsx`, through the
+ * `schema.exportOptions` expression and the `exportConfig` local bound to it,
+ * with objectui's own scanner (`ObjectGrid.exportOptionsKeys.test.ts`, whose
+ * comment/string stripping is what keeps a prose mention of a key from being
+ * counted as a read):
+ *
+ *   formats 2 · streaming 2 · maxRecords 1 · includeHeaders 1 · fileNamePrefix 1
+ *
+ * and an absent-name control (`zzzNotAMember`) reading 0 on the same instrument,
+ * which is what makes those five counts readings rather than a matcher that
+ * matches anything. ⚠️ Those counts are a dated observation and belong to that
+ * tree; this pin does NOT re-derive them, and ⛔ must not be read as asserting
+ * them today.
+ *
+ * ## Why the list is DERIVED here and not restated
+ *
+ * A restated list is a third copy of the contract, and the copy is what drifts —
+ * which is the whole defect this file closes. So the expected member list is
+ * read from `ListViewSchema.exportOptions`'s object branch
+ * (`ListViewExportOptionsSchema`), the spec's OWN five-key declaration of this
+ * same authoring block, itself derived from that same read set at #8010. Both
+ * spellings — the page-component `object-grid` props and the list view's
+ * `exportOptions` — reach one renderer, so the two surfaces describe one block.
+ *
+ * ⇒ Narrowing or widening the declared block reds this pin instead of leaving
+ * the `z.unknown()` prose quietly behind, which is the direction of rot that has
+ * no other guard: the declared side has parse failures, this side has nothing.
+ *
+ * ⛔ This pin does NOT ask the key to stop being `z.unknown()`. Giving it a real
+ * shape is an accept-set change with its own review requirements; the last test
+ * below records that it is unvalidated TODAY, so that change reds here and is
+ * made deliberately rather than by accident.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { ComponentPropsMap } from './component.zod';
+import { ListViewSchema } from './view.zod';
+
+/**
+ * The member names enumerated inside the first `({ … })` group of a describe
+ * string, e.g. `Export config ({ formats, streaming })` -> `['formats', 'streaming']`.
+ *
+ * Deliberately anchored to the parenthesised group rather than "any identifier
+ * in the sentence": the prose around it names `z.unknown()` and
+ * `ListViewSchema.exportOptions`, and a scan that read those as members would
+ * pass for the wrong reason. The self-test below is what proves the anchor
+ * discriminates instead of matching anything.
+ */
+function describedMembers(description: string): string[] {
+  const group = /\(\{([^}]*)\}\)/.exec(description);
+  if (!group) return [];
+  return group[1]!.split(',').map((k) => k.trim()).filter(Boolean);
+}
+
+/** The spec's own declaration of this block: the object branch of the list view's union. */
+function declaredMembers(): string[] {
+  const optional = (ListViewSchema as unknown as { shape: Record<string, unknown> })
+    .shape.exportOptions as { unwrap(): { options: Array<{ shape?: Record<string, unknown> }> } };
+  const branches = optional.unwrap().options;
+  const objectBranch = branches.find((b) => b.shape !== undefined);
+  return objectBranch === undefined ? [] : Object.keys(objectBranch.shape!);
+}
+
+const gridProps = ComponentPropsMap['object-grid'] as unknown as {
+  shape: Record<string, { description?: string }>;
+  safeParse(v: unknown): { success: boolean };
+};
+const description = gridProps.shape.exportOptions?.description ?? '';
+
+describe('object-grid `exportOptions` — the describe names every declared member (#17166)', () => {
+  it('the parser discriminates: it reads a member group and does not invent one', () => {
+    // Lit control — a planted group is read back exactly.
+    expect(describedMembers('Export config ({ alpha, beta })')).toEqual(['alpha', 'beta']);
+    // Dark control — a sentence with no member group yields nothing, so a
+    // green equality below can never come from a matcher that matches anything.
+    expect(describedMembers('Export config, unvalidated.')).toEqual([]);
+    // And a name absent from the group is not produced by prose that mentions it.
+    expect(describedMembers('Export config ({ alpha }) — zzzNotAMember is not a member'))
+      .toEqual(['alpha']);
+  });
+
+  it('scans something: both sides are non-empty and the authority is the five-key block', () => {
+    // Non-vacuity floor. The assertion below is an equality, and an equality
+    // between two empty lists passes for the worst possible reason.
+    expect(description).not.toBe('');
+    expect(describedMembers(description).length).toBeGreaterThanOrEqual(5);
+    expect(declaredMembers().length).toBeGreaterThanOrEqual(5);
+    expect(declaredMembers()).toContain('formats');
+  });
+
+  it('names exactly the members `ListViewExportOptionsSchema` declares', () => {
+    // Named rather than counted: a failure must say WHICH member the prose is
+    // short of, because the fix is to name it — the reader gets nothing else.
+    expect([...describedMembers(description)].sort()).toEqual([...declaredMembers()].sort());
+  });
+
+  it('is still unvalidated, which is why the prose carries the whole account', () => {
+    // The premise of this file, asserted rather than assumed: an undeclared
+    // member is neither refused nor honoured here. If this ever goes red the
+    // key grew an accept set and the describe's "Unvalidated here" sentence —
+    // and this pin's reason to exist — need re-deciding, deliberately.
+    expect(gridProps.safeParse({ exportOptions: { zzzNotAMember: 1 } }).success).toBe(true);
+    expect(description).toContain('Unvalidated here');
+  });
+});

--- a/packages/spec/src/ui/component.zod.ts
+++ b/packages/spec/src/ui/component.zod.ts
@@ -2580,7 +2580,8 @@ export const ObjectGridPropsSchema = lazySchema(() => strictObject({
   reorderableColumns: z.boolean().optional().describe('Allow column drag-reorder'),
   frozenColumns: z.number().optional().describe('How many leading columns stay frozen (default 1)'),
   showColumnTypeIcons: z.boolean().optional().describe('Show field-type icons in column headers'),
-  exportOptions: z.unknown().optional().describe('Export config ({ formats, streaming })'),
+  exportOptions: z.unknown().optional()
+    .describe('Export config ({ formats, maxRecords, includeHeaders, fileNamePrefix, streaming }). Unvalidated here (`z.unknown()`), so this list is the whole account of the shape; `ListViewSchema.exportOptions` declares the same five members with their per-member contract'),
   operations: z.unknown().optional().describe('Operation toggles ({ export: false, … })'),
   /**
    * Data source binding — `ViewDataSchema`, the #5090-pinned authority the


### PR DESCRIPTION
Fixes #17166

Clause-②: no — the key stays `z.unknown()`. Nothing about it is parsed, refused or stripped before this change or after it, so naming three more members in the prose moves no accept set in either direction. The measurement below is what the reading rests on, not the claim comment's expectation.

Authored by the `domain:spec` execution seat in session `session_01MkQhmuuJAVDjmeWNixwDDH`, from the claim on issue 17166.

## What was wrong

`ComponentPropsMap['object-grid'].exportOptions` is `z.unknown()`. An author who writes a member that does not exist gets no error and no effect; an author who omits one that does exist has no way to discover it from the schema. So the `.describe()` string is not a summary of an enforced shape — it is the **entire** account of the key's shape, and it projects into `content/docs/references/ui/component.mdx`, which is what an author (or a generating model, ADR-0033) reads.

It named two members. The only renderer reads five.

## The measurement — re-derived, not inherited

The card's five counts were taken on objectui `origin/main` on 2026-09-09. They were re-derived here against the commit **this repo actually pins**, `.objectui-sha` = `53ded82bf7a494f54e344e19099dbf00854b8694`, using objectui's own scanner from `packages/plugin-grid/src/__tests__/ObjectGrid.exportOptionsKeys.test.ts` at that same commit — its comment/string stripping is load-bearing, because `ObjectGrid.tsx` mentions `exportOptions.fileNamePrefix` in a comment two lines above the real read, and a naive grep counts that line.

Alias binding found by the scanner: `exportConfig` (from `const exportConfig = schema.exportOptions;`).

| member | read sites at the pin | what each match was |
|---|---|---|
| `formats` | 2 | `schema.exportOptions?.formats` ×2 |
| `streaming` | 2 | `schema.exportOptions?.streaming`, `exportConfig?.streaming` |
| `maxRecords` | 1 | `exportConfig?.maxRecords` |
| `includeHeaders` | 1 | `exportConfig?.includeHeaders` |
| `fileNamePrefix` | 1 | `exportConfig?.fileNamePrefix` |
| **control** `zzzNotAMember` | **0** | nothing — the dark control that makes the five counts readings |

The scanner's own key set at the pin is exactly those five, and `ListViewExportOptions` in objectui `packages/types/src/objectql.ts` declares exactly those five at the pin as well. Re-running the same instrument at objectui `3fbdd4a2dae1` (505+ commits later) gives the same five members with the same per-member counts, so the set is not an artefact of the pin's age.

⇒ The card's premise holds, and the three members with no authoring surface are `maxRecords`, `includeHeaders` and `fileNamePrefix`.

**objectui#8842** was checked, as the claim asked: it merged 2026-09-09T14:46Z, and the pin this repo builds against is **behind** that merge commit — so at the pin objectui's own registration prose is still the four-member string without `streaming`. Its direction is the opposite of this one's and neither list is a subset of the other, so nothing here was copied from it.

## What changed

The describe string names all five members, states that the key is unvalidated, and points at the sibling declaration that carries the per-member contract. `content/docs/references/ui/component.mdx` is the regenerated projection of that string — a forced path, run as `gen:schema` then `gen:docs`, in that order.

⛔ Out of scope and untouched: giving `exportOptions` a real shape. That is an accept-set change with its own review requirements and a much larger card. No migration entry is needed or added.

## The pin, and why the list is derived

`packages/spec/src/ui/component-object-grid-export-options-members.pin.test.ts` holds the describe string's member enumeration equal to the members `ListViewExportOptionsSchema` declares — reached through `ListViewSchema.exportOptions`'s object branch, the spec's own five-key declaration of this same authoring block, itself derived from that same read set. A restated list would be a third copy of the contract, and the copy is what drifts; that is the defect being closed here, so it is not reproduced inside the guard. Narrowing or widening the declared block now reds the `z.unknown()` prose instead of leaving it quietly behind — the declared side has parse failures to catch drift, this side had nothing.

It also carries a non-vacuity floor (both sides non-empty, the authority branch found and containing `formats`), a lit/dark control on its own member parser, and a record that the key is unvalidated **today**, so the day it grows an accept set is a deliberate decision rather than a silent one.

## Ablation — the pin can fail, proved on this tree

Reverted the describe string to the two-member form on top of the implementation commit, proved the mutation reached disk (anchor grep 1→0 for the new form, 0→1 for the old; `git hash-object` moved from `f5e6bf1d720f` to `2c841d72f456`), ran the pin:

```
MUTATED_RUN_EXIT=1
  x scans something: both sides are non-empty and the authority is the five-key block
  x names exactly the members `ListViewExportOptionsSchema` declares
AssertionError: expected 2 to be greater than or equal to 5
AssertionError: expected [ 'formats', 'streaming' ] to deeply equal [ 'fileNamePrefix', 'formats', ...(3) ]
Test Files  1 failed (1) · Tests  2 failed | 2 passed (4)
```

Restored with `git checkout HEAD -- PATH` (naming HEAD explicitly, never a bare `--`); the blob hash returned to `f5e6bf1d720f`, `git diff HEAD` came back empty, and the pin re-ran green (4 passed). Direction observed: **turned red**, as predicted. No test file is left behind by the ablation.

## Verification

Under `scripts/pm/os-verify-lock.sh`, verdicts read from the gate's own printed line and exit codes captured before any pipe:

- `pnpm --filter @objectstack/spec test` — VERDICT command-exit 0 · 469 files passed / 1 skipped, 13226 tests passed
- `pnpm --filter @objectstack/spec typecheck` — VERDICT command-exit 0 (`tsc --noEmit`, `check:scripts-typecheck`, `check:test-typecheck`; the new pin file is in the `tsconfig.test.json` program — `--listFiles` matches it once, a planted absent name matches zero)
- `pnpm --filter @objectstack/spec build` — VERDICT command-exit 0 (owed because `check:api-surface` and `check:generated` read `dist`)

Gate families derived with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` from the real change set: **106 commands, all 106 run**. 99 exit 0. Zero red findings. The remaining 7 never reached a verdict on this diff and are recorded as NOT MEASURED, separately from red:

| command | exit | why nothing was measured |
|---|---|---|
| `pnpm --filter @objectstack/spec run check:skill-examples` | 1 | `packages/client-react/dist` holds no `.d.ts` — the consumer package is unbuilt |
| `pnpm check:docs-transcript-drift` | 3 | `packages/lint/dist/index.js` absent |
| `pnpm --filter @objectstack/lint run check:doc-formula-expressions` | 3 | `@objectstack/formula` and `@objectstack/lint` unbuilt |
| `pnpm --filter @objectstack/lint run check:doc-security-posture` | 3 | `@objectstack/lint` unbuilt |
| `pnpm check:dual-build-cjs-loads` | 3 | reads built output; some package has no `dist/` |
| `pnpm check:lean-entry-closure` | 3 | loads built entry points; a target is absent |
| `pnpm check:type-check-debt` | 3 | its own declared prerequisite is unmet |

Every one of those is a missing **build** of a package this diff does not touch, and each says so in its own words ("This is NOT a pass and NOT a finding: nothing was measured"). CI builds them, so CI measures them. `exit 3` is that refusal's code and is read here as neither green nor red.

`pnpm --filter @objectstack/spec run check:react-declaration-parity` invoked bare also refuses (exit 1, "MANIFEST is not set … This gate did NOT run"), but it **can** run locally and does: `MANIFEST="$PWD/sdui.manifest.json" pnpm --filter @objectstack/spec check:react-declaration-parity --baseline react-declaration-parity.baseline.json --strict` exits **0** — no new declaration divergence vs the accepted baseline. That is a reading, so it is counted among the 99 rather than above.

Two spec gates were red until their prerequisite was met, recorded so the sequence is legible: `check:docs` refused a `json-schema` tree older than `src` (the ablation moved the source mtime) and passes after re-running `gen:schema`; `check:generated` reported `api-surface/` stale before the package was built and reports all 15 artifacts up to date after.

`gen:authorable-surface-base` was not run and `authorable-surface.base.json` is not in this diff; `check:authorable-surface` is green.

## Not fixed here, deliberately

`element:record_picker`'s `filter` docblock, two lines from this edit, still says the four `object-*` blocks declare `filter` as `z.unknown()`. That claim was falsified by a different card and belongs to a different key and a different carrier — it is named here only so the next reader of this block knows it was seen and left alone, and none of its framing is reused in the prose this PR writes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MkQhmuuJAVDjmeWNixwDDH)_