### PR TITLE
refactor(examples): migrate the two in-repo hook examples to defineHook()

### DIFF
--- a/examples/app-crm/src/hooks/opportunity.hook.ts
+++ b/examples/app-crm/src/hooks/opportunity.hook.ts
@@ -1,12 +1,12 @@
 // Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
 
-import type { Hook, HookContext } from '@objectstack/spec/data';
+import { defineHook, type HookContext } from '@objectstack/spec/data';
 
 /**
  * Pin the probability to 100% when an opportunity is marked Closed Won,
  * and 0% when Closed Lost. Demonstrates a basic before-update hook.
  */
-export const OpportunityStageHook: Hook = {
+export const OpportunityStageHook = defineHook({
   name: 'opportunity_stage_probability',
   object: 'crm_opportunity',
   events: ['beforeInsert', 'beforeUpdate'],
@@ -16,4 +16,4 @@ export const OpportunityStageHook: Hook = {
     if (input.stage === 'closed_won') input.probability = 100;
     if (input.stage === 'closed_lost') input.probability = 0;
   },
-};
+});

--- a/examples/app-todo/src/objects/task.hook.ts
+++ b/examples/app-todo/src/objects/task.hook.ts
@@ -1,6 +1,6 @@
 // Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
 
-import { HookContext, Hook } from '@objectstack/spec/data';
+import { defineHook, type HookContext } from '@objectstack/spec/data';
 
 /**
  * Lifecycle logic for `todo_task` — insert defaults and the completion stamp.
@@ -47,7 +47,7 @@ import { HookContext, Hook } from '@objectstack/spec/data';
  * timestamp that every report and list view reads as fact. The same
  * `readonly`/strip reasoning applies — only a hook can write the clear.
  */
-const taskHook: Hook = {
+const taskHook = defineHook({
   name: 'task_logic',
   object: 'todo_task',
   events: ['beforeInsert', 'beforeUpdate', 'afterUpdate'],
@@ -120,6 +120,6 @@ const taskHook: Hook = {
       // runs daily and selects on `due_date` directly.
     }
   }
-};
+});
 
 export default taskHook;


### PR DESCRIPTION
Fixes #14850

Clause-②: no

Re-derived from what this PR actually ships, not copied from the claim comment. The clause-② surface is "a schema key, a closed-set member, a published export or a registry entry". This diff is two TypeScript files inside two `private: true` example packages: it adds no schema key, no closed-set member, no published export and no registry entry. `defineHook` was already exported before this PR and is untouched by it. The dispatching seat declared `no` and the measurement agrees.

## What this does

Ruling **A** of #14685 item 1 (director record `5520452691`, 2026-09-03): 「同意，然后执行契约复审」 — the `defineHook()` prescription **stays** in the published data skill, and one card migrates the two in-repo hook examples so the platform's own examples match what the skill teaches. The skill text is not touched here; the ruling keeps it as-is.

Two files, three changed lines each — the import, the opening line and the closing brace. **Every field inside each object is byte-identical**, which the diff shows directly:

| file | before | after |
|:--|:--|:--|
| `examples/app-crm/src/hooks/opportunity.hook.ts` | `export const OpportunityStageHook: Hook = {` | `export const OpportunityStageHook = defineHook({` |
| `examples/app-todo/src/objects/task.hook.ts` | `const taskHook: Hook = {` | `const taskHook = defineHook({` |

## Premise, re-measured on this PR's own merge base

`origin/main` `bea76c9280` — all four rows of the card's table still hold, so nothing was adapted around:

```
examples/app-crm/src/hooks/opportunity.hook.ts  'export const OpportunityStageHook: Hook = {' : 1
examples/app-todo/src/objects/task.hook.ts      'const taskHook: Hook = {'                    : 1
packages/spec/src/data/hook.zod.ts              'export function defineHook'                  : 1
defineHook( callers under packages/** examples/** apps/**, outside spec and cli               : 0
```

The zero was re-taken with a live control (`defineStack(` over the same `examples/**` scope hits 10+ files), so it is an absence and not a dead grep. One reading did move and it is a line number only: `defineHook` is at `packages/spec/src/data/hook.zod.ts:1238` today, not the `:1016` the card recorded at `f3ae441fa2`. Everything here is anchored by content.

## The export path, measured rather than assumed

The card makes this its first instruction. `@objectstack/spec/data` is the specifier, confirmed on both layers against a real build:

