### PR TITLE
fix(rest): parse the dataset-query selection at the door, matching the analytics family

### DIFF
--- a/.changeset/analytics-dataset-query-selection-door-parse.md
+++ b/.changeset/analytics-dataset-query-selection-door-parse.md
@@ -1,0 +1,39 @@
+---
+'@objectstack/rest': minor
+---
+
+`POST /analytics/dataset/query` parses its `selection` at the door, the way its two siblings already do
+
+The route checked one thing about the body it forwards — that
+`selection.measures` was a non-empty array — and forwarded everything else
+unexamined. `/analytics/query` and `/analytics/sql` Zod-parse their body at
+the entry and lift a malformed member to a 400 before the service is reached,
+so a client met two postures on one family depending on which door it knocked
+on, and a malformed member of `selection` travelled into `dataset-executor` to
+be answered by whatever the face behind it happened to do with it.
+
+⚠️ **A 400 is newly reachable.** Requests that previously slipped through are
+now refused. Two shapes:
+
+- A `timeDimensions[].dateRange` outside the closed preset vocabulary answers
+  `400 ANALYTICS_DATE_RANGE_UNRECOGNIZED` — the same code, status and wording
+  the sibling door has answered for the identical condition since the
+  vocabulary closed. Measured on the tree before this change, the literal
+  string `not a range at all` reached the executor under an ordinary `200`.
+- Anything else malformed answers `400 VALIDATION_FAILED` with
+  `details.fields[]`, each entry naming the member as `selection.<path>`.
+
+**What is NOT newly refused, deliberately.** `selection` is a
+`DatasetSelection`, which is *not* the `AnalyticsQuery` the siblings parse: it
+carries no `cube`, and `runtimeFilter`, `dateGranularity`, `compareTo` and
+`totals` are members of its own. Reusing the sibling schema would have refused
+every real dashboard widget. What the door parses is the projection of the
+seven members whose declaration on `DatasetSelection` *is* the `AnalyticsQuery`
+member of the same name — `dimensions`, `measures`, `timeDimensions` (declared
+there by reference), `order`, `limit`, `offset`, `timezone` — so the refusal
+set is exactly what the published interface already declared. The four
+dataset-only members are projected away before the parse and keep reaching the
+executor untouched.
+
+Validation-only: the caller's `selection` object is what `queryDataset`
+receives, by identity, never a parse output.

--- a/packages/rest/src/analytics-dataset-selection-door.test.ts
+++ b/packages/rest/src/analytics-dataset-selection-door.test.ts
@@ -19,6 +19,14 @@
  * A door that refuses too much is a worse defect than the one being fixed.
  */
 
