### PR TITLE
docs(agents): point os-dev at the surviving decision-frame copy

### DIFF
--- a/.claude/agents/os-dev.md
+++ b/.claude/agents/os-dev.md
@@ -352,7 +352,7 @@ model: opus
 - 两种读法通向两种架构时同此;⛔ 不写投机代码。
 - 返回 `status: "needs_decision"`,把每个问题连同选项、成本与你的推荐写进 `open_questions`。
 - 升级分析的四轴决策框架由派发词携带,PM 从自己那份副本填入。
-- 已发布模板里它是 `rules/dev-template.md` 的 `{decision_frame}` 槽位。
+- 框架唯一副本在 pm-dispatch SKILL.md 〈升级与决策〉;派发词逐字粘贴,dev ⛔ 不留副本。
 - 每个方案逐轴分析,推荐也按那些轴给理由;派发词没带,停下向 PM 索取,⛔ 不自拟一套轴。
 - `main` 碎了、依赖未合并、CI 基础设施故障 ⇒ 报 `blocked` 附证据,重试到排除你的改动。
 


### PR DESCRIPTION
Fixes #17520

One line of `.claude/agents/os-dev.md` (:355) pointed at `rules/dev-template.md`'s `{decision_frame}` slot — a template that left the tree when the maintainer deleted the published PM skill (#17311 → PR #17325). The line is rewritten in place to point at the single declared copy of the frame and to state the two dev-side facts that hold today: the dispatch word carries the frame verbatim, and the dev keeps no copy. Nothing else moves — :354 (the mandate) and :356 (the stop-and-ask rule) are byte-identical, and no other file is touched.

## The line

| | text | width |
|---|---|---|
| before | `- 已发布模板里它是 \`rules/dev-template.md\` 的 \`{decision_frame}\` 槽位。` | 83 B |
| after | `- 框架唯一副本在 pm-dispatch SKILL.md 〈升级与决策〉;派发词逐字粘贴,dev ⛔ 不留副本。` | 112 B |

The after-line is the seat's candidate verbatim (measured here at 112 B, matching the seat's reading). One tighter spelling was measured and rejected: dropping 「框架」 gives 106 B, but leaves 「唯一副本」 without its noun when :355 is read on its own (a grep hit, a quoted line) — the 6 B buys nothing, since the 120 B limit is a per-line width, not a budget. A same-width register variant (「住」 for 「在」) was measured at 112 B and not adopted: no gain over the reviewed wording.

## Why "stale" — the three readings (branch `claude/issue-17520-os-dev-frame-pointer`, base `efa2533d`)

- `grep -n 'dev-template' .claude/agents/os-dev.md` → exactly `355:- 已发布模板里它是 …` (one hit).
- `git grep -n decision_frame` → `.claude/agents/os-dev.md:355` and `scripts/check-skill-frame-sync.mjs:17` (a header comment) — nothing else.
- `git ls-files | grep -c dev-template` → `0`.

`check-skill-frame-sync` declares ONE copy of the frame (`.claude/skills/pm-dispatch/SKILL.md`, the 〈升级与决策〉 section) and scans 74 markdown files for an undeclared second one; the new line carries none of its four fingerprints, so it points without copying.

## Four-axis note (the one judgement: the pointer's wording)

实际业务需求: two rounds on one day each paid a round-trip because :355 named a template nobody could open — measured in the card's own citations, not inferred; the line's job is to send a dev who reads it to where the frame actually lives, and the candidate names that place. 项目长远合理性: a pointer to the single declared copy is the contract-first shape; any dev-side restatement of the axes would recreate the multi-copy drift the frame-sync gate was built to end. 防 AI 写代码犯错: the wording that structurally prevents the wrong move is one that both names the copy and says the dev keeps none — a line that named the copy alone would invite the next author to paste the axes back in, which the gate would then refuse; the chosen line says both, and the shorter 106 B variant was rejected precisely because it weakens what the line says on its own. 创业阶段不扩散需求: one line rewritten, no new gate, no default axes, no ceiling raise, no re-wrap — the dev-side behaviour (:354/:356) is unchanged, so a dispatch word that omits the frame is still answered by stopping and asking, never by a default.

## Verification

Local scope: no package is touched, so there is no dependency-closure build (①) and no package test/typecheck (②) owed; the derived gate families (③) are below. All readings at head `03b37059` unless marked "before".

Zone-2 measurements:
- `node scripts/pm/check-skill-line-ratchet.mjs` before → exit 0, `✓ check-skill-line-ratchet: .claude/agents/os-dev.md is 403 lines (ceiling 403; headroom 0).`; after → exit 0, identical verdict line.
- `awk 'NR==355' .claude/agents/os-dev.md | tr -d '\n' | wc -c` before → `83`; after → `112`.
- `pnpm check:skill-frame-sync` before → exit 0; after → exit 0, `74 markdown files scanned for undeclared copies.` both times (scan count unchanged; the new line adds no copy). Verdict: `✓ check-skill-frame-sync: the one declared copy of the decision frame is internally coherent (.claude/skills/pm-dispatch/SKILL.md; …)`.
- `pnpm check:pm-skill-id-lint` before → exit 0; after → exit 0, `✓ check-skill-id-lint: 27 file(s) clean (pattern /#[0-9]{3,}/g).`
- `node scripts/pm/dispatch-gates.mjs --self-test` before → exit 0, `✓ dispatch-gates self-test: 1678 cases pass.`; after → exit 0, `✓ dispatch-gates self-test: 1678 cases pass.` (incl. `✓ the dispatch-gates gate declares the frame-sync module the tier mandate is defined against` and `✓ the declared frame-sync module exists`).

