### PR TITLE
docs(spec,metadata): point the four stale cluster-semantics.mdx citations at the live page

### DIFF
--- a/.changeset/15141-cluster-doc-pointer-site-urls.md
+++ b/.changeset/15141-cluster-doc-pointer-site-urls.md
@@ -1,0 +1,39 @@
+---
+'@objectstack/spec': patch
+---
+
+`EventMetadata.cluster` and `ServiceMetadata.cluster` cite the live docs page by SITE URL, not a dead filename
+
+Both `.describe()` strings pointed at `cluster-semantics.mdx`, a page that is no
+longer in the tree — `apps/docs/redirects.mjs` has redirected
+`/docs/concepts/cluster-semantics` to `/docs/kernel/cluster` since the page was
+folded in. The section numbers still resolved, so nothing was broken for a
+reader following a link; what was broken is retrieval by filename, which finds
+nothing.
+
+These two strings are the published half. `gen:docs` copies them into
+`content/docs/references/kernel/events-core.mdx` and `service-registry.mdx`, and
+they also ship as JSON Schema `description` values under `packages/spec/json-schema/`
+and as string literals in `packages/spec/dist/`. So the citation had to become
+something a SITE reader can follow:
+
+```
+- See cluster-semantics.mdx §4.        (a file that does not exist)
++ See /docs/kernel/cluster §4.         (the address the redirect already resolves to)
+```
+
+⛔ Deliberately NOT the in-repo house style. Source comments elsewhere in the
+tree cite `` `content/docs/kernel/cluster.mdx` §N `` — a repo path, correct for a
+reader who has the repo checked out. Copying that convention into a `.describe()`
+would tell a docs-site reader to open a `content/docs/...` file they do not
+have, which is the same class of unfollowable reference pointed the other way.
+There is no in-repo precedent to copy either way: these are the only two
+`.describe()` strings in `packages/spec/src` that cite a docs page at all.
+
+The site URL is also redirect-independent — it is the redirect's own target, so
+the reference survives the redirect being retired.
+
+No accept set moves and no authorable key is added or removed: the schemas,
+their parse behaviour and their exported types are byte-identical apart from
+these two description strings. The two regenerated reference pages carry the
+same one-line change on three rows.

--- a/content/docs/references/kernel/events-core.mdx
+++ b/content/docs/references/kernel/events-core.mdx
@@ -43,7 +43,7 @@ const result = EventSchema.parse(data);
 | **correlationId** | `string` | optional | Correlation ID for event tracing |
 | **causationId** | `string` | optional | ID of the event that caused this event |
 | **priority** | `Enum<'critical' \| 'high' \| 'normal' \| 'low' \| 'background'>` | optional (default: `"normal"`) | Event priority |
-| **cluster** | `{ scope: Enum<'local' \| 'cluster' \| 'tenant'>; deliverySemantics?: Enum<'best-effort' \| 'at-least-once' \| 'exactly-once'>; partitionKey?: string }` | optional | Per-emit cluster routing & delivery options. See cluster-semantics.mdx §4. |
+| **cluster** | `{ scope: Enum<'local' \| 'cluster' \| 'tenant'>; deliverySemantics?: Enum<'best-effort' \| 'at-least-once' \| 'exactly-once'>; partitionKey?: string }` | optional | Per-emit cluster routing & delivery options. See /docs/kernel/cluster §4. |
 
 
 ---
@@ -61,7 +61,7 @@ const result = EventSchema.parse(data);
 | **correlationId** | `string` | optional | Correlation ID for event tracing |
 | **causationId** | `string` | optional | ID of the event that caused this event |
 | **priority** | `Enum<'critical' \| 'high' \| 'normal' \| 'low' \| 'background'>` | optional (default: `"normal"`) | Event priority |
