### PR TITLE
docs(skills): bind three evidence controls onto the retirement playbook's liveness step

### DIFF
--- a/.claude/skills/spec-property-retirement/SKILL.md
+++ b/.claude/skills/spec-property-retirement/SKILL.md
@@ -52,23 +52,23 @@ preview renderer 不算消费者)与 AGENTS.md §"Touched `packages/spec`?"(八�
       conversion 表的 fixture 不相交契约(§3)会因叠放而失败。先例:
       `agent.knowledge` 在发布前吞掉了 `topics`→`sources` 改名。
 - [ ] **台账判它 `live-elsewhere` 吗?** 本仓实测无消费者、姊妹仓真在强制执行的
-      键 —— **永不是删除候选**。单读 `dead` 会批准一次删除,而它删掉的是姊妹仓某
-      道门的输入。该核的不是删除面,是它的佐证纪律:外仓指针、
+      键 —— **永不是删除候选**。该核的不是删除面,是它的佐证纪律:外仓指针、
       `evidenceScope: "cross-repo"`、带日期的 `verifiedAt`、180 天过期 —— 四条由
       `packages/spec/scripts/liveness/elsewhere.mts` 执行,出处见 README 的
       `live-elsewhere` 一节。
+- [ ] **零编写实例普查要并跑一个同族已知存活的键作对照**,两读数都报;同得零即没测出。
+- [ ] **拿 `cross-repo` 行当论据,就当刻重核路径与行号**:漂了读作重新取证,⛔ 不是 `dead`。
+- [ ] **「零编写实例」≠「没有代码读它」。** 前者答的是示例应用,后者才是退役的证据。
 
 ## 1. 裁判是构建,不是台账
 
-台账的 `dead` 裁定是删除的**输入**,不能替代构建自己的证明。它是一条带时间戳的声
-明,代码在它底下双向移动(`flow.status` 与 `action.undoable` 都被*低估*过)。
+台账的 `dead` 裁定是删除的**输入**,不能替代构建自己的证明。代码在它底下双向移动
+(`flow.status` 与 `action.undoable` 都被*低估*过)。
 
 所以:**先尝试删除,让构建来裁。** #3896 收尾里,`view.form.data` 挂在工作清单上是
-dead(「两个仓都没有 form 路径的读者」),而删除打断了 `gen:schema` —— `defineForm`
-往每个 `*.form.ts` 写 `data: { provider: 'schema', schemaId }`,`metadata-protocol`
-把它喂给 metadata-admin 管线。正确的回应**不是**硬删:把台账条目改回 `live`、附真实
-证据与 `verifiedAt`,收窄 conversion,钉上 non-warn。十四个键里有一个是这样被证伪的
-—— 给它留预算。
+dead(「两个仓都没有 form 路径的读者」),而删除打断了 `gen:schema`。正确的
+回应**不是**硬删:把台账条目改回 `live`、附真实证据与 `verifiedAt`,收窄
+conversion,钉上 non-warn。十四个键里有一个是这样被证伪的 —— 给它留预算。
 
 两条推论:
 


### PR DESCRIPTION
Fixes #17553

Two retirement rounds in one day rested on a "dead key" premise that measured
false. The retirement playbook's evidence step already bound the ledger side —
a `dead` verdict is an **input**, never a proof; the four-condition
`live-elsewhere` discipline; the fourteen-keys record — but it bound nothing
about the *reading a seat offers* for deadness. Three rules land beside those
bindings, in the file's own register and voice.

## The three rules as landed

`.claude/skills/spec-property-retirement/SKILL.md`, appended to section 0's
pre-flight checklist immediately after the `live-elsewhere` item:

| line | rule |
|---|---|
| **:59** | `- [ ] **零编写实例普查要并跑一个同族已知存活的键作对照**,两读数都报;同得零即没测出。` |
| **:60** | `- [ ] **拿 cross-repo 行当论据,就当刻重核路径与行号**:漂了读作重新取证,⛔ 不是 dead。` |
| **:61** | `- [ ] **「零编写实例」≠「没有代码读它」。** 前者答的是示例应用,后者才是退役的证据。` |

(The table renders the two inline code spans of :60 as plain words so the row
survives the body sanitizer; the file itself carries them as code spans.)

**Why section 0 and not section 1.** Section 0 is the pre-flight checklist —
「动手删之前:删除是正确的处置吗?」 — and every item in it is a question about
whether the disposition is right, answered in one or two lines. All three rules
are exactly that: tests a seat applies to its own evidence *before* it commits
to a removal. Section 1 ("裁判是构建,不是台账") argues one thesis in prose and
carries no checklist; three `- [ ] **…**` items appended there would have needed
a list of their own. The `live-elsewhere` item is the nearest neighbour by
subject, so they sit directly under it.

They sit **beside** the existing bindings, not on top of them: `:55-:58` still
carries the four-condition cross-repo discipline and its `elsewhere.mts` /
README provenance, `:65` still carries 「台账的 `dead` 裁定是删除的**输入**,不能
替代构建自己的证明」, and `:71` still carries the fourteen-keys record.

## Payment ledger — 337 lines in, 337 lines out

The ceiling is 337 with zero headroom, so each added line is bought by deleted
content, never by re-wrapping. Three lines added, three lines of content
deleted, all three inside the declared region.

| deleted phrase | the fact it carried | where that fact still lives |
|---|---|---|
| `live-elsewhere` item: 「单读 `dead` 会批准一次删除,而它删掉的是姊妹仓某道门的输入。」 (88 B) | a lone `dead` read would authorise a deletion; the casualty is a sibling repo's gate input | both halves survive adjacent to it — the item's own 「姊妹仓真在强制执行的键 —— **永不是删除候选**」 names the casualty, and section 1's opening 「台账的 `dead` 裁定是删除的**输入**,不能替代构建自己的证明」 (`:65`) states that a `dead` read alone is not authority |
| section 1: 「它是一条带时间戳的声明,」 (36 B) | the ledger entry is a **timestamped** claim | `:56` 「带日期的 `verifiedAt`、180 天过期」 and `:70` 「附真实证据与 `verifiedAt`」 — and the new `:60` now turns on that clock explicitly |
| section 1: 「`defineForm` 往每个 `*.form.ts` 写 `data: ...`,`metadata-protocol` 把它喂给 metadata-admin 管线。」 (146 B) | the write site and consumer chain of `view.form.data` | narrative tail of the precedent. The precedent itself stays whole — 「`view.form.data` 挂在工作清单上是 dead…而删除打断了 `gen:schema`」 plus its correct response. `:309` in the same file independently names 「一个 `defineForm` 会写的键」, and the very next sentence instructs the reader to put the chain in the ledger entry's own evidence string |

Nothing outside the region moved: the four diff hunks span old lines 55-71
only, and the file is byte-identical elsewhere.

⚠️ **A dispatch premise measured false, recorded rather than acted on.** The
order said the 120-byte line cap does not bind this file because "7 lines
already exceed it". Measured: `MAX_LINE_BYTES = 120` in
`scripts/pm/check-skill-line-ratchet.mjs` **does** cover this file, and the 7
over-120-byte lines are all structurally exempt classes — table rows at
`:86-:88`, `:101`, `:126-:127` and a blockquote at `:117`. Every prose line in
the region is under 120 bytes today. The three new lines were therefore written
to 120 / 116 / 120 bytes, which satisfies both readings; no existing line was
reflowed. The order's other reading — "an over-wide line elsewhere in the same
region" as a payment source — has no referent: no line in `:50-:72` exceeds 120
bytes.

## The census control, re-measured on this branch

The card's decisive control, re-run once as the premise check, on
`ad715aca` (`git grep -lE -- 'KEY:' examples apps | wc -l`):

```
columns 31 files  ·  hiddenFields 0  ·  fieldOrder 0  ·  rowColor 1
```

Identical to the card's reading on `6e3462df47`. `hiddenFields` is graded
`live` in `packages/spec/liveness/view.json` with a cross-repo evidence string
naming its own filter in objectui's ListView — indisputably live — and it
scores the same zero as `fieldOrder`. `columns` at 31 proves the instrument
works. **The premise holds.**

## The one judgement, on the four axes

The judgement here is where the three rules sit and what pays for them.
**实际业务需求**: measured, not speculative — two dispatched rounds in one day
turned on exactly these three gaps, and the census control is one command whose
reading is reproduced above; the pre-flight checklist is where a seat actually
stands when it decides, so a rule placed there is read at the moment it binds.
**项目长远合理性**: the rules tighten the evidence contract at the point of
authorship rather than adding a consumer-side accommodation; no new gate, no new
ledger field, nothing to keep in sync. **防 AI 写代码犯错**: this is the
AI-authoring axis at its sharpest — the failure mode is an agent reading a
cited path, finding it deleted, and inferring "dead", so `:60` makes drift read
as 「重新取证」 and names the wrong inference explicitly (⛔ 不是 `dead`); a
census with no control is the same shape one layer down, and `:59` refuses it.
**创业阶段不扩散需求**: paid entirely from inside the file at a flat 337 lines
with no ceiling raise and no new surface — three lines of protocol text against
a method that has already carried a maintainer's signature onto the deletion of
a working channel. The axes do not conflict here; the only tension is density,
and it is settled by the ledger above rather than by a budget increase.

## Verification

Gate families derived from the final diff by
`node scripts/pm/dispatch-gates.mjs --commands --repo objectstack-ai/objectstack`
(the script derives its own change set; 1 path, three-dot against merge base
`ad715aca5`). Every exit code captured **before** any pipe.

| gate | exit | verdict line |
|---|---|---|
| `pnpm check:pm-skill-ratchet` (before edit) | 0 | `✓ check-skill-line-ratchet: .claude/skills/spec-property-retirement/SKILL.md is 337 lines (ceiling 337; headroom 0).` · `widest table row is 326 bytes (pin 326; headroom 0)` |
| `pnpm check:pm-skill-ratchet` (after edit) | 0 | **byte-identical to the two lines above** — 337 / 337, 326 / 326 |
| `pnpm check:nul-bytes` | 0 | `check-nul-bytes: OK (scanned 8331 text file(s) ... no raw ASCII control bytes).` |
| `pnpm check:skill-frame-sync` | 0 | `✓ check-skill-frame-sync: the one declared copy of the decision frame is internally coherent` |
| `pnpm check:pm-governed-merges` | 0 | `✓ check-governed-merges --self-test: 317 assertions ...` |
| `node scripts/check-closing-keyword-parity.mjs` | 0 | `check-closing-keyword-parity: OK (3 parsers agree on all 9 keywords and both measured separators; sweep found 5 file(s) carrying the grammar across 8338 tracked file(s), all registered).` |
| `node scripts/check-closing-keyword-parity.mjs --self-test` | 0 | self-test pass |
| `node scripts/check-ci-filter-parity.mjs` | 0 | pass |
| `node scripts/check-comment-mask-corpus.mjs` | 0 | pass |
| `node scripts/report-test-timings.mjs --self-test` | 0 | pass |
| `pnpm --filter @objectstack/lint run check:doc-formula-expressions` | 0 | first run exited **3** = PREREQUISITE NOT MET (「Nothing was measured」), not a finding; re-run green after `turbo run build --filter=@objectstack/formula --filter=@objectstack/lint` under `scripts/pm/os-verify-lock.sh` (`VERDICT command-exit 0 · held the lock 184s · waited 0s`) |
| `pnpm check:agent-test-spelling` | 0 | pass |
| `pnpm check:cross-package-test-inputs` | 0 | pass |
| `pnpm check:doc-authoring` | 0 | pass |
| `pnpm check:driver-memory-census` | 0 | pass |
| `pnpm check:refd-timer-probe` | 0 | pass |
| `pnpm check:required-contexts` | 0 | pass |
| `pnpm check:watch-hint-literal` | 0 | pass |

Reconciliation, exit codes recorded per family:
`✓ dispatch-gates --ran: 17 derived famil(ies) accounted for — 17 run, 0
NOT-MEASURED (a DERIVED zero — all 17 recorded an exit code and none of them is
3).`

Path face — `node scripts/pm/check-governed-merges.mjs --branch
claude/issue-17553-retirement-evidence-controls`, exit **3**:
`⛔ GOVERNED — a human merge is the review record for this PR (#9495 regime).`
`.claude/** ×1`. This PR stays **draft**; no seat flips it ready, enqueues it,
or arms auto-merge.

Two order-named checks that could not run as written, recorded rather than
skipped: `node scripts/check-closing-keyword-parity.mjs --body` — **no such
flag exists** on this base (`ad715aca`); the script takes only the bare form,
`--self-test` and `--list`, and both runnable forms are green above.
`pnpm check:pm-skill-id-lint` — this file is **not in its set**: the gate scans
`.claude/skills/pm-dispatch/**` plus `.claude/agents/os-dev.md` and `AGENTS.md`
(`SCAN_ROOT` / `EXTRA_FILES`), and reports `27 file(s) clean` on a tree that
does not include this one. That is why the file legitimately carries issue
numbers such as `#3896`; the three new lines carry none.

No changeset: the diff is `.claude/**` only, which ships in no package's
`files[]` — the `skip-changeset` fast track. Label applied.

Clause-②: no

## Acceptance notes

- `noted, not filed:` `packages/spec/liveness/view.json`'s
  `/props/list/children/fieldOrder` row still grades `live` while its evidence
  string cites `objectui: packages/react/src/spec-bridge/bridges/list-view.ts`
  (deleted from objectui) and `ListView.tsx:1499-1500` (drifted to
  `:2424-2425`). It reads as a class (b) contract breach against the liveness
  README's 「A `live` verdict *is* its evidence pointer, so a pointer into thin
  air is a claim nothing can falsify」 — but it is already carried by two open
  records: this card's own body documents it as instance 2, and **#15184** is
  open with `needs-user-decision` precisely because its ruling rested on it.
  Carrier: the spec lane, on #15184's disposition. Filing a third card would
  duplicate them. `packages/spec/liveness/**` is outside this order's surface.
- `noted, not filed:` the dispatch order's 120-byte premise and its
  "over-wide line" payment suggestion are both measured false against this
  file (detail in the payment ledger above). Not a repo defect — a correction
  to the order, for the seat's dispatch text. Carrier: the skills seat.
- `noted, not filed:` the claim comment 5626386832 says each rule line is
  「≤ 120 B」 and the dispatch order says the cap does not bind. The landed
  lines satisfy the claim (120 / 116 / 120 B). Recorded because the two
  seat artefacts disagree with each other; the file's measured behaviour
  settles it. Carrier: the skills seat.

## 维护者速读(草稿)

**改了什么** —— 退役 playbook 的证据步(section 0 的动手前清单)多了三条规则:①
拿「本仓零编写实例」当死键证据时,必须同时跑一个同族**已知存活**的键作对照,两个读数
一起报;对照拿到同样的零,这次普查什么都没测出来。② 拿一条 `cross-repo` 台账行当删除
论据时,在**引用当刻**重核它引的路径与行号;漂了读作「重新取证」,不读作「dead」。③
「零编写实例」和「没有代码读它」是两件事,退役要的是后者。文件行数不变(337/337),三
行新规则由文件内部三处删减买单,删的每一处都在正文的付款表里点名,以及那条事实现在住
在哪儿。

**为什么改** —— 同一天派出的两张退役卡,前提都实测为假:一张要删的键服务端在读,另一
张要删的键姊妹仓在用,而且第二张**已经拿到维护者裁决**。两轮都没造成损失,靠的是派发
词里的停止条件 —— 那是**派发**上的控制,不是**方法**上的。方法这一侧此前是无守卫的。

**风险与代价(含回滚)** —— 纯协议文本,没有代码、没有门禁、没有新面;唯一的代价是文
件密度:为了不抬 ceiling,section 1 里 `view.form.data` 那段先例的管道细节和两处重述被
删掉了,先例本身、它的教训与更正动作都完整保留。回滚成本为零 —— 单文件、单 commit,
`git revert` 即可,没有任何生成物或台账跟着动。

**席位意见** ——

**你要做的** —— 这是受管面(`.claude/**`),PR 保持 draft,由你人工合并;⛔ 没有任何
席位会翻 ready 或挂 auto-merge。要看的就一件事:三条规则是不是你要的说法,以及付款表里
删掉的三处你是否同意其中没有丢失事实。

---
_Generated by [Claude Code](https://claude.ai/code/session_01YKEjmbYNvYWJvWGSWx26zK)_