### PR TITLE
fix(spec): label an `any` index signature as its own position, and state the direct-parent boundary

### DIFF
--- a/packages/spec/scripts/check-skill-examples.ts
+++ b/packages/spec/scripts/check-skill-examples.ts
@@ -95,11 +95,11 @@
  * SCOPE — the annotation must BE `any`, in a position where it erases checking
  * wholesale: a parameter, a variable/property/return annotation, an index
  * signature, a type alias, or an `as any` / `satisfies any` / angle-bracket
- * assertion. `any` NESTED inside a
- * larger type (`Record<string, any>`, `any[]`, `Promise<any>`) is deliberately
- * NOT flagged — the same line `check-exported-any.ts` draws for the same reason:
- * a nested `any` is a much broader question, and holding the gate at zero false
- * positives is what keeps red meaning broken.
+ * assertion. `any` NESTED inside a larger type (`Record<string, any>`, `any[]`,
+ * `Promise<any>`) is deliberately NOT flagged — the same line
+ * `check-exported-any.ts` draws for the same reason: a nested `any` is a much
+ * broader question, and holding the gate at zero false positives is what keeps
+ * red meaning broken.
  *
  * "NESTED" IS A CLAIM ABOUT THE `any`, NOT ABOUT ITS ANCESTRY (#14910). The three
  * examples above share one property: the `any` is a COMPONENT of a composite type

--- a/packages/spec/scripts/check-skill-examples.ts
+++ b/packages/spec/scripts/check-skill-examples.ts
@@ -93,12 +93,27 @@
  * defects, zero diagnostics.
  *
  * SCOPE — the annotation must BE `any`, in a position where it erases checking
- * wholesale: a parameter, a variable/property/return annotation, a type alias,
- * or an `as any` / `satisfies any` / angle-bracket assertion. `any` NESTED inside a
+ * wholesale: a parameter, a variable/property/return annotation, an index
+ * signature, a type alias, or an `as any` / `satisfies any` / angle-bracket
+ * assertion. `any` NESTED inside a
  * larger type (`Record<string, any>`, `any[]`, `Promise<any>`) is deliberately
  * NOT flagged — the same line `check-exported-any.ts` draws for the same reason:
  * a nested `any` is a much broader question, and holding the gate at zero false
  * positives is what keeps red meaning broken.
+ *
+ * "NESTED" IS A CLAIM ABOUT THE `any`, NOT ABOUT ITS ANCESTRY (#14910). The three
+ * examples above share one property: the `any` is a COMPONENT of a composite type
+ * — a type argument, an element type — filling no annotation slot of its own, so
+ * its direct parent is a TypeReference/ArrayType/TupleType and `parent.type` is
+ * not it. It does NOT mean "somewhere under a type argument". A function type's
+ * return `any` fills the return slot of that function type and is flagged wherever
+ * the function type sits, `Array<() => any>` included: the annotation IS `any`,
+ * every call of such a function is unchecked, and the alternative reading would
+ * hand an author going red the one-token evasion this gate already refuses for
+ * parameters (below) — wrap the offending function type in a type argument and the
+ * gate goes green over an unchanged defect. Nothing here widens the boundary: it
+ * is still `parent.type === node` on the DIRECT parent, one sentence, same
+ * (zero-row) baseline.
  *
  * Casts and locals are in scope, and not for symmetry: a parameter-only rule is
  * defeated by exactly the edit an author reaches for when it goes red — move the
@@ -874,6 +889,22 @@ interface AnyFinding {
  * `any[]`, `Promise<any>` — has a TypeReference/ArrayType parent and is not a
  * finding. That boundary is the gate's zero-false-positive line; widening it is
  * a different question with a different (much larger) baseline.
+ *
+ * The boundary is the DIRECT parent and nothing else (#14910, and the SCOPE
+ * paragraph at the top of this file). `Array<() => any>` IS a finding, labelled
+ * `return type`: the `any`'s parent is the FunctionTypeNode whose return slot it
+ * fills, not the TypeReference above it. "Nested" describes an `any` that is a
+ * component of a composite type, never an `any` that happens to have a type
+ * argument among its ancestors.
+ *
+ * ORDER MATTERS in one place. `ts.isFunctionLike` is true for every
+ * SignatureDeclaration kind, IndexSignatureDeclaration included, so a bare
+ * `[k: string]: any` would fall into the `return type` arm and be reported at a
+ * position it does not occupy (#14910). Flagging it is right — an `any` index
+ * signature erases checking on every keyed access — so the fix is a label, not an
+ * exclusion, and the arm has to come BEFORE the function-like fallback. The label
+ * is half of a finding's row key, so a wrong one is a finding that cannot be
+ * declared or baselined the day such a site appears.
  */
 function describeAnyPosition(node: ts.Node): string | null {
   const parent = node.parent;
@@ -890,7 +921,12 @@ function describeAnyPosition(node: ts.Node): string | null {
   if (ts.isAsExpression(parent) && parent.type === node) return '`as any` assertion';
   if (ts.isSatisfiesExpression(parent) && parent.type === node) return '`satisfies any` assertion';
   if (ts.isTypeAssertionExpression(parent) && parent.type === node) return '`< any >` type assertion';
-  // Return annotations: functions, methods, arrows, getters, signatures.
+  // BEFORE the function-like fallback: an IndexSignatureDeclaration IS a
+  // SignatureDeclaration, so `isFunctionLike` claims it and its `any` would be
+  // reported as a `return type` it does not have.
+  if (ts.isIndexSignatureDeclaration(parent) && parent.type === node) return 'index signature';
+  // Return annotations: functions, methods, arrows, getters, signatures —
+  // including a FunctionTypeNode standing inside a type argument.
   if (ts.isFunctionLike(parent) && parent.type === node) return 'return type';
   return null;
 }
@@ -1542,6 +1578,60 @@ function selfTest(): never {
       );
     }
 
+    // ── RED, positions (#14910): the two shapes whose LABEL was the defect. ──
+    //    Both were already flagged before #14910, so a leg asserting only "it is
+    //    a finding" passes on the broken code and pins nothing. Each leg asserts
+    //    the label string, because the label is half a finding's row key.
+    //
+    //    1. An `any` index signature was reported as `return type`:
+    //       `ts.isFunctionLike` is true for every SignatureDeclaration kind, and
+    //       an IndexSignatureDeclaration is one. Flagging stays; the label is now
+    //       `index signature`.
+    //    2. A function type's return `any` standing inside a type argument is a
+    //       `return type` finding and stays one — the boundary is the DIRECT
+    //       parent, so `Array<() => any>` is the function type's return slot, not
+    //       a "nested" `any`. This leg is the header's rule made executable: the
+    //       day someone reads "nested `any` is deliberately not flagged" as
+    //       ancestry and narrows the arm, it goes red here rather than silently
+    //       handing authors a one-token evasion.
+    const redPositions = path.join(dir, 'red-positions.md');
+    fs.writeFileSync(
+      redPositions,
+      [
+        '# Position fixture', // 1
+        '', // 2
+        '<!-- os:check -->', // 3
+        '```ts', // 4
+        'interface Bag {', // 5
+        '  [key: string]: any;', // 6  ← index signature, NOT a return type
+        '}', // 7
+        'const fns: Array<() => any> = [];', // 8  ← return type, inside a type argument
+        'void fns;', // 9
+        '```', // 10
+        '',
+      ].join('\n'),
+      'utf8',
+    );
+    const positions = extractFromFile(redPositions, skillsRoot);
+    check(
+      positions.examples.length === 1,
+      `positions fixture: extracted ${positions.examples.length} block(s), expected 1`,
+    );
+    if (positions.examples.length === 1) {
+      const ex = positions.examples[0];
+      const got = findBareAny(ex.code, 'red-positions.ts')
+        .map((h) => `${ex.bodyStartLine + h.line - 1}:${h.where}`)
+        .sort();
+      const want = ['6:index signature', '8:return type'].sort();
+      check(
+        JSON.stringify(got) === JSON.stringify(want),
+        `positions fixture: got ${JSON.stringify(got)}, expected ${JSON.stringify(want)} — an \`any\` index ` +
+          `signature must be labelled "index signature" (\`isFunctionLike\` matches an IndexSignatureDeclaration, ` +
+          `so it used to read "return type"), and a function type's return \`any\` inside a type argument must ` +
+          `stay a "return type" finding (the boundary is the DIRECT parent, not ancestry)`,
+      );
+    }
+
     // ── GREEN: the same function honestly typed, plus every shape that must
     //    NOT be flagged, plus an UNMARKED block that must not be read at all. ─
     const green = path.join(dir, 'green.mdx');
@@ -1561,15 +1651,20 @@ function selfTest(): never {
         '  const bag: Record<string, any> = {};', // 11 nested — out of scope by design
         '  const rows: any[] = [];', // 12 nested
         `  const kind: Kind = 'any';`, // 13 string literal
-        '  void ctx; void bag; void rows; void kind;', // 14
-        '}', // 15
-        '```', // 16
-        '', // 17
-        'An UNMARKED block — the gate judges only what the author marked:', // 18
-        '', // 19
-        '```ts', // 20
-        'export function unchecked(ctx: any) { void ctx; }', // 21
-        '```', // 22
+        '  const later: Promise<any> = Promise.resolve(1);', // 14 nested (#14910)
+        '  const pair: [any, string] = [1, \'x\'];', // 15 nested, tuple element (#14910)
+        '  void ctx; void bag; void rows; void kind; void later; void pair;', // 16
+        '}', // 17
+        '', // 18
+        'type Widen<T = any> = T;', // 19 nested — a type-parameter DEFAULT, not an annotation (#14910)
+        'type Bags = Record<string, Array<any>>;', // 20 nested, two levels
+        '```', // 21
+        '', // 22
+        'An UNMARKED block — the gate judges only what the author marked:', // 23
+        '', // 24
+        '```ts', // 25
+        'export function unchecked(ctx: any) { void ctx; }', // 26
+        '```', // 27
         '',
       ].join('\n'),
       'utf8',
@@ -2632,7 +2727,10 @@ function selfTest(): never {
   }
   console.log(
     '✅  self-test: flags a bare `any` parameter / variable / property / return / alias / cast in a\n' +
-      '    marked block at the right page line, and flags nothing in an honestly typed one; a\n' +
+      '    marked block at the right page line, and flags nothing in an honestly typed one; an `any`\n' +
+      '    index signature is labelled `index signature` and not `return type`, while a function\n' +
+      '    type\'s return `any` inside a type argument stays a `return type` finding and the nested\n' +
+      '    shapes around it (`Promise<any>`, a `T = any` default, a tuple element) stay unflagged; a\n' +
       '    JSDoc-gutter-wrapped ```tsx block (client SDK surface) extracts, strips and maps lines\n' +
       '    identically, and a misplaced gutter-wrapped marker is still caught as an orphan; a marker\n' +
       '    shown as example text inside another fenced block is not an orphan, while a genuine\n' +
@@ -3049,7 +3147,10 @@ function main() {
         `       that cannot be typed against the real declarations (generated third-party\n` +
         `       code, a partial subtree). An unmarked block is honest; a marked \`any\` is not.\n\n` +
         `  Nested \`any\` (\`Record<string, any>\`, \`any[]\`, \`Promise<any>\`) is NOT flagged\n` +
-        `  — only an annotation, cast or alias that IS \`any\`.`,
+        `  — only an annotation, cast, index signature or alias that IS \`any\`. "Nested" means\n` +
+        `  the \`any\` is a COMPONENT of a composite type, not that a type argument sits\n` +
+        `  somewhere above it: \`Array<() => any>\` is a \`return type\` finding, because that\n` +
+        `  \`any\` IS the function type's return annotation.`,
     );
   }
 


### PR DESCRIPTION
Fixes #14910

Clause-②: no

> **A note on spelling in this body.** GitHub's body sanitizer deletes tag-shaped angle
> fragments — inside fenced code and inline code too — so every generic below is written with
> `&lt;` / `&gt;` entities in prose, and code blocks avoid angle brackets by spelling the shape
> in words. The source file itself carries the ordinary spellings.

Re-derived from what this PR ships, not inherited from the claim. The diff is one file,
`packages/spec/scripts/check-skill-examples.ts` — CI tooling. Measured on this branch: the file
carries **0** `^export` lines, so no new exported symbol; and no published payload gains a key
— grepping `@objectstack/spec`'s `files[]` roster (`dist`, `json-schema`, `liveness`, `prompts`,
`llms.txt`, `README.md`, `api-surface`, `spec-changes.json`) for a symbol from the changed file
returns **0 files**, with the positive control (`HookContext`) lighting **34**. The baseline this
card worried about turns out not to exist as an artifact at all (see "Premise re-measured"), so
there is no governed accept set that moves either.

## What was wrong

`describeAnyPosition` keys a bare `any`'s position on its DIRECT parent node kind. The last arm
was `ts.isFunctionLike(parent) && parent.type === node` returning `'return type'`, and
`ts.isFunctionLike` is true for **every** SignatureDeclaration kind — `IndexSignatureDeclaration`
included. Measured on this tree's TypeScript (6.0.3):

| probe | parent kind | `isFunctionLike` | `parent.type === node` | today's label |
|:--|:--|:--|:--|:--|
| `interface Bag { [k: string]: any }` | IndexSignature | **true** | true | `return type` ← **wrong position** |
| `const fns: Array&lt;() =&gt; any&gt; = []` | FunctionType | true | true | `return type` ← correct |
| `function f(): any` | FunctionDeclaration | true | true | `return type` |
| `const b: Record&lt;string, any&gt; = {}` | TypeReference | false | **false** | not flagged |
| `const r: any[] = []` | ArrayType | false | **false** | not flagged |
| `const t: [any, string] = [1, 'x']` | TupleType | false | **false** | not flagged |
| `type D&lt;T = any&gt; = T` | TypeParameter | false | **false** | not flagged |

So an `any` index signature was reported at a position it does not occupy. Flagging it is right
— an `any` index signature erases checking on every keyed access — so the fix is a **label**,
not an exclusion: an `IndexSignatureDeclaration` arm placed BEFORE the function-like fallback,
returning `index signature`.

## The judgement triage placed on this card, and how it was settled

**Shape (2) — a function type's return `any` inside a type argument — is IN SCOPE. It stays
flagged, labelled `return type`, and the arm is unchanged. The header is what was wrong.**

Settled from the file's own declared rule, not by preference. The `describeAnyPosition` docblock
defines the boundary operationally in the same sentence that names the exclusions:

> The check is `parent.type === node` (or the assertion's own type slot), so an `any` nested in
> a larger type — `Record&lt;string, any&gt;`, `any[]`, `Promise&lt;any&gt;` — **has a
> TypeReference/ArrayType parent** and is not a finding.

"Nested" is therefore a claim about the `any` itself — that it is a *component* of a composite
type, filling no annotation slot of its own — and not a claim about its ancestry. All three
named exclusions share exactly that property, and the table above confirms it: each has
`parent.type === node` **false**. In `Array&lt;() =&gt; any&gt;` the `any` fills the return slot
of a FunctionTypeNode (`parent.type === node` **true**), which the top-of-file SCOPE list already
names in so many words: "a variable/property/**return** annotation". The header and the arm never
actually conflicted; the shorthand "nested `any` is deliberately not flagged" simply reads as
ancestry when quoted without its operational clause. So there was nothing to stop and escalate on
— the file does give a way to tell which reading is authoritative — and this PR writes that
reading into the header, the docblock and the gate's own failure text.

The four axes agree, and none was the deciding one on its own:

- **实际业务需求** — a function type returning `any` is the #5720/#5605 defect class verbatim:
  every call of such a callback is unchecked. Narrowing would hand an author whose block just
  went red a one-token evasion (wrap the function type in a type argument) and leave the gate
  green over an unchanged defect. The file already refuses precisely that reasoning for
  parameters: *"a parameter-only rule is defeated by exactly the edit an author reaches for when
  it goes red."*
- **项目长远合理性** — the rule stays one sentence: `parent.type === node` on the direct parent.
  The alternative reading requires a second, transitive notion of "nested" that the code cannot
  express without an ancestry walk, and the header warns that widening the boundary is *"a
  different question with a different (much larger) baseline."*
- **防 AI 写元数据 app 犯错** — a marked doc example is copy-paste source. Keeping it flagged
  means the corpus cannot ship such a shape under an `os:check` marker; narrowing would create a
  documented-but-unenforced hole in exactly the surface AI authors read.
- **创业阶段不扩散** — zero new machinery, zero baseline movement, one arm and one paragraph.

⚠️ **For the objectui port (`objectstack-ai/objectui#7653`, which carries `Blocked-by:` on this
card):** the decision is *label shape (1), keep shape (2)*. Add the `IndexSignatureDeclaration`
arm before the function-like fallback with the label `index signature`; do **not** narrow the
function-like arm; state the direct-parent boundary in the header. The port should not re-derive
this.

## Premise re-measured — one premise falsified

**There is no baseline artifact for this gate.** The card and the dispatch both plan around
"find the baseline, measure which rows move, regenerate it with the repo's own tooling". That
artifact does not exist. The file says so itself:

> Measured at the time of writing, the whole 208-block corpus contained three bare `any`
> annotations, all in one block, so the wider scope cost nothing to adopt and **there is no
> ratchet file: the baseline is zero and stays zero.**

Measured rather than taken on the file's word, with a lit control: `packages/spec` carries
**nine** ratchet/baseline artifacts — `authorable-surface.base.json`,
`docs-import-surface.baseline.json`, `dual-source-exports.baseline.json`,
`entry-nameability.baseline.json`, `react-declaration-parity.baseline.json`,
`scripts/liveness/key-mention.baseline.json`,
`scripts/liveness/undrilled-containers.baseline.json`, `test-typecheck-debt.json`,
`unemitted-schemas.baseline.json` — and **0** of them name this gate. The gate reads no accept
set at all: its only JSON reads are two `package.json` reads. It calls `fail()` on the first hit.
So the label is half a row key only in the prospective sense the card meant, and **nothing to
regenerate exists today**.

**The corpus re-measure the card asked for (objectstack's own marked population, never measured
when the card was filed): zero sites, of either shape or any other.**

```
   258 marked example(s) across 106 file(s), 3 surface(s):
     - skills + docs (@objectstack/spec): 225 block(s)
     - spec source TSDoc (@objectstack/spec): 10 block(s)
     - client SDK (@objectstack/client-react, @objectstack/client): 23 block(s)

OK 258 prose examples type-check across 3 surface(s) - every marked block parsed, so tsc ran the SEMANTIC pass on all of them
os-verify-lock: VERDICT command-exit 0
```

⇒ no verdict changes, no message changes, no row moves. The grade stays `p3`.

## Verification

**Ablation — two mutations, both predicted before running, both proven landed on disk, both
restored by blob equality under an `EXIT`/`INT`/`TERM` trap.** No `dist` is involved: the gate
runs from source via `tsx`, so the mutation's path to the code under test is the file itself.

| leg | mutation | proof it landed | self-test | failing legs |
|:--|:--|:--|:--|:--|
| control | none | — | **exit 0** | 0 |
| **A** | delete the `IndexSignatureDeclaration` arm | removed-anchor count 1 to 0, injected 0 to 1, `1 insertion(+), 1 deletion(-)`, blob `1b8f63a8…` ≠ HEAD `b7cf53d6…` | **exit 1 — RED, as predicted** | **1, the new leg only** |
| **B** | narrow the function-like arm to the *ancestry* reading (bail if any ancestor is a TypeReference) | removed-anchor count 1 to 0, injected 0 to 1, `9 insertions(+), 1 deletion(-)`, blob `0f328d26…` ≠ HEAD | **exit 1 — RED, as predicted** | **1, the new leg only** |

```
A: positions fixture: got ["6:return type","8:return type"], expected ["6:index signature","8:return type"]
B: positions fixture: got ["6:index signature"],             expected ["6:index signature","8:return type"]

restore: disk=b7cf53d6ce997f078c5739ab837e1a215fc449e7 head=b7cf53d6ce997f078c5739ab837e1a215fc449e7  git-diff-HEAD-empty=yes
```

Ablation B exists because shape (2) was **already** flagged before this PR, so a leg asserting
only "line 8 is a finding" would pass on the broken code and pin nothing. B proves the leg can
fail, which is what makes it a pin on the boundary rather than a restatement of today's output.
Both legs assert the **label string**, for the same reason: the bug is the label, so "it is
flagged" is not an assertion about it.

**Gates.** Families derived mechanically, never hand-listed —
`node scripts/pm/dispatch-gates.mjs --commands --repo objectstack-ai/objectstack`, change set
derived by the tool itself (1 path). Reconciled with `--ran`, exit codes recorded per command:

```
dispatch-gates --ran: 54 derived famil(ies) accounted for - 53 run, 1 NOT-MEASURED (1 DERIVED from a recorded exit 3).
  NOT-MEASURED - DERIVED (1): pnpm check:dual-build-cjs-loads [recorded exit 3 - PREREQUISITE NOT MET]
```

`check:dual-build-cjs-loads` exits **3**, its own "PREREQUISITE NOT MET — this is NOT a pass:
nothing was measured" code: it reads built output and 33 packages have no `dist/` in this
worktree. Declared to CI, which builds first; **not** reported as a failing check. All other 53
exited **0**.

**Tests and type-checking.** Every heavy verdict read from `os-verify-lock`'s own
`VERDICT command-exit` line, never through a pipe:

- `pnpm --filter @objectstack/spec run check:skill-examples` — **exit 0** (self-test plus the
  real 258-block corpus; re-run green on the final commit).
- `pnpm --filter @objectstack/spec exec vitest run --maxWorkers=2` — **exit 0**,
  `Test Files 500 passed (500)`, `Tests 13781 passed (13781)`.
- `pnpm --filter @objectstack/spec typecheck` — **exit 0**, and proven to actually reach the
  changed file rather than assumed. `tsconfig.json` and `tsconfig.test.json` both use
  `include: ["src/**/*"]` and list it **0** times; the package's `typecheck` chains
  `check:scripts-typecheck` (`tsc --noEmit -p tsconfig.scripts.json`), whose `--listFiles` names
  `scripts/check-skill-examples.ts` **1** time in a 909-file program. A direct
  `tsc --ignoreConfig --strict` over the file reports **0** diagnostics, with a lit control (an
  injected `const CONTROL: number = 'not a number'`) reddening it at `TS2322` and then restored,
  proven by blob equality against HEAD.
- `eslint . --no-inline-config --format json` — **exit 0**, **6586 files, 0 errors, 0 warnings**,
  the changed file present in the run, measured on the final commit `c23aa7a4`. The repo-wide run
  fit in budget, so no narrowing is claimed and none is needed.
- Control characters: `pnpm check:nul-bytes` green, plus a direct `grep -naP` over the changed
  file for the C0/DEL range — no hits.

## No changeset — `skip-changeset`

Nothing published moves, measured above (0 symbol hits across the `files[]` roster, positive
control lit at 34). `packages/spec/scripts/**` ships in no package. This is the case
`.github/workflows/lint.yml` names in its own words: *"'this PR edits a CI-internal script' is
the textbook `skip-changeset` case — such a PR releases nothing, so by the workflow's own
prescription it takes the label."*

## 验收备注

- **The dispatch order asked for a changeset; the measurement says `skip-changeset`.** Flagged
  rather than resolved silently. A changeset here would version-bump `@objectstack/spec` for a
  change that ships in nothing.
- *noted, not filed:* the function-like fallback also claims `MethodSignature`, `CallSignature`,
  `ConstructSignature`, `FunctionType`, `ConstructorType` and the accessors. All of those
  genuinely have a return slot, so `return type` is correct for each — measured, not assumed. No
  further arm is owed. 承接者: whoever ports this to objectui#7653.
- *noted, not filed:* a first reading of `packages/spec`'s tsconfigs suggested `scripts/**` sat
  outside every tsc program. That reading was **wrong** and is corrected above —
  `tsconfig.scripts.json` covers it. Recorded because the wrong reading is one a future author is
  likely to reach independently. 承接者: none.

## Reviewer's one-minute read

The behavioural delta is **one label string, on one shape that does not occur in the corpus
today**. Everything else in the diff is the header, the docblock, the gate's failure text and the
self-test legs — the parts that make the boundary say out loud what the code has always done, so
the next reader of "nested `any` is deliberately not flagged" does not narrow a good arm.

⛔ Do not flip this out of draft, enqueue it, arm auto-merge or submit an approving review — the
at-tier verdict is the seat's.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MkQhmuuJAVDjmeWNixwDDH

---
_Generated by [Claude Code](https://claude.ai/code/session_01MkQhmuuJAVDjmeWNixwDDH)_