### PR TITLE
fix(spec): overlay screen nodes inside ADR-0031 regions in `translateFlow`

### DIFF
--- a/.changeset/translate-flow-walks-adr-0031-regions.md
+++ b/.changeset/translate-flow-walks-adr-0031-regions.md
@@ -1,0 +1,34 @@
+---
+'@objectstack/spec': patch
+---
+
+`translateFlow` overlays screen nodes inside ADR-0031 regions, at any depth
+
+`translateFlow` (`system/i18n-resolver.ts`) read the flat `flow.nodes` array and
+nothing else. But `FlowNode.config` carries ADR-0031 regions —
+`loop.config.body`, `parallel.config.branches[].nodes`,
+`try_catch.config.try`/`.catch` — each holding a full `nodes` array that nests
+arbitrarily, and a `type: 'screen'` node inside one is a real screen: the
+executor pauses on it and the client receives its `ScreenSpec.nodeId`.
+
+So `flows.<name>.screens.<node_id>.{title,fields.*}` was authored for such a
+node, parsed (the bundle schema is keyed by node id and knows nothing about
+depth) and was then silently never applied. The wizard step rendered its
+source-locale heading and field labels while its siblings one level up were
+translated.
+
+The descent now runs through `mapFlowNodeList`, a per-flow region-aware
+copy-on-write walk shared with the ADR-0087 conversions' `mapFlowNodes`, which
+reads `FLOW_REGION_SLOTS_BY_TYPE` — the single declaration of where a region
+lives (`automation/region-slots.ts`). This resolver is therefore not a fifth
+hand-rolled reader of that table; the fourth pass written against the flat
+one-liner is the last one that had to be.
+
+Reference identity is unchanged and is pinned: a node that resolves nothing
+comes back as the same reference, every container `config` and region `nodes`
+array on the way down is copied only when a descendant actually changed, and a
+flow the bundle does not carry is returned as the same object.
+
+⛔ No wiring changed. `translateFlow` is still deliberately absent from
+`translateMetadataDocument`'s dispatch table and no liveness row moved — that
+decision belongs to the downstream runner card, as its docblock records.

--- a/packages/spec/src/conversions/walk.ts
+++ b/packages/spec/src/conversions/walk.ts
@@ -115,6 +115,53 @@ function mapNodeTree(
 }
 
 /**
+ * Immutably map ONE flow's `nodes[]` — **including the nodes nested inside
+ * ADR-0031 structured regions** (`loop.config.body`,
+ * `parallel.config.branches[]`, `try_catch.config.try`/`.catch`), to any depth.
+ *
+ * Returns the **same array reference** when nothing under it changed, so a
+ * caller can tell "rewritten" from "untouched" by identity — the copy-on-write
+ * contract this module states for the stack, one level in.
+ *
+ * `mapper` receives each node dict and its path (`${basePath}[i]`, or
+ * `${basePath}[i].config.body.nodes[j]` for a nested one) and returns either the
+ * same reference (no change) or a new dict. Non-dict elements pass through
+ * untouched.
+ *
+ * **Exported because the flow-node unit has more than one consumer, and every
+ * consumer that hand-rolled it walked `nodes` FLAT.** {@link mapFlowNodes} is
+ * the stack-shaped consumer (the ADR-0087 conversions); `translateFlow`
+ * (`system/i18n-resolver.ts`) is the document-shaped one — it is handed a
+ * single flow, never a stack, so it could not reach `mapFlowNodes` at all and
+ * walked `flow.nodes` flat instead, leaving a `type: 'screen'` node inside any
+ * region unoverlaid. Both now descend through this one function, so the region
+ * table has one reader per unit rather than one per call site: the "why does
+ * the flat walk keep being reachable" question is answered by there being a
+ * region-aware helper at the shape a document-level caller actually holds.
+ *
+ * ⚠️ Deliberately NOT re-exported from `conversions/index.js`: this is
+ * cross-module reuse inside `packages/spec`, not a published entry-point
+ * export. `walk.ts` reaches no `exports` subpath of the package
+ * (`packages/spec/api-surface/*.json` lists none of its symbols), and that is
+ * the boundary that keeps this a repair rather than a widening of the
+ * package's public surface.
+ */
+export function mapFlowNodeList(
+  nodes: readonly unknown[],
+  basePath: string,
+  mapper: (node: Dict, path: string) => Dict,
+): readonly unknown[] {
+  let changed = false;
+  const next = nodes.map((node, ni) => {
+    if (!isDict(node)) return node;
+    const mapped = mapNodeTree(node, `${basePath}[${ni}]`, mapper, 0);
+    if (mapped !== node) changed = true;
+    return mapped;
+  });
+  return changed ? next : nodes;
+}
+
+/**
  * Immutably map every flow node in `stack.flows[].nodes[]` — **including the
  * nodes nested inside ADR-0031 structured regions** (`loop.config.body`,
  * `parallel.config.branches[]`, `try_catch.config.try`/`.catch`), to any depth.
@@ -124,6 +171,9 @@ function mapNodeTree(
  * the same reference (no change) or a new dict. The stack, the `flows` array, an
  * individual flow, its `nodes` array, and every container `config` on the way
  * down are each copied only when a descendant actually changed.
+ *
+ * The per-flow descent is {@link mapFlowNodeList}'s — one implementation, so
+ * this walker and the document-overlay one cannot drift about which nodes exist.
  */
 export function mapFlowNodes(
   stack: Dict,
@@ -135,14 +185,8 @@ export function mapFlowNodes(
   let flowsChanged = false;
   const nextFlows = flows.map((flow, fi) => {
     if (!isDict(flow) || !Array.isArray(flow.nodes)) return flow;
-    let nodesChanged = false;
-    const nextNodes = flow.nodes.map((node, ni) => {
-      if (!isDict(node)) return node;
-      const mapped = mapNodeTree(node, `flows[${fi}].nodes[${ni}]`, mapper, 0);
-      if (mapped !== node) nodesChanged = true;
-      return mapped;
-    });
-    if (!nodesChanged) return flow;
+    const nextNodes = mapFlowNodeList(flow.nodes, `flows[${fi}].nodes`, mapper);
+    if (nextNodes === flow.nodes) return flow;
     flowsChanged = true;
     return { ...flow, nodes: nextNodes };
   });

--- a/packages/spec/src/system/i18n-resolver.test.ts
+++ b/packages/spec/src/system/i18n-resolver.test.ts
@@ -3472,6 +3472,207 @@ describe('translateFlow (#11287)', () => {
   });
 });
 
