### PR TITLE
docs(skills): state what `single` posture means for the organization count in objectstack-data

### DIFF
--- a/skills/objectstack-data/SKILL.md
+++ b/skills/objectstack-data/SKILL.md
@@ -625,14 +625,17 @@ tenant-authored metadata.
 
 ## Seed Data & Fixtures (`defineSeed()`)
 
-Object definition and its seed data live together — writing a `*.object.ts`
-almost always goes with a `*.seed.ts` (test fixtures, reference rows,
-bootstrap data). `defineSeed()` is type-safe: pass the object definition
-and TypeScript checks every record's field keys at compile time.
+Object definition and seed data live together — a `*.object.ts` usually
+pairs with a `*.seed.ts` (fixtures, reference rows, bootstrap data).
+`defineSeed()` is type-safe: TypeScript checks every record's field keys
+against the object definition.
 
-> The factory is named `defineSeed` — **not** `defineDataset`. The `dataset`
-> name is reserved for the unrelated ADR-0021 analytics semantic layer
-> (`defineDataset` from `@objectstack/spec/ui`), which is not a seed factory.
+> The factory is `defineSeed` — **not** `defineDataset`, which is the
+> unrelated ADR-0021 analytics semantic layer (`@objectstack/spec/ui`).
+
+> ⛔ `sys_organization` is platform-bootstrapped — never a seed target; the
+> deployment posture decides how many exist (`rules/security.md`
+> § Multi-tenancy).
 
 ### Quick start
 
@@ -689,8 +692,8 @@ Full Zod shape: `node_modules/@objectstack/spec/src/data/seed.zod.ts`.
 
 ### `externalId` selection
 
-Pick a stable natural business key. **Never use `id`** — UUIDs differ
-across environments.
+Pick a stable natural key. **Never use `id`** — UUIDs differ across
+environments.
 
 | Scenario | Key |
 |:---------|:----|
@@ -705,11 +708,11 @@ For `lookup` fields, supply the **natural key** of the target record (not
 its UUID). The seed runner resolves at load time. Order seeds so parents
 appear before children in the exported array:
 
