### PR TITLE
docs(spec): stop documenting `options.stageOrder` for a chart type that does not exist

### DIFF
--- a/.changeset/dashboard-stageorder-doc-names-only-funnel.md
+++ b/.changeset/dashboard-stageorder-doc-names-only-funnel.md
@@ -1,0 +1,14 @@
+---
+"@objectstack/spec": patch
+---
+
+docs(spec): `options.stageOrder` no longer documents a chart type that cannot be built, and says plainly that only `funnel` reads it (#17344)
+
+`DashboardWidgetOptionsSchema.stageOrder` is an ungated member of the open widget `options` bag, so its one sentence of prose is the whole author-time surface: nothing warns, nothing refuses, and a widget carrying the key renders with the authored order simply absent. That sentence said *"Explicit category order for ordered-sequence charts — `funnel` / `pyramid` stages above all"*, and it was wrong twice over.
+
+- **`pyramid` is not a widget type.** It was removed from `ChartTypeSchema` as a variant that only ever rendered as `funnel`, and `chart.test.ts` pins that refusal alongside its fallback-only siblings — so the headline example in the option's own documentation could not be authored at all.
+- **The plural framing promised more than the renderer delivers.** "ordered-sequence charts" and "stages above all" read as a statement about ordered marks generally. It is not one: `funnel` is the only type whose branch consults the forwarded order, measured against this repo's pinned objectui renderer.
+
+The corrected JSDoc and `.describe()` name `funnel` only, state outright that no other widget type reads the key, and send the other types to `sortBy` / `sortOrder`, which lower into the dataset query itself. The generated reference page (`content/docs/references/ui/dashboard.mdx`) is regenerated from the new `.describe()`.
+
+No schema shape changes: `stageOrder` still parses exactly as before, on every widget type. Whether the key should be *gated* to the type that honours it is ADR-0049 enforce-or-remove on an accepted key — a published-surface narrowing, and deliberately not this change; it stays open on #17344 together with the locale-dependent order/colour drop, which lives in the objectui renderer rather than here.

--- a/content/docs/references/ui/dashboard.mdx
+++ b/content/docs/references/ui/dashboard.mdx
@@ -246,7 +246,7 @@ Dashboard header action
 | **sortBy** | `string` | optional | Dimension/measure name to order by |
 | **sortOrder** | `Enum<'asc' \| 'desc'>` | optional | Sort direction for sortBy |
 | **limit** | `integer` | optional | Max rows (applied after ordering) |
-| **stageOrder** | `(string \| number \| boolean)[]` | optional | Explicit category order for funnel/pyramid stages (stored values) |
+| **stageOrder** | `(string \| number \| boolean)[]` | optional | Explicit stage order for a funnel widget, as the dimension's stored values. `funnel` is the only widget type that reads it: on any other type the key parses and is never consulted, so order those with sortBy/sortOrder instead. There is no `pyramid` widget type — write `funnel`. |
 
 
 ---
@@ -263,7 +263,7 @@ Widget configuration — declared query keys + open renderer extras
 | **sortBy** | `string` | optional | Dimension/measure name to order by |
 | **sortOrder** | `Enum<'asc' \| 'desc'>` | optional | Sort direction for sortBy |
 | **limit** | `integer` | optional | Max rows (applied after ordering) |
-| **stageOrder** | `(string \| number \| boolean)[]` | optional | Explicit category order for funnel/pyramid stages (stored values) |
+| **stageOrder** | `(string \| number \| boolean)[]` | optional | Explicit stage order for a funnel widget, as the dimension's stored values. `funnel` is the only widget type that reads it: on any other type the key parses and is never consulted, so order those with sortBy/sortOrder instead. There is no `pyramid` widget type — write `funnel`. |
 
 
 ---

--- a/packages/spec/src/ui/dashboard.test.ts
+++ b/packages/spec/src/ui/dashboard.test.ts
@@ -14,7 +14,9 @@ import {
   GlobalFilterOptionsFromSchema,
   DATE_RANGE_PRESETS,
   DATE_RANGE_DEFAULT_RANGES,
+  DashboardWidgetOptionsSchema,
 } from './dashboard.zod';
+import { ChartTypeSchema } from './chart.zod';
 import { dashboardForm } from './dashboard.form';
 
 /**
@@ -794,5 +796,83 @@ describe('#16458 — DashboardHeaderAction fields carry an item-level `title`', 
     const parsed = DashboardSchema.parse({ name: 'dash_x', label: 'D', widgets: [] });
     expect(parsed.columns).toBeUndefined();
     expect('columns' in parsed).toBe(false);
+  });
+});
+
+
+/**
+ * `options.stageOrder` documented a chart type that cannot be built.
+ *
+ * The shipped prose is the whole surface here: `stageOrder` is an ungated
+ * member of the open `options` bag, so the one sentence an author reads before
+ * writing it is the only thing standing between them and a key that parses and
+ * does nothing. That sentence named `funnel` / `pyramid` "stages above all",
+ * and `pyramid` was removed from `ChartTypeSchema` as a variant that only ever
+ * rendered as `funnel` — so its headline example could not be authored at all,
+ * and its plural framing read as a promise about ordered marks generally.
+ *
+ * These pin the corrected prose against BOTH ways it can rot:
+ *  - the vocabulary moving under it (a `pyramid` re-admitted to the taxonomy
+ *    would make the sentence false in the other direction), and
+ *  - the sentence being trimmed back to the plural framing.
+ *
+ * The renderer half is deliberately NOT pinned here: which chart types consult
+ * the forwarded order is objectui's fact, measured against this repo's
+ * `.objectui-sha` pin and reported on the issue, not something `packages/spec`
+ * can assert.
+ */
+describe('DashboardWidgetOptions.stageOrder — the shipped doc string', () => {
+  const description = () => {
+    const d = (DashboardWidgetOptionsSchema as unknown as {
+      shape: { stageOrder: { description?: string } };
+    }).shape.stageOrder.description;
+    expect(typeof d).toBe('string');
+    return d as string;
+  };
+
+  it('names `funnel` and never `pyramid`', () => {
+    const d = description();
+    expect(d).toMatch(/funnel/);
+    expect(d).not.toMatch(/pyramid.*(is|are) (a|the) (chart|widget) type/i);
+    // The word may only appear as the correction that it does NOT exist.
+    expect(d).toMatch(/no `?pyramid`? widget type/i);
+  });
+
+  it('states plainly that no other widget type reads the key', () => {
+    const d = description();
+    expect(d).toMatch(/only widget type that reads it/);
+    // and points the other types at the keys that DO order them
+    expect(d).toMatch(/sortBy/);
+    expect(d).toMatch(/sortOrder/);
+  });
+
+  it('CONTROL — the taxonomy behind that prose: `funnel` parses, `pyramid` does not', () => {
+    expect(ChartTypeSchema.safeParse('funnel').success).toBe(true);
+    expect(ChartTypeSchema.safeParse('pyramid').success).toBe(false);
+    // dark control: a type that never existed refuses the same way, so the
+    // `pyramid` refusal above is not an artifact of how the probe is written
+    expect(ChartTypeSchema.safeParse('ziggurat').success).toBe(false);
+  });
+
+  it('CONTROL — a `funnel` widget carrying `stageOrder` still parses unchanged', () => {
+    const w = DashboardWidgetSchema.parse({
+      id: 'stage_funnel', type: 'funnel', dataset: 'contracts',
+      dimensions: ['status'], values: ['count'],
+      layout: { x: 0, y: 0, w: 6, h: 4 },
+      options: { stageOrder: ['draft', 'submitted', 'approved'] },
+    });
+    expect(w.options?.stageOrder).toEqual(['draft', 'submitted', 'approved']);
+  });
+
+  it('CONTROL — the key is still UNGATED: a non-funnel widget carrying it parses too', () => {
+    // This is finding 1 of the card, recorded as a fact rather than fixed:
+    // gating the key is a published-surface narrowing and is not this PR.
+    const w = DashboardWidgetSchema.parse({
+      id: 'stage_bars', type: 'horizontal-bar', dataset: 'contracts',
+      dimensions: ['status'], values: ['count'],
+      layout: { x: 0, y: 0, w: 6, h: 4 },
+      options: { stageOrder: ['draft', 'submitted', 'approved'] },
+    });
+    expect(w.options?.stageOrder).toEqual(['draft', 'submitted', 'approved']);
   });
 });

--- a/packages/spec/src/ui/dashboard.zod.ts
+++ b/packages/spec/src/ui/dashboard.zod.ts
@@ -255,15 +255,32 @@ export const DashboardWidgetOptionsSchema = lazySchema(() => z.object({
   limit: z.number().int().positive().optional().describe('Max rows (applied after ordering)'),
 
   /**
-   * Explicit category order for ordered-sequence charts — `funnel` / `pyramid`
-   * stages above all. Values are the dimension's STORED values (e.g.
-   * `['qualification', 'needs_analysis', 'proposal', 'negotiation']`), not
-   * display labels. Omit to let the renderer fall back to the dimension
-   * field's own picklist option order, which is the pipeline order an author
-   * already declared on the object.
+   * Explicit stage order for a `funnel` widget. Values are the dimension's
+   * STORED values (e.g. `['qualification', 'needs_analysis', 'proposal',
+   * 'negotiation']`), not display labels. Omit to let the renderer fall back
+   * to the dimension field's own picklist option order, which is the pipeline
+   * order an author already declared on the object.
+   *
+   * `funnel` is the ONLY widget `type` that reads this key. On every other
+   * type — `bar` / `horizontal-bar` / `column`, `line`, `area`, `pie`,
+   * `donut`, `treemap`, `sankey`, `radar`, `scatter`, `combo`, the tabular and
+   * single-value families — the key parses, is forwarded to the renderer, and
+   * no branch consults it: the rendered order stays whatever the analytics
+   * query returned. Order those with `sortBy` / `sortOrder`, which lower into
+   * the dataset query itself.
+   *
+   * There is no `pyramid` widget type. It was removed from `ChartTypeSchema`
+   * as a variant that only ever rendered as `funnel` (see the taxonomy NOTE at
+   * the foot of `chart.zod.ts`; `chart.test.ts` pins the refusal alongside its
+   * fallback-only siblings). Write `type: 'funnel'`.
    */
   stageOrder: z.array(z.union([z.string(), z.number(), z.boolean()])).optional()
-    .describe('Explicit category order for funnel/pyramid stages (stored values)'),
+    .describe(
+      'Explicit stage order for a funnel widget, as the dimension\'s stored values. '
+      + '`funnel` is the only widget type that reads it: on any other type the key '
+      + 'parses and is never consulted, so order those with sortBy/sortOrder instead. '
+      + 'There is no `pyramid` widget type — write `funnel`.',
+    ),
 }).passthrough().describe('Widget configuration — declared query keys + open renderer extras'));
 
 // ── `compareTo` convergence prescriptions (#5011) ────────────────────────────


### PR DESCRIPTION
Part of #17344

Clause-②: no — nothing here narrows an accept set. `stageOrder` parses exactly as it did before, on every widget type; the diff is prose (JSDoc + `.describe()`), the reference page that projects from it, four pins, and a changeset.

This is the `packages/spec` slice of a three-finding card. All three are named below, and the PR lands only the one that lives in this repo. **The card stays open.**

## The three findings, and where each one is

**Finding 2 — the doc string names a chart type that cannot be built. FIXED HERE.**

`DashboardWidgetOptionsSchema.stageOrder` said *"Explicit category order for ordered-sequence charts — `funnel` / `pyramid` stages above all"*. Re-measured on this tree (the reporter measured published 17.4.0 tarballs), against the built `@objectstack/spec`, with lit and dark controls:

```
ACCEPT  "funnel"        LIT   — a chart type that IS in the enum
ACCEPT  "bar"           LIT   — second lit control
REFUSE  "pyramid"       CLAIM — the type the doc string named
REFUSE  "ziggurat"      DARK  — fabricated, never existed
REFUSE  "bi-polar-bar"  DARK  — sibling variant removed in the same batch as pyramid
```

The claim reproduces, and the current tree says more than the tarball did about *why*: `pyramid` was deliberately removed as a variant that only ever rendered as `funnel` — the taxonomy NOTE at the foot of `packages/spec/src/ui/chart.zod.ts`, pinned by `chart.test.ts`'s `fallbackOnly` list. So the corrected prose can cite something a reader can act on instead of an issue id.

Both halves of the correction that the card asks for are in the new text: it names `funnel` only, **and** it says outright that no other widget type reads the key, sending the rest to `sortBy` / `sortOrder`. The plural framing was load-bearing, not cosmetic — *"ordered-sequence charts"*, *"stages above all"* is exactly what makes an author conclude the key applies to ordered marks generally, which is finding 1.

**Finding 1 — which chart types honour it. MEASURED, NOT FIXED.**

Re-derived against this repo's `.objectui-sha` pin (`53ded82bf7a494f54e344e19099dbf00854b8694`), not the published bundle. The renderer is reachable at that pin, so this is measured, not inherited:

- `@object-ui/core`'s `buildCategoryRank` is the function that turns the forwarded order into a rank map. In `packages/plugin-charts/src/AdvancedChartImpl.tsx` it is imported once (line 52) and called **once** (line 1514).
- Line 1514 sits inside `if (chartType === 'funnel')` (line 1473). Every sibling branch in that file — `pie`/`donut` (1400), `treemap` (1555), `sankey` (1590), `radar` (1719), `scatter` (1750), `combo` (1847), the cartesian fall-through that draws `bar` / `horizontal-bar` / `column` / `line` / `area` (1923+), plus the single-value and tabular families short-circuited at 1360/1376 — never reads `categoryOrder`.
- `column` is aliased to `bar` before the branch table is consulted (lines 2093 and 2175), so it is covered by the cartesian reading rather than being a separate unknown.
- On the producing side there is no gate either: `packages/plugin-dashboard/src/DatasetWidget.tsx` builds `explicitOrder` from `options.stageOrder` for **any** widget (1468–1474) and forwards it whenever non-empty (1529).

⇒ funnel-only reproduces at the pin. Recorded as a fact; the gate is **not** written here, deliberately. Gating an accepted key is ADR-0049 enforce-or-remove ⇒ a published-surface narrowing ⇒ `Clause-②: yes`, `needs:contract-review`, and an ADR-0087 disposition — which means a migration entry in `packages/spec/src/migrations/registry.ts`, a file with two other open writers right now. Two of the new pins record the ungated behaviour as it stands, so whoever does write that gate has a red test to flip rather than a silence to interpret.

**Finding 3 — the locale-dependent drop (and its category-colour sibling). ELSEWHERE, NOT THIS REPO.**

The `categoryOrder` / `categoryColors` pair is built in one `useMemo` over label-resolved dimension metadata in `@objectstack/console`'s dashboard plugin — the **objectui** renderer. `packages/console`'s `dist` here is script-generated and never hand-edited, so there is nothing in this repository to change for it. The cross-repo half is the `domain:spec` seat's; it is not attempted here and no file under `packages/console` is touched.

## What is in the diff

| file | why |
|:--|:--|
| `packages/spec/src/ui/dashboard.zod.ts` | the JSDoc and `.describe()` for `stageOrder` |
| `packages/spec/src/ui/dashboard.test.ts` | four pins on the corrected prose and the taxonomy behind it |
| `content/docs/references/ui/dashboard.mdx` | generated — a `.describe()` edit forces `gen:schema` then `gen:docs`, in that order |
| `.changeset/dashboard-stageorder-doc-names-only-funnel.md` | the published surface moves, so it carries a patch changeset |

The regenerated reference page is a forced path, declared rather than scope growth.

## The pins, and proof they can fail

Two ablation legs, each run from the committed state, each proving the mutation reached disk (a `git hash-object` comparison against the HEAD blob, plus a grep for the injected and removed anchors) before the verdict was read, and each restored with `git checkout HEAD -- FILEPATH` verified byte-exact:

| leg | mutation | result |
|:--|:--|:--|
| M1 | revert the `.describe()` to the old wording | `2 failed, 68 passed` — the `pyramid` pin **and** the funnel-only pin |
| M2 | keep the new wording, drop only *"is the only widget type that reads it"* | `1 failed, 69 passed` — only the funnel-only pin |

M2 is what makes the two assertions discriminators rather than one probe both sides pass: the `pyramid` pin stays green under it. The suite resolves `./dashboard.zod` as a relative source path inside the same package, so no `dist` participates and no rebuild step is part of either leg.

## Verification

`pnpm --filter @objectstack/spec test` — **469 files / 13229 tests passed**. `pnpm --filter @objectstack/spec typecheck` — clean (`tsc --noEmit`, `check:scripts-typecheck`, `check:test-typecheck`).

Gate families derived with `scripts/pm/dispatch-gates.mjs` from the diff itself and reconciled with `--ran`: **106 derived, 103 run green, 3 NOT MEASURED, 0 unrun**. The three are `check:dual-build-cjs-loads`, `check:lean-entry-closure` and `check:type-check-debt` — all exit **3**, each refusing its own prerequisite because it reads built output from packages far outside this diff's closure. Exit 3 is neither a pass nor a finding; CI builds those closures. `check:generated` is green after a rebuild (its first red was a stale `dist`, not drift), and `check:doc-authoring` is green — the new `.describe()` carries no bare issue id, which is the shape it refuses.

`pnpm exec eslint . --no-inline-config` was run over the **whole repository** rather than narrowed: 6559 files, 0 errors, 0 warnings, at `3d1635d7`.

## 验收备注

- Three hand-written sites still carry the same stale `pyramid` claim, outside this round's declared file face: `skills/objectstack-ui/rules/dashboards.md:345`, `content/docs/ui/dashboards.mdx:121` and `packages/sdui-parser/src/dashboard-widget-options.ts:51`. Filed as sub-issue #17471 with the measurement — deliberately untouched here, and note that the `skills/**` one sits under a published-skill line ratchet whose budget is the PM seat's to grant.
- The same stale two-type prose also lives on the objectui side of the pin, on the prop's own JSDoc in `packages/plugin-charts/src/AdvancedChartImpl.tsx` (line 235) and in `content/docs/plugins/plugin-dashboard.mdx` (line 300). That is the cross-repo half's territory, recorded here so it is not lost.
- `dispatch-gates` warns the branch is a few commits behind `origin/main` and that three files it derives from moved in that range — all three are PM board-snapshot tooling, none of them a family this diff touches.

Authored by the `domain:spec` execution seat's `os-dev` in session `https://claude.ai/code/session_01MkQhmuuJAVDjmeWNixwDDH`, which inherits the claim and the assignee on #17344 and posted no second claim.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MkQhmuuJAVDjmeWNixwDDH)_