- **Runtime**, importing the built package from inside `examples/app-crm`: `defineHook` is `typeof "function"`. Positive control `HookSchema` is also `"function"`; negative control `defineHookNotAThing` is `undefined`, so the probe discriminates.
- **Types**, in `packages/spec/dist/data/index.d.mts`: `defineHook` is re-exported from the shared `datasource.zod-*.mjs` chunk on the same line as `H as Hook` and `R as ResolvedHook`. It is not spelled `declare function defineHook` in that file, which is why a naive grep of the subpath declaration finds nothing — the barrel re-exports it under a minified alias.

`@objectstack/spec` (root) also exposes it, but the two files already imported from the `/data` subpath and stay there.

## `ResolvedHook` vs `Hook` — the difference is real, and no consuming site depends on it

```
type Hook         = z.input.typeof HookSchema.     packages/spec/src/data/hook.zod.ts:1203
type ResolvedHook = z.output.typeof HookSchema.    packages/spec/src/data/hook.zod.ts:1206
declare function defineHook(config: Hook): ResolvedHook
```

They differ, and the difference is observable: `HookSchema` defaults `priority` to `100` and `async` to `false`, so `ResolvedHook` has both as required properties where `Hook` has them optional. Measured on the real module — importing `task.hook.ts` after this change yields `name="task_logic" priority=100 async=false`, where the pre-change bare literal yielded `priority=undefined async=undefined`.

That is the documented intent rather than a side effect: `defineHook`'s own docblock says the returned `ResolvedHook` "has defaults materialized, so scan-path output matches what `defineStack({ hooks })` binding produces" — and `task.hook.ts` is exactly the convention-scan path (`src/objects/*.hook.ts`).

**No consuming site depends on the distinction, and this was checked rather than assumed** — `ResolvedHook` is assignable everywhere `Hook` was:

- `examples/app-crm/src/hooks/index.ts:5` — `allHooks` becomes `ResolvedHook[]` and still satisfies `objectstack.config.ts:92`'s `hooks: allHooks`.
- `examples/app-crm/test/opportunity-stage-hook.test.ts:271` — reads `.name` only.
- `examples/app-todo/test/derived-flag-removal.test.ts:161` — stringifies `.handler`; Zod passes the function through by reference, and the suite is green.
- `objectql.bindHooks([taskHook], …)` in three app-todo suites — the binder parses anyway, so a pre-parsed input is idempotent.

**No cast was added anywhere**, which is the outcome the card asked for. Both example `typecheck` scripts are green with no `as`, no `@ts-expect-error` and no schema widening.

## Verification

Every verdict below is the command's own exit code, captured before any pipe.

| run | verdict |
|:--|:--|
| `pnpm --filter @objectstack/example-crm --filter @objectstack/example-todo typecheck` | **0** — both `tsc --noEmit` echoed, `Scope: 2 of 81` |
| `pnpm --filter @objectstack/example-crm --filter @objectstack/example-todo test` | **0** — app-crm 45/45, app-todo 106/106 |
| `pnpm --filter … validate` (`objectstack validate`, both apps) | **0** — `✓ Validation passed` for each; the remaining warnings are pre-existing field-liveness and flow-organization notes that name no hook |
| `pnpm lint` (repo-wide `eslint . --no-inline-config`, **not** narrowed) | **0** |
| 33 gate families from `dispatch-gates.mjs --commands --repo objectstack-ai/objectstack` | **33/33 exit 0** |
| `pnpm check:skill-examples` · `check-corpus-claim-drift.mjs` | **0** — run because this diff has a prose twin, see the acceptance note |

`dispatch-gates --ran` reconciles clean: *"33 derived, 33 run, 0 NOT-MEASURED, 0 UNRUN"*, with every line carrying its exit code so the zero is derived rather than claimed. All readings are from `6bb5dd1062`, the final commit.

One honest classification: `pnpm check:dual-build-cjs-loads` first returned **exit 3** — `PREREQUISITE NOT MET`, because the gate reads built output and ten packages outside this card's dependency closure had no `dist/`. That is NOT MEASURED, not a red. Rather than declare a narrowing it was made measurable: the full tree was built and the gate re-run, and it then passed at **exit 0** (104 require entry points across 67 packages).

## Ablation — predicted direction stated before each run

