### PR TITLE
docs(cli): os create plugin standalone output is unscoped and private, not a publishable @objectstack package

### DIFF
--- a/content/docs/deployment/cli.mdx
+++ b/content/docs/deployment/cli.mdx
@@ -102,8 +102,8 @@ Scaffolds a new ObjectStack project with configuration, TypeScript setup, and in
 
 | The word `plugin` in | Names | What it emits | Built by | Publishable? | Read next |
 |:---------------------|:------|:--------------|:---------|:-------------|:----------|
-| `os init <name> -t plugin` | A **metadata package** — declarative objects another stack loads, no kernel code | `objectstack.config.ts` whose manifest declares `type: 'plugin'`, plus `src/objects/*.object.ts` | `objectstack compile` (its `build` script) | **No** — the emitted `package.json` is `private: true` | [`os init`](#os-init) below, and [Object Metadata](/docs/data-modeling/objects) for the objects it holds |
-| `os create plugin <name>` | A **kernel code plugin** — TypeScript implementing the kernel `Plugin` contract | `src/index.ts` exporting a `Plugin` with `init` / `destroy` | `tsc` (its `build` script) | **Yes** — a publishable `@objectstack/plugin-<name>` package | [`os create`](#os-create) below, then [Plugin Anatomy](/docs/plugins/anatomy) and [Plugin Development](/docs/plugins/development) |
+| `os init <name> -t plugin` | A **metadata package** — declarative objects another stack loads, no kernel code | `objectstack.config.ts` whose manifest declares `type: 'plugin'`, plus `src/objects/*.object.ts` | `objectstack compile` (its `build` script) | **No** — the emitted `package.json` is `private: true`, and no flag lifts it | [`os init`](#os-init) below, and [Object Metadata](/docs/data-modeling/objects) for the objects it holds |
+| `os create plugin <name>` | A **kernel code plugin** — TypeScript implementing the kernel `Plugin` contract | `src/index.ts` exporting a `Plugin` with `init` / `destroy` | `tsc` (its `build` script) | **Only with `--in-repo`** — the default standalone emission is an unscoped `plugin-<name>` marked `private: true`; `--in-repo` emits a publishable `@objectstack/plugin-<name>` | [`os create`](#os-create) below, then [Plugin Anatomy](/docs/plugins/anatomy) and [Plugin Development](/docs/plugins/development) |
 
 Every page under [Plugins & Packages](/docs/plugins) teaches the **kernel code plugin**, so
 `os create plugin` is the scaffolder those pages mean — `os init -t plugin` will not give
@@ -1334,7 +1334,7 @@ third-party extension primitive, authored as `src/skills/<name>.skill.ts` with
 #### `os create`
 
 Scaffolds a **standalone** **kernel code** plugin project (the `Plugin` contract,
-built by `tsc`, publishable; *not* the **metadata package** `os init -t plugin` emits — see
+built by `tsc`; *not* the **metadata package** `os init -t plugin` emits — see
 [Which scaffolder?](#os-init)) into the current directory:
 
 ```bash
@@ -1362,6 +1362,14 @@ The emitted `package.json` declares its `@objectstack/*` dependencies as
 published semver ranges pinned to the version of the CLI that generated it, and
 the emitted `tsconfig.json` is self-contained, so the project installs and
 builds anywhere — a workspace around it is neither needed nor assumed.
+
+That manifest is named `plugin-<name>` — **unscoped** — and carries
+`"private": true`, because `@objectstack` is a scope the developer this command
+scaffolds for cannot publish to: an accidental `npm publish` is refused loudly
+instead of being aimed at a namespace you do not own. To publish it yourself,
+rename it under a scope you control and drop that flag. Only `--in-repo` below
+emits a scoped, publishable `@objectstack/plugin-<name>`, and it lands under
+`packages/plugins/` where every sibling genuinely carries that scope.
 
 **Options:**
 - `-d, --dir <directory>` — Write the project here instead of `./<name>`

--- a/content/docs/plugins/index.mdx
+++ b/content/docs/plugins/index.mdx
@@ -77,9 +77,11 @@ Plugins follow a strict three-phase lifecycle (`init()` → `start()` → `destr
 
 <Callout type="info">
 **Which artifact this page means.** Every plugin taught here is a **kernel code
-plugin** — TypeScript implementing the `Plugin` contract, built by `tsc`, published as
-`@objectstack/plugin-<name>`. That is what `os create plugin` scaffolds. If what you
-want instead is a **metadata package** — declarative objects another stack loads, with
+plugin** — TypeScript implementing the `Plugin` contract, built by `tsc`. That is
+what `os create plugin` scaffolds: by default an unscoped `plugin-<name>` package
+marked `"private": true`, or a publishable `@objectstack/plugin-<name>` under
+`--in-repo` inside a checkout of the ObjectStack monorepo. If what you want instead
+is a **metadata package** — declarative objects another stack loads, with
 no kernel code — the scaffolder is `os init <name> -t plugin`, and
 [Which scaffolder?](/docs/deployment/cli#os-init) routes between the two by artifact
 rather than by the word `plugin`, which the CLI spells the same for both.


### PR DESCRIPTION
`os create plugin`'s standalone output is an unscoped, `private` package named `plugin-NAME`. Three hand-written statements in `content/docs/` still promised the pre-ruling behaviour — a publishable `@objectstack/plugin-NAME` — so a reader who followed them is refused by `npm publish` at the last step of a documented workflow, with the doc as the only thing that told them to try.

Closes #17103

## The emitted name, re-derived from the generator

Read out of `packages/cli/src/commands/create.ts` on `origin/main`, never copied from the ruling text or from the card:

```ts
// :153  — standalone is the default placement
export const DEFAULT_PLACEMENT: ScaffoldPlacement = 'standalone';

// :313-315  — the emitted directory name
function pluginDirName(name: string): string {
  return `plugin-${name}`;
}

// :357-360  — the emitted PACKAGE name, COMPOSED from the directory name
function pluginPackageName(placement: ScaffoldPlacement, name: string): string {
  return placement === 'in-repo'
    ? `@objectstack/${pluginDirName(name)}`
    : pluginDirName(name);
}

// :381  — the structural half: npm publish refuses a private manifest
...(standalone ? { private: true } : {}),

// :668  — how placement is chosen
const placement: ScaffoldPlacement = flags['in-repo'] ? 'in-repo' : DEFAULT_PLACEMENT;
```

⇒ **standalone, i.e. the default: `plugin-NAME` plus `"private": true`. `--in-repo`: `@objectstack/plugin-NAME`, publishable, landing under `packages/plugins/`.**

Cross-checked against this package's own literal pins in `packages/cli/test/create.test.ts:260-281`. `packages/cli` is read-only for this change — the generator is the evidence, never the target.

## What changed — three statements, not two

The card names two. A third turned up at source and is the same claim in the same section, so it is corrected here rather than left to falsify the fix:

| Site | Was | Now |
|:--|:--|:--|
| `content/docs/deployment/cli.mdx` scaffolder-routing table, **Publishable?** cell | "**Yes** — a publishable `@objectstack/plugin-NAME` package" | "**Only with `--in-repo`** — the default standalone emission is an unscoped `plugin-NAME` marked `private: true`" |
| `content/docs/deployment/cli.mdx`, `#### os create` intro prose | "the `Plugin` contract, built by `tsc`, **publishable**" | the word dropped; the section now states the emitted name, the `private` flag and why |
| `content/docs/plugins/index.mdx` "Which artifact this page means" callout | "built by `tsc`, **published as** `@objectstack/plugin-NAME`" | the default unscoped/private name, with the scoped one attached to `--in-repo` |

## The **Publishable?** column — what it now says, and why it still discriminates

The card's third item is a consequence, not a false claim: once `os create plugin` is also `private: true`, a column whose two cells both read "No" stops doing the one job that table exists for. The decision taken here is to keep the column and make each cell say what is actually true of that scaffolder, which restores the discrimination on a real axis rather than a stale one:

- `os init NAME -t plugin` → "**No** — the emitted `package.json` is `private: true`, and no flag lifts it". Measured, not assumed: `renderScaffoldPackageJson` in `packages/cli/src/commands/init.ts:409-425` writes a bare, unscoped `name` and an unconditional `private: true`, with no placement flag anywhere in that command.
- `os create plugin NAME` → "**Only with `--in-repo`**", with both halves spelled out.

So the two cells give different answers, and the difference is the one a reader needs: one scaffolder can never be published, the other can be, under a flag that is for platform work inside this monorepo.

## The card's executable criterion, run as a two-legged proof

The criterion: *after the fix, no hand-written page states that `os create plugin`'s standalone output is publishable or `@objectstack`-scoped, while the `--in-repo` behaviour is still described accurately.* The same sweep was run over both trees, scoped to `content/docs/` and excluding the release-owned `content/docs/releases/`.

**Leg A — `origin/main` (must find them).** Placeholder-scoped spelling: **2** lines, `content/docs/deployment/cli.mdx:106` and `content/docs/plugins/index.mdx:81`. Publishability claims on pages naming `os create plugin`: **4** lines, adding `cli.mdx:1337` (the third statement) and the column header.

**Leg B — this branch (must not).** Placeholder-scoped spelling: **3** lines, and reading each one, every occurrence is attached to `--in-repo`: `cli.mdx:106` ("`--in-repo` emits a publishable …"), `cli.mdx:1371-1372` ("Only `--in-repo` below emits a scoped, publishable …"), `plugins/index.mdx:82` ("… under `--in-repo`"). No line states the standalone output is publishable or scoped.

**The `--in-repo` half survives, and is described accurately.** `--in-repo` is named on 8 lines across 4 pages after the change (5 lines / 4 pages before — the fix adds descriptions of it, it removes none), and both files' `--in-repo` prose is unchanged except where it now carries the scoped name the standalone emission gave up.

**Controls.** Positive: `@objectstack/plugin-auth` is on **30** lines in both legs, unchanged. Fabricated: `@objectstack/plugin-zzznotarealplugin` and `os create widget` each return **0** in both legs, so the instrument can answer zero.

## What was deliberately NOT touched

`@objectstack/plugin-` occurs **89** times in `content/docs/` outside `releases/` on this branch; **86** of those are genuinely first-party, genuinely published plugins and are untouched. That is a reading, not an assumption: the 11 distinct names behind those 86 occurrences — `plugin-auth`, `plugin-security`, `plugin-audit`, `plugin-hono-server`, `plugin-email`, `plugin-sharing`, `plugin-approvals`, `plugin-reports`, `plugin-pinyin-search`, `plugin-dev`, `plugin-webhooks` — were each resolved to a real `packages/plugins/plugin-*/package.json` whose `name` matches and which carries no `private` flag. A blanket find-and-replace on that prefix would have been a much larger defect than the one being fixed.

Read and left alone, as the card asked: `content/docs/protocol/kernel/index.mdx:387-408` describes the scaffold and already prints `./plugin-NAME/` unscoped, and its `--in-repo` sentence is about `workspace:*` dependencies, not publishability — accurate. `content/docs/getting-started/your-first-project.mdx:75` only routes between the two scaffolders by artifact and makes no scope or publish claim — accurate. `content/docs/deployment/cli.mdx:1341` already read `os create plugin analytics # Create ./plugin-analytics` and served as a positive control that the correct spelling was already reachable in this page.

## Verification

- **41 of 41** derived gate families run, every one exit `0`, reconciled with `node scripts/pm/dispatch-gates.mjs --ran` at `36d9b307`: *"41 derived famil(ies) accounted for — 41 run, 0 NOT-MEASURED"*. Exit codes were captured by redirect-then-`$?`, never through a pipe.
- Five of those first answered `PREREQUISITE NOT MET` (three at exit `3`, two at exit `1` with the same substance) because the tree was unbuilt. Nothing was read from those runs; `@objectstack/spec`, `@objectstack/lint`, `@objectstack/formula`, `@objectstack/client` and `@objectstack/client-react` were built and all five re-run to a real exit `0`.
- `pnpm lint` — the whole repository, `eslint . --no-inline-config`, exit `0`. Not narrowed.
- Tree freshness: derived once before merging `origin/main` and once after; both lists are byte-identical at 41 commands. The post-merge derivation is the one reconciled.

## Changeset

`skip-changeset`, and it is measured rather than assumed. No package's `files[]` ships `content/docs/` — checked across all **70** workspace packages that declare a `files[]`, with `dist` as the positive control (**70/70** match it) and a fabricated term as the negative (**0**). The docs site itself, `apps/docs`, is `private: true`. So this diff publishes nothing from any released package, which is exactly what that label is for.

Clause-②: no

`Contract-text:` `packages/cli/src/commands/create.ts:313-315`, `:357-360` and `:381`, quoted above. Correcting prose to match code that already shipped is a pull-back onto already-declared behaviour: it widens no accept set, adds no key to any published payload and exports no symbol.

## Scope

Two files, both hand-written docs. `content/docs/releases/` is release-owned and untouched. `packages/cli` is untouched. Numbers cited for context only, with no verb beside them: the ruling is on issue #15530, its code half landed as PR #17096, and issue #16140 was considered and rejected as a neighbour by the card.

_Generated by [Claude Code](https://claude.ai/code/session_01DapQyvYrFb1MxSYe7BL2nt)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01DapQyvYrFb1MxSYe7BL2nt)_