### PR TITLE
docs(spec): search-fields docblock says $icontains, the operator the engine emits

### DIFF
--- a/.changeset/15052-search-fields-docblock-icontains.md
+++ b/.changeset/15052-search-fields-docblock-icontains.md
@@ -1,0 +1,38 @@
+---
+'@objectstack/spec': patch
+---
+
+`search-fields.ts`'s module docblock says `$search` expands to an `$or` of `$icontains`, the operator the engine actually emits
+
+The docblock's ENGINE bullet claimed `@objectstack/objectql`'s
+`expandSearchToFilter` expands a `$search` term into an `$or` of **`$contains`**
+clauses. It has compiled to `$icontains` since objectstack#7641:
+`packages/objectql/src/search-filter.ts:23` carries the ruling verbatim — *"The
+case-insensitive operator is `$icontains`, NOT `$contains`. `$contains` is
+contractually case-SENSITIVE (#4706 Q2 = A)"* — and both return paths of
+`fieldClausesForTerm` (`:109`, `:111`) emit `$icontains`.
+
+**Why the distinction is worth a clause rather than a word swap.** `$contains`
+is contractually case-SENSITIVE, so a reader who trusted the old sentence built
+an ingress gate, a test or a driver **stricter** than the platform is — a false
+refusal, not a leak. The corrected bullet now says that in one clause, so the
+next reader of this module does not have to reconstruct it from two other
+packages.
+
+⛔ No behaviour changes. This is a module docblock; the engine has been right
+since #7641 and no accept set, authorable key or published behaviour moves.
+
+**This is shipped, which is why it carries a changeset rather than
+`skip-changeset`.** `@objectstack/spec`'s published `files[]` ships `dist`, and
+this TSDoc is emitted into `dist/data/index.d.ts` and `dist/data/index.d.mts` —
+measured on the built artifact, with the old spelling absent from all 216 built
+files afterwards and the docblock's own neighbouring sentence present at 2 as
+the lit control. `src/data/search-fields.ts` is not a `.zod.ts`, so it is not
+shipped as source; the emitted declarations are the whole of its published
+reach, and they change.
+
+The sibling INGRESS sentence two lines below — `@objectstack/metadata-protocol`
+`findData` refusing a `$searchFields` override the resolved set does not admit
+(#4254) — was measured on the same tip and is unchanged: `findData` still calls
+`assertSearchFieldsAreSearchable`, which resolves through this module's own
+`resolveSearchFieldResolution` rather than re-implementing the rule.

--- a/packages/spec/src/data/search-fields.ts
+++ b/packages/spec/src/data/search-fields.ts
@@ -6,7 +6,10 @@
  * ONE resolution shared by the two layers that must agree on it:
  *
  * - the ENGINE (`@objectstack/objectql` `expandSearchToFilter`), which expands
- *   a `$search` term into a `$or` of `$contains` clauses over exactly this set;
+ *   a `$search` term into a `$or` of `$icontains` clauses over exactly this set
+ *   — `$icontains` since #7641, NOT `$contains`, which is contractually
+ *   case-SENSITIVE (#4706 Q2 = A): a gate, test or driver written to the old
+ *   sentence is STRICTER than the platform — a false refusal, not a leak;
  * - the INGRESS gate (`@objectstack/metadata-protocol` `findData`), which
  *   refuses a `$searchFields` override naming a field this set does not admit
  *   (#4254), instead of letting the engine drop it silently.


### PR DESCRIPTION
Fixes #15052

Clause-②: no

The module docblock of `packages/spec/src/data/search-fields.ts` said `@objectstack/objectql`'s `expandSearchToFilter` expands a `$search` term into an `$or` of **`$contains`** clauses. It has compiled to `$icontains` since #7641. One sentence, one file.

## The correction

```diff
  * - the ENGINE (`@objectstack/objectql` `expandSearchToFilter`), which expands
- *   a `$search` term into a `$or` of `$contains` clauses over exactly this set;
+ *   a `$search` term into a `$or` of `$icontains` clauses over exactly this set
+ *   — `$icontains` since #7641, NOT `$contains`, which is contractually
+ *   case-SENSITIVE (#4706 Q2 = A): a gate, test or driver written to the old
+ *   sentence is STRICTER than the platform — a false refusal, not a leak;
```

The added clause is the half worth having: `$contains` is contractually case-SENSITIVE (#4706 Q2 = A), so a reader who trusted the old sentence built an ingress gate, a test or a driver **stricter** than the platform is. A false refusal, not a leak. The wording `$or` of `$icontains` is the spelling the landed half of this family already uses at `packages/objectql/src/search-filter.ts:8`, so the two now read alike.

## Premise re-measured on this branch's merge base

The dispatching seat measured on `ad715aca57`; `main` had moved to `a36b526fc1` by the time this branch was cut, so every reading was taken again here.

| reading | result |
|---|---|
| the wrong sentence, `packages/spec/src/data/search-fields.ts:9` | present, verbatim |
| lit control — `the ENGINE` in that same file | 1 occurrence, so the reading above is a reading |
| the ruling, `packages/objectql/src/search-filter.ts:23` | present, verbatim |
| `fieldClausesForTerm` return paths `:109` and `:111` | both emit `$icontains` |
| not published — `clauses over exactly this set` under `content/` | 0 |
| lit control — `server-resolved searchable fields` under `content/docs` | hits `content/docs/protocol/objectql/query-syntax.mdx`, so that 0 is a reading |

Both halves hold. Line numbers above are what this branch measures, not what the card quotes.

## The sibling INGRESS sentence: measured, still true, untouched

Two lines below, the docblock describes the ingress half — `@objectstack/metadata-protocol` `findData` refusing a `$searchFields` override that the allowed set does not admit (#4254). It was measured on this same tip and is **still true**, so it is unchanged:

- `findData` is `packages/metadata-protocol/src/protocol.ts:10384`, and the call at `:10646` to `assertSearchFieldsAreSearchable` is inside it — no other member declaration opens between the two.
- That method (`:10008`) refuses with `code: 'INVALID_FIELD'`, `status: 400`.
- It resolves the allowed set at `:10050` through `resolveSearchFieldResolution`, imported from `@objectstack/spec/data` — this module. The rule is read from here, not re-implemented, which is exactly what the docblock claims #4254 did.

## Ablation, both ways, proven by state

The probe reads the **emitted artifact**, not the source, and it was driven to fail before it was believed.

| leg | source | `dist` carries the NEW spelling | `dist` carries the OLD spelling | lit control (`ONE resolution shared by the two`) |
|---|---|---|---|---|
| shipped | the committed fix | present in 2 built files | absent from all 216 | 2 |
| mutation | old sentence written back | absent from all 216 | present in 2 built files | 2 |
| restore | `git checkout HEAD -- ...` | present in 2 built files | absent from all 216 | 2 |

Each leg is a real `pnpm --filter @objectstack/spec build`, and each is verified through `scripts/ablation-dist-preflight.mjs`. The mutation reached disk before the rebuild: source hash `5616ff7470` against the committed blob `9f75584aad`. The restore is proven by **state**, not by an exit code — whole-tree `git status --porcelain` empty, worktree hash back to `9f75584aad4d03c985e3c59ec219a57f7e361299`, identical to `HEAD:packages/spec/src/data/search-fields.ts`. Counts are occurrences (`grep -o | wc -l`), not line counts.

The two emitted files are `dist/data/index.d.ts` and `dist/data/index.d.mts`.

## Changeset: measured, not assumed — and owed

The instrument is `packages/spec`'s published `files[]` plus what the build emits, exactly as dispatched:

- `files[]` is `["dist", "json-schema", "liveness", "prompts", "llms.txt", "README.md", "src/**/*.zod.ts", "CHANGELOG.md", "api-surface", "spec-changes.json"]`.
- `src/data/search-fields.ts` is not a `.zod.ts`, so it does **not** ship as source.
- But the TSDoc is emitted into `dist/data/index.d.ts` and `dist/data/index.d.mts`, and `dist` is shipped.

So published content moves and `skip-changeset` is unavailable. `.changeset/15052-search-fields-docblock-icontains.md` grades `@objectstack/spec` `patch`. The measurement is written into the changeset body so the next reader does not redo it.

## Clause ②

`Clause-②: no`, re-derived from what this PR actually ships rather than inherited: the diff adds no key to any published payload, moves no accept set, and changes no authorable surface. `pnpm --filter @objectstack/spec run check:api-surface` agrees on its own axis — *public API surface + factory signatures unchanged*. No disagreement with the dispatch to report.

## Verification

Run locally, each exit code captured before any pipe:

- `pnpm --filter @objectstack/spec build` — exit 0
- `pnpm --filter @objectstack/spec typecheck` — exit 0
- `pnpm --filter @objectstack/spec test` — exit 0, **472 files / 13368 tests passed**, 614.50s
- gate families derived with `node scripts/pm/dispatch-gates.mjs --commands --repo objectstack-ai/objectstack` (75 commands from the real change set). Run here, all exit 0: `check-spec-docblock-symbol-anchors` (+ self-test), `check-comment-mask-adoption` (+ self-test), `check-comment-mask-corpus`, `check-empty-changeset --base origin/main` (+ self-test), `check-changeset-no-major --base origin/main` (+ self-test), `check-closing-keyword-parity` (+ self-test), `check-keyed-text-bounds`, `docs-audit/check-affected-docs`, `docs-audit/check-drift-comment`, `check:nul-bytes`, `check:published-files`, `check:api-surface`, `check:docs`, `check:authorable-surface`.
- A declared narrowing: the remaining derived commands are repo-wide sweeps CI owns; they are not skipped, they are CI's leg.
- Control characters: `grep -naP` over both touched files — zero hits.

Verified at `d353759306`.

## Scope

One source file plus its changeset. The exclusion list the dispatch carried was re-read and nothing on it was touched — `driver-sql`'s JSON-column `$contains` (now at `sql-driver.ts:2935`, drifted from the `:2646` the card cites) and its pinning test are **correct** as written, `having-filter.ts:414` is the `$notContains` mirror, `search-filter.ts` is the landed half, and the six `CHANGELOG.md` hits are historical records that stay true about the past.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MkQhmuuJAVDjmeWNixwDDH

---
_Generated by [Claude Code](https://claude.ai/code/session_01MkQhmuuJAVDjmeWNixwDDH)_