Derived families — `node scripts/pm/dispatch-gates.mjs --commands` (no paths; change set derived from git: 1 path vs merge base `efa2533dd`, three-dot) → 17 commands; every exit captured before any pipe; `--ran` reconciliation: `✓ dispatch-gates --ran: 17 derived famil(ies) accounted for — 17 run, 0 NOT-MEASURED (a DERIVED zero — all 17 recorded an exit code and none of them is 3).`

| command | exit | verdict line |
|---|---|---|
| `pnpm check:agent-model-declared` | 0 | `✓ check-agent-model-declared: 1 agent definition(s) under .claude/agents/ all declare a model` — `os-dev.md → opus` |
| `pnpm check:nul-bytes` | 0 | `check-nul-bytes: OK (scanned 8319 text file(s) … no raw ASCII control bytes).` |
| `pnpm check:pm-skill-id-lint` | 0 | `✓ check-skill-id-lint: 27 file(s) clean` |
| `pnpm check:skill-frame-sync` | 0 | `✓ check-skill-frame-sync: the one declared copy … internally coherent` |
| `pnpm check:pm-skill-ratchet` | 0 | `✓ check-skill-line-ratchet: .claude/agents/os-dev.md is 403 lines (ceiling 403; headroom 0).` |
| `pnpm check:pm-governed-merges` | 0 | `✓ check-governed-merges --self-test: 317 assertions …` |
| `node scripts/pm/check-governed-queue-guard.mjs --self-test` | 0 | `✓ check-governed-queue-guard self-test: 183 cases pass` |
| `node scripts/check-closing-keyword-parity.mjs` | 0 | `check-closing-keyword-parity: OK (3 parsers agree on all 9 keywords …)` |
| `node scripts/check-closing-keyword-parity.mjs --self-test` | 0 | `✓ check-closing-keyword-parity --self-test: 24 assertions …` |
| `node scripts/check-comment-mask-corpus.mjs` | 0 | `✓ comment-mask corpus sweep: 6586 files, 0 disagree, 0 unparseable` |
| `pnpm --filter @objectstack/lint run check:doc-formula-expressions` | 0 | `✓ check:doc-formula-expressions: 22 record-scoped formula example(s) across 438 files / 1375 TS blocks judged clean` (first run exited 3 PREREQUISITE NOT MET — `@objectstack/formula` / `@objectstack/lint` unbuilt; built under `os-verify-lock.sh` — `VERDICT command-exit 0 · held the lock 166s` — then re-run) |
| `pnpm check:agent-test-spelling` | 0 | self-test carried; cleared spellings listed by `--list` |
| `pnpm check:doc-authoring` | 0 | `✓ doc authoring guard: 44 published skill files clean — no internal issue-id references.` |
| `pnpm check:driver-memory-census` | 0 | `check-driver-memory-census: OK — every declaration is ledgered …` |
| `pnpm check:partof-closing-keyword` | 0 | `✓ check-partof-closing-keyword self-test: 95 cases pass.` |
| `pnpm check:refd-timer-probe` | 0 | `OK  check-refd-timer-probe: 6581 source file(s) swept` |
| `pnpm check:watch-hint-literal` | 0 | `✓ check-watch-hint-literal: 69 declaration(s) across 4 rostered name(s)` |

Path face: `node scripts/pm/check-governed-merges.mjs --branch claude/issue-17520-os-dev-frame-pointer` → exit 3, `⛔  GOVERNED — a human merge is the review record for this PR` — `.claude/** ×1 — .claude/agents/os-dev.md`. This PR stays a draft; the maintainer merges.

Changeset: none — `.claude/**` publishes nothing; `skip-changeset` applied.

Clause-②: no

## Acceptance notes

- noted, not filed: the card's second defect (a `Claim:` comment whose first line opens with bold markup, so `check-clause2-carriers --pair` reads no declaration limb) was ruled discipline in the grading against SKILL.md :473–:474 and the :799 template — the literal first line is already bound and the predicate is not to be loosened. Carrier: the filer's own repair of its #14488 claim comment (that card has no PR today, so nothing is blocked); 承接者: the spec seat that wrote it. #14488 remains open and is not touched here.
- noted, not filed: `scripts/check-skill-frame-sync.mjs:17` still says "the dev prompt's `{decision_frame}` slot" in its header narrative; the seat ruled the comment is not a rule and outside this surface. 承接者:无.
- noted, not filed: the commit's author name reads `claude[bot]` (this session set `user.name` from `origin/main`'s last author; the e-mail is the shared identity's). Cosmetic; the branch was not rewritten for it.

## 维护者速读(草稿)

**改了什么**:`.claude/agents/os-dev.md` 第 355 行一行改写。旧行指向已随发布版 PM skill 一起删除的 `rules/dev-template.md` 模板槽位;新行改为指向决策框架现存的唯一副本(pm-dispatch SKILL.md 的〈升级与决策〉节),并写明派发词逐字粘贴、dev 不留副本。行数不变(403/403),新行 112 字节。

**为什么改**:同一天两个开发轮次因派发词没带决策框架而各多跑一趟,卡片把它归为模板缺陷;席位定档后认定「要求」本身已在(:354/:356),缺的只是这一行指向了一个不存在的文件。改指向即止,不新增默认轴,不复制框架文本(frame-sync 门禁正是为拒绝第二份副本而设)。

**风险与代价(含回滚)**:纯指令文本,无发布面、无 changeset;派生的 17 个门禁族与四项前后对照读数全绿。回滚即还原该行为原文(83 字节)。

**席位意见**:(留空,由席位定稿)

**你要做的**:确认新行措辞;受管面(`.claude/**`),由维护者人工合并,PR 保持 draft。

---
_Generated by [Claude Code](https://claude.ai/code/session_01YKEjmbYNvYWJvWGSWx26zK)_