### PR TITLE
docs(pm): engine lane red line points at the anchoring rule's lint exception

### DIFF
--- a/.claude/skills/pm-dispatch/references/lanes/engine.md
+++ b/.claude/skills/pm-dispatch/references/lanes/engine.md
@@ -12,7 +12,7 @@
   driver-sqlite-wasm、driver-turso。
 - 红线:改元数据格式或接受面 ⇒ `domain:spec`,判据是改变接受面而不是碰到 spec。
 - `/meta` 路由本体在 `packages/rest` ⇒ `domain:cli`;`packages/services/**` ⇒ `domain:services`。
-- `content/docs/**` 与 `packages/lint` ⇒ `domain:devx`。
+- `content/docs/**` 与 `packages/lint` ⇒ `domain:devx`;`packages/lint` 的唯一例外见 SKILL.md 锚定规则。
 
 ## 常设承诺
 


### PR DESCRIPTION
Fixes #17088

`references/lanes/engine.md:15` — the engine seat's 红线 list — stated `packages/lint` ⇒ `domain:devx` with no qualification, while the anchoring rule in `SKILL.md` carves out the part of that package which turns on the spec contract. A seat reading its own charter, the one text it is entitled to trust, was handed the wrong lane for a real file family.

## The line

Before — 60 bytes:

