### PR TITLE
fix(spec)!: refuse a padded `grouping.fields[].field` name at the producer instead of handing three renderers a lookup that always misses

### DIFF
--- a/.changeset/grouping-field-non-padded.md
+++ b/.changeset/grouping-field-non-padded.md
@@ -1,0 +1,48 @@
+---
+"@objectstack/spec": minor
+---
+
+fix(spec)!: `grouping.fields[].field` refuses a padded field name instead of handing three renderers a lookup that always misses (#17360, ruling C on objectui#7347)
+
+<!-- adr-0087: registered ui-list-view-grouping-field-padded-refused -->
+
+**BREAKING** — an accept-set narrowing on a published authoring surface. `GroupingFieldSchema.field` was a bare `z.string()`, so `'  business_unit  '` was valid authored metadata; it is now refused at parse. Shipped as `minor` under the repo's launch-window convention for accept-set narrowings. Stored metadata carrying a padded grouping name now fails validation and must be re-authored — the hand-migration prescription is registered under protocol major 18 as `ui-list-view-grouping-field-padded-refused`.
+
+## What was wrong
+
+The padded name never failed anywhere. It failed to *group*.
+
+Measured on objectui (M1–M11, with live controls): the projection harvester `collectGroupingFieldRefs` **trims** the name when it builds `$select`, while **three** renderers bucket rows by the **raw** name — plugin-grid `usableGroupingFields`, plugin-list `ObjectGallery.groupedItems`, plugin-kanban `effectiveSwimlaneField`. So the server answers under `business_unit`, every per-row lookup asks for `'  business_unit  '`, reads `undefined`, and the view collapses into one `(empty)` group (grid, gallery) or one `Uncategorized` lane (kanban) holding every record.
+
+That is a silent wrong answer that reads as a true statement about the data: a user looking at one giant `(empty)` group has no way to tell it apart from a dataset where the field genuinely is empty. Nothing weaker than a parse refusal is honest about it.
+
+## What it does now
+
+`grouping.fields[].field` carries a **non-padded** pattern — no leading and no trailing whitespace. The refusal lands at `grouping.fields[N].field` (the offending element's own key, not the view or the array) and names the offending spelling verbatim, so the whitespace an author cannot see in an editor is visible in the message, together with the trimmed name to write instead.
+
+⛔ **Not a `.trim()`.** A trimming schema makes `'  a  '` and `'a'` silently equivalent, which is the consumer-tolerance direction AGENTS.md #0.1 refuses: the padded spelling is a mistake the author should be told about, not a dialect the producer quietly normalises away. objectui's harvester trim stays as defence-in-depth; nothing is removed there.
+
+## FROM → TO
+
+| you wrote | write instead |
+|:--|:--|
+| `grouping: { fields: [{ field: '  business_unit  ' }] }` | `grouping: { fields: [{ field: 'business_unit' }] }` |
+| `grouping: { fields: [{ field: 'status\n' }] }` | `grouping: { fields: [{ field: 'status' }] }` |
+
+The remedy is always the same: write the field name exactly as the object declares it and the server answers under. If a view has been silently showing one `(empty)` group, re-authoring the name is also the fix for that.
+
+## Scope — what is deliberately NOT narrowed
+
+- **The blank name is unchanged.** It is already refused loudly one layer down by `compileListViewGroupQuery`'s `grouping_field_blank` (`400`, path `['grouping','fields',N,'field']`). This narrowing exists for the **silent** case; the empty string still parses here exactly as before.
+- **This is not the snake_case machine-name grammar.** `packages/spec` spells `/^[a-z_][a-z0-9_]*$/` inline for object, field and tool **names**, and this key deliberately does not take it: a grouping level is authored as a field **reference**, and a dotted relationship path (`owner.name`) is an in-tree spelling of one. The ruling asked for a non-padded pattern and this is exactly that — nothing wider, nothing narrower.
+- **The sibling `groupByField` axis** (kanban / gantt / timeline) is symmetric and is **not** touched by this change.
+
+## Who is affected, measured
+
+Every `grouping.fields[].field` spelling in this repo parses unchanged: 50 literal occurrences under a `grouping:` key across 19 files, harvested with the TypeScript parser and cross-checked against a deliberately over-approximating second pass over 906 shape-exact `{ field, order?, collapsed? }` literals in `packages/**`. The single harvested spelling this refuses is `' '` in `view-grouping-query.test.ts` — a **negative** fixture handed straight to `compileListViewGroupQuery` with no parse on its path, pinning that same `grouping_field_blank` refusal. Nothing in the tree reddens.
+
+Outside the repo, only metadata that was already grouping wrongly is affected: a padded name has never produced a correct grouped view on any renderer.
+
+## Consumer
+
+**objectui#7347 unblocks on the INSTALLABLE RELEASE of this package, not on merge.** Its side of the work — a pin bump plus a regression test that a padded name is refused before it reaches any renderer — needs a published `@objectstack/spec` to depend on, so it stays `pm:blocked` until this ships in a release a consumer can install. The gallery and kanban sites are covered by this one producer fix and get no cards of their own.

--- a/content/docs/references/ui/view.mdx
+++ b/content/docs/references/ui/view.mdx
@@ -639,7 +639,7 @@ Record grouping configuration — SERVER-SIDE: the set of groups and every numbe
 
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
-| **field** | `string` | ✅ | Field name to group by — one `groupBy` column of the group header query; the header row carries its raw stored value (null for the empty group) |
+| **field** | `string` | ✅ | Field name to group by — one `groupBy` column of the group header query; the header row carries its raw stored value (null for the empty group). NO leading or trailing whitespace: the name is compiled into the aggregate query verbatim, so a padded spelling buckets every row into one empty group instead of grouping them. |
 | **order** | `Enum<'asc' \| 'desc'>` | optional (default: `"asc"`) | Group sort order — applied by the consumer over the header rows (the aggregate query carries no orderBy) |
 | **collapsed** | `boolean` | optional (default: `false`) | Collapse groups by default (presentation only) |
 
@@ -652,7 +652,7 @@ Record grouping configuration — SERVER-SIDE: the set of groups and every numbe
 
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
-| **field** | `string` | ✅ | Field name to group by — one `groupBy` column of the group header query; the header row carries its raw stored value (null for the empty group) |
+| **field** | `string` | ✅ | Field name to group by — one `groupBy` column of the group header query; the header row carries its raw stored value (null for the empty group). NO leading or trailing whitespace: the name is compiled into the aggregate query verbatim, so a padded spelling buckets every row into one empty group instead of grouping them. |
 | **order** | `Enum<'asc' \| 'desc'>` | optional (default: `"asc"`) | Group sort order — applied by the consumer over the header rows (the aggregate query carries no orderBy) |
 | **collapsed** | `boolean` | optional (default: `false`) | Collapse groups by default (presentation only) |
 

--- a/packages/spec/src/migrations/entries/semantic/18.ui-list-view-grouping-field-padded-refused.ts
+++ b/packages/spec/src/migrations/entries/semantic/18.ui-list-view-grouping-field-padded-refused.ts
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+import type { SemanticMigration } from '../../types.js';
+
+export const entry: SemanticMigration = {
+  id: 'ui-list-view-grouping-field-padded-refused',
+  surface: 'list-view grouping level names — `grouping.fields[].field` '
+    + '(`GroupingFieldSchema`, the rows inside `ListView.grouping.fields[]`) — '
+    + 'values carrying leading or trailing whitespace',
+  replacement: 'the field name written with no leading and no trailing whitespace — the '
+    + 'same spelling the object declares and the server answers under. A padded value is '
+    + 'RE-AUTHORED, never trimmed on the author\'s behalf: `\'  business_unit  \'` becomes '
+    + '`\'business_unit\'`. The refusal names the offending spelling verbatim, so the '
+    + 'whitespace an author cannot see in an editor is visible in the message.',
+  reason:
+    '#17360, ruling C on objectui#7347 (maintainer 「其他同意」, decision batch #110 item 5): '
+    + 'refuse at the producer. `field` was a bare `z.string()`, so a padded grouping level '
+    + 'was valid authored metadata all the way to the renderers. Measured on objectui '
+    + '(M1-M11 with live controls): the projection harvester `collectGroupingFieldRefs` '
+    + 'TRIMS the name when it builds `$select`, while THREE renderers bucket rows by the '
+    + 'RAW name — plugin-grid `usableGroupingFields`, plugin-list '
+    + '`ObjectGallery.groupedItems`, plugin-kanban `effectiveSwimlaneField`. The server '
+    + 'therefore answers under `business_unit` while every per-row lookup asks for '
+    + '`\'  business_unit  \'`, reads `undefined`, and the view collapses into ONE `(empty)` '
+    + 'group (grid, gallery) or ONE `Uncategorized` lane (kanban) holding every record — a '
+    + 'silent wrong answer that reads as a true statement about the data, which is why '
+    + 'nothing weaker than a parse refusal is honest here. ⛔ NOT a `.trim()`: a trimming '
+    + 'schema makes `\'  a  \'` and `\'a\'` silently equivalent, the consumer-tolerance '
+    + 'direction AGENTS.md #0.1 refuses. objectui\'s harvester trim stays as '
+    + 'defence-in-depth; nothing is removed there. The narrowing is non-padded ONLY and '
+    + 'deliberately not the snake_case machine-name grammar `/^[a-z_][a-z0-9_]*$/` this '
+    + 'package spells inline for object/field/tool NAMES: a grouping level is authored as '
+    + 'a field REFERENCE and a dotted relationship path (`owner.name`) is an in-tree '
+    + 'spelling of one. The blank name is unchanged here — it is already refused loudly '
+    + 'one layer down by `compileListViewGroupQuery`\'s `grouping_field_blank`, and this '
+    + 'narrowing exists for the SILENT case. Ships at once, no deprecation window '
+    + '(2026-08-27 maintainer ruling 「短期不考虑渐进」).',
+  acceptanceCriteria:
+    'Every stored list view whose `grouping.fields[].field` carries leading or trailing '
+    + 'whitespace is refused on its next authoring-path save, with a per-element issue at '
+    + '`grouping.fields[N].field` naming the offending spelling and the trimmed name to '
+    + 'write instead. Names with no padding parse byte-identically to before — nothing is '
+    + 'normalised on the way through, and a dotted relationship path stays valid. Views '
+    + 'with no `grouping` block are untouched. Every `grouping.fields[].field` spelling '
+    + 'in this repo at the time of the change parses unchanged: 50 literal occurrences '
+    + 'under a `grouping:` key across 19 files, harvested with the TypeScript parser and '
+    + 'cross-checked against 906 shape-exact `{ field, order?, collapsed? }` literals in '
+    + '`packages/**`. The single harvested spelling this refuses — `\' \'` at '
+    + '`view-grouping-query.test.ts` — is a NEGATIVE fixture handed straight to '
+    + '`compileListViewGroupQuery` with no parse on its path, pinning that same '
+    + '`grouping_field_blank` refusal; the producer now refuses it one layer earlier for '
+    + 'the same reason.',
+};

--- a/packages/spec/src/migrations/registry.ts
+++ b/packages/spec/src/migrations/registry.ts
@@ -10353,6 +10353,55 @@ const step18: MigrationStep = {
         + 'author re-gates by record state or moves the gate to an app surface.',
     },
     {
+      id: 'ui-list-view-grouping-field-padded-refused',
+      surface: 'list-view grouping level names — `grouping.fields[].field` '
+        + '(`GroupingFieldSchema`, the rows inside `ListView.grouping.fields[]`) — '
+        + 'values carrying leading or trailing whitespace',
+      replacement: 'the field name written with no leading and no trailing whitespace — the '
+        + 'same spelling the object declares and the server answers under. A padded value is '
+        + 'RE-AUTHORED, never trimmed on the author\'s behalf: `\'  business_unit  \'` becomes '
+        + '`\'business_unit\'`. The refusal names the offending spelling verbatim, so the '
+        + 'whitespace an author cannot see in an editor is visible in the message.',
+      reason:
+        '#17360, ruling C on objectui#7347 (maintainer 「其他同意」, decision batch #110 item 5): '
+        + 'refuse at the producer. `field` was a bare `z.string()`, so a padded grouping level '
+        + 'was valid authored metadata all the way to the renderers. Measured on objectui '
+        + '(M1-M11 with live controls): the projection harvester `collectGroupingFieldRefs` '
+        + 'TRIMS the name when it builds `$select`, while THREE renderers bucket rows by the '
+        + 'RAW name — plugin-grid `usableGroupingFields`, plugin-list '
+        + '`ObjectGallery.groupedItems`, plugin-kanban `effectiveSwimlaneField`. The server '
+        + 'therefore answers under `business_unit` while every per-row lookup asks for '
+        + '`\'  business_unit  \'`, reads `undefined`, and the view collapses into ONE `(empty)` '
+        + 'group (grid, gallery) or ONE `Uncategorized` lane (kanban) holding every record — a '
+        + 'silent wrong answer that reads as a true statement about the data, which is why '
+        + 'nothing weaker than a parse refusal is honest here. ⛔ NOT a `.trim()`: a trimming '
+        + 'schema makes `\'  a  \'` and `\'a\'` silently equivalent, the consumer-tolerance '
+        + 'direction AGENTS.md #0.1 refuses. objectui\'s harvester trim stays as '
+        + 'defence-in-depth; nothing is removed there. The narrowing is non-padded ONLY and '
+        + 'deliberately not the snake_case machine-name grammar `/^[a-z_][a-z0-9_]*$/` this '
+        + 'package spells inline for object/field/tool NAMES: a grouping level is authored as '
+        + 'a field REFERENCE and a dotted relationship path (`owner.name`) is an in-tree '
+        + 'spelling of one. The blank name is unchanged here — it is already refused loudly '
+        + 'one layer down by `compileListViewGroupQuery`\'s `grouping_field_blank`, and this '
+        + 'narrowing exists for the SILENT case. Ships at once, no deprecation window '
+        + '(2026-08-27 maintainer ruling 「短期不考虑渐进」).',
+      acceptanceCriteria:
+        'Every stored list view whose `grouping.fields[].field` carries leading or trailing '
+        + 'whitespace is refused on its next authoring-path save, with a per-element issue at '
+        + '`grouping.fields[N].field` naming the offending spelling and the trimmed name to '
+        + 'write instead. Names with no padding parse byte-identically to before — nothing is '
+        + 'normalised on the way through, and a dotted relationship path stays valid. Views '
+        + 'with no `grouping` block are untouched. Every `grouping.fields[].field` spelling '
+        + 'in this repo at the time of the change parses unchanged: 50 literal occurrences '
+        + 'under a `grouping:` key across 19 files, harvested with the TypeScript parser and '
+        + 'cross-checked against 906 shape-exact `{ field, order?, collapsed? }` literals in '
+        + '`packages/**`. The single harvested spelling this refuses — `\' \'` at '
+        + '`view-grouping-query.test.ts` — is a NEGATIVE fixture handed straight to '
+        + '`compileListViewGroupQuery` with no parse on its path, pinning that same '
+        + '`grouping_field_blank` refusal; the producer now refuses it one layer earlier for '
+        + 'the same reason.',
+    },
+    {
       id: 'ui-mcp-connect-agent-unknown-keys-refused',
       surface: 'page `mcp:connect-agent` component — `properties` (any key at all: the widget '
         + 'declares no props)',

--- a/packages/spec/src/ui/view.test.ts
+++ b/packages/spec/src/ui/view.test.ts
@@ -2036,6 +2036,112 @@ describe('GroupingFieldSchema', () => {
 
     expect(() => GroupingFieldSchema.parse(field)).not.toThrow();
   });
+
+  // ==========================================================================
+  // [#17360] A padded `field` is REFUSED, not trimmed
+  // (objectui#7347 ruling C, decision batch #110 item 5 — refuse at the producer)
+  // ==========================================================================
+  //
+  // The defect: `field` was a bare `z.string()`, so `'  business_unit  '` was
+  // valid authored metadata. objectui measured that its projection harvester
+  // TRIMS the name for `$select` while three renderers bucket rows by the RAW
+  // name (plugin-grid `usableGroupingFields`, plugin-list
+  // `ObjectGallery.groupedItems`, plugin-kanban `effectiveSwimlaneField`), so
+  // the server answers under `business_unit`, every per-row lookup reads
+  // `undefined`, and the view shows ONE `(empty)` group / `Uncategorized` lane
+  // holding every record — a wrong answer that reads as a true statement.
+
+  it('refuses a padded grouping field name BY NAME at `grouping.fields[N].field`', () => {
+    const result = ListViewSchema.safeParse({
+      columns: ['name', 'business_unit'],
+      grouping: { fields: [{ field: 'status' }, { field: '  business_unit  ' }] },
+    });
+
+    expect(result.success).toBe(false);
+    const issues = result.error!.issues;
+
+    // BY NAME: the issue is addressed to the offending element's own `field`
+    // key, not to the view or to the array — index 1, the padded one.
+    expect(issues.map((i) => i.path.join('.'))).toContain('grouping.fields.1.field');
+
+    // ...and the refusal names the offending spelling, so the author can see
+    // the whitespace they cannot see in their editor.
+    const issue = issues.find((i) => i.path.join('.') === 'grouping.fields.1.field')!;
+    expect(issue.message).toContain('"  business_unit  "');
+    expect(issue.message).toContain('grouping.fields[].field');
+  });
+
+  it.each([
+    ['leading', ' business_unit'],
+    ['trailing', 'business_unit '],
+    ['both', '  business_unit  '],
+    ['a tab', '\tbusiness_unit'],
+    ['a newline', 'business_unit\n'],
+    ['whitespace only', ' '],
+  ])('refuses %s whitespace', (_label, spelling) => {
+    expect(GroupingFieldSchema.safeParse({ field: spelling }).success).toBe(false);
+  });
+
+  // ⛔ NOT a `.trim()`. A trimming schema would make `'  a  '` and `'a'`
+  // silently equivalent — the consumer-tolerance direction AGENTS.md #0.1
+  // refuses. This arm is what tells the two designs apart: a trimming schema
+  // passes the refusal pins above only by NOT refusing, so it would fail there
+  // first; this arm additionally pins that nothing normalises the value on the
+  // way through for the names that ARE accepted.
+  it('does not trim — an accepted name arrives byte-identical', () => {
+    expect(GroupingFieldSchema.parse({ field: 'business_unit' }).field).toBe('business_unit');
+    expect(GroupingFieldSchema.safeParse({ field: '  business_unit  ' }).success).toBe(false);
+  });
+
+  // ==========================================================================
+  // [#17360] The narrowing reddens NO existing grouping fixture in the repo
+  // ==========================================================================
+  //
+  // Every DISTINCT `grouping.fields[].field` spelling harvested from the repo
+  // with the TypeScript parser (50 literal occurrences under a `grouping:` key
+  // across 19 files; cross-checked against a deliberately over-approximating
+  // second pass over 906 shape-exact `{ field, order?, collapsed? }` literals
+  // in `packages/**`). Exactly one harvested spelling is refused by this
+  // narrowing — `' '` at `view-grouping-query.test.ts:507` — and that one is a
+  // NEGATIVE fixture handed straight to `compileListViewGroupQuery` with no
+  // Zod parse anywhere on its path, pinning the consumer's own
+  // `grouping_field_blank` refusal. It is therefore not a fixture that has to
+  // parse, and the producer now refuses it one layer earlier for the same
+  // reason. So: zero reddened fixtures, and it is recorded here rather than
+  // used as a reason to widen the pattern to fit.
+  //
+  // `owner.name` is the load-bearing member: a grouping level is authored as a
+  // field REFERENCE and a dotted relationship path is an in-tree spelling of
+  // one, which is why this key does NOT take the snake_case machine-name
+  // grammar (`/^[a-z_][a-z0-9_]*$/`) the rest of `packages/spec` spells inline
+  // for object/field/tool NAMES.
+  const IN_TREE_GROUPING_FIELD_SPELLINGS = [
+    'A7_no_such_field', 'a', 'actor_id', 'b', 'business_unit', 'category',
+    'count', 'count_notes', 'department', 'kind', 'namespace', 'object_name',
+    'organization_id', 'owner.name', 'priority', 'provider_id', 'status',
+    'sum_amount', 'topic', 'user_id',
+  ] as const;
+
+  it.each(IN_TREE_GROUPING_FIELD_SPELLINGS)('still parses the in-tree spelling %s', (spelling) => {
+    expect(GroupingFieldSchema.safeParse({ field: spelling }).success).toBe(true);
+  });
+
+  it('the in-tree enumeration is non-vacuous — lit and dark controls', () => {
+    // LIT: the two spellings the harvest is anchored on are actually in the
+    // list, so the `it.each` above cannot be passing over an empty table.
+    expect(IN_TREE_GROUPING_FIELD_SPELLINGS).toContain('business_unit');
+    expect(IN_TREE_GROUPING_FIELD_SPELLINGS).toContain('owner.name');
+    expect(IN_TREE_GROUPING_FIELD_SPELLINGS.length).toBeGreaterThan(15);
+
+    // DARK: a spelling the repo does not carry is absent — the list is a
+    // harvest, not a wish-list that would pass no matter what was measured.
+    expect(IN_TREE_GROUPING_FIELD_SPELLINGS).not.toContain('zz_no_such_grouping_field');
+
+    // And the discriminator: the accepting arm above would pass just as well
+    // against the OLD bare `z.string()`, so pin that this schema is genuinely
+    // narrower than the one it replaces.
+    expect(GroupingFieldSchema.safeParse({ field: ' owner.name' }).success).toBe(false);
+  });
 });
 
 describe('GalleryConfigSchema', () => {

--- a/packages/spec/src/ui/view.zod.ts
+++ b/packages/spec/src/ui/view.zod.ts
@@ -839,6 +839,60 @@ export const RowHeightSchema = lazySchema(() => z.enum([
   'extra_tall',  // Maximum padding, rich content preview
 ]).describe('Row height / density setting for list view'));
 
+/*
+ * ---------------------------------------------------------------------------
+ * `grouping.fields[].field` — the non-padded name rule (#17360)
+ * ---------------------------------------------------------------------------
+ */
+
+// The ruling is objectui#7347 ruling C (decision batch #110 item 5) — internal
+// readers get the ids here; the author-facing sentence carries the date only,
+// which is what a refused author can act on.
+const GROUPING_FIELD_RULING = 'ruled 2026-09-10';
+
+/**
+ * A name with no leading and no trailing whitespace.
+ *
+ * Deliberately **not** the snake_case machine-name grammar
+ * (`/^[a-z_][a-z0-9_]*$/`) this package spells inline for object, field and
+ * tool NAMES: a grouping level is authored as a field REFERENCE, and a dotted
+ * relationship path (`owner.name`) is an in-tree spelling of one, so the
+ * machine-name grammar is the wrong vocabulary for this key. The ruling asks
+ * for a non-padded pattern, and that is exactly what this is — nothing wider,
+ * nothing narrower.
+ *
+ * The empty string still matches, on purpose: a blank grouping name is already
+ * refused LOUDLY one layer down (`compileListViewGroupQuery`'s
+ * `grouping_field_blank`), and this narrowing exists for the SILENT case only.
+ */
+const GROUPING_FIELD_NON_PADDED_PATTERN = /^(?:\S|\S[\s\S]*\S)?$/;
+
+/**
+ * Validate one `grouping.fields[].field` name against the ruling. Returns the
+ * author-facing refusal, or `undefined` when the value conforms.
+ *
+ * ⛔ Not a `.trim()`. A trimming schema would make `'  a  '` and `'a'` silently
+ * equivalent, which is the consumer-tolerance direction AGENTS.md #0.1 refuses:
+ * the padded spelling is a mistake the author should be told about, not a
+ * dialect the producer should quietly accept and normalise away.
+ */
+function checkGroupingFieldName(raw: string): string | undefined {
+  if (GROUPING_FIELD_NON_PADDED_PATTERN.test(raw)) return undefined;
+
+  const trimmed = raw.trim();
+  const remedy = trimmed === ''
+    ? 'Name the field to group by — this value is nothing but whitespace.'
+    : `Write ${JSON.stringify(trimmed)}.`;
+
+  return '`grouping.fields[].field` names the field exactly as it is stored, with no leading or '
+    + `trailing whitespace — received ${JSON.stringify(raw)}. The group header query is compiled `
+    + 'from this string verbatim (`compileListViewGroupQuery` sends it as a `groupBy` column) and '
+    + 'the server answers under the unpadded name, so a padded spelling makes every renderer\'s '
+    + 'per-row lookup miss: the grid and the gallery show a single `(empty)` group and the kanban '
+    + 'a single `Uncategorized` lane holding every record — a wrong answer that reads as a true '
+    + `statement about the data. ${remedy} (${GROUPING_FIELD_RULING}.)`;
+}
+
 /**
  * Grouping Field Configuration
  * Defines a single grouping level for record grouping.
@@ -854,7 +908,17 @@ export const GroupingFieldSchema = lazySchema(() => strictObject({
   surface: 'this grouping field',
   history: VIEW_HISTORY,
 }, {
-  field: z.string().describe('Field name to group by — one `groupBy` column of the group header query; the header row carries its raw stored value (null for the empty group)'),
+  field: z.string()
+    .superRefine((raw, ctx) => {
+      const refusal = checkGroupingFieldName(raw);
+      if (refusal) ctx.addIssue({ code: 'custom', message: refusal });
+    })
+    .describe(
+      'Field name to group by — one `groupBy` column of the group header query; the header row '
+      + 'carries its raw stored value (null for the empty group). NO leading or trailing '
+      + 'whitespace: the name is compiled into the aggregate query verbatim, so a padded spelling '
+      + 'buckets every row into one empty group instead of grouping them.',
+    ),
   order: z.enum(['asc', 'desc']).default('asc').describe('Group sort order — applied by the consumer over the header rows (the aggregate query carries no orderBy)'),
   collapsed: z.boolean().default(false).describe('Collapse groups by default (presentation only)'),
 }));


### PR DESCRIPTION
Fixes #17360

Clause-②: yes — fixed **by the ruling**, not by the diff's size. This is a spec narrowing, and the objectui#8285 precedent says a spec narrowing declares `yes`. `needs:contract-review` rides on both carriers (already on the card; hung on this PR too), the changeset is `minor` with a `**BREAKING**` note, and the ADR-0087 disposition is registered. It needs an at-tier verdict on the head that lands — ⛔ this PR is a draft and the at-tier verdict is the `domain:spec` seat's to commission, so nothing here flips ready, enqueues, or arms auto-merge.

Implemented by an `os-dev` subagent in session `session_01MkQhmuuJAVDjmeWNixwDDH`, inheriting the claim and assignee from the `domain:spec` execution seat's `Claim:` comment on #17360 (no second claim posted, assignee untouched).

## The ruling

Ruling **C on objectui#7347**, maintainer verbatim 「其他同意」, decision batch #110 item 5: **refuse at the producer.** `GroupingFieldSchema.field` gets a non-padded pattern with a refusal naming the field and the offending spelling.

⛔ **Not `.trim()`.** A trimming schema makes `'  a  '` and `'a'` silently equivalent, which is the consumer-tolerance direction AGENTS.md #0.1 refuses. objectui's harvester trim stays as defence-in-depth; nothing is removed there. The sibling `groupByField` axis is explicitly not this card and is untouched.

## ⭐ The "reuse the vocabulary if one exists" conditional — I measured it and took the FIRST branch, which is not what I inherited

The ruling asks for a non-padded pattern *"the same shape the field-name vocabulary already uses elsewhere in `packages/spec` **if one exists** — reuse it, do not invent a second"*.

The seat's hold notes measured that `FieldNameSchema` was **retired under protocol 18**, and concluded the conditional resolves to its **second** branch (define the pattern). I re-verified that against `origin/main` and **half of it is right, but the conclusion is not** — and the correction comes from the retired-def's own text:

```
packages/spec/src/migrations/entries/retired-defs/18.shared__FieldName.ts
  "No schema in either repo ever composed `FieldNameSchema`, so the promised brand
   safety was unobtainable. The real field-name contract is the inline
   `z.string().regex(/^[a-z_][a-z0-9_]*$/)` at `data/field.zod.ts` — untouched by
   this retirement."
```

So the branded **schema** is retired (confirmed: the retired-def entry and the semantic entry `18.branded-identifier-schemas-retired` are both on `origin/main`), but a field-name **vocabulary** is alive and ubiquitous: `/^[a-z_][a-z0-9_]*$/`, spelled inline at 30+ sites including `data/field.zod.ts:932` — the field `name` itself. The conditional therefore resolves to its **first** branch, and no protocol-18 retirement has to be re-opened to read it. **⛔ Nothing here revives the retired branded-identifier family** — there is no 回翻 in this diff and the card did not have to be returned.

**And then I did not adopt that vocabulary — measured, with the evidence:**

`grouping.fields[].field` is authored as a field **reference**, not a machine **name**, and the repo proves it: `packages/lint/src/validate-list-view-field-refs.test.ts:537` carries `grouping: { fields: [{ field: 'owner.name' }] }`, a dotted relationship path, in a test that asserts it produces **no** finding. `/^[a-z_][a-z0-9_]*$/` refuses `owner.name`. Adopting it would have reddened an in-tree grouping fixture — which the acceptance criteria name as a **finding to report, not a reason to widen** — and would have been a *different, larger* narrowing than the one ruled.

⇒ The pattern is **non-padded only**: `/^(?:\S|\S[\s\S]*\S)?$/`. Exactly what the ruling asked for, nothing wider, nothing narrower. Stated in the source docblock so the next reader does not have to re-derive it.

## What changed

`packages/spec/src/ui/view.zod.ts` — anchored by content on `export const GroupingFieldSchema` (it happened to still be at :853, but nothing here depends on that):

- a module-level `GROUPING_FIELD_NON_PADDED_PATTERN` and a `checkGroupingFieldName(raw)` refusal builder, following this file's own house idiom for a dynamic per-value message (`checkSubmitRedirectUrl` + `.superRefine`), which is what lets the message name the **offending spelling** as well as the key;
- `field` gains the `.superRefine`, and its `.describe()` states the rule.

The refusal lands at `grouping.fields[N].field` — the offending element's own key — and reads, for `'  business_unit  '`:

> `grouping.fields[].field` names the field exactly as it is stored, with no leading or trailing whitespace — received `"  business_unit  "`. The group header query is compiled from this string verbatim … Write `"business_unit"`. (ruled 2026-09-10.)

**Deliberately left alone:** the empty string still parses. A blank name is already refused *loudly* one layer down by `compileListViewGroupQuery`'s `grouping_field_blank` (400, path `['grouping','fields',N,'field']`); this narrowing exists for the **silent** case, and refusing the blank here too would be scope the ruling did not ask for.

Also: the ADR-0087 semantic entry `18.ui-list-view-grouping-field-padded-refused`, `registry.ts` regenerated with `gen:migration-registry` (⛔ no hand edit — the insertion is at :10355, inside the `os-generated semantic:18` markers at :5452/:10565), the changeset, and the regenerated `content/docs/references/ui/view.mdx`.

## ⭐ Acceptance — the fixture enumeration, which is the item that bites

Harvested with the **TypeScript parser**, not a grep — the tool's own predicate rather than a re-implementation:

| pass | population | result |
|:--|:--|:--|
| 1 — literal `grouping: { fields: [ … ] }` | 50 occurrences across 19 files | 1 refused |
| 2 — over-approximating: every shape-exact `{ field, order?, collapsed? }` literal in `packages/**` | 906 literals | 1 refused |

**Lit controls:** `business_unit` present in the harvest; `priority` present (it is the `GroupingFieldSchema.parse` fixture that pass 1 structurally could not see, which is why pass 2 exists). **Dark control:** `zz_no_such_grouping_field` absent.

The one refused spelling is `' '` at `packages/spec/src/ui/view-grouping-query.test.ts:507`. It is a **negative** fixture handed straight to `compileListViewGroupQuery` with no Zod parse anywhere on its path, pinning that same `grouping_field_blank` refusal — so it is not a fixture that has to parse, and the producer now refuses it one layer earlier for the same reason. **Zero in-tree fixtures redden**, and the pattern was not widened to fit anything.

Pins added in `view.test.ts`: the by-name refusal at `grouping.fields.1.field` (asserted through `ListViewSchema` so the path is the real one), the six whitespace shapes, a not-a-trim arm, the 20 harvested spellings as an `it.each` table, and a lit/dark control test that also carries the discriminator (`' owner.name'` is refused) — because the accepting arms alone would pass just as well against the old bare `z.string()`.

## Verification

**Reverse verification (ablation).** Predicted direction: red. Removed the `.superRefine` and rebuilt nothing (the test resolves `./view.zod` relatively — no `dist` on the path). On-disk proof before and after: injected-text count 2 to 0, `git diff --stat HEAD` non-empty. Result: **9 pins red**, exactly the ruling's ones (`× refuses a padded grouping field name BY NAME at grouping.fields[N].field`, the six whitespace shapes, the not-a-trim arm, the lit/dark discriminator); the 20 accepting arms stayed green, which is the expected asymmetry. Restore leg via `git checkout HEAD -- PATH` under a `trap … EXIT INT TERM` with an absolute path, proven byte-identical: worktree blob `848f63fa33f3e63da434e59bcc51abcdbdfc8718` equals the HEAD blob.

| run | result |
|:--|:--|
| `@objectstack/spec` full suite | 498 files / **13724 passed** |
| `@objectstack/spec` typecheck | exit 0 (source + scripts + test layer) |
| `@objectstack/lint` · `@objectstack/rest` · `@objectstack/platform-objects` | 3743 · 3146 (+1 skipped) · 561, all passed |
| repo-wide `eslint . --no-inline-config` | exit 0 over **6569** files, 0 errors 0 warnings |
| derived gate families (`dispatch-gates.mjs`) | 108 derived, **106 run green**, 2 NOT MEASURED, 0 unrun |

The downstream three are run because an accept-set narrowing changes the runtime face even though the exported byte shape does not; their first run was the `MODULE_NOT_FOUND` class (unbuilt `@objectstack/formula`) and was re-run after building the closures rather than recorded as red.

**NOT MEASURED, called out separately from red — neither is a finding:**
- `pnpm check:dual-build-cjs-loads` — exit **3**, PREREQUISITE NOT MET: 33 packages have no `dist/`. Needs a whole-monorepo build; declared to CI.
- `pnpm check:type-check-debt` — exit **3**, PREREQUISITE NOT MET: `@objectstack/metadata-core` unbuilt, and the gate refuses to measure a different world. Its coverage half (`check:type-check-coverage`) ran green.

`check:react-declaration-parity`, run exactly as dispatched: **exit 0**, manifest `sdui.manifest.json` **at the repository root** (66910 bytes) — not the `packages/spec` path a literal `$PWD` gives you, which the gate itself rejects with a loud "this gate did NOT run". ⚠️ The snapshot's freshness relative to `.objectui-sha` remains unmeasured (#17405), so this green is about parity against the committed manifest, not about the manifest being current.

Two residuals I am not able to close from here and am therefore declaring rather than papering over: the gate derivation ran on a tree ~9 commits behind `origin/main`, and one file it derives from (`scripts/measure-reserved-identity-name-census.mjs`) changed in that range, so CI's re-derivation on the true merge base is the authority on the family set; and the 45 artifact-roster families, the 11 wide-population families and the 6 path-scheduled CI jobs are outside the derived total by construction.

## ⚠️ One thing the seat should know: the declared file face has a co-tenant

The claim's batch-independence line reads "measured disjoint from … every open PR at claim time". Re-checked at write time: **PR #17298** (`feat(spec)!: retire the type: 'page' list-view mount`, open, `mergeable_state: dirty`) touches **all three** of `view.zod.ts`, `view.test.ts` and `registry.ts`.

I did not widen my face and I did not reorder anything. The hunks are disjoint by a wide margin — #17298's earliest `view.zod.ts` hunk is at :1629 against my :853, its earliest `view.test.ts` hunk at :3754 against my ~:2050, and `registry.ts` is generated and regenerates — so this merges cleanly rather than needing the serial hold that #17447 got. Recording it because the claim's reading of it was different from mine, and that is the seat's to arbitrate, not mine.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MkQhmuuJAVDjmeWNixwDDH)_