**A1, type layer. Predicted RED.** An unknown key injected into the `defineHook({...})` literal must be refused by excess-property checking. Mutation proved on disk before running (anchor count 1, injected marker count 1, `git diff --stat` `1 insertion(+)`, blob `40131dac` → `86a0fe34`) — never inferred from an editor's exit code. Observed **RED**, `tsc` exit 2:

```
src/hooks/opportunity.hook.ts(14,3): error TS2353: Object literal may only specify
known properties, and 'ablationUnknownKey' does not exist in type '{ name: string; … }'
```

**A2, runtime layer, three legs. Predicted THROW under mutation, NO_THROW on the pre-change control.** This is the leg that shows what the ruling actually buys, so the pre-change form was run against the identical mutation:

| leg | form | broken `name` | result |
|:--|:--|:--|:--|
| 0 | post-change `defineHook(…)` | no | `NO_THROW` — `name="task_logic" priority=100 async=false` |
| 1 | post-change `defineHook(…)` | `'Task Logic'` | **`THROW`** — `ZodError`, `invalid_format`, `pattern: /^[a-z_][a-z0-9_]*$/` |
| 2 | pre-change `: Hook` literal from `bea76c9280` | `'Task Logic'` | `NO_THROW` — `name="Task Logic" priority=undefined async=undefined` |

Leg 2 is the counter-example the card is about: under the old spelling a hook name that the schema forbids is accepted silently at author time. That is now a hard failure at import.

Both ablations ran under an `EXIT INT TERM` trap restoring with `git checkout HEAD -- path` (never a bare `git checkout --`), with absolute paths seeded from `git rev-parse --show-toplevel`. Restoration is proved by **blob equality against HEAD**, not by an exit code — `40131dac…` and `34ffb8c4…` both matched, with `git diff HEAD` and `git status --porcelain` each empty afterwards. Leg 2 additionally staged content via `git checkout bea76c9280 -- path`; the porcelain check confirms the index was reset too. No ablation artifact is left in the tree.

## `skip-changeset`, measured

This PR carries the **`skip-changeset`** label rather than a changeset file, which is what the card prescribes. It was measured, not assumed:

- `examples/app-crm` and `examples/app-todo` are both `private: true`, so nothing they contain is published.
- Neither is in `.changeset/config.json`'s `fixed` release group (0 occurrences).
- Neither hook symbol appears in any published package's shipped `dist/` (positive control: `defineHook` is found in `packages/spec/dist/index.d.ts` by the same grep, so the search works).
- `pr-automation.yml` names this exact case in its own guidance: *"examples/, tests-only, and the like) → apply the 'skip-changeset' label. ⇐ PREFERRED"*.

Because no changeset file exists, the 13 gate families that `dispatch-gates` reports as *"apply once this card's changeset exists"* stay non-applicable rather than unrun.

## 验收备注

**One out-of-scope observation, noted and deliberately not filed and not fixed.** `content/docs/automation/index.mdx:14` carries an `os:check` fenced block that reproduces `OpportunityStageHook` in the old bare-literal form and introduces it as *"(from the CRM example app)"* — a third in-repo reading of the very hook this PR migrates. After this PR the prose page and the app it names use different spellings.

It is left alone on purpose, and the reasoning is offered for review rather than asserted:

- It is **not a defect** — copy the snippet and it compiles and runs; both gates that read it are green here (`pnpm check:skill-examples` type-checks 258 marked blocks across 106 files, and `check-corpus-claim-drift` reports no unpinned claim site).
- It is **not a contract violation** — the snippet is already not a byte-exact quote (it drops the licence header and the docblock), and the gate that exists to pin corpus claims does not pin this one.
- The card fences this PR at two files, and `content/docs/**` would pull in a docs validation surface this change set does not otherwise schedule.

Successor: whoever next edits `content/docs/automation/index.mdx`, or the docs half of the #14685 / #14292 programme. Flagging it here because "you migrated the CRM hook but not the copy of it in the docs" is the first question a reviewer will reasonably ask.

**Conflict reported rather than silently resolved.** The dispatch order listed "a changeset" among the deliverables and the claim comment's declared file face said "plus a changeset", while the card body says to apply `skip-changeset`. The measurement above resolves it to `skip-changeset`; the dispatch line is noted here so the seat can correct the claim if it disagrees.

This PR is **draft** and stays draft: the at-tier verdict is the seat's. It is not enqueued, not armed for auto-merge, and carries no approving review from this session.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MkQhmuuJAVDjmeWNixwDDH)_