```text
- `content/docs/**` 与 `packages/lint` ⇒ `domain:devx`。
```

After — 117 bytes of the file's 120-byte cap:

```text
- `content/docs/**` 与 `packages/lint` ⇒ `domain:devx`;`packages/lint` 的唯一例外见 SKILL.md 锚定规则。
```

Net-zero lines: the file stays **32/32** (ceiling unmoved, no `CEILINGS` row touched, `scripts/pm/check-skill-line-ratchet.mjs` not on this diff). Everything else in the file is byte-identical — `git diff --stat` reads `1 file changed, 1 insertion(+), 1 deletion(-)`.

The new clause is a **pointer, not a restatement**. It names the default, says an exception exists and attaches it to the `packages/lint` token, and names where the exception lives. It does not repeat the exception's test — 「围着 spec 契约转的归 `domain:spec`,余留 devx」 — which stays at exactly one site, so this PR creates no fourth copy to drift. The pointer string 「唯一例外见 SKILL.md 锚定规则」 is reused **verbatim** from `references/core-rules.md:64`, so the pointer family greps as one string.

## Carrier grep — is there a fourth?

`grep -rn 'packages/lint' .claude/ AGENTS.md` at this branch head, every hit quoted:

| site | what it carries |
|:--|:--|
| `SKILL.md:240` | the anchoring rule's exception itself — 「唯一例外 `packages/lint` 等与 spec 相交的 devx 面:围着 spec 契约转的归 `domain:spec`,余留 devx。」 the single statement |
| `SKILL.md:247` | the `domain:devx` table row, already qualified — 「三者与 spec 相交面按锚定规则例外归 `domain:spec`」 |
| `references/lanes/engine.md:15` | the unqualified half — **this PR** |
| `.claude/skills/spec-property-retirement/SKILL.md:267` | a source path in a retirement checklist (`packages/lint/src/lint-liveness-properties.ts`) — not a lane-routing statement, so not a carrier |

`grep -rn 'domain:devx' .claude/ AGENTS.md` adds only pointers and cross-repo routing: `references/lanes/devx.md:7` 「本席路径面全量在 SKILL.md 域车道表 `domain:devx` 行,⛔ 不另抄」, `devx.md:10` 「SUBJECT 例外与 spec 三面切分在 SKILL.md 域车道表」, `core-rules.md:64` 「每个包恰好属于一个域(唯一例外见 SKILL.md 锚定规则)」, plus `SKILL.md:198` and `lanes/ui.md:14`, neither of which carries a package list. `AGENTS.md` carries neither token.

**Answer: there is no fourth carrier.** After this PR the split is one statement plus pointers, and nothing unqualified is left.

## The one judgement, on the four axes

指针 vs 重述子句,以及措辞。**实际业务需求** — 服务的是真实场景而非投机面:读这行的是 engine 席的分诊动作,而 `packages/lint` 的 spec 相交面恰好会被它路由错;实测三处载体、两处已带限定,只余此一处不带,需求由实测确立而不是「读起来像有用」。**项目长远合理性** — 指针优于重述:重述造出第四份会漂移的副本,而「单一陈述 + 指针」是本仓已声明的形态,把判据留在锚定规则处是 contract-first,不是就地补丁;代价是读者多一跳,换来的是这条规则永远只有一处可改。**防 AI 写错** — 限定挂在 `packages/lint` 这个 token 上(而非 `后者` 一类指代),让快读红线表的 agent 在结构上无法停在 `⇒ domain:devx` 就下结论;这是把正确读法做成更难写错的形状,而不是要求读者更小心。**创业阶段不扩散** — 净零行、不动 ceiling、不新增验证面、不碰另外四处文本,能力面零扩张,亦无渐进窗口可留。四轴无冲突,一致指向已落地的指针形。

## Verification

Gate families derived from this branch's own changeset, not from a hand-written list: `node scripts/pm/dispatch-gates.mjs --commands --repo objectstack-ai/objectstack` (stderr names the tree — `objectstack-ai/objectstack` at `655739ff`; change set `1 path(s) vs merge base 92865f62c`). All 14 run, each exit code captured **before** any pipe.

| family | exit | its own verdict line |
|:--|:--|:--|
| `node scripts/check-closing-keyword-parity.mjs` | 0 | `check-closing-keyword-parity: OK (3 parsers agree on all 9 keywords and both measured separators; sweep found 5 file(s) carrying the grammar across 8314 tracked file(s), all registered).` |
| `node scripts/check-closing-keyword-parity.mjs --self-test` | 0 | `✓ ... --self-test: 24 assertions, 5 mutations of the shipped parsers each driven to red.` |
| `node scripts/check-comment-mask-corpus.mjs` | 0 | `✓ comment-mask corpus sweep: 6580 files, 0 disagree, 0 unparseable, 64.2s (comparator self-test: 26 cases pass).` |
| `pnpm --filter @objectstack/lint run check:doc-formula-expressions` | 0 | `✓ check:doc-formula-expressions (spec TSDoc): 9 @example(s) judged clean across 1381 packages/spec/src files` |
| `pnpm check:agent-test-spelling` | 0 | `✓ check-agent-test-spelling: 0 violations — 499 file(s) · 7979 bare -- token(s) · 1674 launcher-rooted run(s) · 12 separator(s) JUDGED` |
| `pnpm check:doc-authoring` | 0 | `✓ doc authoring guard: 15025 customer-facing string(s) across 938 spec sources clean — no internal issue-id references.` |
| `pnpm check:driver-memory-census` | 0 | `OK  self-test: classifies every module-binding form ... and holds the ruled set to the rulings that admitted it` |
| `pnpm check:nul-bytes` | 0 | `✓ check-nul-bytes --self-test: 75 assertions over a temp git repo (real scan() path)` |
| `pnpm check:pm-governed-merges` | 0 | `✓ check-governed-merges --self-test: 274 assertions (the unified governed predicate + near misses ...)` |
| `pnpm check:pm-skill-id-lint` | 0 | `✓ check-skill-id-lint: 27 file(s) clean (pattern /#[0-9]{3,}/g).` |
| `pnpm check:pm-skill-ratchet` | 0 | `✓ check-skill-line-ratchet: .claude/skills/pm-dispatch/references/lanes/engine.md is 32 lines (ceiling 32; headroom 0).` |
| `pnpm check:refd-timer-probe` | 0 | `OK  check-refd-timer-probe: 6575 source file(s) swept; the process-global timer probe is read in packages/qa/refd-timer-testkit/src/index.ts and nowhere else.` |
| `pnpm check:skill-frame-sync` | 0 | `✓ check-skill-frame-sync: the one declared copy of the decision frame is internally coherent (.claude/skills/pm-dispatch/SKILL.md)` |
| `pnpm check:watch-hint-literal` | 0 | `✓ check-watch-hint-literal: 69 declaration(s) across 4 rostered name(s) ... no unrostered spelling of the idiom in the tree.` |

Reconciled against the derivation, exit codes included:

```text
✓ dispatch-gates --ran: 14 derived famil(ies) accounted for — 14 run,
  0 NOT-MEASURED (a DERIVED zero — all 14 recorded an exit code and none of them is 3).
```

**Ratchet, before and after** (`node scripts/pm/check-skill-line-ratchet.mjs`, exit 0 both times) — identical verdict on both legs, which is the point:

```text
✓ check-skill-line-ratchet: .claude/.../lanes/engine.md: widest table row is 0 bytes (pin 0; headroom 0).
✓ check-skill-line-ratchet: .claude/.../lanes/engine.md is 32 lines (ceiling 32; headroom 0).
```

**Path face** — `node scripts/pm/check-governed-merges.mjs --test .claude/skills/pm-dispatch/references/lanes/engine.md`, exit **3**:

```text
governed-surface predicate: 1 of 1 path(s) hit the register (5 surfaces, repo-agnostic).
  ⛔  GOVERNED — a human merge is the review record for this PR.
      .claude/** ×1 — the agent instruction tree (skills, agents, hooks, settings)
```

Exit 3 there is the GOVERNED verdict, not a failure — proved with a control leg on a non-governed path (`packages/core/src/index.ts`), which returns exit **0** and `✅ NOT governed`. File list taken three-dot: `git diff --name-only origin/main...HEAD` = the one file.

Also run outside the gate set: `grep -naP` over the edited file for control characters — no hits.

**Changeset: none, `skip-changeset` applied.** Nothing published moves: the diff is one line of `.claude/**`, which the fast track names as a non-publishing surface, and no package `files[]` entry reaches it.

`Clause-②: no` — instruction text; no accept set widens and no public surface moves.

## Acceptance notes

- `noted, not filed:` the card's Refs line and the dispatch both cite `lanes/devx.md:12` for the pointer 「SUBJECT 例外与 spec 三面切分在 SKILL.md 域车道表」; on `main` today that sentence sits at `:10`, and `:12` is a different rule. Line-number rot — exactly what `lanes/engine.md:26` rules on (「行号数小时内即腐烂,恒按符号定位」). No tree defect, nothing to fix. Who hits it: the skills seat reviewing this PR, which re-reads that citation.
- `noted, not filed:` the dispatch's Zone-3 suggested wording measures **134 bytes**, over this file's 120-byte cap, so it could not land verbatim; the pointer form that landed is 117 bytes. Who hits it: the dispatching seat, on the next lane-file card.
- `noted, not filed:` `.claude/skills/spec-property-retirement/SKILL.md:267` names `packages/lint/src/lint-liveness-properties.ts`. It is a source path in a retirement checklist, not a lane-routing statement, so it is not a fourth carrier and is off this surface. Who hits it: nobody — 承接者:无.

Nothing here meets the three admissible filing classes (reproducible defect · declared-contract breach · a trap that makes an AI author metadata the runtime rejects), so nothing was filed.

## 维护者速读(草稿)

**改了什么** —— engine 席岗位说明的红线表第 15 行,一行。原文说 `content/docs/**` 与 `packages/lint` 都归 `domain:devx`,句号,没有任何限定;现在同一行末尾加了一句指针,说明 `packages/lint` 有唯一例外,例外本身在 `SKILL.md` 的锚定规则里。文件仍是 32 行,不动 ceiling,其余每个字节不变。

**为什么改** —— 锚定规则里明写着:`packages/lint` 里围着 spec 契约转的那部分归 `domain:spec`,其余留 devx。域车道表那行已经带了这个限定,devx 席的岗位说明也已经指向它,唯独 engine 席读到的是不带限定的半句。分诊席读自己的岗位说明是本分,结果拿到的是现成的错答案。本轮实测:全仓再无第四处不带限定的载体,补完这一处,这一族就闭合了。

**风险与代价(含回滚)** —— 风险接近于零:纯指令文本,没有代码、没有 schema、没有接受面;14 个派生门禁全绿,行数棘轮前后同判。代价是读者多一跳(要去 `SKILL.md` 查例外),换来的是这条规则永远只有一处可改 —— 刻意不在此重述,否则就多出第四份会漂移的副本。回滚就是把这一行还原成原来的 60 字节版本,单行 revert,无任何下游。

**席位意见** ——(留空,由 skills 席定稿)

**你要做的** —— 这是受管面(`.claude/**`),按规矩停在 draft,由你合并;没有任何 agent 会翻 ready 或挂 auto-merge。请确认一件事:例外用**指针**而不是就地重述,是否合你意 —— 这是本卡唯一的判断题。

---
_Generated by [Claude Code](https://claude.ai/code/session_01YKEjmbYNvYWJvWGSWx26zK)_