### PR TITLE
fix(plugin-auth): let `ImportProtocolLike` type the admin import protocol's three members

### DIFF
--- a/.changeset/import-protocol-implementor-typed.md
+++ b/.changeset/import-protocol-implementor-typed.md
@@ -1,0 +1,13 @@
+---
+"@objectstack/plugin-auth": patch
+---
+
+fix(plugin-auth): let `ImportProtocolLike` type the admin import protocol's members (#17422)
+
+`admin-import-users.ts` is the only hand-written in-repo implementor of the runner's `ImportProtocolLike`, and it annotated all three required members `args: any`. An explicit parameter annotation wins over the contextual type, so #16952's newly declared request dialect held every implementor except this one — the one with a demonstrated history: before #16950 this file read `args?.query?.$filter ?? {}`, the runner moved to the canonical spelling, the read went `undefined`, and the `?? {}` default degraded the import's duplicate probe into match-everything, so `POST /api/v1/auth/admin/import-users` updated the wrong users without a sound.
+
+The three annotations are deleted, so `findData` / `createData` / `updateData` are typed by the contract they implement. Measured: with the annotations gone, reading a retired wire alias (`args.query?.$filter`) is `TS2339 Property '$filter' does not exist on type 'QueryInput'`; with `args: any` restored the identical probe type-checks at exit 0.
+
+`FindDataRequest` declares `query` optional, so `findData` now states its refusal in code — a thrown `Error` carrying the already-registered `INVALID_REQUEST` code — instead of relying on an incidental `TypeError` from a property read on `undefined`. No `??` fallback and no optional chaining were added: both spell match-everything, which is the defect this closes.
+
+No API, request body, response shape or exported signature changes. A caller that reaches `findData` through `runImport` always supplies `query`, so no supported call moves; only a protocol call that was already failing now fails with a code attached.