-| **cluster** | `{ scope: Enum<'local' \| 'cluster' \| 'tenant'>; deliverySemantics?: Enum<'best-effort' \| 'at-least-once' \| 'exactly-once'>; partitionKey?: string }` | optional | Per-emit cluster routing & delivery options. See cluster-semantics.mdx §4. |
+| **cluster** | `{ scope: Enum<'local' \| 'cluster' \| 'tenant'>; deliverySemantics?: Enum<'best-effort' \| 'at-least-once' \| 'exactly-once'>; partitionKey?: string }` | optional | Per-emit cluster routing & delivery options. See /docs/kernel/cluster §4. |
 
 ### Nested Shape: `EventMetadata.cluster`
 

--- a/content/docs/references/kernel/service-registry.mdx
+++ b/content/docs/references/kernel/service-registry.mdx
@@ -95,7 +95,7 @@ const result = ScopeConfigSchema.parse(data);
 | **type** | `string` | optional | Service type or interface name |
 | **registeredAt** | `integer` | optional | Unix timestamp in milliseconds when service was registered |
 | **metadata** | `Record<string, any>` | optional | Additional service-specific metadata |
-| **cluster** | `{ clusterScope: Enum<'node' \| 'cluster'>; leaderStrategy?: Enum<'leader-elected' \| 'partitioned' \| 'idempotent-broadcast'>; clusterId?: string }` | optional | Cluster scope & leader strategy. See cluster-semantics.mdx §5. |
+| **cluster** | `{ clusterScope: Enum<'node' \| 'cluster'>; leaderStrategy?: Enum<'leader-elected' \| 'partitioned' \| 'idempotent-broadcast'>; clusterId?: string }` | optional | Cluster scope & leader strategy. See /docs/kernel/cluster §5. |
 
 ### Nested Shape: `ServiceMetadata.cluster`
 