-> If a lookup value matches no natural key, the loader now falls back to
-> resolving it as the target's `id` — so a reference to a real existing
-> record by internal id resolves instead of dangling to null. Natural keys
-> remain the portable default; rely on the id fallback only for records you
-> didn't seed (e.g. a system user).
+> If a lookup value matches no natural key, the loader falls back to
+> resolving it as the target's `id` — so a reference to an existing record
+> by internal id resolves instead of dangling to null. Natural keys remain
+> the portable default; rely on the id fallback only for records you didn't
+> seed (e.g. a system user).
 
 ```typescript
 const contacts = defineSeed(Contact, {

--- a/skills/objectstack-data/references/data-hooks.md
+++ b/skills/objectstack-data/references/data-hooks.md
@@ -620,14 +620,16 @@ when a hook must work regardless of whether a user resolved.
 > **Two isolation axes — don't conflate them.** `organization_id` is
 > **org row-scoping**: many organizations share one database and every row
 > carries its owning org (`current_user.organizationId` filters reads/writes;
-> multi-org needs cloud + `@objectstack/organizations`). That is different from
+> it needs a walled posture — `OS_TENANCY_POSTURE=group|isolated` — with
+> `@objectstack/organizations` declared by the app, open core since
+> ADR-0132). That is different from
 > **environment / database-per-tenant** isolation (`service-tenant`,
 > `driver-turso`), where "tenant" means an entire environment/database and the
 > generic driver-layer `tenantId` knob can carry that environment id. The
 > object-metadata `tenancy.*` knob configures the *mechanism* (isolation on/off
 > + which column); the *value* you read and write is your `organization_id`
-> column. Community edition never populates an org, so `organizationId` is
-> `undefined` there.
+> column. Under `single` the bootstrapped Default Organization is the only
+> one, so there is nothing to scope by (`rules/security.md` § Multi-tenancy).
 
 ### `input` — Operation Parameters
 

--- a/skills/objectstack-data/rules/security.md
+++ b/skills/objectstack-data/rules/security.md
@@ -152,33 +152,34 @@ fields: {
 
 ## Multi-tenancy
 
-For SaaS, set `tenancy` on the object schema for row-level tenant isolation
-(the tenant field is injected on write and enforced on read). The block is
-**strict** — exactly two keys:
+Organization count is a **deployment posture** fact, never object metadata.
+`single` (default) = one logical tenant: the bootstrapped Default Organization
+only, a second refused (`403`); sub-units are business units. Tenants as
+`sys_organization` rows need a walled posture (`group`/`isolated`; open core,
+ADR-0132) — ⛔ never `single` + your own RLS. See ADR-0093, ADR-0105 §"Today's
+two postures", https://objectstack.ai/docs/deployment/tenancy-modes.
+
+Within a posture, `tenancy` on the object is the row-level knob (stamped on
+write, enforced on read); **strict**, two keys:
 
 ```typescript
 tenancy: {
-  enabled: true,   // enable row-level tenant isolation
-  // tenantField — NO default; omit it and the driver uses `organization_id`
+  enabled: true,
+  // tenantField: no default — omit it ⇒ `organization_id`
 }
 ```
 
-- **Database-per-tenant isolation is not object metadata** — it is an
-  environment/deployment choice (each environment carries its own database URL).
-
 ## Platform-global / admin-only objects (visibility posture)
 
-Some system/config objects are **env-global** (not partitioned per org) and
-should be visible to a **platform admin env-wide** but hidden from members —
-e.g. identity tables a plugin writes via its own adapter (`sys_sso_provider`,
-OAuth clients). These hit a non-obvious interaction:
+Some system objects are **env-global** — **platform admin** sees all, members
+none — e.g. identity tables a plugin writes via its own adapter
+(`sys_sso_provider`, OAuth clients):
 
-- Reads of a tenant object pass the **Layer 0 tenant wall** (ADR-0095 D1): an
-  `organization_id == <the caller's organization>` filter AND-composed ahead of
-  every business RLS policy. Any row whose `organization_id` is **null or
-  absent** (common for adapter-written rows that never get the tenant stamp) is
-  **denied** — the list renders empty. Single-tenant deployments never hit this;
-  the wall is inert there.
+- Reads of a tenant object pass the **Layer 0 tenant wall** (ADR-0095 D1):
+  `organization_id == <caller's organization>`, AND-composed ahead of all
+  business RLS. A row with **null or absent** `organization_id`
+  (adapter-written rows often lack it) is **denied** — the list renders empty.
+  Under `single` the wall is inert.
 - The `viewAllRecords` superuser bit is **posture-gated and wall-blind**: it
   short-circuits **business RLS only**, and only on objects whose posture allows
   it (`access.default: 'private'`, `tenancy: { enabled: false }`, or a


### PR DESCRIPTION
Fixes #17019

Governed surface (`skills/**`) — this PR stays DRAFT and the maintainer merges it (Prime Directive #14). Clause-②: no — published prose only; no schema accept set moves and no public surface widens (the sentences narrow what an author may believe).

## The contract, and where the skill lacked it

The deployment posture decides how many organizations exist: `tenancy-modes.mdx` :48 「`single` is not "multi-org with the walls left standing"」 and :138–140 (creating additional organizations is refused `403` under `single`); ADR-0105 :70 / :153 / :512 (one logical tenant; factories as business units in one tree); ADR-0093 (the posture ladder); ADR-0131 D9 (「under `single` the Default Organization is the only one」). The published `objectstack-data` skill — the one text guaranteed to be in an AI author's context — carried none of it and pointed the other way in three places. Re-measured on this branch's base `3644fadc` (origin/main had moved on from the dispatch reading `fd62a66b`; all three premises held unchanged):

| site | before (base `3644fadc`) | after (`f301e3ca`) |
|---|---|---|
| `rules/security.md` :155 | 「For SaaS, set `tenancy` on the object schema for row-level tenant isolation」 — the object knob presented as *the* multi-tenancy instruction; no posture sentence | 「Organization count is a **deployment posture** fact, never object metadata. `single` (default) = one logical tenant: the bootstrapped Default Organization only, a second refused (`403`); sub-units are business units. Tenants as `sys_organization` rows need a walled posture (`group`/`isolated`; open core, ADR-0132) — ⛔ never `single` + your own RLS. See ADR-0093, ADR-0105 §"Today's two postures", https://objectstack.ai/docs/deployment/tenancy-modes.」 followed by 「Within a posture, `tenancy` on the object is the row-level knob (stamped on write, enforced on read) …」 |
| `rules/security.md` :180–181 | 「Single-tenant deployments never hit this; the wall is inert there」 — what `single` *does*, never what it *means* | 「Under `single` the wall is inert.」 — the meaning now lives one section up |
| `SKILL.md` § Seed Data & Fixtures | nothing about `sys_organization` | 「⛔ `sys_organization` is platform-bootstrapped — never a seed target; the deployment posture decides how many exist (`rules/security.md` § Multi-tenancy).」 |
| `references/data-hooks.md` :623 | 「multi-org needs cloud + `@objectstack/organizations`」 | 「it needs a walled posture — `OS_TENANCY_POSTURE=group\|isolated` — with `@objectstack/organizations` declared by the app, open core since ADR-0132」 |
| `references/data-hooks.md` :629–630 | 「Community edition never populates an org, so `organizationId` is `undefined` there」 | 「Under `single` the bootstrapped Default Organization is the only one, so there is nothing to scope by (`rules/security.md` § Multi-tenancy).」 |

Reader of every added line: an AI author choosing between `tenancy` on an object schema and a posture declared on the deployment.

Re-check greps. Base: `git grep -ciE 'one logical tenant|Default Organization' -- skills/` = 0 (control over `content/docs/deployment/`: `environment-variables.mdx:1`, `tenancy-modes.mdx:5`). On `f301e3ca`: 「one logical tenant」 under `skills/` → `rules/security.md:156` (was 0); the card's four-term alternation (`exactly one organization|one logical tenant|Default Organization|sys_organization`) → `security.md:2`, `SKILL.md:1`, `data-hooks.md:1` (was 0); 「For SaaS, set .tenancy」 in `security.md` → 0 (was 1); 「needs cloud」 in `data-hooks.md` → 0 (was 1).

## Zone 2 — mechanism assumptions, measured

- **(a)** All three readings re-measured true on `3644fadc` before writing (quoted in the table).
- **(b)** Open-core claim: #16215 merged 2026-09-07T06:15Z (`c677cda8`; REST `pulls/16215` → `merged: true`); #16719 merged 2026-09-08T02:13Z (`5e53d73d`; `merged: true`); `packages/plugins/organizations` is on `origin/main` and its acceptance test pins `supportedPostures` = `['group', 'isolated']` (`src/open-only-wall-acceptance.test.ts:592`). The shallow clone (108 commits) cannot see either landing, so the REST state is the reading. The clause is written as 「open core, ADR-0132」 / 「open core since ADR-0132」.
- **(c)** #16718 is an issue (closed); its fix PR #17371 merged 2026-09-10T10:50Z and touched no file under `skills/` (`git show --stat 50bc9c73 -- skills/` is empty), so :623 was still stale on base and is rewritten here rather than left. Against ADR-0132 D1/D3/D4 (the runtime ships from this repo, Apache-2.0; an app declares `@objectstack/organizations` from npm; the open package entitles both walled postures) the sentence is **rewritten, not deleted** — the two-axes distinction it carries is still correct, only its edition claim was stale.
- **(d)** `git diff --name-only origin/main...HEAD` = exactly the three skill files. `origin/main` moved `3644fadc` → `ab489388` during the run and touched nothing under `skills/` (`git diff --name-only 3644fadc origin/main -- skills/` is empty), so no rebase was needed.

## Judgement calls, on the four axes

Frame (SKILL.md :734–:752, axes verbatim): 实际业务需求 · 项目长远合理性 · 防 AI 写代码犯错,尤其是防 AI 写元数据 app 犯错 · 创业阶段不扩散需求.

**1. Paying the token ratchet.** `rules/security.md` sat at headroom 0 (2480/2480) and `SKILL.md` at headroom 10 tokens. The sentence being replaced (180 bytes) cannot pay for a contract paragraph (~480 bytes), so the Zone-1 line "tighten the sentences you replace" was arithmetically insufficient on its own — a first draft that only tightened those sentences landed +444 bytes over the ceiling. Options: **A** pay by deleting lower-value content inside the declared region; **B** expand the region into the ⚠️ blockquote at :197–:209 (nobody's claim, but a declared-surface breach); **C** report `blocked`. Chosen **A**. 实际业务需求: the reader needs the contract more than a restated third axis. 项目长远合理性: no ceiling moves and no region breach. 防 AI 犯错: the deleted bullet 「Database-per-tenant isolation is not object metadata」 survives verbatim in the same skill's `data-hooks.md` § Two isolation axes, so no fact leaves the bundle; the code comment 「// enable row-level tenant isolation」 restated the prose above it. 创业阶段不扩散: the addition is exactly the four readers' lines and `security.md` ends 5 bytes *smaller*. Deleted (all inside :153–:181): that bullet, that code comment, and 「(not partitioned per org)」 / 「These hit a non-obvious interaction:」 / 「common for adapter-written rows that never get the tenant stamp」 respelled shorter with the same content.

**2. Where the pointer lives (Zone 3 step 3 — deviation).** The route said "extend the Sources line at :210" (「Posture model: ADR-0066; tenant wall: ADR-0095 D1」). That line documents the *visibility* posture of ADR-0066 — a different sense of "posture" — and appending the tenancy-posture sources there would conflate the two for the very reader this card is about. The pointer (ADR-0093 / ADR-0105 § "Today's two postures" / the tenancy-modes page) sits in the Multi-tenancy paragraph next to the sentence it substantiates; :210 is untouched. 防 AI 犯错 decides it; the other three axes are neutral (same token cost either way).

**3. The docs pointer is the published URL**, `https://objectstack.ai/docs/deployment/tenancy-modes`, not `content/docs/deployment/tenancy-modes.mdx`: the skill is installed into customer projects (`npx skills add …`) where the repo path does not exist; `SKILL.md` :612 already cites docs this way. The route is listed in `content/docs/deployment/meta.json` :7. 实际业务需求 and 防 AI 犯错 both point the same way; the URL costs 5 more bytes, paid in the same edit.

**4. `data-hooks.md` :629–:630 — a two-line increment to the declared surface, declared here.** The claim named the :622–:623 sentence. The closing sentence of the same blockquote asserts the same stale edition split (ADR-0132 makes the edition irrelevant to the posture) and is wrong on its own terms: under `single` a session carries the Default Organization (`packages/plugins/plugin-auth/src/ensure-default-organization.ts` :6–:7, 「so their sessions can carry an `activeOrganizationId`」). Leaving it would have put 「open core since ADR-0132」 and 「Community edition never populates an org」 in one paragraph. The in-place-fix exemption's four conditions hold: same defect class (a stale posture/edition claim in this skill); mechanical fix with the shape pinned by ADR-0132 D1/D3 and ADR-0131 D9; no other claim holds this file (#17359 is on `security.md` :33 and blocked; #17371 is merged and left `skills/` untouched); same gate family, no new verification surface. The identical sentence in `packages/*/CHANGELOG.md` and `content/docs/releases/v16.mdx` is RELEASE-OWNED and untouched.

## Verification

Tree `objectstack-ai/objectstack` at `f301e3ca` (merge-base `3644fadc`); every exit code captured before any pipe.

- Path face: `node scripts/pm/check-governed-merges.mjs --test` on the three files → exit 3, 「⛔ GOVERNED — a human merge is the review record for this PR (#9495 regime)」, `skills/** ×3`.
- Tier: `node scripts/pm/dispatch-gates.mjs --tier` on the three files → 「Model tier — MANDATORY: claude-fable-5-1 (derived from the file surface, not recalled)」.
- Derivation: `node scripts/pm/dispatch-gates.mjs --commands` (no paths; the changeset from the merge-base, three-dot) → 25 commands; `--ran` → 「✓ dispatch-gates --ran: 25 derived famil(ies) accounted for — 25 run, 0 NOT-MEASURED」.

| family | exit | verdict line (the gate's own) |
|---|---|---|
| `node scripts/check-skills-token-ratchet.mjs` (on `f301e3ca`) | 0 | 「✓ check-skills-token-ratchet: 34 authored bundle file(s) within their ceilings; 10 generator-owned file(s) measured, not ratcheted.」 — `security.md` 2479/2480 (headroom 1), `SKILL.md` 10006/10009 (headroom 3), `data-hooks.md` 9781/12611 |
| `node scripts/check-skills-token-ratchet.mjs --self-test` | 0 | 「✓ check-skills-token-ratchet self-test: 65 cases pass.」 |
| `pnpm --filter @objectstack/spec run check:skill-docs` | 0 | 「✅ Skill docs in sync」 |
| `pnpm --filter @objectstack/spec run check:skill-refs` | 0 | 「✅ 9 generated files in sync with packages/spec」 |
| `pnpm check:skill-frame-sync` | 0 | 「✓ check-skill-frame-sync: the one declared copy of the decision frame is internally coherent … 74 markdown files scanned for undeclared copies.」 |
| `node scripts/check-doc-route-spelling.mjs --advisory` / `--self-test` | 0 / 0 | 「✓ route-spelling guard (advisory): population clean — every shape-matched literal spells its ledger row.」 |
| `pnpm check:nul-bytes` | 0 | 「check-nul-bytes: OK (scanned 8278 text file(s) … no raw ASCII control bytes).」 |
| `pnpm check:skill-identifier-liveness` | 0 | 「check-skill-identifier-liveness OK — Leg 1: 457 citation(s) over 44 published file(s) checked against 101257 implementation word tokens」 |
| `pnpm check:skill-compatibility` | 0 | 「✓ check-skill-compatibility-version: 10 SKILL.md file(s) reconciled against 80 workspace packages」 |
| `pnpm check:doc-authoring` | 0 | 「✓ doc authoring guard: sibling-package prose ids hold the baseline — 821 pinned site(s) across 231 file(s) … no growth」 |
| `pnpm check:corpus-claim-drift` | 0 | 「check-corpus-claim-drift: OK, no new claim sites beside a pinned spelling.」 |
| `pnpm --filter @objectstack/lint run check:doc-formula-expressions` | 0 | 「✓ check:doc-formula-expressions: 22 record-scoped formula example(s) across 438 files / 1375 TS blocks judged clean」 — after `turbo run build --filter=@objectstack/formula --filter=@objectstack/lint` under the verify lock (「VERDICT command-exit 0 · held the lock 184s」); the first attempt returned 「PREREQUISITE NOT MET」 exit 3, which is NOT MEASURED, not a finding |
| `node scripts/check-ci-filter-parity.mjs` · `check-closing-keyword-parity.mjs` (+ `--self-test`) · `check-comment-mask-corpus.mjs` · `report-test-timings.mjs --self-test` · `pnpm check:agent-test-spelling` · `check:cross-package-test-inputs` · `check:driver-memory-census` · `check:pm-governed-merges` · `check:refd-timer-probe` · `check:role-word` · `check:watch-hint-literal` | 0 each | whole-tree families placed by the derivation; their verdict lines are in the report comment on #17019 |

Changeset: none — no package under `packages/**` changes, and no released package's `files[]` ships `skills/` (`create-objectstack` `files[]` = `dist`, `README.md`, `CHANGELOG.md`; the catalog reaches customers by `npx skills add` from the git tree) ⇒ `skip-changeset`. Control-character self-scan over the three files: 0 hits. Package build/test (local scope ①/②): no package touched ⇒ none owed; the `formula`/`lint` build above was a gate prerequisite only. Not run locally, CI's: the repo-wide `pnpm lint` and the artifact-roster families.

### Skills-bundle readings (lines; tokens = ceil(utf8 bytes / 4), the ratchet's own convention)

| file | lines before → after | tokens before → after (ceiling) |
|---|---|---|
| `skills/objectstack-data/rules/security.md` | 210 → 211 | 2480 → 2479 (2480) |
| `skills/objectstack-data/SKILL.md` | 851 → 854 | 9999 → 10006 (10009) |
| `skills/objectstack-data/references/data-hooks.md` | 983 → 985 | 9741 → 9781 (12611) |
| all `skills/*/SKILL.md` (whole published catalog) | 6127 → 6130 | — |

Net +6 lines across three files; no ceiling raised.

## Acceptance notes

- noted, not filed: ADR-0132's status line still reads 「Proposed (2026-09-06) — awaiting the maintainer's hand-merge」 although the file is on `main` (by its own text the merge is the acceptance act); a one-line status update is a doc nit. 承接者:无.
- noted, not filed: `content/docs/deployment/tenancy-modes.mdx` :35 says `organization_id` is not filled in on write under `single`, while ADR-0131 D9 (Accepted 2026-09-04) says a missing stamp is *derived* to the Default Organization under `single`. The skill text here relies only on the organization count, on which both agree; whether the table row is stale is a docs question outside this card's surface. 承接者:无.
- `rules/indexing.md` :77 「You never write the posture」 (named by the card) is outside the declared surface and untouched; with the Multi-tenancy section now stating what the posture means, it reads as intended ("an index declaration is posture-independent").
- #17359 (blocked on #17189) owns `rules/security.md` :33; this diff touches :153–:181 only — region-disjoint, as the claim declared. #17010 (the boot-time organization count) remains open and is the runtime half.

## 维护者速读(草稿)

- **改了什么**:在对外发布的 `objectstack-data` skill 里补上「部署 posture 决定组织数量」这条契约:`single` = 只有平台自举的 Default Organization,再建即 `403`;把租户建成 `sys_organization` 行必须在部署上声明 walled posture(`group`/`isolated`,ADR-0132 之后是开源能力),⛔ 不是 `single` + 自写 RLS。种子章节加一行 ⛔ `sys_organization` 不是 seed 目标;hooks 参考里两句过时的「多组织需要 cloud / 社区版不填组织」改成现状。
- **为什么改**:#16934 里您问「ats 为什么会搞错,是我们的 skills 或者文档没写清楚吗?」——答案是 skill 没写。AI 作者读 skill 时只看到对象级 `tenancy` 开关和「single 下墙惰性」,于是得出 ats 那套「留在 single、每租户一个组织、自己立墙」的设计;禁止这种形态的句子只在 `tenancy-modes.mdx` 和 ADR-0105 里,skill 没有指过去。
- **风险与代价(含回滚)**:纯文案,三个文件净增 6 行;token 棘轮不抬上限,靠删掉一条与 `data-hooks.md` 重复的 bullet 和精简措辞付账。回滚 = revert 本 PR 的一个 commit,无数据、无运行时影响。
- **席位意见**:(留空,席位定稿)
- **你要做的**:确认契约表述无误后人工合并(受管面 `skills/**`:AI 席位不合并、不排队、不翻 ready)。

---
_Generated by [Claude Code](https://claude.ai/code/session_01YKEjmbYNvYWJvWGSWx26zK)_