--- a/packages/plugins/plugin-auth/src/admin-import-users.test.ts
+++ b/packages/plugins/plugin-auth/src/admin-import-users.test.ts
@@ -1,11 +1,17 @@
 // Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
 
 import { describe, it, expect, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { assertEngineUpdateDispatch } from '@objectstack/objectql';
 import { runAdminImportUsers, IMPORT_USERS_MAX_ROWS, type IdentityImportDeps } from './admin-import-users.js';
 import type { AdminActor } from './admin-user-endpoints.js';
 
 const ACTOR: AdminActor = { id: 'admin-1', email: 'admin@example.com' };
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const IMPORT_USERS_SOURCE = readFileSync(resolve(HERE, 'admin-import-users.ts'), 'utf8');
 
 function makeRequest(body: unknown): Request {
   return new Request('http://localhost/api/v1/auth/admin/import-users', {
@@ -623,4 +629,34 @@ describe('runAdminImportUsers — CSV payloads', () => {
     expect(data.summary.created).toBe(2);
     expect(m.createUser.mock.calls.map((c) => c[0].body.email).sort()).toEqual(['c1@x.co', 'c2@x.co']);
   });
+});
+
+/**
+ * [#17422] The IMPLEMENTOR half of #16952's contract.
+ *
+ * `ImportProtocolLike` types the three required members, but an EXPLICIT
+ * parameter annotation wins over a contextual type — so `findData(args: any)`
+ * opts this file back out of the contract while `tsc --noEmit` stays green.
+ * Measured on #17422 in this package: with the annotation restored, a probe
+ * reading the retired wire alias (`args.query?.$filter` — the pre-#16950 read
+ * whose `?? {}` default degraded the duplicate probe into match-everything)
+ * type-checks at exit 0; with the annotation gone the same probe is
+ * `TS2339 Property '$filter' does not exist on type 'QueryInput'`.
+ *
+ * ⇒ Nothing else in the repo can see that difference. The behavioural upsert
+ * tests above discriminate the CONSEQUENCE (ablated to the historical read,
+ * two of them go red) but not the opt-out itself: re-annotating the parameter
+ * leaves every one of them green and every gate green. This is that guard.
+ */
+describe('[#17422] the import protocol literal is typed BY `ImportProtocolLike`', () => {
+  it('binds the literal to the exported contract', () => {
+    expect(IMPORT_USERS_SOURCE).toContain('const protocol: ImportProtocolLike = {');
+  });
+
+  for (const member of ['findData', 'createData', 'updateData'] as const) {
+    it(`leaves \`${member}\`'s parameter unannotated, so the contract types it`, () => {
+      expect(IMPORT_USERS_SOURCE).toContain(`async ${member}(args) {`);
+      expect(IMPORT_USERS_SOURCE).not.toMatch(new RegExp(`async\\s+${member}\\s*\\(\\s*args\\s*:`));
+    });
+  }
 });

--- a/packages/plugins/plugin-auth/src/admin-import-users.ts
+++ b/packages/plugins/plugin-auth/src/admin-import-users.ts
@@ -362,17 +362,34 @@ export async function runAdminImportUsers(
     // to `{}` stops constraining anything, so the duplicate probe matches rows
     // it was given no key for and the upsert updates the WRONG user. One
     // dialect, read straight — a request that arrives without a `query` is a
-    // caller defect and costs a loud TypeError, not a silent match-everything.
-    async findData(args: any) {
-      const where = args.query.where;
-      const limit = args.query.limit;
+    // caller defect and is refused loudly, not softened into match-everything.
+    //
+    // [#17422] The parameter is deliberately UNANNOTATED: `ImportProtocolLike`
+    // types it, and an explicit annotation here would win over that contextual
+    // type and opt this implementor back out of the contract (the runner's own
+    // docblock says so). `FindDataRequest` declares `query` OPTIONAL, so the
+    // contract makes this file write its refusal down instead of leaving it as
+    // an incidental TypeError from a property read on `undefined`.
+    // ⛔ Not `args.query ?? {}` and ⛔ not `args.query?.where`: both spell
+    // match-everything, which is the exact regression this protocol's history
+    // is about.
+    async findData(args) {
+      const query = args.query;
+      if (!query) {
+        throw Object.assign(
+          new Error('import-users: findData was called without a query — refusing to match every user'),
+          { code: 'INVALID_REQUEST' },
+        );
+      }
+      const where = query.where;
+      const limit = query.limit;
       return engine.find(args.object, { where, limit, context: SYSTEM_CTX } as any);
     },
 
     // One better-auth create per row — hashing + credential sys_account.
     // Deliberately NO createManyData: there is no safe bulk primitive for
     // identities, and scrypt dominates the cost anyway.
-    async createData(args: any) {
+    async createData(args) {
       const data: Record<string, any> = args?.data ?? {};
       const email: string = typeof data.email === 'string' && data.email.length > 0
         ? data.email
@@ -431,7 +448,7 @@ export async function runAdminImportUsers(
 
     // Upsert updates touch PROFILE fields only — never email, never anything
     // credential- or system-managed. An empty filtered patch is a no-op.
-    async updateData(args: any) {
+    async updateData(args) {
       const patch: Record<string, any> = {};
       for (const [k, v] of Object.entries(args?.data ?? {})) {
         if (UPDATE_ALLOWED_FIELDS.has(k) && v !== undefined && v !== null && v !== '') patch[k] = v;


### PR DESCRIPTION
Fixes #17422

Clause-②: no

_(declaration line written by the `domain:services` review seat, not by the implementer. `Check Changeset` went RED on head `fb659886` for the ABSENCE of this line, not for a wrong one: with no declaration and no `needs:contract-review` carrier, the gate resolves `not-measured-material` — a moved package graded `patch` is exactly what a `yes` would have refused. Declaring `no` resolves it as `not-declared`. **Measured on THIS diff, ⛔ not predicted from the dispatch** — the dispatch predicted `no` on the reasoning that deleting a parameter annotation only narrows, and that reasoning did NOT cover the new refusal this diff adds, so both limbs were re-measured:

  • **limb A (accept set): unchanged.** A `findData` call arriving without `query` was **already** rejected — by an incidental `TypeError` on a property read of `undefined`. It is now rejected by a named throw. Nothing is newly accepted and nothing is newly refused; the same call fails, legibly. ⛔ Not a widening.
  • **limb B (public surface): unchanged.** **0** added lines containing `export` in `packages/**` outside tests, against a control of **23** added source lines. The **1** added `code:` entry is `INVALID_REQUEST`, which is already registered in `packages/spec/src/api/error-code-ledger.zod.ts` — and `@objectstack/plugin-auth` is already listed as an owner of it (`:550`, inside the owner block opening at `:536`), so `check:error-code-provenance` needs neither a new owner-key row nor a `PROVENANCE_WAIVERS` entry. ⛔ No `packages/spec` edit is owed, and none is made.

⇒ `no` + a `patch` changeset is the correct and consistent pair here. ⛔ Do not delete this line; the gate reads the body, so removing it re-reds the PR.)_

## What this closes

`packages/plugins/plugin-auth/src/admin-import-users.ts` is the only hand-written in-repo implementor of the runner's `ImportProtocolLike`, and it annotated all three required members `args: any`. An explicit parameter annotation wins over the contextual type, so the contract #16952 declared held every implementor **except** the one with the demonstrated history — the file whose frozen `$filter` read once degraded the import's duplicate probe into match-everything and updated the wrong users.

**Three annotations removed**, all members of the `const protocol: ImportProtocolLike = {` literal (positions re-derived by text, not from the card's line numbers):

| member | was | now |
|:--|:--|:--|
| `findData` | `async findData(args: any)` | `async findData(args)` |
| `createData` | `async createData(args: any)` | `async createData(args)` |
| `updateData` | `async updateData(args: any)` | `async updateData(args)` |

The three OPTIONAL members of the interface — `createManyData`, `insertManyData`, `validateData` — are **not implemented** by this literal (`grep -c` for each: 0 implementations; `createManyData`'s absence is deliberate and commented in place). So the class the card names is exactly three here, not "three plus".

Repo-wide sweep for other implementors: every other `ImportProtocolLike` literal is in `packages/rest`'s own test doubles, and #16952 already annotated those FROM the exported declaration (`Parameters[ImportProtocolLike['findData']]` and siblings). The two production `runImport` call sites in `rest-server.ts` hand it the real `DataProtocol` service, not a hand-written literal.

## Triage's fork, answered: MERELY UNTYPED — **not** a dialect divergence

Triage asked to stop and report if the errors revealed a genuinely different dialect. They do not. Every key this file reads is one the protocol declares:

- `findData` reads `args.object`, `args.query.where`, `args.query.limit` — `FindDataRequest` declares `object` and `query`; `QuerySchema` declares `where` and `limit`.
- `createData` reads `args.data` — declared, required.
- `updateData` reads `args.data` and `args.id` — both declared, both required.

The compiler reported **two** errors and both are about **optionality**, not about an undeclared key:

```
src/admin-import-users.ts(367,21): error TS18048: 'args.query' is possibly 'undefined'.
src/admin-import-users.ts(368,21): error TS18048: 'args.query' is possibly 'undefined'.
```

`FindDataRequestSchema` declares `query` optional (`packages/spec/src/api/protocol.zod.ts:1865`), while all three of the runner's `findData` dispatch sites always supply it (`import-runner.ts:446`, `:489`, `:612`, all through `findArgsBase`). So the file was reading the right key untypedly, and the contract's only complaint is that the file never wrote down what it does when the caller omits `query`.

**Resolution — one change, no cast.** `findData` now states the refusal instead of leaning on an incidental `TypeError` from a property read on `undefined`:

```ts
const query = args.query;
if (!query) {
  throw Object.assign(
    new Error('import-users: findData was called without a query — refusing to match every user'),
    { code: 'INVALID_REQUEST' },
  );
}
const where = query.where;
const limit = query.limit;
```

No `as any`, no `@ts-expect-error`, no `!`, no widened local alias, and deliberately **no** `args.query ?? {}` and **no** `args.query?.where` — both of those spell match-everything, which is the exact regression the file's own comment block is about. `INVALID_REQUEST` is already registered for `@objectstack/plugin-auth` in `packages/spec/src/api/error-code-ledger.zod.ts:550`, so no spec file is touched by this PR (⛔ `packages/spec` was the lane's red line) and `pnpm check:error-code-casing` stays green.

`packages/rest/src/import-runner.ts` was read only. Nothing in it needed to move.

## Reverse verification — the green is a reading, not a dead check

Two legs plus a control, then restored **by state**.

| leg | tree | `pnpm --filter @objectstack/plugin-auth exec tsc --noEmit` |
|:--|:--|:--|
| 1 — mutation | parameter UNANNOTATED + probe reading the retired wire alias `args.query?.$filter` | **exit 1** — `src/admin-import-users.ts(384,43): error TS2339: Property '$filter' does not exist on type 'QueryInput'.` |
| 2 — control | the identical probe, with `args: any` restored | **exit 0** |
| 3 — restore | `git checkout HEAD -- path` | blob `a371c6d7c7938833b7130040b98335c0cfc6656d` equals the HEAD blob; `git diff HEAD` empty; `git status --porcelain` empty |

Leg 2 is the point: the probe does not decide the colour — the annotation does. (The card cited `TS2353`; that came from an object-literal probe. This probe is a property READ, so the same live type answers `TS2339`. Direction as predicted; the code differs because the probe shape differs.)

## Does a regression test for the `$filter` to match-everything history exist?

**Behaviourally, yes — and it discriminates.** Ablated `findData` back to the pre-#16950 read (`(args.query as any)?.$filter ?? {}`) and ran the sibling suite: **2 of 26 failed** —

- `upsert > matches by email …` — `AssertionError: expected 2 to be 1` (with `where` empty the second row matches the existing user instead of creating one: the wrong-user update, reproduced)
- `upsert > matches by phone_number when enabled` — the `expect(find).toHaveBeenCalledWith(…, objectContaining({ where: … }))` pin fails.

Restored by state (blob hash equal to HEAD, `git diff HEAD` empty).

**For the opt-out itself, no — nothing could see it.** Re-annotating all three members `any` and re-running: `tsc --noEmit` **exit 0** and all 26 behavioural tests **green**. That is precisely how this hole stayed open under a green #16952. So this PR adds the missing guard as a source pin in the package's own test sibling (the same technique `rest-server-canonical-query-ast.test.ts` §1b uses for the declaration half). Ablated: with the three annotations restored, **3 of 30 fail** — exactly the three new pins — and the other 27 stay green.

## Verification

Working tree clean at `fb6598867`; every exit code captured **before** any pipe.

- `pnpm --filter @objectstack/plugin-auth build` — exit 0, `check-dts-emitted: 2/2 declared declaration file(s) present`.
- `pnpm --filter @objectstack/plugin-auth typecheck` — **exit 0** (`tsc --noEmit` + `tsconfig.examples.json` + `check:test-typecheck`; the test layer compiles under `tsconfig.test.json` with its shrink-only debt ledger unmoved: 10 files / 94 errors / 23 pinned signatures).
- `pnpm --filter @objectstack/plugin-auth test` — **exit 0**, **106 files / 2260 tests passed**.
- `pnpm lint` (`eslint . --no-inline-config`, the whole repo, not a narrowed set) — **exit 0** in 1m53s at this same head.
- Dependency closure built first: `pnpm --filter '@objectstack/plugin-auth^...' build` — exit 0, so `tsc` read a freshly built `packages/rest/dist/index.d.ts` carrying the narrowed interface (verified by grepping the three member signatures out of the emitted `.d.ts`), not a stale one.
- `scripts/pm/dispatch-gates.mjs --commands --repo objectstack-ai/objectstack` derived **61** families; all 61 run, **59 exit 0**, **2 exit 3 = PREREQUISITE NOT MET = NOT MEASURED** (`check:dual-build-cjs-loads`, `check:type-check-debt` — both refuse without a whole-workspace build, which is CI's `Build Core` / `TypeScript Type Check`, not a package-scoped local tier). `--ran` reconciliation with exit codes recorded: `61 derived, 59 run, 2 NOT-MEASURED, 0 UNRUN`.
- The five artifact-roster gates whose roster sits under a path in this diff were run rather than read as silent: `check-changeset-fixed`, `check:auth-mount-ledger`, `check:authz-resolver`, `check:error-code-casing`, `check:filter-alias-parity` — all exit 0.
- Heavy runs went through `scripts/pm/os-verify-lock.sh`; every verdict read from its `VERDICT command-exit` line.

## Acceptance notes

Observations from this file, deliberately **not** changed here and **not** filed (none meets the file-an-issue bar — no repro, no violated declared contract, no metadata-authoring trap):

- `IdentityImportEngine` at `src/admin-import-users.ts:89`–`:91` (`find(objectName: string, query?: any)`, `update(…, data: any, options?: any)`, `insert(…)`) is a **different, local, engine-shaped interface** and not part of `ImportProtocolLike`. Left exactly as found, per the dispatch. Typing it against ObjectQL's real engine surface would be its own card; no PR or seat is in flight over it today.
- `createData` / `updateData` still spell `args?.data ?? {}`. Both request types declare `data` **required**, so the fallback is now provably unreachable rather than merely unused — belt-and-braces of the family Prime Directive #12 names, but not a defect and not compiler-forced. The next PR touching this literal is the natural carrier.
- `engine.find(args.object, { where, limit, context: SYSTEM_CTX } as any)` keeps its pre-existing `as any` on the OPTIONS bag (a consequence of the local interface above, not of the protocol). `pnpm check:query-options-erasure` is green over it.
- The runner's docblock instruction ("Leave the parameter unannotated and let this declaration type it") is now enforced for this implementor only, by the pin added here. A future implementor in another package gets no such guard; a repo-wide check would be a separate piece of work, and nothing violates the contract today.


---
_Generated by [Claude Code](https://claude.ai/code)_