--- a/packages/metadata/src/metadata-manager.ts
+++ b/packages/metadata/src/metadata-manager.ts
@@ -499,7 +499,7 @@ export class MetadataManager implements IMetadataService {
   // Realtime service for event publishing
   private realtimeService?: IRealtimeService;
 
-  // ── Cluster wiring (cluster-semantics.mdx §5) ────────────────────────
+  // ── Cluster wiring (`content/docs/kernel/cluster.mdx` §6.2, lane 1) ──
   // When attached via `attachClusterPubSub()`, metadata-change events
   // become cluster-wide:
   //   • Local notifyWatchers() publishes on `metadata.changed` so peers
@@ -3108,8 +3108,8 @@ export class MetadataManager implements IMetadataService {
   protected notifyWatchers(type: string, event: MetadataWatchEvent) {
     this.notifyWatchersLocal(type, event);
 
-    // Cluster fan-out (cluster-semantics.mdx §5). Best-effort: a publish
-    // failure must never block the local update.
+    // Cluster fan-out (`content/docs/kernel/cluster.mdx` §6.2, lane 1).
+    // Best-effort: a publish failure must never block the local update.
     if (this.clusterPubSub) {
       const payload: ClusterMetadataChangedPayload = {
         originNode: this.clusterNodeId,

--- a/packages/spec/src/kernel/events/core.zod.ts
+++ b/packages/spec/src/kernel/events/core.zod.ts
@@ -70,7 +70,7 @@ export const EventMetadataSchema = lazySchema(() => z.object({
    * @see content/docs/kernel/cluster.mdx §4
    */
   cluster: EventClusterOptionsSchema.optional()
-    .describe('Per-emit cluster routing & delivery options. See cluster-semantics.mdx §4.'),
+    .describe('Per-emit cluster routing & delivery options. See /docs/kernel/cluster §4.'),
 }));
 
 // ==========================================

--- a/packages/spec/src/kernel/service-registry.zod.ts
+++ b/packages/spec/src/kernel/service-registry.zod.ts
@@ -86,7 +86,7 @@ export const ServiceMetadataSchema = lazySchema(() => z.object({
    * @see content/docs/kernel/cluster.mdx §5
    */
   cluster: ServiceClusterAnnotationsSchema.optional()
-    .describe('Cluster scope & leader strategy. See cluster-semantics.mdx §5.'),
+    .describe('Cluster scope & leader strategy. See /docs/kernel/cluster §5.'),
 }));
 
 export type ServiceMetadata = z.input<typeof ServiceMetadataSchema>;


### PR DESCRIPTION
Fixes #15141

Four in-source citations named `content/docs/concepts/cluster-semantics.mdx`, a page that is no longer in the tree. `apps/docs/redirects.mjs:98` redirects `/docs/concepts/cluster-semantics` to `/docs/kernel/cluster`, so a reader following a *link* was fine; what was broken is retrieval by *filename*, which finds nothing.

## The two halves get different spellings, on purpose

| Site | New citation | Why |
|---|---|---|
| `packages/spec/src/kernel/events/core.zod.ts` `.describe()` | `/docs/kernel/cluster` §4 | site URL |
| `packages/spec/src/kernel/service-registry.zod.ts` `.describe()` | `/docs/kernel/cluster` §5 | site URL |
| `packages/metadata/src/metadata-manager.ts` (x2) | `` `content/docs/kernel/cluster.mdx` §6.2, lane 1 `` | house style |

The `.describe()` half is the one that matters. `gen:docs` copies those strings into published reference pages, and they also ship as JSON Schema `description` values and as string literals in the package tarball — so a repo path there would tell a docs-site reader to open a `content/docs/...` file they do not have. That is the same class of unfollowable reference as #15150, pointed the other way. The site URL is additionally redirect-independent: it *is* the redirect's target, so the reference survives the redirect being retired.

There is no in-repo precedent for a docs-citing `.describe()` — these two are the only ones in all of `packages/spec/src` — so the source-comment convention was deliberately **not** carried over to them.

## The card's §5 is wrong for the two metadata comments — they are §6.2 lane 1

Measured per-site against `content/docs/kernel/cluster.mdx`, the four sites are not one answer:

```
## 4. Event scope and delivery semantics   (:96)   <- the two .describe() strings   card correct
## 5. Service scope and leader election    (:216)  <- service-registry.zod.ts        card correct
### 6.2 The cluster-invalidation family    (:325)  <- the two metadata comments      card says 5
```

Both metadata comments are about `metadata.changed` / `ClusterMetadataChangedPayload` / cache invalidation. The §6.2 lane-1 row at `cluster.mdx:334` names exactly those three: `metadata.changed` · `ClusterMetadataChangedPayload` · `@objectstack/metadata` · converges `MetadataManager`'s registry/list caches. §5 is service registration and leader election, unrelated.

Corroboration, verified rather than assumed: PR #15139 already corrected a fifth pointer in this same file, at `metadata-manager.ts:235`, and it cites `` `content/docs/kernel/cluster.mdx` §6.2, lane 1 ``. Following the card would have contradicted an already-merged correction a few hundred lines above.

## Four more sites exist repo-wide and are deliberately untouched

- `apps/docs/redirects.mjs:98` — the redirect itself. It stays; deleting it is the opposite of this change.
- `content/docs/references/kernel/events-core.mdx` (x2) and `service-registry.mdx` — `gen:docs` output, converged by regeneration, never hand-edited.

Regeneration was part of the change: `pnpm --filter @objectstack/spec build` then `check:generated --fix`. It rewrote exactly those three rows in those two pages and nothing else. After the change, the only remaining `cluster-semantics` string repo-wide is the redirect.

## Changeset: MEASURED, and one is owed

The claim comment deliberately did not assert this. Measured against the published `files[]` rosters, with a positive control on every reading:

- **`@objectstack/spec` — publishes the change, so a changeset is owed.** Its `files[]` is `["dist","json-schema","liveness","prompts","llms.txt","README.md","src/**/*.zod.ts","CHANGELOG.md","api-surface","spec-changes.json"]`. Both edited files match the `src/**/*.zod.ts` entry and ship verbatim in the tarball. The new string is also present in 4 shipped bundles under `packages/spec/dist/` and as a `description` in 6 files under the shipped `packages/spec/json-schema/` tree.
- **`@objectstack/metadata` — publishes nothing here, so it is not in the changeset.** Its `files[]` is `["dist","README.md","CHANGELOG.md"]`; the comment text has **zero** hits in `packages/metadata/dist/`, while two positive controls from the same source file (`CLUSTER_CHANNEL`, `metadata.changed`) are lit in 4-6 dist files each. Comments are stripped by the build.

One reading correction worth recording, because it is the reason the controls exist: the first grep of `packages/spec/dist/` for the new string returned **zero** — a false zero. The build emits `§` as an escaped `\xA7`, so the literal did not match. The positive control was lit, which is what prompted the re-grep that found it. A zero is not an absence.

Changeset: `@objectstack/spec: patch`.

## Contract review scope

Clause-②: no

Re-derived from what shipped, not inherited. No accept set moves in either direction, no authorable key is added or removed, no closed-set member or published export changes. The diff is two `.describe()` description strings, two source comments, three regenerated table rows and a changeset. The `.describe()` strings are published *prose*, not a published contract — parse behaviour and exported types are byte-identical.

## Verification

All at final head `bf55c7a9e9`.

- **Gate families derived, not hand-listed.** `node scripts/pm/dispatch-gates.mjs --commands --repo objectstack-ai/objectstack`, re-derived after the changeset existed (it grew from 96 to 101 commands — the changeset families apply only once the file exists). All 101 run; reconciled with `--ran`: `101 derived, 101 run, 0 NOT-MEASURED, 0 UNRUN`.
- **98 green. 3 not green, none of them red:**
  - `check:skill-examples` exited 1 with `packages/client-react/dist holds no .d.ts declarations — the package is not built`. That is a gate refusing its own prerequisite, not a verdict. It type-checks spec source TSDoc, which this diff edits, so the prerequisite was built and it was re-run: **green**, 258 prose examples across 3 surfaces.
  - `check:dual-build-cjs-loads` and `check:lean-entry-closure` exited **3** with `PREREQUISITE NOT MET`; both need a whole-repo build (58+ packages with no `dist/`). **NOT MEASURED** — neither a pass nor a failure. Left to CI, which builds the tree. This diff moves no entry point or export, so neither gate has a path to move.
- **`check:docs` green** — the gate this change is measured by: `222 generated files in sync with packages/spec`. `check:generated`, `check:docs-redirects`, `check:nul-bytes`, `check:published-files` also green at final head.
- **Tests:** `pnpm --filter @objectstack/spec --filter @objectstack/metadata test` — spec `Test Files 472 passed (472)` / `Tests 13368 passed (13368)`; metadata `Test Files 53 passed (53)` / `Tests 788 passed (788)`. (The metadata log contains ERROR lines by design — a test drives a loader outage.)
- **Typecheck:** same filter, exit 0, with both script names echoed (`packages/spec typecheck$ tsc --noEmit && ...`, `packages/metadata typecheck$ tsc --noEmit`) so this is not a zero-script no-op.
- **Lint: the whole population, not a narrowing.** `eslint . --no-inline-config --format json` completed in budget at `bf55c7a9e9`: **6588 files, 0 errors, 0 warnings**. The file count is read from eslint's own JSON output, and the population is eslint's own config resolution rather than a hand-built path list, so no narrowing claim is needed here.
- No pin was added or adjusted, so there is nothing to ablate.

## 验收备注

`noted, not filed` — `packages/services/service-cluster/src/cluster.ts:78` throws a runtime error whose text ends `See content/docs/kernel/cluster.mdx §6.` That is a repo path handed to an application developer consuming the published `@objectstack/service-cluster` package, who does not have the repo — arguably the same unfollowable-reference class this PR removes from the two `.describe()` strings. Not filed: it meets none of the three filing classes (it is not a reproducible defect, breaches no declared contract, and is not a trap producing metadata the runtime refuses). It is also outside this card's scope and outside the claim's declared file face. **Successor: none known** — no in-flight PR or queued card that I can name touches this file.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MkQhmuuJAVDjmeWNixwDDH)_