+// The dynamic `import()`s below are paid HERE, at module scope, so the
+// transform lands during collection rather than inside a clocked window
+// (`pnpm check:test-source-alias`; this package resolves both specifiers
+// through `dist/`). The dynamic calls stay where they are — this only decides
+// where the first load is paid.
+import '@objectstack/spec/api';
+import '@objectstack/spec/data';
+
 import { describe, it, expect, vi } from 'vitest';
 import { RestServer } from './rest-server';
 import {

--- a/packages/rest/src/analytics-dataset-selection-door.test.ts
+++ b/packages/rest/src/analytics-dataset-selection-door.test.ts
@@ -1,0 +1,365 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * [#17058] `POST /analytics/dataset/query` parses its `selection` AT THE DOOR.
+ *
+ * The defect: the route checked only that `selection.measures` was a non-empty
+ * array, so every other member reached `dataset-executor` unrefused — while the
+ * sibling routes (`/analytics/query`, `/analytics/sql`) lift the identical
+ * failure to a 400 at their entry. One family, two postures.
+ *
+ * ## The measurement the card left open, taken here and PINNED
+ *
+ * The card asked whether the dataset route's `selection` is genuinely the same
+ * shape as the siblings' before reusing their schema. It is **not** — §1 below
+ * drives that against the real schema — so the door parses a PROJECTION of the
+ * members whose declarations coincide, and the four dataset-only members are
+ * projected away rather than refused. §5 is the other half of that answer and
+ * the one that matters most: a fully-loaded VALID selection still passes.
+ * A door that refuses too much is a worse defect than the one being fixed.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { RestServer } from './rest-server';
+import {
+    SELECTION_MEMBERS_SHARED_WITH_ANALYTICS_QUERY,
+    datasetSelectionRefusal,
+} from './analytics-selection-door';
+
+// ── harness (the shape `analytics-routes.test.ts` uses) ──────────────────────
+
+function mockServer() {
+    return {
+        get: vi.fn(), post: vi.fn(), put: vi.fn(), delete: vi.fn(), patch: vi.fn(),
+        use: vi.fn(), listen: vi.fn().mockResolvedValue(undefined), close: vi.fn().mockResolvedValue(undefined),
+    };
+}
+function mockProtocol() {
+    return {
+        getDiscovery: vi.fn().mockResolvedValue({ version: 'v0', routes: { data: '', metadata: '' } }),
+        getMetaTypes: vi.fn().mockResolvedValue([]),
+        getMetaItems: vi.fn().mockResolvedValue([]),
+    };
+}
+function mockRes() {
+    const res: any = { statusCode: 200, body: undefined };
+    res.status = vi.fn((c: number) => { res.statusCode = c; return res; });
+    res.json = vi.fn((b: any) => { res.body = b; return res; });
+    res.end = vi.fn(() => res);
+    return res;
+}
+
+const inlineDataset = {
+    name: 'sales',
+    label: 'Sales',
+    object: 'opportunity',
+    dimensions: [
+        { name: 'region', field: 'region', type: 'string' },
+        { name: 'close_date', field: 'close_date', type: 'date' },
+    ],
+    measures: [{ name: 'revenue', aggregate: 'sum', field: 'amount' }],
+};
+
+function buildRoute() {
+    const queryDataset = vi.fn().mockResolvedValue({ rows: [], fields: [] });
+    const server = mockServer();
+    const rest = new RestServer(
+        server as any, mockProtocol() as any, { api: { requireAuth: false } } as any,
+        undefined, undefined, undefined, undefined, undefined, undefined, undefined,
+        undefined, undefined, undefined, undefined,
+        async () => ({ queryDataset }),
+    );
+    (rest as any).resolveExecCtx = async () => ({ userId: 'test-user' });
+    rest.registerRoutes();
+    const route = rest.getRoutes().find((r) => r.method === 'POST' && r.path.endsWith('/analytics/dataset/query'))!;
+    expect(route, 'POST …/analytics/dataset/query must be registered').toBeTruthy();
+    return { route, queryDataset };
+}
+
+/** POST a body through the REAL route and return `{ res, queryDataset }`. */
+async function post(body: unknown) {
+    const { route, queryDataset } = buildRoute();
+    const res = mockRes();
+    await route.handler({ method: 'POST', params: {}, headers: {}, body } as any, res);
+    return { res, queryDataset };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// §1 — the shape question: `DatasetSelection` is NOT the siblings' shape
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('#17058 §1 — the dataset route\'s `selection` is not the sibling routes\' body shape', () => {
+    /**
+     * A legal, ordinary dashboard-widget selection. Every member here is
+     * declared on `DatasetSelection` (`spec/contracts/analytics-service.ts`).
+     */
+    const legalSelection = {
+        dimensions: ['region'],
+        measures: ['revenue'],
+        runtimeFilter: { region: 'NA' },
+        timeDimensions: [{ dimension: 'close_date', granularity: 'month', dateRange: 'last_30_days' }],
+        dateGranularity: 'month',
+        order: { revenue: 'desc' },
+        limit: 10,
+        offset: 0,
+        compareTo: { kind: 'previousPeriod' },
+        totals: { groupings: [['region'], []] },
+        timezone: 'Asia/Shanghai',
+    } as const;
+
+    it('the siblings\' own schema REFUSES it — on `cube` and on all four dataset-only members', async () => {
+        const { AnalyticsQueryRequestSchema } = await import('@objectstack/spec/api');
+        const parsed = (AnalyticsQueryRequestSchema as any).safeParse(legalSelection);
+
+        expect(parsed.success, 'a legal DatasetSelection must NOT parse as an AnalyticsQuery').toBe(false);
+        const paths: string[] = parsed.error.issues.map((i: any) => i.path.join('.'));
+        const unrecognized: string[] = parsed.error.issues
+            .filter((i: any) => i.code === 'unrecognized_keys')
+            .flatMap((i: any) => i.keys ?? []);
+
+        // `cube` is required there and absent here — a dataset selection names
+        // no cube; the dataset is addressed by `body.dataset`/`datasetName`.
+        expect(paths).toContain('cube');
+        // …and the schema is `.strict()`, so the dataset-only members are keys
+        // it has never heard of. This is why reusing it would 400 every real
+        // dashboard widget.
+        expect(unrecognized.sort()).toEqual(
+            ['compareTo', 'dateGranularity', 'runtimeFilter', 'totals'].sort(),
+        );
+    });
+
+    it('the shared projection accepts the same selection — that is the half this door parses', async () => {
+        expect(await datasetSelectionRefusal(legalSelection)).toBeUndefined();
+    });
+
+    /**
+     * The projection list is a claim about two declarations agreeing. Pin both
+     * directions so a later edit cannot quietly move a member into or out of it.
+     */
+    it('every projected member is an `AnalyticsQuery` member; no dataset-only member is', async () => {
+        const { AnalyticsQuerySchema } = await import('@objectstack/spec/data');
+        const analyticsMembers = Object.keys((AnalyticsQuerySchema as any).shape);
+        for (const member of SELECTION_MEMBERS_SHARED_WITH_ANALYTICS_QUERY) {
+            expect(analyticsMembers, `${member} must be declared on AnalyticsQuery`).toContain(member);
+        }
+        for (const datasetOnly of ['runtimeFilter', 'dateGranularity', 'compareTo', 'totals']) {
+            expect(analyticsMembers).not.toContain(datasetOnly);
+            expect(SELECTION_MEMBERS_SHARED_WITH_ANALYTICS_QUERY as readonly string[])
+                .not.toContain(datasetOnly);
+        }
+    });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// §2 — the card's measured specimen, driven through the real route
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('#17058 §2 — a malformed `dateRange` is refused at the door, not by the face behind it', () => {
+    it('answers 400 ANALYTICS_DATE_RANGE_UNRECOGNIZED and never reaches the service', async () => {
+        const { res, queryDataset } = await post({
+            dataset: inlineDataset,
+            selection: {
+                dimensions: ['region'],
+                measures: ['revenue'],
+                timeDimensions: [{ dimension: 'close_date', dateRange: 'not a range at all' }],
+            },
+        });
+
+        expect(res.statusCode).toBe(400);
+        // The SAME code the sibling door answers for the identical condition —
+        // one condition, one code (ADR-0112 D3 / the #5240 convention).
+        expect(res.body.code).toBe('ANALYTICS_DATE_RANGE_UNRECOGNIZED');
+        // The message locates the offending member on the REQUEST body…
+        expect(res.body.message).toContain('selection.timeDimensions.0.dateRange');
+        // …and carries the schema's own prescription, quoted not restated.
+        expect(res.body.message).toContain('not a range at all');
+        expect(res.body.message).toContain('last_7_days');
+        // The whole point of a door: the executor never sees it.
+        expect(queryDataset).not.toHaveBeenCalled();
+    });
+
+    it('the envelope\'s code is a registered vocabulary member, not a dialect', async () => {
+        const { ApiErrorSchema } = await import('@objectstack/spec/api');
+        const { res } = await post({
+            dataset: inlineDataset,
+            selection: {
+                measures: ['revenue'],
+                timeDimensions: [{ dimension: 'close_date', dateRange: 'Last 7 days' }],
+            },
+        });
+        const parsed = (ApiErrorSchema as any).safeParse({
+            code: res.body.code,
+            message: res.body.message,
+            httpStatus: res.statusCode,
+        });
+        expect(parsed.success, JSON.stringify(parsed.success ? null : parsed.error.issues)).toBe(true);
+    });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// §3 — the rest of the shape: `timeDimensions` is not special
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('#17058 §3 — the generic refusal is 400 VALIDATION_FAILED + details.fields[]', () => {
+    const cases: Array<{ name: string; selection: Record<string, unknown>; field: string }> = [
+        {
+            name: 'a typo\'d nested key (`granuarity`) — top-level strictness does not recurse',
+            selection: {
+                measures: ['revenue'],
+                timeDimensions: [{ dimension: 'close_date', granuarity: 'month' }],
+            },
+            field: 'selection.timeDimensions.0',
+        },
+        {
+            name: 'a measure name that is not a string',
+            selection: { measures: [42] },
+            field: 'selection.measures.0',
+        },
+        {
+            name: 'a dimension list that is not a list',
+            selection: { measures: ['revenue'], dimensions: 'region' },
+            field: 'selection.dimensions',
+        },
+        {
+            name: 'an order direction outside the declared pair',
+            selection: { measures: ['revenue'], order: { revenue: 'ASC' } },
+            field: 'selection.order.revenue',
+        },
+        {
+            name: 'a `limit` sent as a string',
+            selection: { measures: ['revenue'], limit: '10' },
+            field: 'selection.limit',
+        },
+    ];
+
+    for (const c of cases) {
+        it(`refuses ${c.name}`, async () => {
+            const { res, queryDataset } = await post({ dataset: inlineDataset, selection: c.selection });
+            expect(res.statusCode).toBe(400);
+            expect(res.body.code).toBe('VALIDATION_FAILED');
+            const fields: Array<{ field: string; code: string }> = res.body.details.fields;
+            expect(fields.map((f) => f.field)).toContain(c.field);
+            expect(queryDataset).not.toHaveBeenCalled();
+        });
+    }
+
+    it('the date-range lift is all-or-nothing: a body wrong in MORE places stays generic', async () => {
+        const { res } = await post({
+            dataset: inlineDataset,
+            selection: {
+                measures: ['revenue'],
+                timeDimensions: [{ dimension: 'close_date', dateRange: 'nope', granuarity: 'month' }],
+            },
+        });
+        expect(res.statusCode).toBe(400);
+        expect(res.body.code).toBe('VALIDATION_FAILED');
+        const fields: Array<{ field: string }> = res.body.details.fields;
+        expect(fields.map((f) => f.field)).toContain('selection.timeDimensions.0.dateRange');
+        expect(fields.map((f) => f.field)).toContain('selection.timeDimensions.0');
+    });
+
+    it('the `measures` door ahead of the parse keeps its own sentence', async () => {
+        const { res } = await post({ dataset: inlineDataset, selection: { dimensions: ['region'] } });
+        expect(res.statusCode).toBe(400);
+        expect(res.body.code).toBe('VALIDATION_FAILED');
+        expect(res.body.message).toContain('body.selection.measures');
+    });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// §4 — the four dataset-only members keep passing (they are projected away)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('#17058 §4 — the dataset-only members are NOT judged by the sibling schema', () => {
+    const datasetOnly: Array<[string, unknown]> = [
+        ['runtimeFilter', { region: { $ne: 'EU' } }],
+        ['dateGranularity', 'quarter'],
+        ['compareTo', { kind: 'previousYear' }],
+        ['totals', { groupings: [[]] }],
+    ];
+
+    for (const [member, value] of datasetOnly) {
+        it(`\`${member}\` reaches the service untouched`, async () => {
+            const selection = { dimensions: ['region'], measures: ['revenue'], [member]: value };
+            const { res, queryDataset } = await post({ dataset: inlineDataset, selection });
+            expect(res.statusCode).toBe(200);
+            expect(queryDataset).toHaveBeenCalledTimes(1);
+            expect(queryDataset.mock.calls[0][1]).toBe(selection);
+        });
+    }
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// §5 — ⭐ the negative side: a valid selection still passes, unmodified
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('#17058 §5 — a valid selection still passes, and passes through unchanged', () => {
+    it('a fully-loaded selection — all eleven members — answers 200', async () => {
+        const selection = {
+            dimensions: ['region'],
+            measures: ['revenue'],
+            runtimeFilter: { region: 'NA' },
+            timeDimensions: [{ dimension: 'close_date', granularity: 'month', dateRange: 'last_30_days' }],
+            dateGranularity: 'month',
+            order: { revenue: 'desc' },
+            limit: 10,
+            offset: 0,
+            compareTo: { kind: 'previousPeriod', dimension: 'close_date' },
+            totals: { groupings: [['region'], []] },
+            timezone: 'Asia/Shanghai',
+        };
+        const { res, queryDataset } = await post({ dataset: inlineDataset, selection });
+        expect(res.statusCode).toBe(200);
+        expect(queryDataset).toHaveBeenCalledTimes(1);
+        // Validation-only: the CALLER's object is what the service receives,
+        // by identity — never a parse output that could carry a schema default.
+        expect(queryDataset.mock.calls[0][1]).toBe(selection);
+    });
+
+    it('the explicit `[start, end]` window arm is untouched by the closing', async () => {
+        const { res, queryDataset } = await post({
+            dataset: inlineDataset,
+            selection: {
+                measures: ['revenue'],
+                timeDimensions: [{ dimension: 'close_date', dateRange: ['2026-01-01', '{today}'] }],
+            },
+        });
+        expect(res.statusCode).toBe(200);
+        expect(queryDataset).toHaveBeenCalledTimes(1);
+    });
+
+    /**
+     * The leniency sweep, as a test. Every `selection` literal the in-repo
+     * suites POST at this route (and the one `packages/qa/dogfood` sends) is
+     * replayed through the new door: if any of them had been relying on the
+     * leniency, the fix would have broken it, and triage asked for that answer
+     * explicitly rather than as an impression.
+     */
+    it('every in-repo selection specimen still passes the door', async () => {
+        const specimens: Array<Record<string, unknown>> = [
+            // packages/rest/src/analytics-dataset-dimension-gate.test.ts
+            { measures: ['account_count'], dimensions: ['bogus_dim'] },
+            { measures: ['account_count'], dimensions: ['industry'], timeDimensions: [{ dimension: 'bogus_dim', granularity: 'month' }] },
+            // packages/rest/src/analytics-dataset-where-gate.test.ts
+            { measures: ['account_count'], runtimeFilter: { bogus_col: 'x' } },
+            { measures: ['account_count'], runtimeFilter: { industry: { $sortOf: 'tech' } } },
+            // packages/rest/src/analytics-dataset-refusal-envelope.test.ts
+            { dimensions: ['stage'], measures: ['revenue'], order: { profit: 'desc' } },
+            { dimensions: ['stage'], measures: ['revenue'], totals: { groupings: [['region']] } },
+            // packages/rest/src/analytics-dataset-unlisted-refusal-envelope.test.ts
+            { dimensions: ['stage'], measures: ['revenue'], timeDimensions: [{ dimension: 'close_date', dateRange: ['2026-01-01', 'the-first-of-never'] }], compareTo: { kind: 'previousPeriod' } },
+            { dimensions: ['stage'], measures: ['revenue'], timeDimensions: [{ dimension: 'close_date', granularity: 'month' }], compareTo: { kind: 'previousPeriod' } },
+            { dimensions: ['stage'], measures: ['revenue'], timeDimensions: [{ dimension: 'account_opened', granularity: 'month' }] },
+            // packages/client/src/client.test.ts
+            { measures: ['amount_sum'] },
+            // packages/qa/dogfood/test/temporal-storage-e2e.dogfood.test.ts
+            { measures: ['cnt'], timeDimensions: [{ dimension: 'issued', granularity: 'month' }] },
+        ];
+        for (const selection of specimens) {
+            expect(
+                await datasetSelectionRefusal(selection),
+                `specimen must still pass: ${JSON.stringify(selection)}`,
+            ).toBeUndefined();
+        }
+    });
+});

--- a/packages/rest/src/analytics-selection-door.ts
+++ b/packages/rest/src/analytics-selection-door.ts
@@ -1,0 +1,192 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * [#17058] The door parse for `POST {basePath}/analytics/dataset/query`'s
+ * `selection` — the half of the analytics family this route never had.
+ *
+ * ## The gap
+ *
+ * `/analytics/query` and `/analytics/sql` Zod-parse their body at the entry
+ * (`runtime/src/domains/analytics.ts` → `assertAnalyticsQueryBody`) and lift a
+ * malformed member to a 400 before the service is reached. The dataset route
+ * checked only that `selection.measures` was a non-empty array, so every other
+ * member travelled into `dataset-executor` unrefused and was answered by
+ * whatever the face behind it happened to do with it. That is the same door,
+ * one family, two postures — the inconsistency a client cannot predict.
+ *
+ * ## Why this is a PROJECTION and not a reuse of the siblings' schema
+ *
+ * ⚠️ Measured before writing a line, because the card left it open: **the
+ * dataset route's `selection` is NOT the sibling routes' shape.** It is
+ * `DatasetSelection` (`spec/contracts/analytics-service.ts`), and against
+ * `AnalyticsQueryRequestSchema` a perfectly legal selection fails twice over —
+ * the sibling schema requires `cube` (a dataset selection never carries one:
+ * the dataset is addressed by `body.dataset` / `body.datasetName`) and it is
+ * `.strict()`, so `runtimeFilter`, `dateGranularity`, `compareTo` and `totals`
+ * are all rejected as unrecognized keys. ⛔ Reusing it would refuse every real
+ * dashboard widget — a far worse defect than the one being fixed.
+ *
+ * What IS shared is member-by-member, and it is most of the shape. Seven of
+ * `DatasetSelection`'s eleven members declare exactly the type the
+ * `AnalyticsQuery` member of the same name declares:
+ *
+ * | member | `DatasetSelection` | `AnalyticsQuery` |
+ * |:---|:---|:---|
+ * | `dimensions` | `string[]?` | `string[]?` |
+ * | `measures` | `string[]` | `string[]` |
+ * | `timeDimensions` | `AnalyticsQuery['timeDimensions']` — declared BY REFERENCE | itself |
+ * | `order` | `Record<string, 'asc' \| 'desc'>?` | same |
+ * | `limit` / `offset` | `number?` | same |
+ * | `timezone` | `string?` | same |
+ *
+ * So parsing those seven against `AnalyticsQuerySchema.pick(…)` enforces the
+ * contract `DatasetSelection` already declares — a pull-back onto published
+ * text, never a narrowing past it. The four dataset-only members
+ * (`runtimeFilter`, `dateGranularity`, `compareTo`, `totals`) are PROJECTED
+ * AWAY before the parse, deliberately: `.pick()` carries `.strict()` through,
+ * so handing the raw selection to the picked schema would reject them.
+ *
+ * ⚠️ Those four therefore still have no door. `DatasetSelection` is a
+ * TypeScript interface with no Zod schema anywhere in the repo, and authoring
+ * one belongs in `packages/spec` beside the interface (Prime Directive #1),
+ * not here in a consumer — a second declaration of a spec-owned wire shape is
+ * the dialect Prime Directive #12 exists to prevent. Filed separately; this
+ * module is deliberately the derivable half.
+ *
+ * ## The refusal shapes, and why the date-range code is not spelled here
+ *
+ * Two answers, matching the family:
+ *
+ * - Every issue is the closed-vocabulary `timeDimensions[].dateRange` refusal
+ *   ⇒ `400 ANALYTICS_DATE_RANGE_UNRECOGNIZED`, the ADR-0112 envelope the
+ *   sibling door answers for the identical condition. All-or-nothing, exactly
+ *   as `assertAnalyticsQueryBody` lifts it: a body wrong in several places
+ *   stays the generic failure, whose per-field carrier is the right one there.
+ * - Anything else ⇒ `400 VALIDATION_FAILED` + `details.fields[]`, the shape
+ *   this route's two neighbouring hand-built doors already answer with.
+ *
+ * ⛔ The date-range code is read off {@link analyticsDateRangeUnrecognizedError}
+ * — `@objectstack/core`'s ONE constructor for this refusal — and never spelled
+ * as a literal in this package. Two reasons, and both are load-bearing:
+ * ADR-0112 D3 registers the code under `@objectstack/runtime` (the door that
+ * names the wire vocabulary) with a recorded provenance waiver for `core`'s
+ * shared constructor, so a literal here would be a stamp site under an owner
+ * key that does not list it; and the #5240 convention wants one condition to
+ * keep one wording, which a second spelling quietly ends. That constructor's
+ * own TSDoc names this route as the caller it was waiting for.
+ *
+ * The `message` is built the way the sibling builds it — `<field>: <message>`
+ * joined — over `zodIssuesToFields`, the one ADR-0114 D3 mapper. Field paths
+ * are prefixed `selection.` because they are reported against the REQUEST
+ * body, where the parsed object sits one level down.
+ *
+ * Validation-only: the caller's `selection` is forwarded to the service
+ * untouched, never the parse output — the rule `assertAnalyticsQueryBody`
+ * records for the same reason (a default someone adds to the schema later must
+ * not silently override the engine's own resolution chain).
+ */
+
+import { zodIssuesToFields } from '@objectstack/spec/api';
+import { analyticsDateRangeUnrecognizedError } from '@objectstack/core';
+
+/**
+ * The `DatasetSelection` members whose declared type IS the `AnalyticsQuery`
+ * member of the same name — the projection this door parses.
+ *
+ * ⛔ Adding a member here is a claim about the two declarations agreeing:
+ * check `DatasetSelection` in `spec/contracts/analytics-service.ts` against
+ * `AnalyticsQuerySchema` in `spec/data/analytics.zod.ts` first. A member that
+ * only LOOKS alike (`runtimeFilter` vs `where` — same `FilterCondition`, a
+ * different key on each side) does not belong: this list is what makes the
+ * parse a pull-back rather than a new contract. `.pick()` is type-checked
+ * against the schema, so a member that leaves `AnalyticsQuery` fails the
+ * build here rather than silently dropping out of coverage.
+ */
+export const SELECTION_MEMBERS_SHARED_WITH_ANALYTICS_QUERY = [
+    'dimensions',
+    'measures',
+    'timeDimensions',
+    'order',
+    'limit',
+    'offset',
+    'timezone',
+] as const;
+
+/** A door refusal, ready for `res.status(...).json(...)`. */
+export interface DatasetSelectionRefusal {
+    status: number;
+    body: Record<string, unknown>;
+}
+
+/**
+ * Built on first use and memoised — `@objectstack/spec/data` stays off this
+ * module's init path, the same lazy `await import` the analytics route already
+ * performs for `DatasetSchema`.
+ */
+let sharedSelectionSchema: { safeParse(input: unknown): any } | undefined;
+
+async function getSharedSelectionSchema(): Promise<{ safeParse(input: unknown): any }> {
+    if (!sharedSelectionSchema) {
+        const { AnalyticsQuerySchema } = await import('@objectstack/spec/data');
+        sharedSelectionSchema = (AnalyticsQuerySchema as any).pick({
+            dimensions: true,
+            measures: true,
+            timeDimensions: true,
+            order: true,
+            limit: true,
+            offset: true,
+            timezone: true,
+        });
+    }
+    return sharedSelectionSchema!;
+}
+
+/**
+ * Parse the shared members of a dataset `selection` and describe the refusal,
+ * or `undefined` when the selection passes.
+ *
+ * A non-object `selection` answers `undefined`: the route's own check ahead of
+ * this one (`selection.measures` must be a non-empty array) already owns that
+ * case and answers it with a message naming the member, which is the better
+ * sentence for by far the most common mistake. This function is about the
+ * members that had no door at all.
+ */
+export async function datasetSelectionRefusal(
+    selection: unknown,
+): Promise<DatasetSelectionRefusal | undefined> {
+    if (!selection || typeof selection !== 'object' || Array.isArray(selection)) return undefined;
+
+    const source = selection as Record<string, unknown>;
+    const projection: Record<string, unknown> = {};
+    for (const member of SELECTION_MEMBERS_SHARED_WITH_ANALYTICS_QUERY) {
+        if (member in source) projection[member] = source[member];
+    }
+
+    const schema = await getSharedSelectionSchema();
+    const parsed = schema.safeParse(projection);
+    if (parsed.success) return undefined;
+
+    const issues: Array<{ code: string; path: ReadonlyArray<PropertyKey>; input?: unknown }> =
+        parsed.error.issues;
+    const fields = zodIssuesToFields(issues, projection).map((entry) => ({
+        ...entry,
+        field: `selection.${entry.field}`,
+    }));
+    const message = `Invalid dataset selection: ${fields
+        .map((f) => `${f.field}: ${f.message}`)
+        .join('; ')}`;
+
+    const { isAnalyticsDateRangeRefusalIssue } = await import('@objectstack/spec/data');
+    if (issues.length > 0 && issues.every((issue) => isAnalyticsDateRangeRefusalIssue(issue))) {
+        // The code and status come from the platform's one constructor for this
+        // condition; only the sentence is this door's, and it is the family's
+        // `<field>: <message>` form over the schema's own prescription.
+        const declared = analyticsDateRangeUnrecognizedError(issues[0]?.input) as Error & {
+            code?: string;
+            status?: number;
+        };
+        return { status: declared.status ?? 400, body: { code: declared.code, message } };
+    }
+
+    return { status: 400, body: { code: 'VALIDATION_FAILED', message, details: { fields } } };
+}

--- a/packages/rest/src/rest-server.ts
+++ b/packages/rest/src/rest-server.ts
@@ -304,6 +304,10 @@ import { runImport } from './import-runner.js';
 // [#16581] The public picker's authoring-dialect → parser-grammar lowering.
 import { lowerViewFilterRules } from './view-filter-rule-lowering.js';
 import { prepareImportRequest } from './import-prepare.js';
+// [#17058] The `POST …/analytics/dataset/query` door parse — the half of the
+// analytics family this route never had. See the module header for the
+// measurement that decides its shape.
+import { datasetSelectionRefusal } from './analytics-selection-door.js';
 import { loadExcelJs, type Worksheet } from './xlsx-module.js';
 import { enrichOpenApiWithEndpoints } from './openapi-endpoints.js';
 import { buildBuiltinPaths } from './openapi-builtin-paths.js';
@@ -10918,6 +10922,29 @@ export class RestServer {
                             code: 'VALIDATION_FAILED',
                             message: 'body.selection.measures must be a non-empty array of measure names.',
                         });
+                    }
+
+                    // [#17058] …and every OTHER member of `selection` had no
+                    // door at all, so a malformed one travelled into
+                    // `dataset-executor` and was answered by whatever the face
+                    // behind it happened to do with it — while the sibling
+                    // routes (`/analytics/query`, `/analytics/sql`) lift the
+                    // identical failure to a 400 at the entry. One family, two
+                    // postures, decided by which door the client knocked on.
+                    //
+                    // The parse is a PROJECTION, never the siblings' schema:
+                    // `selection` is a `DatasetSelection`, which is NOT the
+                    // `AnalyticsQuery` the siblings parse — it carries no
+                    // `cube` and has four members of its own, so the sibling
+                    // schema would 400 every real dashboard widget.
+                    // {@link datasetSelectionRefusal} carries that measurement
+                    // and the reason those four are deliberately left out.
+                    //
+                    // Validation-only: the caller's `selection` is what reaches
+                    // `queryDataset` below, never a parse output.
+                    const selectionRefusal = await datasetSelectionRefusal(selection);
+                    if (selectionRefusal) {
+                        return res.status(selectionRefusal.status).json(selectionRefusal.body);
                     }
 
                     // ADR-0037 P3 — draft data preview: the canvas / preview


### PR DESCRIPTION
Closes #17058

`POST {basePath}/analytics/dataset/query` checked exactly one thing about the body it forwards — that `selection.measures` was a non-empty array — and forwarded everything else unexamined. Its two siblings, `/analytics/query` and `/analytics/sql`, Zod-parse their body at the entry (`runtime/src/domains/analytics.ts` → `assertAnalyticsQueryBody`) and lift a malformed member to a 400 before the service is reached. One family, two postures, decided by which door the client knocked on.

Triage's ruling, verbatim:

> ⇒ Parse at the door, matching the siblings' shape. ⛔ Do not invent a different validation posture for this route; copy the family's.

## ⭐ The measurement the card left open — taken first, and it changes the shape of the fix

The card was explicit that the decisive measurement had not been taken:

> ⚠️ Whoever takes this should check whether the dataset route's `selection` is genuinely the same shape as the sibling routes' before reusing their schema — that was **not** measured here.

**Answer: the shapes are not the same, and reusing the siblings' schema would have been a worse defect than the one being fixed.**

`selection` is a `DatasetSelection` (`packages/spec/src/contracts/analytics-service.ts:177`, published as `DatasetSelection (interface)` in `packages/spec/api-surface/contracts.json:74`). Parsed against `AnalyticsQueryRequestSchema` — the schema the siblings use — an ordinary, entirely legal dashboard selection fails twice over: that schema requires `cube` (a dataset selection never carries one; the dataset is addressed by `body.dataset` / `body.datasetName`), and it is `.strict()`, so `runtimeFilter`, `dateGranularity`, `compareTo` and `totals` all come back as unrecognized keys. That is pinned as a test rather than asserted — see §1 of the new suite.

What **is** shared is member by member, and it is most of the shape. Seven of `DatasetSelection`'s eleven members declare exactly the `AnalyticsQuery` member of the same name:

| member | `DatasetSelection` | `AnalyticsQuery` |
|:---|:---|:---|
| `dimensions` | `string[]?` | `string[]?` |
| `measures` | `string[]` | `string[]` |
| `timeDimensions` | `AnalyticsQuery['timeDimensions']` — declared **by reference** | itself |
| `order` | `Record<string, 'asc' \| 'desc'>?` | same |
| `limit` / `offset` | `number?` | same |
| `timezone` | `string?` | same |

So the door parses a **projection** of those seven against `AnalyticsQuerySchema.pick(…)`, and projects the four dataset-only members away before parsing (`.pick()` carries `.strict()` through, so handing it the raw selection would reject them). That is triage's *posture* — parse at the door, lift to 400 — applied to the shape this route actually has, which is what the instruction asks for; forcing one schema onto a different shape is not.

## Both refusal shapes come from the family, including the code

- Every issue is the closed-vocabulary `timeDimensions[].dateRange` refusal ⇒ **`400 ANALYTICS_DATE_RANGE_UNRECOGNIZED`**, the ADR-0112 envelope the sibling door answers for the identical condition. All-or-nothing, exactly as `assertAnalyticsQueryBody` lifts it.
- Anything else ⇒ **`400 VALIDATION_FAILED`** with `details.fields[]`, each entry naming the member as `selection.` followed by the member path, mapped through `zodIssuesToFields` (the one ADR-0114 D3 implementation).

⛔ The date-range code is **read off `analyticsDateRangeUnrecognizedError`** (`@objectstack/core`, the platform's one constructor for this refusal) and never spelled as a literal in `packages/rest`. Two reasons, both load-bearing. ADR-0112 D3 registers the code under `@objectstack/runtime` with a recorded provenance waiver for `core`'s shared constructor, so a literal here would be a stamp site under an owner key that does not list it — `check:error-code-provenance` measured green with the delivered diff (`scanned 2282 files; 334 registered-code stamp site(s): 317 listed, 17 waived`). And the #5240 convention wants one condition to keep one wording, which a second spelling quietly ends. That constructor's own TSDoc already names this route as the caller it was waiting for:

> Reachability: … It is the answer for the in-process caller past that door — `AnalyticsService.query`, a driver's cube face called directly, and `POST /analytics/dataset/query`, which types `selection.timeDimensions` from `AnalyticsQuery` but does not Zod-parse it.

Validation-only: the caller's `selection` object is what reaches `queryDataset`, by identity, never a parse output — the rule `assertAnalyticsQueryBody` records for the same reason.

## Did anything in-repo rely on the leniency?

Triage asked for this as a measurement, not an impression. **No.** The sweep, with its controls:

- Every `selection` literal POSTed at this route by an in-repo suite (`packages/rest/src/analytics-dataset-{dimension-gate,where-gate,refusal-envelope,unlisted-refusal-envelope}.test.ts`, `analytics-routes.test.ts`, `analytics-filter-refusal-envelope.test.ts`, `analytics-16019-driver-declared-fault.test.ts`), plus `packages/client/src/client.test.ts` and the one dogfood caller (`packages/qa/dogfood/test/temporal-storage-e2e.dogfood.test.ts:274`), is replayed through the new door as a test — §5's last case. All pass.
- `packages/rest`'s whole suite: **189 files, 3165 passed, 1 skipped, 0 failed.**
- The nearest thing to a leniency-reliant specimen is `analytics-dataset-unlisted-refusal-envelope.test.ts:181`, `dateRange: ['2026-01-01', 'the-first-of-never']` — the *array* arm, which the contract admits and the executor refuses deeper. It still reaches the executor and still refuses there.
- `examples/`, `content/docs/` and `apps/` carry `runtimeFilter` only on authoring metadata (report/dashboard definitions the renderer lowers), never a wire `selection`. Controls on that sweep: `grep` for `dataset` in `examples/` returns 10 files; a fabricated key returns 0.

## ⭐ The negative side — a valid selection must still pass

A door that refuses too much is a worse bug than the one being fixed, and it is what triage's "newly reachable 400" warning points at. §4 and §5 cover it: each of the four dataset-only members reaches the service untouched; a fully-loaded eleven-member selection answers 200 with the caller's own object arriving at `queryDataset` **by identity**; and the explicit `[start, end]` window arm is untouched by the closing.

## What this does NOT close, and why it is not widened here

The four dataset-only members (`runtimeFilter`, `dateGranularity`, `compareTo`, `totals`) still have no door. `DatasetSelection` is a TypeScript interface with **no Zod schema anywhere in the repo** — measured: zero hits for a `DatasetSelection`-shaped schema, with `CursorSelectionSchema` firing as the positive control on the same grep and a fabricated name returning 0. Authoring one belongs in `packages/spec` beside the interface (Prime Directive 1, Zod First), not in a consumer, where a second declaration of a spec-owned wire shape is exactly the dialect Prime Directive 12 exists to prevent. `packages/spec` is read-only for this card, so it is reported rather than smuggled in — see the acceptance notes.

## Evidence

| what | result |
|:---|:---|
| new suite `packages/rest/src/analytics-dataset-selection-door.test.ts` | 19 passed / 19, at `c9df758b` |
| **ablation** — the door call replaced on disk, hash-verified before and after, restored to the HEAD blob | **8 failed / 11 passed**; the card's specimen answered `200` again |
| `packages/rest` full suite | 189 files, 3165 passed, 1 skipped |
| `pnpm --filter @objectstack/rest typecheck` | exit 0 |
| `pnpm lint` (`eslint . --no-inline-config`, whole repo, no narrowing) | exit 0 |
| `dispatch-gates` families — 61 commands, derived twice (auto-derived from the tree, and with `--paths` over all four changed paths; the two lists are **identical**) | all exit 0 |
| `check:error-code-provenance` (not in the derived set; added because the diff is a new refusal site) | exit 0 |

The ablation is symmetric and one-shot: mutate, prove the anchor count went 1 → 0 and the injected marker 0 → 1 on disk, run, restore via `git checkout HEAD --` on the target file under a `trap`, and prove the restored blob hash equals the HEAD blob (`efdd46f7…` both sides). No permanent test file was left behind.

Two families first reported `PREREQUISITE NOT MET` (exit 3) — `check:dual-build-cjs-loads` and `check:type-check-debt`, both of which read built output. Neither was read as a pass: the full closure was built (`turbo run build --filter='./packages/*' --filter='./packages/*/*'`, 72/72 successful) and both re-run to exit 0, then re-run once more at the delivered commit.

## Contract grade

Clause-②: no

`Contract-text:` the refusal set is exactly what the published interface already declared — `DatasetSelection`, `packages/spec/src/contracts/analytics-service.ts:177-232`, exported in `packages/spec/api-surface/contracts.json:74`:

```ts
export interface DatasetSelection {
    /** Dimension names from the dataset. */
    dimensions?: string[];
    /** Measure names from the dataset (may include derived measures). */
    measures: string[];
    …
    /** Optional time-dimension windows passed through to the runtime. */
    timeDimensions?: AnalyticsQuery['timeDimensions'];
    …
    order?: Record<string, 'asc' | 'desc'>;
    …
    limit?: number;
    offset?: number;
    …
    timezone?: string;
}
```

Nothing this door refuses is admitted by that text; nothing that text admits is refused. The claim comment graded `yes` conservatively — 「claim 拿不准 ⇒ 按 `yes` 挂标走席内契约复核」 — expressly pending this measurement, and the measurement drops it to `no`. `needs:contract-review` is hung on the PR regardless, per 「PR 一存在即挂」; the seat clears it.

## Acceptance notes

Out of scope, noted, not filed by this PR (the dedup channel is documented as not answering — the card's own control: a term query for `ListViewSchema` returns 0 while an open issue carries it in its title — so these are handed to the PM to file rather than filed on an unverifiable zero):

- **`DatasetSelection` has no Zod schema**, so its four dataset-only members have no door at any layer. The concrete consequence, measured: `shiftRange` in `packages/services/service-analytics/src/dataset-executor.ts:568-580` branches on `kind === 'previousYear'` and lets **everything else** fall through to the `previousPeriod` arm, so `compareTo: { kind: 'nonsense' }` silently returns a previous-period comparison under a `200`. Successor: whoever authors `DatasetSelectionSchema` in `packages/spec`.
- The scope note the card already carries is unchanged: PR #17015 closed the `dateRange` half behind the route rather than at it, and this PR is the door. Neighbours on the same route named by the card and **not** addressed here: #16642, #16390, #16178. Cards referenced for provenance only, with no work claimed against them: #16322, #17014.

⛔ Left as a draft; not queued, not armed, not marked ready.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DapQyvYrFb1MxSYe7BL2nt)_