+describe('translateFlow — screens inside ADR-0031 regions (#11745)', () => {
+  // The fourth pass in this repo written against a flat `flow.nodes` walk
+  // (#4347 `applyConversionsToFlow`, #4380 the flow lint rules, #5383
+  // `flow-inert-node-condition` were the first three). `FlowNode.config`
+  // carries regions — `loop.config.body`, `parallel.config.branches[].nodes`,
+  // `try_catch.config.try`/`.catch` — each a full `nodes` array that nests
+  // arbitrarily. A `type: 'screen'` node inside one is a real screen: the
+  // executor pauses on it and the client receives its `ScreenSpec.nodeId`, so
+  // `flows.<name>.screens.<node_id>` is authored for it and parses (the bundle
+  // schema is keyed by node id and knows nothing about depth). The flat walk
+  // accepted those keys and silently never applied them.
+  const bundle: FlowTestBundle = {
+    'zh-CN': {
+      flows: {
+        nested_regions: {
+          label: '嵌套区域',
+          screens: {
+            top_screen: { title: '顶层', fields: { f_top: { label: '顶层字段' } } },
+            loop_screen: { title: '循环内', fields: { f_loop: { label: '循环字段', placeholder: '请输入' } } },
+            branch_screen: { title: '分支内' },
+            try_screen: { title: 'try 内' },
+            catch_screen: { title: 'catch 内' },
+            deep_screen: { title: '深层' },
+          },
+        },
+      },
+    },
+  };
+
+  /**
+   * One flow carrying a screen in EVERY region slot the table declares, plus
+   * one two-levels-deep (a screen inside a loop inside a try's `try` region)
+   * and two negative controls the bundle deliberately omits — a non-screen
+   * node inside a region, and a nested screen with no bundle entry.
+   */
+  const regionFlow = (): any => ({
+    name: 'nested_regions',
+    label: 'Nested Regions',
+    type: 'screen',
+    nodes: [
+      {
+        id: 'top_screen',
+        type: 'screen',
+        label: 'Top',
+        config: { title: 'Top', fields: [{ name: 'f_top', label: 'Top Field' }] },
+      },
+      {
+        id: 'the_loop',
+        type: 'loop',
+        label: 'Loop',
+        config: {
+          collection: '{items}',
+          body: {
+            nodes: [
+              {
+                id: 'loop_screen',
+                type: 'screen',
+                label: 'In Loop',
+                config: { title: 'In Loop', fields: [{ name: 'f_loop', label: 'Loop Field' }] },
+              },
+              { id: 'loop_script', type: 'script', label: 'Loop Script' },
+              {
+                id: 'untranslated_screen',
+                type: 'screen',
+                label: 'Untranslated',
+                config: { title: 'Untranslated' },
+              },
+            ],
+            edges: [],
+          },
+        },
+      },
+      {
+        id: 'the_parallel',
+        type: 'parallel',
+        label: 'Parallel',
+        config: {
+          branches: [
+            { nodes: [{ id: 'branch_script', type: 'script', label: 'Branch Script' }], edges: [] },
+            {
+              nodes: [
+                { id: 'branch_screen', type: 'screen', label: 'In Branch', config: { title: 'In Branch' } },
+              ],
+              edges: [],
+            },
+          ],
+        },
+      },
+      {
+        id: 'the_try',
+        type: 'try_catch',
+        label: 'Try',
+        config: {
+          try: {
+            nodes: [
+              { id: 'try_screen', type: 'screen', label: 'In Try', config: { title: 'In Try' } },
+              {
+                id: 'inner_loop',
+                type: 'loop',
+                label: 'Inner Loop',
+                config: {
+                  collection: '{rows}',
+                  body: {
+                    nodes: [
+                      { id: 'deep_screen', type: 'screen', label: 'Deep', config: { title: 'Deep' } },
+                    ],
+                    edges: [],
+                  },
+                },
+              },
+            ],
+            edges: [],
+          },
+          catch: {
+            nodes: [{ id: 'catch_screen', type: 'screen', label: 'In Catch', config: { title: 'In Catch' } }],
+            edges: [],
+          },
+        },
+      },
+    ],
+    edges: [],
+  });
+
+  // Explicit paths rather than a recursive finder: the assertion then names
+  // the SLOT it is about, so a failure says which region stopped being walked.
+  const loopScreen = (d: any) => d.nodes[1].config.body.nodes[0];
+  const branchScreen = (d: any) => d.nodes[2].config.branches[1].nodes[0];
+  const tryScreen = (d: any) => d.nodes[3].config.try.nodes[0];
+  const deepScreen = (d: any) => d.nodes[3].config.try.nodes[1].config.body.nodes[0];
+  const catchScreen = (d: any) => d.nodes[3].config.catch.nodes[0];
+
+  it('overlays a screen in EVERY region slot — loop.body, parallel.branches[], try_catch.try and .catch', () => {
+    const out: any = translateFlow(regionFlow(), bundle, { locale: 'zh-CN' });
+    expect(loopScreen(out).config.title).toBe('循环内');
+    expect(branchScreen(out).config.title).toBe('分支内');
+    expect(tryScreen(out).config.title).toBe('try 内');
+    expect(catchScreen(out).config.title).toBe('catch 内');
+  });
+
+  it('reaches ARBITRARY depth — a screen inside a loop inside a try_catch', () => {
+    const out: any = translateFlow(regionFlow(), bundle, { locale: 'zh-CN' });
+    expect(deepScreen(out).config.title).toBe('深层');
+  });
+
+  it('overlays per-FIELD copy on a nested screen, not just its title', () => {
+    const out: any = translateFlow(regionFlow(), bundle, { locale: 'zh-CN' });
+    const field = loopScreen(out).config.fields.find((f: any) => f.name === 'f_loop');
+    expect(field.label).toBe('循环字段');
+    expect(field.placeholder).toBe('请输入');
+  });
+
+  it('still overlays the FLAT top-level screen — the reach grew, it did not move', () => {
+    const out: any = translateFlow(regionFlow(), bundle, { locale: 'zh-CN' });
+    expect(out.label).toBe('嵌套区域');
+    expect(out.nodes[0].config.title).toBe('顶层');
+    expect(out.nodes[0].config.fields[0].label).toBe('顶层字段');
+  });
+
+  it('preserves REFERENCE IDENTITY for everything that resolved nothing', () => {
+    // Load-bearing: `nodesChanged` is read by identity, so a node copied
+    // without cause turns every untouched document into a changed one.
+    const doc = regionFlow();
+    const out: any = translateFlow(doc, bundle, { locale: 'zh-CN' });
+
+    // A non-screen node inside a region, and a nested screen the bundle omits.
+    expect(loopScreen(out) === loopScreen(doc)).toBe(false);          // this one DID resolve
+    expect(out.nodes[1].config.body.nodes[1]).toBe(doc.nodes[1].config.body.nodes[1]);
+    expect(out.nodes[1].config.body.nodes[2]).toBe(doc.nodes[1].config.body.nodes[2]);
+
+    // A whole branch under which nothing resolved keeps its own reference,
+    // including its `nodes` array.
+    expect(out.nodes[2].config.branches[0]).toBe(doc.nodes[2].config.branches[0]);
+    expect(out.nodes[2].config.branches[0].nodes).toBe(doc.nodes[2].config.branches[0].nodes);
+
+    // The input document is never mutated.
+    expect(doc.nodes[1].config.body.nodes[0].config.title).toBe('In Loop');
+  });
+
+  it('returns the SAME flow reference when nothing resolved, regions included', () => {
+    // The negative control for the identity discipline one level up: a flow
+    // the bundle does not carry must come back untouched by reference, or
+    // `nodesChanged` starts reporting untouched documents as changed.
+    const doc = { ...regionFlow(), name: 'no_such_flow' };
+    expect(translateFlow(doc, bundle, { locale: 'zh-CN' })).toBe(doc);
+  });
+
+  it('leaves a region-shaped value that is not a region alone (`config` is an open record)', () => {
+    // `body` is also an ordinary key elsewhere — an `http` node's request
+    // payload. The descent checks the SHAPE (`{ nodes: [...] }`), never the
+    // key name alone, so a `loop` whose `body` is a string is passed through.
+    const doc: any = {
+      name: 'nested_regions',
+      label: 'Nested Regions',
+      nodes: [{ id: 'the_loop', type: 'loop', label: 'Loop', config: { collection: '{i}', body: 'not a region' } }],
+    };
+    const out: any = translateFlow(doc, bundle, { locale: 'zh-CN' });
+    expect(out.nodes[0]).toBe(doc.nodes[0]);
+    expect(out.label).toBe('嵌套区域');
+  });
+});
+
 describe('resolveFlowScreenTitle (#11287)', () => {
   const bundle: FlowTestBundle = {
     'zh-CN': {

--- a/packages/spec/src/system/i18n-resolver.ts
+++ b/packages/spec/src/system/i18n-resolver.ts
@@ -55,6 +55,8 @@
  * here.
  */
 
+import { mapFlowNodeList } from '../conversions/walk.js';
+
 import type { TranslationBundle, TranslationData } from './translation.zod';
 
 /**
@@ -3478,6 +3480,27 @@ export function resolveFlowScreenTitle(
  * `help`) is ignored, never overlaid (the negative `translatePage` pins for
  * the retired `submitLabel`).
  *
+ * **Every screen node, at any DEPTH.** `FlowNode.config` carries ADR-0031
+ * regions — `loop.config.body`, `parallel.config.branches[]`,
+ * `try_catch.config.try`/`.catch` — each holding a full `nodes` array, nesting
+ * arbitrarily, and a `type: 'screen'` node inside one is a real screen: the
+ * executor pauses on it and the client receives its `ScreenSpec.nodeId`. So
+ * `flows.<name>.screens.<node_id>` is authored for it, parses (the bundle
+ * schema is keyed by node id and knows nothing about depth) and must be
+ * overlaid. A flat `flow.nodes.map(…)` walked straight past those, accepting
+ * the translation and silently never applying it — the fourth pass in this
+ * repo to be written against the flat one-liner. The descent is
+ * {@link mapFlowNodeList}'s, which reads `FLOW_REGION_SLOTS_BY_TYPE`: WHERE a
+ * region lives is declared once (`automation/region-slots.ts`) and walked by
+ * one function per unit, so this resolver is not a fifth hand-rolled reader of
+ * that table.
+ *
+ * That helper is also what preserves the identity discipline through the
+ * descent: it returns the SAME `nodes` array when no node under it resolved
+ * anything, and every container `config` on the way down is copied only when a
+ * descendant actually changed — so `nodesChanged` below stays a true reading
+ * and an untouched document still comes back as the same reference.
+ *
  * ⚠️ Deliberately NOT registered in {@link translateMetadataDocument}'s
  * dispatch table: that table reaches the REST metadata boundary by itself
  * (`TRANSLATABLE_METADATA_TYPES` drives `@objectstack/rest`, #3786), which
@@ -3497,14 +3520,14 @@ export function translateFlow<T extends FlowLike>(
 
   const label = lookupFlowLabel(bundle, name, opts);
 
-  let nodesChanged = false;
   const nodes = Array.isArray(flow.nodes)
-    ? flow.nodes.map((node) => {
-        const next = translateScreenNode(node, name, bundle, opts);
-        if (next !== node) nodesChanged = true;
-        return next;
-      })
+    ? mapFlowNodeList(
+        flow.nodes,
+        `flows.${name}.nodes`,
+        (node) => translateScreenNode(node as FlowNodeLike, name, bundle, opts) as Record<string, unknown>,
+      ) as FlowNodeLike[]
     : undefined;
+  const nodesChanged = nodes !== undefined && nodes !== flow.nodes;
 
   if (label === undefined && !nodesChanged) return flow;
   return {


### PR DESCRIPTION
Fixes #11745

Clause-②: no

`translateFlow` (`packages/spec/src/system/i18n-resolver.ts`) read the flat `flow.nodes` array and nothing else. `FlowNode.config` carries ADR-0031 regions — `loop.config.body`, `parallel.config.branches[].nodes`, `try_catch.config.try` / `.catch` — each holding a full `nodes` array that nests arbitrarily, and a `type: 'screen'` node inside one is a real screen: the executor pauses on it and the client receives its `ScreenSpec.nodeId`. So `flows.NAME.screens.NODE_ID.{title,fields.*}` was authored for such a node, parsed (the bundle schema is keyed by node id and knows nothing about depth), and was then silently never applied.

## Premises falsified first, on this branch's own merge base

Re-measured on `76ddab772f` (the merge base of this branch), not inherited. The card had been falsely auto-closed once and reopened with "if the defect has since been fixed elsewhere, close it again naming the fix" — it had not been.

```
packages/spec/src/system/i18n-resolver.ts
  translateFlow  → const nodes = Array.isArray(flow.nodes) ? flow.nodes.map(…)   ← still flat
  walkFlowNodes      references in this file : 0
  FLOW_REGION_SLOTS  references in this file : 0
  mapFlowNodes       references in this file : 0
  LIT CONTROL 'translateScreenNode'          : 3     ← the zeros are absences, not a bad path
```

The claim comment's correction to the triage comment also holds: `walkFlowNodes` is declared at `packages/lint/src/flow-walk.ts`, and `packages/spec`'s dependencies are `pg-connection-string` and `zod` — `@objectstack/lint` is not among them, so importing it would invert the dependency direction. Spec's own machinery is `FLOW_REGION_SLOTS_BY_TYPE` (`automation/region-slots.ts`) and the copy-on-write walk in `conversions/walk.ts`.

**One measured answer the triage comment asked for and could not supply from another lane:** the flat walk is **not** load-bearing anywhere. `translateFlow` has no production caller in this repo at all — the only references outside its own file are its own test file, a comment in `translation.test.ts`, and two docblocks in `packages/cli/src/utils/i18n-extract.ts`. Nothing relied on region nodes *not* being translated.

## The fork, and why this one

`mapFlowNodes` (`conversions/walk.ts`) is region-aware to any depth and reference-identity preserving, but it takes a whole `stack` and maps `stack.flows[]`. `translateFlow` receives a SINGLE flow, so it could not reach that walker at all — which is precisely why it grew its own flat one-liner. Its per-node helpers `mapRegionNodes` / `mapNodeTree` were module-private.

Two branches were on the table: **(A)** export a per-flow helper from `walk.ts` and consume it, or **(B)** drive a local region walk in `i18n-resolver.ts` off `FLOW_REGION_SLOTS_BY_TYPE`.

**Taken: (A)**, and the deciding argument is the repo's own declared rule, not effort. `automation/region-slots.ts` states why the region walks are deliberately NOT merged:

> The **walks** are deliberately NOT merged: they take different inputs (parsed `FlowNodeParsed` vs raw authored records), yield different units (a graph, a node, a rewritten tree), and one of them formats human diagnostic trails, which is consumer logic rather than protocol (Prime Directive #2). Only the fact they all need — *this* table — is shared.

Every one of those three distinctions is **absent** between `translateFlow` and `mapNodeTree`. `translateFlow` is documented as "schema-independent on purpose" and reads raw authored records — the same input. It yields a copy-on-write rewritten tree — the same unit. It formats no diagnostic trail. The stated reason for keeping walks apart does not reach this pair, so merging them is what that rule supports, and (B) would have made this resolver a fifth hand-rolled reader of the slot table — the exact shape the card says produced four passes.

The per-flow descent now lives in `mapFlowNodeList`, and `mapFlowNodes` delegates to it, so there is **one** implementation rather than two that could drift about which nodes exist.

## Why the declaration is `Clause-②: no`, measured rather than assumed

The dispatch order predicted `yes` for branch (A) on the ground that it "adds a public export to `packages/spec`". **Measured, it does not**, and this is the one place this PR contradicts its order:

- `conversions/walk.ts` reaches **no** `exports` subpath of the package. `conversions/index.ts` is the conversions layer's declared public surface and re-exports nothing from `walk.ts`; its only in-tree importers are `conversions/registry.ts` and its own test.
- None of `walk.ts`'s existing exports (`mapFlowNodes`, `mapPages`, `mapPageComponents`, `mapViewPayloads`, `renameKey`, `renameConfigKey`, …) appears in `packages/spec/api-surface/*.json`.
- `pnpm --filter @objectstack/spec run check:api-surface`, run after a real `pnpm --filter @objectstack/spec build` (it refuses with exit 3 on an unbuilt tree, so an unbuilt green would have been a false one), prints: `@objectstack/spec public API surface + factory signatures unchanged ✓` — and `git diff -- packages/spec/api-surface` is empty.
- `node scripts/pm/check-widening-tells.mjs --declaration no --diff …` exits 0: *"4 changed file(s) — 2 judged against a declared surface (no widening tell), 2 NOT MEASURED"* (the changeset has no declared surface; a test file declares no contract).

Directionally this is a repair toward the declared contract, not a widening: no schema key, no closed-set member, no registry entry and no published export moves, and no accept set changes in either direction — the bundle schema already accepted these keys at any depth, and the resolver was dropping them.

⚠️ **One carrier this PR cannot satisfy, for the seat.** The clause-② declaration limb is read from the **card's claim comment**, and the claim comment on #11745 carries no `Clause-②:` line. This round inherits that claim and is forbidden from posting a second one, so the declaration above is on the PR body only. If the carrier check is to read `no` on the card, the seat has to put it there.

## Reference identity is load-bearing, and pinned

`mapFlowNodeList` returns the **same** `nodes` array reference when nothing under it resolved, and every container `config` and region `nodes` array on the way down is copied only when a descendant actually changed. Pinned by:

- an untranslated nested screen and a non-screen node inside a region both come back `===`;
- a `parallel` branch under which nothing resolved keeps its own reference **and** its own `nodes` array;
- `translateFlow` returns the **same** `flow` reference when nothing resolved at all;
- a `loop` whose `body` is a string (`config` is an open record, and `body` is an ordinary key on an `http` node) is passed through by reference — the descent checks the shape, never the key name alone.

## Scope held

⛔ `translateFlow` is still deliberately absent from `translateMetadataDocument`'s dispatch table, `TRANSLATABLE_METADATA_TYPES` is unchanged and no liveness row moved — that wiring is the downstream runner card of #11287, as the docblock records, and the existing pin for that absence is untouched and green. The client-side path (`resolveFlowScreenTitle` / `lookupFlowScreenCopy`) was already correct and is not touched.

**The live disagreement the triage comment named is now closed in the runtime's favour, and I re-read the other side to confirm rather than assume.** `packages/lint/src/validate-translation-references.ts` collects its universe with `walkFlowNodes` and says so in as many words ("Nodes are collected through `walkFlowNodes`, NOT `flow.nodes` directly … Reading the flat array would leave every nested screen out of the universe and report each of its keys as an orphan"). The lint rule already treated a nested screen's keys as live; the runtime now applies them. The two agree, and the lint rule is compensating for nothing — no change needed there.

## Verification

All heavy runs through `scripts/pm/os-verify-lock.sh`; every verdict below is read from the wrapper's own `VERDICT command-exit` line or from an exit code captured before any pipe.

| run | verdict |
|:---|:---|
| `pnpm --filter @objectstack/spec test` (project `local`) | `VERDICT command-exit 0` — 470 files passed, 1 skipped; **13291 tests passed** |
| `pnpm --filter @objectstack/spec exec tsc --noEmit` | `VERDICT command-exit 0` |
| `pnpm --filter @objectstack/spec build` | `VERDICT command-exit 0` — 34/34 declaration files present |
| `pnpm lint` (`eslint . --no-inline-config`, whole repo, not narrowed) | `VERDICT command-exit 0` |
| gate families, `node scripts/pm/dispatch-gates.mjs --commands --repo objectstack-ai/objectstack` | 82 derived, **78 run green**, 4 NOT MEASURED |

The 4 NOT MEASURED are `exit 3` — a gate refusing its own prerequisite, never a red: `check:dual-build-cjs-loads`, `check:lean-entry-closure`, `check:type-check-debt` and `@objectstack/lint check:doc-formula-expressions` each need built output from packages outside this diff (`PREREQUISITE NOT MET`). Reconciled with `--ran`: *"82 derived famil(ies) accounted for — 78 run, 4 NOT-MEASURED (4 DERIVED from a recorded exit 3)"*. Five spec surface gates (`check:api-surface`, `check:browser-reachable-entries`, `check:dual-source-exports`, `check:entry-nameability`, `check:exported-any`) first exited 1 on an unbuilt tree with the same prerequisite refusal; they were re-run after the build and all exit 0. Figures cited at `5c45aa02d8`, the final commit; the lint and gate runs are on that same head.

### Ablation — required, direction predicted before running

**Predicted:** removing the region descent (restoring the flat `flow.nodes.map`) turns the four nested-region pins RED while the flat-screen pin, the same-reference pin and the non-region-shape pin stay GREEN.

Mutation proven on disk before the run, never inferred from an editor's exit code:

```
injected 'flow.nodes.map((node) => {' : 1
removed  'mapFlowNodeList('           : 0
mutated blob: 1da02c8d1f4c873c3bf432271c395666faa60d64
 packages/spec/src/system/i18n-resolver.ts | 12 ++++++------
 1 file changed, 6 insertions(+), 6 deletions(-)
```

**Observed, matching the prediction exactly** — `VERDICT command-exit 1`, `Tests 4 failed | 274 passed (278)`, and the four are precisely:

```
× overlays a screen in EVERY region slot — loop.body, parallel.branches[], try_catch.try and .catch
× reaches ARBITRARY depth — a screen inside a loop inside a try_catch
× overlays per-FIELD copy on a nested screen, not just its title
× preserves REFERENCE IDENTITY for everything that resolved nothing
```

The flat top-level screen pin, the same-flow-reference pin, the not-a-region pin and the whole pre-existing `translateFlow (#11287)` block stayed green — so the pins fail for the region walk's absence and nothing else.

Restored with `git checkout HEAD -- ABSOLUTE_PATH` from a `trap … EXIT INT TERM`, and restoration proven by blob equality rather than by an exit code:

```
HEAD blob   : edd8dfb635880fab50d6dba427b8743e96afdae0
on-disk blob: edd8dfb635880fab50d6dba427b8743e96afdae0
git diff HEAD --stat : (empty)
```

No `dist/` preflight applies: `i18n-resolver.test.ts` imports `./i18n-resolver` as a relative source specifier inside the same package, so the ablation ran against the mutated source with no build in the resolution path.

## 验收备注

- **Filed as #17511** — `packages/cli/src/utils/i18n-extract.ts`'s `walkScreenFlows` walks `flow.nodes` flat too, so a nested screen gets no skeleton entry from `os i18n extract` and no coverage row. Measured in that file: `FLOW_REGION_SLOTS` 0, `walkFlowNodes` 0, `try_catch` 0, `config.body` 0, with `walkScreenFlows` 2 as the literal control. Out of this card's declared file surface (a different package, a different unit — it collects expected keys with a diagnostic scope, not a copy-on-write rewrite) and it adds a verification surface this PR does not carry, so it is a card rather than an in-place fix. Its own docblock already argues the case one step short of the nesting: *"`translateFlow` overlays every screen node, and a walker that skipped one would re-open the extractable-but-ungated gap in miniature."* That premise is now true.
- `dispatch-gates.mjs` reported STALE TREE (origin/main moved during this round). The derivation was re-read afterwards and no derived family changed for these paths; the two stale files it named (`check-governed-queue-guard.mjs`, `check-widening-tells.mjs`) are gate scripts this diff does not touch.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MkQhmuuJAVDjmeWNixwDDH)_