### PR TITLE
test(spec): pin the author-visible message at every string-or-object union site that has one

### DIFF
--- a/packages/spec/src/shared/union-author-message-pins.test.ts
+++ b/packages/spec/src/shared/union-author-message-pins.test.ts
@@ -127,11 +127,24 @@
  * 1. **The rendered message names the key, the surface and the rename.** This
  *    is the half that was missing. It reads `formatZodError`, the real
  *    `defineStack`/CLI door, not the raw issue tree.
- * 2. **Branch selection is structural, not an accident of one fixture.** Every
- *    fixture gives the object branch MORE THAN ONE issue, so a descent that
- *    happened to surface a single issue cannot pass for a working one; and the
- *    string arm's `expected string, received object` — a kind mismatch, not a
- *    prescription — must NOT be rendered.
+ * 2. **Branch selection is structural, not an accident of one fixture.** Each
+ *    row DECLARES how many issues the branch `selectUnionBranches` actually
+ *    picks carries, and that count is asserted exactly; twelve of the thirteen
+ *    declare two or more, so a descent that surfaced only a lone issue could
+ *    not pass for a working one. The thirteenth (`data/object.zod.ts:855`)
+ *    declares one and says so at the row — see there. The selected branch must
+ *    also be the object arm, and the string arm's `expected string, received
+ *    object` — a kind mismatch, not a prescription — must NOT be rendered.
+ *
+ *    ⚠️ This clause was VACUOUS in the first two revisions and is worth the
+ *    warning, because it is this card's own subject matter turning up inside
+ *    the fix for it. It read `(union.errors ?? []).flat().length > 1` — every
+ *    branch summed together. At a string-or-object site the string arm always
+ *    contributes exactly one `invalid_type`, so the bound held however few
+ *    issues the object arm raised: a pin that could not fail, certifying a
+ *    structural property nobody had measured. Measured once it counted the
+ *    right branch, two of the thirteen rows did not satisfy the claim the
+ *    header was making for all of them.
  * 3. **The accept side is unmoved.** A bare string entry and a legal object
  *    entry both still parse at every site.
  */
@@ -148,6 +161,7 @@ import { ChartGroupBySchema } from '../ui/chart.zod';
 import { RecordHighlightsProps } from '../ui/component.zod';
 import { FormSectionSchema, GanttConfigSchema, GanttQuickFilterSchema } from '../ui/view.zod';
 import { formatZodError } from './error-map.zod';
+import { selectUnionBranches } from './union-branch-policy';
 
 /** A door that renders through `formatZodError` — every schema below is one. */
 interface Door {
@@ -161,10 +175,23 @@ interface UnionMessageSite {
   readonly door: Door;
   /**
    * A body whose OBJECT arm carries more than one issue — pin 2's structural
-   * requirement. `issues` is how many the object branch raises, asserted so a
-   * fixture cannot silently decay into a single-issue one.
+   * requirement.
    */
   readonly reject: unknown;
+  /**
+   * How many issues the branch `selectUnionBranches` actually PICKS carries for
+   * {@link reject} — declared per row, and asserted exactly.
+   *
+   * ⚠️ Declared rather than bounded (`> 1`) because a bound is what went wrong
+   * here. Pin 2 first counted every branch flattened together, and at a
+   * string-or-object site the string arm always contributes one `invalid_type`,
+   * so `> 1` held no matter what the object arm did — a clause that could not
+   * fail. An exact count cannot be satisfied by an unrelated arm, and it fails
+   * loudly when a fixture stops measuring what its row says it measures, in
+   * EITHER direction. Measured, never guessed: the assertion prints the real
+   * per-branch codes when it fails.
+   */
+  readonly selectedBranchIssues: number;
   /** The undeclared key the fixture writes. */
   readonly key: string;
   /**
@@ -216,6 +243,7 @@ const SITES: ReadonlyArray<readonly [name: string, site: UnionMessageSite]> = [
     site: 'automation/state-machine.zod.ts:120',
     door: GuardRefSchema,
     reject: { parms: { a: 1 } },
+    selectedBranchIssues: 2,
     key: 'parms',
     keyInMessage: '`parms`',
     surface: 'this guard reference',
@@ -227,6 +255,7 @@ const SITES: ReadonlyArray<readonly [name: string, site: UnionMessageSite]> = [
     site: 'automation/state-machine.zod.ts:231',
     door: StateNodeSchema,
     reject: { on: { GO: { guard: 'isX', actions: 'not-an-array' } } },
+    selectedBranchIssues: 2,
     key: 'guard',
     keyInMessage: '`guard`',
     surface: 'this state transition',
@@ -239,6 +268,7 @@ const SITES: ReadonlyArray<readonly [name: string, site: UnionMessageSite]> = [
     door: StateMachineSchema,
     reject: { id: 'machine', initial: 'idle', states: { idle: { initial: 'a', states: {} } },
       on: { GO: { guard: 'isX', actions: 'not-an-array' } } },
+    selectedBranchIssues: 2,
     key: 'guard',
     keyInMessage: '`guard`',
     surface: 'this state transition',
@@ -252,6 +282,7 @@ const SITES: ReadonlyArray<readonly [name: string, site: UnionMessageSite]> = [
     site: 'automation/approval.zod.ts:791',
     door: ApprovalNodeConfigSchema,
     reject: { approvers: [{ type: 'user', value: 'u1' }], decisionOutputs: [{ widget: 'user' }] },
+    selectedBranchIssues: 2,
     key: 'widget',
     keyInMessage: '`widget`',
     surface: 'this decision-output declaration',
@@ -264,6 +295,7 @@ const SITES: ReadonlyArray<readonly [name: string, site: UnionMessageSite]> = [
     site: 'automation/flow-function.zod.ts:252',
     door: FlowFunctionEntrySchema,
     reject: { efect: 'pure' },
+    selectedBranchIssues: 2,
     key: 'efect',
     keyInMessage: '`efect`',
     surface: 'this `functions` entry',
@@ -275,6 +307,7 @@ const SITES: ReadonlyArray<readonly [name: string, site: UnionMessageSite]> = [
     site: 'data/field.zod.ts:1438',
     door: FieldSchema,
     reject: { name: 'owner', type: 'lookup', reference: 'account', lookupColumns: [{ name: 'amount' }] },
+    selectedBranchIssues: 2,
     key: 'name',
     keyInMessage: '`name`',
     surface: 'this lookup column',
@@ -286,6 +319,7 @@ const SITES: ReadonlyArray<readonly [name: string, site: UnionMessageSite]> = [
     site: 'data/field.zod.ts:1464',
     door: FieldSchema,
     reject: { name: 'owner', type: 'lookup', reference: 'account', dependsOn: [{ local: 'account' }] },
+    selectedBranchIssues: 2,
     key: 'local',
     keyInMessage: '`local`',
     surface: 'this dependsOn entry',
@@ -297,6 +331,7 @@ const SITES: ReadonlyArray<readonly [name: string, site: UnionMessageSite]> = [
     site: 'ui/chart.zod.ts:767',
     door: ChartGroupBySchema,
     reject: { granularity: 'day' },
+    selectedBranchIssues: 2,
     key: 'granularity',
     keyInMessage: '`granularity`',
     surface: 'this chart groupBy',
@@ -308,6 +343,7 @@ const SITES: ReadonlyArray<readonly [name: string, site: UnionMessageSite]> = [
     site: 'ui/component.zod.ts:1181',
     door: RecordHighlightsProps,
     reject: { fields: [{ field: 'status' }] },
+    selectedBranchIssues: 2,
     key: 'field',
     keyInMessage: '`field`',
     surface: 'this `record:highlights` field',
@@ -319,6 +355,7 @@ const SITES: ReadonlyArray<readonly [name: string, site: UnionMessageSite]> = [
     site: 'ui/view.zod.ts:1379',
     door: GanttQuickFilterSchema,
     reject: { field: 'stage', options: [{ title: 'Won' }] },
+    selectedBranchIssues: 2,
     key: 'title',
     keyInMessage: '`title`',
     surface: 'this gantt quick-filter option',
@@ -331,6 +368,7 @@ const SITES: ReadonlyArray<readonly [name: string, site: UnionMessageSite]> = [
     door: GanttConfigSchema,
     reject: { startDateField: 's', endDateField: 'e', titleField: 't',
       tooltipFields: [{ name: 'amount' }] },
+    selectedBranchIssues: 2,
     key: 'name',
     keyInMessage: '`name`',
     surface: 'this gantt tooltip field',
@@ -350,7 +388,11 @@ const SITES: ReadonlyArray<readonly [name: string, site: UnionMessageSite]> = [
   ['FormSection.fields — a form field entry (curated map + separate `.strict()`)', {
     site: 'ui/view.zod.ts:2895',
     door: FormSectionSchema,
-    reject: { label: 'S', fields: [{ field: 'x', visibleWhenn: 'a', bogus: 1 }] },
+    // ⚠️ `field` is omitted deliberately: the object branch must carry a
+    //    SECOND issue (the missing required key) beside `unrecognized_keys`,
+    //    or pin 2's selected-branch count has nothing to discriminate.
+    reject: { label: 'S', fields: [{ visibleWhenn: 'a', bogus: 1 }] },
+    selectedBranchIssues: 2,
     key: 'visibleWhenn',
     keyInMessage: '`visibleWhenn`, `bogus`',
     surface: 'this form field',
@@ -366,6 +408,14 @@ const SITES: ReadonlyArray<readonly [name: string, site: UnionMessageSite]> = [
     reject: { name: 'lead', label: 'Lead', fields: { a: { type: 'text', label: 'A' } },
       lifecycle: { class: 'audit', retention: { maxAge: '30d',
         onlyWhen: { status: { $in: ['closed'], bogusKey: 1 } } } } },
+    // ⚠️ ONE, and the only row below two. The `$in` arm is selected with a
+    //    lone `unrecognized_keys` (it ties on fewest-issues and wins the
+    //    unknown-key tiebreak over the `$null` arm's two), so this row does
+    //    NOT discriminate 'the WHOLE selected branch is rendered' — only
+    //    that the branch is rendered at all. Re-ordering its fixture to fix
+    //    that is an open card of its own and deliberately NOT done here; the
+    //    count is declared so the gap is visible rather than silent.
+    selectedBranchIssues: 1,
     key: 'bogusKey',
     keyInMessage: 'Unrecognized key: "bogusKey"',
     surface: null,
@@ -423,22 +473,46 @@ describe('[#15423] the AUTHOR-VISIBLE message at a string-or-object union site',
   // ── Pin 2 ─────────────────────────────────────────────────────────────────
   describe('pin 2 — branch selection is structural, not an accident of one fixture', () => {
     it.each(SITES)('%s', (_name, site) => {
-      // Every fixture gives the OBJECT branch more than one issue. A descent
+      // Every fixture gives the SELECTED branch more than one issue. A descent
       // that only ever surfaced a lone issue would pass a single-issue fixture
       // while dropping real diagnoses here.
+      //
+      // ⚠️ "Selected", emphatically not "all branches flattened". The first
+      // version of this clause counted `(union.errors ?? []).flat()`, which
+      // sums EVERY arm — and at a two-arm string-or-object site the string arm
+      // always contributes exactly one `invalid_type`. So `> 1` was satisfied
+      // by the kind mismatch alone, at every row, no matter what the object
+      // arm did: a clause that could not fail, inside a file whose whole
+      // purpose is pins that cannot silently certify coverage they do not
+      // have. It is measured against the branch `selectUnionBranches` really
+      // picks — the same policy the renderer runs — so the count is the one
+      // whose issues actually reach the author.
       const result = site.door.safeParse(site.reject) as {
         error: { issues: ReadonlyArray<{ code: string; errors?: ReadonlyArray<ReadonlyArray<unknown>> }> };
       };
-      type Nested = { code: string; errors?: ReadonlyArray<ReadonlyArray<Nested>> };
+      type Nested = { code: string; path?: PropertyKey[]; errors?: ReadonlyArray<ReadonlyArray<Nested>> };
       const flatten = (issues: ReadonlyArray<Nested>): Nested[] =>
         issues.flatMap((i) => [i, ...(i.errors ?? []).flat().flatMap((n) => flatten([n]))]);
       const union = flatten(result.error.issues as ReadonlyArray<Nested>)
         .find((i) => i.code === 'invalid_union');
       expect(union, `${site.site}: the refusal really is a union collapse`).toBeDefined();
-      const branchIssues = (union!.errors ?? []).flat();
-      expect(branchIssues.length,
-        `${site.site}: the fixture must give the object branch MORE THAN ONE issue`)
-        .toBeGreaterThan(1);
+
+      const { selected } = selectUnionBranches((union!.errors ?? []) as Nested[][]);
+      expect(selected.length,
+        `${site.site}: the policy must select a branch — an empty selection renders nothing`)
+        .toBeGreaterThan(0);
+      expect(selected[0]!.length,
+        `${site.site}: the SELECTED branch's issue count must equal what the row declares `
+        + `— per-branch codes were `
+        + `${JSON.stringify((union!.errors ?? []).map((b) => b.map((i) => i.code)))}`)
+        .toBe(site.selectedBranchIssues);
+
+      // ⛔ And the string arm is genuinely NOT what was selected — the clause
+      // above would be satisfied by any two-issue branch, including a string
+      // arm that somehow carried two complaints.
+      expect(selected[0]!.some((i) => i.code === 'unrecognized_keys'),
+        `${site.site}: the selected branch must be the object arm, which is where the prescription lives`)
+        .toBe(true);
 
       // …and the whole selected branch is rendered, not just its first issue.
       const rendered = formatZodError(
@@ -480,22 +554,38 @@ describe('[#15423] the AUTHOR-VISIBLE message at a string-or-object union site',
       expect(SITES).toHaveLength(13);
       // Each row names a distinct `z.union` coordinate.
       expect(new Set(SITES.map(([, s]) => s.site)).size).toBe(SITES.length);
+
+      // ⛔ The single-issue exemption is BOUNDED. `selectedBranchIssues: 1`
+      // means that row cannot discriminate "the whole selected branch is
+      // rendered", so it may not spread by copy-paste into new rows: exactly
+      // one row carries it today, and it is the one the header names. A
+      // fourteenth row declaring 1 turns this red and has to argue for itself.
+      const singleIssueRows = SITES.filter(([, s]) => s.selectedBranchIssues < 2);
+      expect(singleIssueRows.map(([, s]) => s.site)).toEqual(['data/object.zod.ts:855']);
     });
 
-    it('CONTROL — a class-C (open) arm raises no refusal at all, which is why it is excluded', () => {
+    it('CONTROL — a class-C (open) arm raises no UNKNOWN-KEY refusal, which is why it is excluded', () => {
       // The header's exclusion, asserted rather than asserted-about. The same
-      // probe, one undeclared key, two classes:
+      // probe, one UNDECLARED key, two classes:
       //
       //   class C (`data/query.zod.ts:200`, a non-strict `z.object` arm) —
-      //     the key is STRIPPED and the body parses, so there is no
-      //     author-visible message at that site to pin or to regress;
+      //     the key is STRIPPED and the body parses, so there is no curated
+      //     unknown-key prose at that site to pin or to regress;
       //   class A (`ui/chart.zod.ts:767`, the same shape closed) — refused,
       //     naming the key and the surface.
+      //
+      // ⛔ Read the class-C half narrowly, exactly as the header states it. It
+      // does NOT say a class-C site is silent: a wrong-typed or bad-enum
+      // DECLARED key there IS refused and IS rendered through this same
+      // descent. What these 17 sites lack is curated unknown-key prose — no
+      // surface, no rename — which is the only thing this file's pin shape
+      // knows how to assert. Their rendered half is covered generically by
+      // `shared/error-map.test.ts`.
       //
       // Without the second half the first is just a schema that happened to
       // accept something; together they are the boundary this file draws.
       const openArm = GroupByNodeSchema.safeParse({ field: 'created_at', bogusKey: 1 });
-      expect(openArm.success, 'class C: an undeclared key is stripped, not refused').toBe(true);
+      expect(openArm.success, 'class C: an UNDECLARED key is stripped, not refused').toBe(true);
       expect(openArm.data, 'class C: and it is gone from the parsed value')
         .toEqual({ field: 'created_at' });
 

--- a/packages/spec/src/shared/union-author-message-pins.test.ts
+++ b/packages/spec/src/shared/union-author-message-pins.test.ts
@@ -33,11 +33,10 @@
  * call in `packages/spec/src` was parsed with the TypeScript compiler API and
  * its arms classified, resolving named arms through the tree's own declarations
  * and through `lazySchema()` / `strictObject()`; a site qualifies when one arm
- * resolves to `z.string()` and another to an object schema. On `origin/main`
- * `ad715aca57` (this branch's point of departure): 166 `z.union([...])` sites,
- * of which **31 are string-or-object** (plus 7 in test fixtures, excluded) —
- * re-derived byte-for-byte unchanged on each of the two later merges of `main`,
- * so the reading is not an artifact of one snapshot.
+ * resolves to `z.string()` and another to an object schema. Anchored to
+ * `origin/main` `ad715aca57` (this branch's point of departure) and re-derived
+ * unchanged on each later merge of `main`: **166** `z.union([...])` sites, of
+ * which **32 are string-or-object** (plus 7 in test fixtures, excluded).
  *
  * The scan's own control — sites with any arm it could not resolve, each of
  * which could hide a match — went **46 → 0** as the resolver learned
@@ -45,30 +44,79 @@
  * the final zero a measured absence rather than a scan that saw nothing: the
  * control was demonstrably lit before it was cleared.
  *
- * Those 31 split into three classes by what their OBJECT arm does with an
- * undeclared key, which is what decides whether there is an author-visible
- * message to pin at all:
+ * ⚠️ **A cleared control is not a complete scan, and this file learned that the
+ * hard way.** The first pass of this scan read 31, not 32. It resolved
+ * `lazySchema(() => …)` only when the arrow body was an EXPRESSION, so
+ * `FormFieldBaseSchema` — whose `lazySchema` arrow has a BLOCK body — fell out
+ * as unclassifiable rather than as an object, and `ui/view.zod.ts:2895` never
+ * reached the population at all. Its unresolved-arm control was zero throughout,
+ * because the arm resolved to *something*; it was just the wrong something. A
+ * second, independent re-derivation by a different method (a brace-matching
+ * scanner) found the site, and it was settled by BEHAVIOUR rather than by either
+ * scanner's syntax: the door is refused and the refusal renders curated prose.
+ * ⇒ Two lessons encoded here: the class of a site is decided by what it RENDERS,
+ * and one scanner agreeing with itself across three merge bases is not
+ * independent evidence.
  *
- * - **A — curated `strictObject()` arm (13 sites).** The refusal names the key,
- *   the surface and, where the site declares an alias or edit distance reaches,
- *   the rename. This is the shape PR #14975 pinned, and all 13 are covered:
- *   11 by the table below, `devPlugins` by #14975's own file
+ * Those 32 split into three classes by what their OBJECT arm does with an
+ * undeclared key, which is what decides whether there is curated prose to pin:
+ *
+ * - **A — closed AND curated arm (14 sites).** The refusal names the key, the
+ *   surface and, where the site declares an alias or edit distance reaches, the
+ *   rename. This is the shape PR #14975 pinned. All 14 are covered: 12 by the
+ *   table below, `devPlugins` by #14975's own file
  *   (`kernel/manifest-unknown-keys.test.ts`), `ActionRef` by the CONTROL case
  *   in `automation/state-machine.test.ts`.
- * - **B — bare `.strict()` arm (1 site).** `lifecycleOnlyWhenSchema`
- *   (`data/object.zod.ts`) closes its two object arms with plain zod
- *   `.strict()`, so the refusal names the key and the path but carries no
- *   surface and no rename — there is no curated prose to assert. It is pinned
- *   below anyway, on the half it does have, because it rides the same descent.
+ *
+ *   ⚠️ Curation and closure are INDEPENDENT, which is the trap. Thirteen of the
+ *   14 spell both at once with `strictObject()`. `ui/view.zod.ts:2895` splits
+ *   them: `FormFieldBaseSchema` takes a `strictObjectError({ surface: 'this
+ *   form field', … })` map WITHOUT closing the shape (#6619), and
+ *   `FormFieldSchema` closes it one level up with a plain `.strict()`. A
+ *   classifier that reads `strictObject()` calls alone therefore files it as
+ *   class B and under-states its message. `strictObjectError(` has exactly ONE
+ *   call site in the tree, so this pair has exactly one member today.
+ * - **B — closed but UNCURATED arm (1 site).** `lifecycleOnlyWhenSchema`
+ *   (`data/object.zod.ts:855`) closes its two object arms with plain zod
+ *   `.strict()` and carries no error map, so the refusal names the key and the
+ *   path but no surface and no rename. It is pinned below on the half it has,
+ *   because it rides the same descent.
  * - **C — open object arm (17 sites).** The arm is a non-strict `z.object` or
- *   an explicit `z.looseObject`, so an undeclared key is *stripped* and no
- *   refusal is raised at all. Measured, not assumed: `GroupByNodeSchema` and
- *   `BookNodeSchema` both ACCEPT a bogus key and parse it away, against a lit
- *   control (`ChartGroupBySchema`, class A, same probe) that names the key and
- *   the surface. ⛔ These are deliberately NOT pinned: there is no
- *   author-visible message at them to regress, so a pin would assert the
- *   absence of prose rather than its content, and would go green forever. If a
- *   class-C arm is ever closed, it becomes class A and belongs in the table.
+ *   an explicit `z.looseObject`, so an **undeclared key is stripped** and no
+ *   unknown-key refusal is raised. Measured, not assumed: `GroupByNodeSchema`
+ *   and `BookNodeSchema` both ACCEPT a bogus key and parse it away, against a
+ *   lit control (`ChartGroupBySchema`, class A, same probe) that names the key
+ *   and the surface.
+ *
+ *   ⛔ **What is NOT true of them — the narrower claim is the correct one.**
+ *   A class-C site is not silent in general: a wrong-typed or bad-enum
+ *   **declared** key IS refused there and IS rendered through this very
+ *   descent. Measured — `GroupByNodeSchema.safeParse({ field: 123 })` renders
+ *   `✗ (root): Invalid input` then `✗ field: Invalid input: expected string,
+ *   received number`, with the string arm dropped; `{ dateGranularity:
+ *   'fortnight' }` and `ExpressionInputSchema` `{ dialect: 'cel', source: 5 }`
+ *   behave the same way. So what these 17 lack is **curated unknown-key prose
+ *   to pin**, not an author-visible message. They are excluded on that narrower
+ *   ground: there is no surface phrase and no rename at them, so the pin shape
+ *   this file applies has nothing to assert. Their rendered half is covered
+ *   GENERICALLY rather than per site, by `shared/error-map.test.ts` (`:226`
+ *   nests a union inside a union with open `z.object` arms; `:307-329` walks
+ *   four open-armed levels), which pins the same descent on the same arm shape.
+ *   Whether that generic coverage is enough, or whether these want per-site
+ *   pins, is a scope question this file does not settle.
+ *
+ *   The 17, so the exclusion set is auditable here without re-deriving it:
+ *   `api/protocol.zod.ts:2853` · `data/data-engine.zod.ts:140` ·
+ *   `data/field-value.zod.ts:459` · `data/field-value.zod.ts:555` ·
+ *   `data/filter.zod.ts:405` · `data/query.zod.ts:200` · `data/query.zod.ts:537` ·
+ *   `shared/expression.zod.ts:178` · `shared/expression.zod.ts:242` ·
+ *   `shared/expression.zod.ts:349` · `shared/expression.zod.ts:384` ·
+ *   `system/book.zod.ts:31` · `system/book.zod.ts:48` ·
+ *   `system/metrics.zod.ts:430` · `system/tracing.zod.ts:347` ·
+ *   `ui/action.zod.ts:825` · `ui/component.zod.ts:1593`.
+ *
+ *   If a class-C arm is ever closed AND curated, it becomes class A and belongs
+ *   in the table.
  *
  * ⭐ **Every message asserted below was MEASURED before it was written**, and
  * every one of them was already correct. This file changes no behaviour: the
@@ -98,7 +146,7 @@ import { ObjectSchema } from '../data/object.zod';
 import { GroupByNodeSchema } from '../data/query.zod';
 import { ChartGroupBySchema } from '../ui/chart.zod';
 import { RecordHighlightsProps } from '../ui/component.zod';
-import { GanttConfigSchema, GanttQuickFilterSchema } from '../ui/view.zod';
+import { FormSectionSchema, GanttConfigSchema, GanttQuickFilterSchema } from '../ui/view.zod';
 import { formatZodError } from './error-map.zod';
 
 /** A door that renders through `formatZodError` — every schema below is one. */
@@ -129,8 +177,21 @@ interface UnionMessageSite {
   readonly keyInMessage: string;
   /** The curated surface phrase, or `null` for the one class-B site. */
   readonly surface: string | null;
-  /** The `Did you mean` target, or `null` where the site declares no rename. */
-  readonly rename: string | null;
+  /**
+   * The rename prescription exactly as the message renders it, or `null` where
+   * the site declares none.
+   *
+   * ⚠️ Spelled out per row rather than built from a `` `key` → `target` ``
+   * template on purpose. The template was the first version, and it silently
+   * assumed one rendering: `strictObject()`'s alias/edit-distance line really
+   * does render that arrow, but `ui/view.zod.ts:2895` prescribes its rename as
+   * an ADR-0089 **bullet** (`• If this is the conditional-visibility
+   * predicate, the canonical key is ...`) and carries no arrow at all. A
+   * template would have forced that row to declare `rename: null` and drop a
+   * real prescription out of the pin — the assertion would still be green and
+   * would be measuring less than it claims.
+   */
+  readonly renameInMessage: string | null;
   /** The same slot, written with the STRING arm — must still parse. */
   readonly acceptString: unknown;
   /** The same slot, written with a legal OBJECT arm — must still parse. */
@@ -141,9 +202,14 @@ interface UnionMessageSite {
  * The class-A and class-B population minus the two sites already covered
  * (`devPlugins` by #14975, `ActionRef` by `state-machine.test.ts`).
  *
- * ⛔ Rows are not invented: each `site` is a coordinate the scan produced, and
- * adding a string-or-object union with a closed object arm anywhere in
- * `packages/spec/src` adds a row here.
+ * ⛔ Rows are not invented: each `site` is a coordinate the scan produced.
+ *
+ * ⚠️ Nothing MECHANICALLY holds this table equal to the tree — `toHaveLength`
+ * below pins the snapshot, not the derivation, so a string-or-object union
+ * added with a closed object arm tomorrow makes no test red. Re-deriving is a
+ * manual step, and the header says how. A standing guard that re-scans and
+ * fails on an unpinned new site is the real fix and is deliberately left to its
+ * own card, not asserted here as though it existed.
  */
 const SITES: ReadonlyArray<readonly [name: string, site: UnionMessageSite]> = [
   ['GuardRef — the object arm of a guard reference', {
@@ -153,7 +219,7 @@ const SITES: ReadonlyArray<readonly [name: string, site: UnionMessageSite]> = [
     key: 'parms',
     keyInMessage: '`parms`',
     surface: 'this guard reference',
-    rename: 'params',
+    renameInMessage: '`parms` → `params`',
     acceptString: 'isManager',
     acceptObject: { type: 'log', params: { a: 1 } },
   }],
@@ -164,7 +230,7 @@ const SITES: ReadonlyArray<readonly [name: string, site: UnionMessageSite]> = [
     key: 'guard',
     keyInMessage: '`guard`',
     surface: 'this state transition',
-    rename: 'cond',
+    renameInMessage: '`guard` → `cond`',
     acceptString: { on: { GO: 'next' } },
     acceptObject: { on: { GO: { target: 'next' } } },
   }],
@@ -176,7 +242,7 @@ const SITES: ReadonlyArray<readonly [name: string, site: UnionMessageSite]> = [
     key: 'guard',
     keyInMessage: '`guard`',
     surface: 'this state transition',
-    rename: 'cond',
+    renameInMessage: '`guard` → `cond`',
     acceptString: { id: 'machine', initial: 'idle', states: { idle: { initial: 'a', states: {} } },
       on: { GO: 'idle' } },
     acceptObject: { id: 'machine', initial: 'idle', states: { idle: { initial: 'a', states: {} } },
@@ -189,7 +255,7 @@ const SITES: ReadonlyArray<readonly [name: string, site: UnionMessageSite]> = [
     key: 'widget',
     keyInMessage: '`widget`',
     surface: 'this decision-output declaration',
-    rename: 'type',
+    renameInMessage: '`widget` → `type`',
     acceptString: { approvers: [{ type: 'user', value: 'u1' }], decisionOutputs: ['comment'] },
     acceptObject: { approvers: [{ type: 'user', value: 'u1' }],
       decisionOutputs: [{ key: 'comment', type: 'text' }] },
@@ -201,7 +267,7 @@ const SITES: ReadonlyArray<readonly [name: string, site: UnionMessageSite]> = [
     key: 'efect',
     keyInMessage: '`efect`',
     surface: 'this `functions` entry',
-    rename: 'effect',
+    renameInMessage: '`efect` → `effect`',
     acceptString: 'scoreLead',
     acceptObject: { handler: () => undefined },
   }],
@@ -212,7 +278,7 @@ const SITES: ReadonlyArray<readonly [name: string, site: UnionMessageSite]> = [
     key: 'name',
     keyInMessage: '`name`',
     surface: 'this lookup column',
-    rename: 'field',
+    renameInMessage: '`name` → `field`',
     acceptString: { name: 'owner', type: 'lookup', reference: 'account', lookupColumns: ['amount'] },
     acceptObject: { name: 'owner', type: 'lookup', reference: 'account', lookupColumns: [{ field: 'amount' }] },
   }],
@@ -223,7 +289,7 @@ const SITES: ReadonlyArray<readonly [name: string, site: UnionMessageSite]> = [
     key: 'local',
     keyInMessage: '`local`',
     surface: 'this dependsOn entry',
-    rename: 'field',
+    renameInMessage: '`local` → `field`',
     acceptString: { name: 'owner', type: 'lookup', reference: 'account', dependsOn: ['account'] },
     acceptObject: { name: 'owner', type: 'lookup', reference: 'account', dependsOn: [{ field: 'account' }] },
   }],
@@ -234,7 +300,7 @@ const SITES: ReadonlyArray<readonly [name: string, site: UnionMessageSite]> = [
     key: 'granularity',
     keyInMessage: '`granularity`',
     surface: 'this chart groupBy',
-    rename: 'dateGranularity',
+    renameInMessage: '`granularity` → `dateGranularity`',
     acceptString: 'created_at',
     acceptObject: { field: 'created_at', dateGranularity: 'day' },
   }],
@@ -245,7 +311,7 @@ const SITES: ReadonlyArray<readonly [name: string, site: UnionMessageSite]> = [
     key: 'field',
     keyInMessage: '`field`',
     surface: 'this `record:highlights` field',
-    rename: 'name',
+    renameInMessage: '`field` → `name`',
     acceptString: { fields: ['status'] },
     acceptObject: { fields: [{ name: 'status' }] },
   }],
@@ -256,7 +322,7 @@ const SITES: ReadonlyArray<readonly [name: string, site: UnionMessageSite]> = [
     key: 'title',
     keyInMessage: '`title`',
     surface: 'this gantt quick-filter option',
-    rename: 'label',
+    renameInMessage: '`title` → `label`',
     acceptString: { field: 'stage', options: ['won'] },
     acceptObject: { field: 'stage', options: [{ value: 'won', label: 'Won' }] },
   }],
@@ -268,14 +334,32 @@ const SITES: ReadonlyArray<readonly [name: string, site: UnionMessageSite]> = [
     key: 'name',
     keyInMessage: '`name`',
     surface: 'this gantt tooltip field',
-    rename: 'field',
+    renameInMessage: '`name` → `field`',
     acceptString: { startDateField: 's', endDateField: 'e', titleField: 't',
       tooltipFields: ['amount'] },
     acceptObject: { startDateField: 's', endDateField: 'e', titleField: 't',
       tooltipFields: [{ field: 'amount' }] },
   }],
-  // ── class B: the one bare-`.strict()` site. No surface, no rename — see the
-  //    header. It is here because the KEY half rides the same union descent.
+  // ── class A, the site a `strictObject()`-shaped classifier files as class B.
+  //    `FormFieldBaseSchema` carries the curated map (`strictObjectError`,
+  //    #6619) and `FormFieldSchema` closes the shape one level up with a plain
+  //    `.strict()`, so the message is fully curated — surface AND rename —
+  //    while the syntax looks bare. ⚠️ Its rename is an ADR-0089 guidance
+  //    BULLET, not the `key → target` arrow every other row renders; that is
+  //    why `renameInMessage` is a literal per row rather than a template.
+  ['FormSection.fields — a form field entry (curated map + separate `.strict()`)', {
+    site: 'ui/view.zod.ts:2895',
+    door: FormSectionSchema,
+    reject: { label: 'S', fields: [{ field: 'x', visibleWhenn: 'a', bogus: 1 }] },
+    key: 'visibleWhenn',
+    keyInMessage: '`visibleWhenn`, `bogus`',
+    surface: 'this form field',
+    renameInMessage: 'the canonical key is `visibleWhen`',
+    acceptString: { label: 'S', fields: ['x'] },
+    acceptObject: { label: 'S', fields: [{ field: 'x' }] },
+  }],
+  // ── class B: the one closed-but-uncurated site. No surface, no rename — see
+  //    the header. It is here because the KEY half rides the same union descent.
   ['lifecycle onlyWhen — a row-filter comparand (class B: bare `.strict()`)', {
     site: 'data/object.zod.ts:855',
     door: ObjectSchema,
@@ -285,7 +369,7 @@ const SITES: ReadonlyArray<readonly [name: string, site: UnionMessageSite]> = [
     key: 'bogusKey',
     keyInMessage: 'Unrecognized key: "bogusKey"',
     surface: null,
-    rename: null,
+    renameInMessage: null,
     acceptString: { name: 'lead', label: 'Lead', fields: { a: { type: 'text', label: 'A' } },
       lifecycle: { class: 'audit', retention: { maxAge: '30d', onlyWhen: { status: 'closed' } } } },
     acceptObject: { name: 'lead', label: 'Lead', fields: { a: { type: 'text', label: 'A' } },
@@ -319,11 +403,13 @@ describe('[#15423] the AUTHOR-VISIBLE message at a string-or-object union site',
           .toContain(site.surface);
       }
 
-      // The rename, where the site declares an alias or edit distance reaches
-      // it. This is the half a bare `unrecognized_keys` code cannot carry.
-      if (site.rename !== null) {
+      // The rename, where the site declares an alias, edit distance reaches it,
+      // or a guidance bullet prescribes it. This is the half a bare
+      // `unrecognized_keys` code cannot carry, and the row supplies the exact
+      // rendered text — ⛔ never a template, see `renameInMessage`.
+      if (site.renameInMessage !== null) {
         expect(rendered, `${site.site}: the rename prescription must survive the union descent`)
-          .toContain(`\`${site.key}\` → \`${site.rename}\``);
+          .toContain(site.renameInMessage);
       }
 
       // ⛔ And it is genuinely the union door, not a non-union bypass: zod folds
@@ -385,10 +471,13 @@ describe('[#15423] the AUTHOR-VISIBLE message at a string-or-object union site',
   // all. These two guard the table itself rather than any one site.
   describe('the table is not vacuous', () => {
     it('covers every site the scan found outside the two already pinned elsewhere', () => {
-      // 13 class-A sites + 1 class-B = 14 with an unknown-key refusal to lose;
-      // `devPlugins` (#14975) and `ActionRef` (`state-machine.test.ts`) are
-      // pinned in their own files, so 12 belong here.
-      expect(SITES).toHaveLength(12);
+      // 14 class-A sites + 1 class-B = 15 with a curated-or-bare unknown-key
+      // refusal to lose; `devPlugins` (#14975) and `ActionRef`
+      // (`state-machine.test.ts`) are pinned in their own files, so 13 belong
+      // here. ⚠️ This number certifies the population COMPLETE, which is why
+      // the first pass getting it wrong mattered: at 12 it asserted, forever
+      // and greenly, that `ui/view.zod.ts:2895` was not a member.
+      expect(SITES).toHaveLength(13);
       // Each row names a distinct `z.union` coordinate.
       expect(new Set(SITES.map(([, s]) => s.site)).size).toBe(SITES.length);
     });

--- a/packages/spec/src/shared/union-author-message-pins.test.ts
+++ b/packages/spec/src/shared/union-author-message-pins.test.ts
@@ -1,0 +1,394 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * [#15423] The AUTHOR-VISIBLE message at every string-or-object union site that
+ * has an unknown-key refusal to lose.
+ *
+ * ## Why this file exists
+ *
+ * #14722 asserted that a `devPlugins[]` refusal reaches the author keyless.
+ * Measured, it does not — `formatZodIssue` descends `invalid_union`, ranks the
+ * branches through `selectUnionBranches` (`./union-branch-policy.ts`, #8318),
+ * drops the string arm as kind-mismatch-only and renders the object branch
+ * verbatim. But **nothing pinned that**, so the rendered half was re-reported
+ * as a defect, and rediscovering that the code was already correct cost a
+ * grading, a dispatch and a whole PR. PR #14975 closed the gap for that ONE
+ * site; every other site in the family was still in the state `devPlugins` was
+ * in. This file is the rest of the family.
+ *
+ * ## The distinction the whole thing turns on
+ *
+ * **A pin on the raw issue shape and a pin on the rendered message measure
+ * different halves, and only one of them is what an author experiences.**
+ * `devPlugins` had the first and not the second, which is exactly why it read
+ * as broken. Several sites below had the same split — `RecordHighlightsField`
+ * and `ActionRef`/`GuardRef` each carry a careful raw-shape pin elsewhere in
+ * the tree, and neither carried a rendered-message one. A raw-shape pin stays
+ * green through a regression in the descent, because the descent is not what it
+ * reads.
+ *
+ * ## The population, and how it was derived
+ *
+ * Mechanically, from the tree — never a hand-built list. Every `z.union([...])`
+ * call in `packages/spec/src` was parsed with the TypeScript compiler API and
+ * its arms classified, resolving named arms through the tree's own declarations
+ * and through `lazySchema()` / `strictObject()`; a site qualifies when one arm
+ * resolves to `z.string()` and another to an object schema. On `origin/main`
+ * `ad715aca57`: 166 `z.union([...])` sites, of which **31 are string-or-object**
+ * (plus 7 in test fixtures, excluded). The scan's own control — sites with any
+ * arm it could not resolve, each of which could hide a match — went 46 → 0 as
+ * the resolver learned `lazySchema`, `strictObject` and function declarations,
+ * so the final zero is a measured absence rather than a scan that saw nothing.
+ *
+ * Those 31 split into three classes by what their OBJECT arm does with an
+ * undeclared key, which is what decides whether there is an author-visible
+ * message to pin at all:
+ *
+ * - **A — curated `strictObject()` arm (13 sites).** The refusal names the key,
+ *   the surface and, where the site declares an alias or edit distance reaches,
+ *   the rename. This is the shape PR #14975 pinned, and all 13 are covered:
+ *   11 by the table below, `devPlugins` by #14975's own file
+ *   (`kernel/manifest-unknown-keys.test.ts`), `ActionRef` by the CONTROL case
+ *   in `automation/state-machine.test.ts`.
+ * - **B — bare `.strict()` arm (1 site).** `lifecycleOnlyWhenSchema`
+ *   (`data/object.zod.ts`) closes its two object arms with plain zod
+ *   `.strict()`, so the refusal names the key and the path but carries no
+ *   surface and no rename — there is no curated prose to assert. It is pinned
+ *   below anyway, on the half it does have, because it rides the same descent.
+ * - **C — open object arm (17 sites).** The arm is a non-strict `z.object` or
+ *   an explicit `z.looseObject`, so an undeclared key is *stripped* and no
+ *   refusal is raised at all. Measured, not assumed: `GroupByNodeSchema` and
+ *   `BookNodeSchema` both ACCEPT a bogus key and parse it away, against a lit
+ *   control (`ChartGroupBySchema`, class A, same probe) that names the key and
+ *   the surface. ⛔ These are deliberately NOT pinned: there is no
+ *   author-visible message at them to regress, so a pin would assert the
+ *   absence of prose rather than its content, and would go green forever. If a
+ *   class-C arm is ever closed, it becomes class A and belongs in the table.
+ *
+ * ⭐ **Every message asserted below was MEASURED before it was written**, and
+ * every one of them was already correct. This file changes no behaviour: the
+ * deliverable is COVERAGE, not repair.
+ *
+ * ## What each site is pinned for — the three pins, per #14975
+ *
+ * 1. **The rendered message names the key, the surface and the rename.** This
+ *    is the half that was missing. It reads `formatZodError`, the real
+ *    `defineStack`/CLI door, not the raw issue tree.
+ * 2. **Branch selection is structural, not an accident of one fixture.** Every
+ *    fixture gives the object branch MORE THAN ONE issue, so a descent that
+ *    happened to surface a single issue cannot pass for a working one; and the
+ *    string arm's `expected string, received object` — a kind mismatch, not a
+ *    prescription — must NOT be rendered.
+ * 3. **The accept side is unmoved.** A bare string entry and a legal object
+ *    entry both still parse at every site.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { ApprovalNodeConfigSchema } from '../automation/approval.zod';
+import { FlowFunctionEntrySchema } from '../automation/flow-function.zod';
+import { GuardRefSchema, StateMachineSchema, StateNodeSchema } from '../automation/state-machine.zod';
+import { FieldSchema } from '../data/field.zod';
+import { ObjectSchema } from '../data/object.zod';
+import { GroupByNodeSchema } from '../data/query.zod';
+import { ChartGroupBySchema } from '../ui/chart.zod';
+import { RecordHighlightsProps } from '../ui/component.zod';
+import { GanttConfigSchema, GanttQuickFilterSchema } from '../ui/view.zod';
+import { formatZodError } from './error-map.zod';
+
+/** A door that renders through `formatZodError` — every schema below is one. */
+interface Door {
+  safeParse(value: unknown): { success: boolean; error?: unknown; data?: unknown };
+}
+
+interface UnionMessageSite {
+  /** `<file>:<line>` of the `z.union([...])` call this row pins. */
+  readonly site: string;
+  /** The exported schema an author's value actually arrives at. */
+  readonly door: Door;
+  /**
+   * A body whose OBJECT arm carries more than one issue — pin 2's structural
+   * requirement. `issues` is how many the object branch raises, asserted so a
+   * fixture cannot silently decay into a single-issue one.
+   */
+  readonly reject: unknown;
+  /** The undeclared key the fixture writes, as it must appear in the message. */
+  readonly key: string;
+  /** The curated surface phrase, or `null` for the one class-B site. */
+  readonly surface: string | null;
+  /** The `Did you mean` target, or `null` where the site declares no rename. */
+  readonly rename: string | null;
+  /** The same slot, written with the STRING arm — must still parse. */
+  readonly acceptString: unknown;
+  /** The same slot, written with a legal OBJECT arm — must still parse. */
+  readonly acceptObject: unknown;
+}
+
+/**
+ * The class-A and class-B population minus the two sites already covered
+ * (`devPlugins` by #14975, `ActionRef` by `state-machine.test.ts`).
+ *
+ * ⛔ Rows are not invented: each `site` is a coordinate the scan produced, and
+ * adding a string-or-object union with a closed object arm anywhere in
+ * `packages/spec/src` adds a row here.
+ */
+const SITES: ReadonlyArray<readonly [name: string, site: UnionMessageSite]> = [
+  ['GuardRef — the object arm of a guard reference', {
+    site: 'automation/state-machine.zod.ts:120',
+    door: GuardRefSchema,
+    reject: { parms: { a: 1 } },
+    key: 'parms',
+    surface: 'this guard reference',
+    rename: 'params',
+    acceptString: 'isManager',
+    acceptObject: { type: 'log', params: { a: 1 } },
+  }],
+  ['StateNode.on — a transition written inline on a state', {
+    site: 'automation/state-machine.zod.ts:231',
+    door: StateNodeSchema,
+    reject: { on: { GO: { guard: 'isX', actions: 'not-an-array' } } },
+    key: 'guard',
+    surface: 'this state transition',
+    rename: 'cond',
+    acceptString: { on: { GO: 'next' } },
+    acceptObject: { on: { GO: { target: 'next' } } },
+  }],
+  ['StateMachine.on — the machine-level listener map', {
+    site: 'automation/state-machine.zod.ts:292',
+    door: StateMachineSchema,
+    reject: { id: 'machine', initial: 'idle', states: { idle: { initial: 'a', states: {} } },
+      on: { GO: { guard: 'isX', actions: 'not-an-array' } } },
+    key: 'guard',
+    surface: 'this state transition',
+    rename: 'cond',
+    acceptString: { id: 'machine', initial: 'idle', states: { idle: { initial: 'a', states: {} } },
+      on: { GO: 'idle' } },
+    acceptObject: { id: 'machine', initial: 'idle', states: { idle: { initial: 'a', states: {} } },
+      on: { GO: { target: 'idle' } } },
+  }],
+  ['Approval.decisionOutputs — a declared decision output', {
+    site: 'automation/approval.zod.ts:791',
+    door: ApprovalNodeConfigSchema,
+    reject: { approvers: [{ type: 'user', users: ['u1'] }], decisionOutputs: [{ widget: 'user' }] },
+    key: 'widget',
+    surface: 'this decision-output declaration',
+    rename: 'type',
+    acceptString: { approvers: [{ type: 'user', users: ['u1'] }], decisionOutputs: ['comment'] },
+    acceptObject: { approvers: [{ type: 'user', users: ['u1'] }],
+      decisionOutputs: [{ key: 'comment', type: 'text' }] },
+  }],
+  ['FlowFunctionEntry — a `functions` map entry', {
+    site: 'automation/flow-function.zod.ts:252',
+    door: FlowFunctionEntrySchema,
+    reject: { efect: 'pure' },
+    key: 'efect',
+    surface: 'this `functions` entry',
+    rename: 'effect',
+    acceptString: 'scoreLead',
+    acceptObject: { handler: () => undefined },
+  }],
+  ['Field.lookupColumns — an explicit record-picker column', {
+    site: 'data/field.zod.ts:1438',
+    door: FieldSchema,
+    reject: { name: 'owner', type: 'lookup', lookupColumns: [{ name: 'amount' }] },
+    key: 'name',
+    surface: 'this lookup column',
+    rename: 'field',
+    acceptString: { name: 'owner', type: 'lookup', lookupColumns: ['amount'] },
+    acceptObject: { name: 'owner', type: 'lookup', lookupColumns: [{ field: 'amount' }] },
+  }],
+  ['Field.dependsOn — a dependent-picker binding', {
+    site: 'data/field.zod.ts:1464',
+    door: FieldSchema,
+    reject: { name: 'owner', type: 'lookup', dependsOn: [{ local: 'account' }] },
+    key: 'local',
+    surface: 'this dependsOn entry',
+    rename: 'field',
+    acceptString: { name: 'owner', type: 'lookup', dependsOn: ['account'] },
+    acceptObject: { name: 'owner', type: 'lookup', dependsOn: [{ field: 'account' }] },
+  }],
+  ['ChartGroupBy — the structured category axis', {
+    site: 'ui/chart.zod.ts:767',
+    door: ChartGroupBySchema,
+    reject: { granularity: 'day' },
+    key: 'granularity',
+    surface: 'this chart groupBy',
+    rename: 'dateGranularity',
+    acceptString: 'created_at',
+    acceptObject: { field: 'created_at', dateGranularity: 'day' },
+  }],
+  ['RecordHighlightsField — a `record:highlights` field entry', {
+    site: 'ui/component.zod.ts:1181',
+    door: RecordHighlightsProps,
+    reject: { fields: [{ field: 'status' }] },
+    key: 'field',
+    surface: 'this `record:highlights` field',
+    rename: 'name',
+    acceptString: { fields: ['status'] },
+    acceptObject: { fields: [{ name: 'status' }] },
+  }],
+  ['GanttQuickFilter.options — a fixed-enum option override', {
+    site: 'ui/view.zod.ts:1379',
+    door: GanttQuickFilterSchema,
+    reject: { field: 'stage', options: [{ title: 'Won' }] },
+    key: 'title',
+    surface: 'this gantt quick-filter option',
+    rename: 'label',
+    acceptString: { field: 'stage', options: ['won'] },
+    acceptObject: { field: 'stage', options: [{ value: 'won', label: 'Won' }] },
+  }],
+  ['GanttConfig.tooltipFields — a hover-tooltip field entry', {
+    site: 'ui/view.zod.ts:1439',
+    door: GanttConfigSchema,
+    reject: { startDateField: 's', endDateField: 'e', titleField: 't',
+      tooltipFields: [{ name: 'amount' }] },
+    key: 'name',
+    surface: 'this gantt tooltip field',
+    rename: 'field',
+    acceptString: { startDateField: 's', endDateField: 'e', titleField: 't',
+      tooltipFields: ['amount'] },
+    acceptObject: { startDateField: 's', endDateField: 'e', titleField: 't',
+      tooltipFields: [{ field: 'amount' }] },
+  }],
+  // ── class B: the one bare-`.strict()` site. No surface, no rename — see the
+  //    header. It is here because the KEY half rides the same union descent.
+  ['lifecycle onlyWhen — a row-filter comparand (class B: bare `.strict()`)', {
+    site: 'data/object.zod.ts:855',
+    door: ObjectSchema,
+    reject: { name: 'lead', label: 'Lead', fields: { a: { type: 'text', label: 'A' } },
+      lifecycle: { class: 'audit', retention: { maxAge: '30d',
+        onlyWhen: { status: { $in: ['closed'], bogusKey: 1 } } } } },
+    key: 'bogusKey',
+    surface: null,
+    rename: null,
+    acceptString: { name: 'lead', label: 'Lead', fields: { a: { type: 'text', label: 'A' } },
+      lifecycle: { class: 'audit', retention: { maxAge: '30d', onlyWhen: { status: 'closed' } } } },
+    acceptObject: { name: 'lead', label: 'Lead', fields: { a: { type: 'text', label: 'A' } },
+      lifecycle: { class: 'audit', retention: { maxAge: '30d',
+        onlyWhen: { status: { $in: ['closed'] } } } } },
+  }],
+];
+
+/** Render a body through the real author-facing door. */
+function render(site: UnionMessageSite, body: unknown): string {
+  const result = site.door.safeParse(body);
+  expect(result.success, `${site.site}: the fixture must be REFUSED for the pin to mean anything`)
+    .toBe(false);
+  return formatZodError(result.error as Parameters<typeof formatZodError>[0]);
+}
+
+describe('[#15423] the AUTHOR-VISIBLE message at a string-or-object union site', () => {
+  // ── Pin 1 ─────────────────────────────────────────────────────────────────
+  describe('pin 1 — the rendered message names the key, the surface and the rename', () => {
+    it.each(SITES)('%s', (_name, site) => {
+      const rendered = render(site, site.reject);
+
+      // The key the author actually mistyped. This is the assertion #14722
+      // believed would fail — the "keyless `Invalid input`" claim.
+      expect(rendered, `${site.site}: the undeclared key must reach the author`)
+        .toContain(`\`${site.key}\``);
+
+      // The named authoring surface, so the author knows WHICH shape refused.
+      if (site.surface !== null) {
+        expect(rendered, `${site.site}: the refusal must name its surface`)
+          .toContain(site.surface);
+      }
+
+      // The rename, where the site declares an alias or edit distance reaches
+      // it. This is the half a bare `unrecognized_keys` code cannot carry.
+      if (site.rename !== null) {
+        expect(rendered, `${site.site}: the rename prescription must survive the union descent`)
+          .toContain(`\`${site.key}\` → \`${site.rename}\``);
+      }
+
+      // ⛔ And it is genuinely the union door, not a non-union bypass: zod folds
+      // every branch into one `invalid_union` whose own message is the literal
+      // `Invalid input`, so that wrapper line is present above the prescription.
+      expect(rendered, `${site.site}: the union wrapper line is what makes this a union door`)
+        .toContain('Invalid input');
+    });
+  });
+
+  // ── Pin 2 ─────────────────────────────────────────────────────────────────
+  describe('pin 2 — branch selection is structural, not an accident of one fixture', () => {
+    it.each(SITES)('%s', (_name, site) => {
+      // Every fixture gives the OBJECT branch more than one issue. A descent
+      // that only ever surfaced a lone issue would pass a single-issue fixture
+      // while dropping real diagnoses here.
+      const result = site.door.safeParse(site.reject) as {
+        error: { issues: ReadonlyArray<{ code: string; errors?: ReadonlyArray<ReadonlyArray<unknown>> }> };
+      };
+      type Nested = { code: string; errors?: ReadonlyArray<ReadonlyArray<Nested>> };
+      const flatten = (issues: ReadonlyArray<Nested>): Nested[] =>
+        issues.flatMap((i) => [i, ...(i.errors ?? []).flat().flatMap((n) => flatten([n]))]);
+      const union = flatten(result.error.issues as ReadonlyArray<Nested>)
+        .find((i) => i.code === 'invalid_union');
+      expect(union, `${site.site}: the refusal really is a union collapse`).toBeDefined();
+      const branchIssues = (union!.errors ?? []).flat();
+      expect(branchIssues.length,
+        `${site.site}: the fixture must give the object branch MORE THAN ONE issue`)
+        .toBeGreaterThan(1);
+
+      // …and the whole selected branch is rendered, not just its first issue.
+      const rendered = formatZodError(
+        (result as unknown as { error: Parameters<typeof formatZodError>[0] }).error,
+      );
+      expect(rendered).toContain(`\`${site.key}\``);
+
+      // ⛔ The string arm's complaint is a KIND mismatch, never a prescription,
+      // and `selectUnionBranches` drops it. Rendering it is the "N branches, N
+      // times the noise" failure the policy exists to prevent.
+      expect(rendered, `${site.site}: the string arm's kind mismatch must not be rendered`)
+        .not.toContain('expected string, received object');
+    });
+  });
+
+  // ── Pin 3 ─────────────────────────────────────────────────────────────────
+  describe('pin 3 — the accept side is unmoved', () => {
+    it.each(SITES)('%s', (_name, site) => {
+      expect(site.door.safeParse(site.acceptString).success,
+        `${site.site}: the STRING arm must still parse`).toBe(true);
+      expect(site.door.safeParse(site.acceptObject).success,
+        `${site.site}: a legal OBJECT arm must still parse`).toBe(true);
+    });
+  });
+
+  // ── Anti-vacuity ──────────────────────────────────────────────────────────
+  //
+  // Every assertion above is a `toContain` on a rendered string, so a renderer
+  // that returned one long string containing every phrase would satisfy them
+  // all. These two guard the table itself rather than any one site.
+  describe('the table is not vacuous', () => {
+    it('covers every site the scan found outside the two already pinned elsewhere', () => {
+      // 13 class-A sites + 1 class-B = 14 with an unknown-key refusal to lose;
+      // `devPlugins` (#14975) and `ActionRef` (`state-machine.test.ts`) are
+      // pinned in their own files, so 12 belong here.
+      expect(SITES).toHaveLength(12);
+      // Each row names a distinct `z.union` coordinate.
+      expect(new Set(SITES.map(([, s]) => s.site)).size).toBe(SITES.length);
+    });
+
+    it('CONTROL — a class-C (open) arm raises no refusal at all, which is why it is excluded', () => {
+      // The header's exclusion, asserted rather than asserted-about. The same
+      // probe, one undeclared key, two classes:
+      //
+      //   class C (`data/query.zod.ts:200`, a non-strict `z.object` arm) —
+      //     the key is STRIPPED and the body parses, so there is no
+      //     author-visible message at that site to pin or to regress;
+      //   class A (`ui/chart.zod.ts:767`, the same shape closed) — refused,
+      //     naming the key and the surface.
+      //
+      // Without the second half the first is just a schema that happened to
+      // accept something; together they are the boundary this file draws.
+      const openArm = GroupByNodeSchema.safeParse({ field: 'created_at', bogusKey: 1 });
+      expect(openArm.success, 'class C: an undeclared key is stripped, not refused').toBe(true);
+      expect(openArm.data, 'class C: and it is gone from the parsed value')
+        .toEqual({ field: 'created_at' });
+
+      const closedArm = ChartGroupBySchema.safeParse({ field: 'created_at', bogusKey: 1 });
+      expect(closedArm.success, 'the lit control: a class-A arm DOES refuse').toBe(false);
+      expect(formatZodError(closedArm.error as Parameters<typeof formatZodError>[0]))
+        .toContain('this chart groupBy');
+    });
+  });
+});

--- a/packages/spec/src/shared/union-author-message-pins.test.ts
+++ b/packages/spec/src/shared/union-author-message-pins.test.ts
@@ -34,11 +34,16 @@
  * its arms classified, resolving named arms through the tree's own declarations
  * and through `lazySchema()` / `strictObject()`; a site qualifies when one arm
  * resolves to `z.string()` and another to an object schema. On `origin/main`
- * `ad715aca57`: 166 `z.union([...])` sites, of which **31 are string-or-object**
- * (plus 7 in test fixtures, excluded). The scan's own control — sites with any
- * arm it could not resolve, each of which could hide a match — went 46 → 0 as
- * the resolver learned `lazySchema`, `strictObject` and function declarations,
- * so the final zero is a measured absence rather than a scan that saw nothing.
+ * `ad715aca57` (this branch's point of departure): 166 `z.union([...])` sites,
+ * of which **31 are string-or-object** (plus 7 in test fixtures, excluded) —
+ * re-derived byte-for-byte unchanged on each of the two later merges of `main`,
+ * so the reading is not an artifact of one snapshot.
+ *
+ * The scan's own control — sites with any arm it could not resolve, each of
+ * which could hide a match — went **46 → 0** as the resolver learned
+ * `lazySchema`, `strictObject` and function declarations. That is what makes
+ * the final zero a measured absence rather than a scan that saw nothing: the
+ * control was demonstrably lit before it was cleared.
  *
  * Those 31 split into three classes by what their OBJECT arm does with an
  * undeclared key, which is what decides whether there is an author-visible

--- a/packages/spec/src/shared/union-author-message-pins.test.ts
+++ b/packages/spec/src/shared/union-author-message-pins.test.ts
@@ -112,8 +112,16 @@ interface UnionMessageSite {
    * fixture cannot silently decay into a single-issue one.
    */
   readonly reject: unknown;
-  /** The undeclared key the fixture writes, as it must appear in the message. */
+  /** The undeclared key the fixture writes. */
   readonly key: string;
+  /**
+   * The key exactly as the message spells it. Curated `strictObject()` refusals
+   * backtick it (`` `foo` ``); zod's own bare-`.strict()` message double-quotes
+   * it (`Unrecognized key: "foo"`). Pinning the SPELLING and not just the
+   * substring is what keeps this from passing on a message that merely happens
+   * to contain the letters.
+   */
+  readonly keyInMessage: string;
   /** The curated surface phrase, or `null` for the one class-B site. */
   readonly surface: string | null;
   /** The `Did you mean` target, or `null` where the site declares no rename. */
@@ -138,6 +146,7 @@ const SITES: ReadonlyArray<readonly [name: string, site: UnionMessageSite]> = [
     door: GuardRefSchema,
     reject: { parms: { a: 1 } },
     key: 'parms',
+    keyInMessage: '`parms`',
     surface: 'this guard reference',
     rename: 'params',
     acceptString: 'isManager',
@@ -148,6 +157,7 @@ const SITES: ReadonlyArray<readonly [name: string, site: UnionMessageSite]> = [
     door: StateNodeSchema,
     reject: { on: { GO: { guard: 'isX', actions: 'not-an-array' } } },
     key: 'guard',
+    keyInMessage: '`guard`',
     surface: 'this state transition',
     rename: 'cond',
     acceptString: { on: { GO: 'next' } },
@@ -159,6 +169,7 @@ const SITES: ReadonlyArray<readonly [name: string, site: UnionMessageSite]> = [
     reject: { id: 'machine', initial: 'idle', states: { idle: { initial: 'a', states: {} } },
       on: { GO: { guard: 'isX', actions: 'not-an-array' } } },
     key: 'guard',
+    keyInMessage: '`guard`',
     surface: 'this state transition',
     rename: 'cond',
     acceptString: { id: 'machine', initial: 'idle', states: { idle: { initial: 'a', states: {} } },
@@ -169,12 +180,13 @@ const SITES: ReadonlyArray<readonly [name: string, site: UnionMessageSite]> = [
   ['Approval.decisionOutputs — a declared decision output', {
     site: 'automation/approval.zod.ts:791',
     door: ApprovalNodeConfigSchema,
-    reject: { approvers: [{ type: 'user', users: ['u1'] }], decisionOutputs: [{ widget: 'user' }] },
+    reject: { approvers: [{ type: 'user', value: 'u1' }], decisionOutputs: [{ widget: 'user' }] },
     key: 'widget',
+    keyInMessage: '`widget`',
     surface: 'this decision-output declaration',
     rename: 'type',
-    acceptString: { approvers: [{ type: 'user', users: ['u1'] }], decisionOutputs: ['comment'] },
-    acceptObject: { approvers: [{ type: 'user', users: ['u1'] }],
+    acceptString: { approvers: [{ type: 'user', value: 'u1' }], decisionOutputs: ['comment'] },
+    acceptObject: { approvers: [{ type: 'user', value: 'u1' }],
       decisionOutputs: [{ key: 'comment', type: 'text' }] },
   }],
   ['FlowFunctionEntry — a `functions` map entry', {
@@ -182,6 +194,7 @@ const SITES: ReadonlyArray<readonly [name: string, site: UnionMessageSite]> = [
     door: FlowFunctionEntrySchema,
     reject: { efect: 'pure' },
     key: 'efect',
+    keyInMessage: '`efect`',
     surface: 'this `functions` entry',
     rename: 'effect',
     acceptString: 'scoreLead',
@@ -190,28 +203,31 @@ const SITES: ReadonlyArray<readonly [name: string, site: UnionMessageSite]> = [
   ['Field.lookupColumns — an explicit record-picker column', {
     site: 'data/field.zod.ts:1438',
     door: FieldSchema,
-    reject: { name: 'owner', type: 'lookup', lookupColumns: [{ name: 'amount' }] },
+    reject: { name: 'owner', type: 'lookup', reference: 'account', lookupColumns: [{ name: 'amount' }] },
     key: 'name',
+    keyInMessage: '`name`',
     surface: 'this lookup column',
     rename: 'field',
-    acceptString: { name: 'owner', type: 'lookup', lookupColumns: ['amount'] },
-    acceptObject: { name: 'owner', type: 'lookup', lookupColumns: [{ field: 'amount' }] },
+    acceptString: { name: 'owner', type: 'lookup', reference: 'account', lookupColumns: ['amount'] },
+    acceptObject: { name: 'owner', type: 'lookup', reference: 'account', lookupColumns: [{ field: 'amount' }] },
   }],
   ['Field.dependsOn — a dependent-picker binding', {
     site: 'data/field.zod.ts:1464',
     door: FieldSchema,
-    reject: { name: 'owner', type: 'lookup', dependsOn: [{ local: 'account' }] },
+    reject: { name: 'owner', type: 'lookup', reference: 'account', dependsOn: [{ local: 'account' }] },
     key: 'local',
+    keyInMessage: '`local`',
     surface: 'this dependsOn entry',
     rename: 'field',
-    acceptString: { name: 'owner', type: 'lookup', dependsOn: ['account'] },
-    acceptObject: { name: 'owner', type: 'lookup', dependsOn: [{ field: 'account' }] },
+    acceptString: { name: 'owner', type: 'lookup', reference: 'account', dependsOn: ['account'] },
+    acceptObject: { name: 'owner', type: 'lookup', reference: 'account', dependsOn: [{ field: 'account' }] },
   }],
   ['ChartGroupBy — the structured category axis', {
     site: 'ui/chart.zod.ts:767',
     door: ChartGroupBySchema,
     reject: { granularity: 'day' },
     key: 'granularity',
+    keyInMessage: '`granularity`',
     surface: 'this chart groupBy',
     rename: 'dateGranularity',
     acceptString: 'created_at',
@@ -222,6 +238,7 @@ const SITES: ReadonlyArray<readonly [name: string, site: UnionMessageSite]> = [
     door: RecordHighlightsProps,
     reject: { fields: [{ field: 'status' }] },
     key: 'field',
+    keyInMessage: '`field`',
     surface: 'this `record:highlights` field',
     rename: 'name',
     acceptString: { fields: ['status'] },
@@ -232,6 +249,7 @@ const SITES: ReadonlyArray<readonly [name: string, site: UnionMessageSite]> = [
     door: GanttQuickFilterSchema,
     reject: { field: 'stage', options: [{ title: 'Won' }] },
     key: 'title',
+    keyInMessage: '`title`',
     surface: 'this gantt quick-filter option',
     rename: 'label',
     acceptString: { field: 'stage', options: ['won'] },
@@ -243,6 +261,7 @@ const SITES: ReadonlyArray<readonly [name: string, site: UnionMessageSite]> = [
     reject: { startDateField: 's', endDateField: 'e', titleField: 't',
       tooltipFields: [{ name: 'amount' }] },
     key: 'name',
+    keyInMessage: '`name`',
     surface: 'this gantt tooltip field',
     rename: 'field',
     acceptString: { startDateField: 's', endDateField: 'e', titleField: 't',
@@ -259,6 +278,7 @@ const SITES: ReadonlyArray<readonly [name: string, site: UnionMessageSite]> = [
       lifecycle: { class: 'audit', retention: { maxAge: '30d',
         onlyWhen: { status: { $in: ['closed'], bogusKey: 1 } } } } },
     key: 'bogusKey',
+    keyInMessage: 'Unrecognized key: "bogusKey"',
     surface: null,
     rename: null,
     acceptString: { name: 'lead', label: 'Lead', fields: { a: { type: 'text', label: 'A' } },
@@ -286,7 +306,7 @@ describe('[#15423] the AUTHOR-VISIBLE message at a string-or-object union site',
       // The key the author actually mistyped. This is the assertion #14722
       // believed would fail — the "keyless `Invalid input`" claim.
       expect(rendered, `${site.site}: the undeclared key must reach the author`)
-        .toContain(`\`${site.key}\``);
+        .toContain(site.keyInMessage);
 
       // The named authoring surface, so the author knows WHICH shape refused.
       if (site.surface !== null) {
@@ -333,7 +353,7 @@ describe('[#15423] the AUTHOR-VISIBLE message at a string-or-object union site',
       const rendered = formatZodError(
         (result as unknown as { error: Parameters<typeof formatZodError>[0] }).error,
       );
-      expect(rendered).toContain(`\`${site.key}\``);
+      expect(rendered).toContain(site.keyInMessage);
 
       // ⛔ The string arm's complaint is a KIND mismatch, never a prescription,
       // and `selectUnionBranches` drops it. Rendering it is the "N branches, N


### PR DESCRIPTION
Fixes #15423.

Clause-②: no — this PR adds pins to existing behaviour. No accept set moves, no authorable key is added, no schema is touched. Re-derived from what it ships, not inherited: the diff is one `*.test.ts` file, and the accept side is asserted unmoved at all 12 sites (pin 3 below).

> **Revision 3 — after a narrow re-read returned PASS WITH FINDINGS.** The population question is settled: a **third** method (walking the *built zod graph at runtime* — 65 modules, 11,729 nodes, 178 defs, reading closure and curation from the message zod actually emits) found **39 string-or-object defs and exactly 15 closed arms, mapping one-to-one onto the 14 A + 1 B here, with no closed arm outside them**. Revision 3 fixes the one remaining must-fix and takes one filed card as a declared increment. Changes marked ⟳.
>
> **Revision 2 — after a `CONTRACT_REVIEW_TIER` review returned FAIL.** An independent re-derivation by a *different method* found **one site this PR's first pass dropped**, `ui/view.zod.ts:2895`. It is now enumerated, classified by behaviour, and pinned; the population reads **32**, not 31. The three must-fixes are addressed below and the corrections are marked ⟲. The earlier claim "Nothing was quietly narrowed" was **false by one site** — that is now true as written, and the section below says how the scan was wrong rather than quietly restating a new number.

## Summary

The card asked which string-or-object union sites lack a pin on their **author-visible** message, and for the missing pins in the shape PR #14975 used for `devPlugins`.

**Population enumerated mechanically, pins added, exclusions declared.** One new file, `packages/spec/src/shared/union-author-message-pins.test.ts`; nothing else in the tree changes.

⭐ **Every message this PR asserts was measured before it was written, and every one of them was already correct.** No site was found whose author-visible message is wrong, so nothing is repaired here — the deliverable is coverage. Had one been wrong, it would have been reported rather than fixed, per the card.

## The population, and the command that produced it

⛔ Not a hand-built list. Every `z.union([...])` call in `packages/spec/src` was parsed with the TypeScript compiler API and its arms classified, resolving named arms through the tree's own declarations and through `lazySchema()` / `strictObject()` / function declarations. A site qualifies when one arm resolves to `z.string()` and another to an object schema.

```
files scanned:                 1384
z.union([...]) array sites:    166
STRING-or-OBJECT sites:        39   (production 32 / test fixtures 7)

A  CLOSED + CURATED arm (surface + rename in the message):      14
B  CLOSED, uncurated arm (zod default message, no surface):      1
C  open object arm (unknown keys stripped; no refusal to pin):   17

=== CONTROL: sites with ANY unresolved arm (each could hide a match): 0 ===
```

### ⟲ Must-fix 1 — the site the first pass dropped, and why a lit control did not catch it

The first pass read **31**. It resolved `lazySchema(() => ...)` only when the arrow body was an **expression**, so `FormFieldBaseSchema` — whose `lazySchema` arrow has a **block** body — fell out as unclassifiable rather than as an object, and `ui/view.zod.ts:2895` (`FormSectionSchema.fields`) never entered the population. Its unresolved-arm control was zero the whole time, because the arm did resolve to *something*; it was just the wrong something. ⛔ A cleared control proves the scan resolved every arm, never that it resolved them correctly — and one scanner agreeing with itself across three merge bases is not independent evidence.

Two scanner bugs were fixed and the population re-derived: block-bodied arrow resolution, and `.strict()` applied to the **arm expression** (an identifier root recursed into the declaration and lost the outer `.strict()`). The diff between the old and new scans is exactly one site — no second site of that shape exists.

**It is class A by behaviour, which no arm-syntax classifier gets right.** Curation and closure are independent: `FormFieldBaseSchema` takes a `strictObjectError({ surface: 'this form field', ... })` map *without* closing the shape (#6619), and `FormFieldSchema` closes it a level up with a plain `.strict()`. Measured through `FormSectionSchema`, and again through the real author door `FormViewSchema` at `sections.0.fields.0`:

```text
  ✗ fields.0: Invalid input
    ✗ fields.0: Unrecognized key(s) on this form field: `visibleWhenn`, `bogus`.
  • If this is the conditional-visibility predicate, the canonical key is `visibleWhen` (ADR-0089) ...
```

Surface *and* rename, riding the union descent — the full class-A shape. `strictObjectError(` has exactly **one** call site in the tree, so this pair has exactly one member today. The scanner is now curation-aware and its syntax verdict agrees with the measured behaviour.

⭐ **And it was in the `devPlugins` state precisely.** `ui/view.test.ts:3785-3803` probes `FormFieldSchema` directly and reads the raw issue — a raw-shape pin. Under the ablation below, that pin sits **green** while the new rendered pin goes red. The card's own failure mode, found inside the fix for it.

**The lit control is the scan's own unresolved count.** A zero from a scan that resolves nothing is not an absence, so the control was watched while it was cleared: it read **46** on the first pass — including, tellingly, the known `devPlugins` site — and fell **46 → 2 → 0** as the resolver learned `lazySchema()`, `strictObject()` and function declarations. The final zero is therefore a measured absence, not a scan that saw nothing.

The reading is anchored to `ad715aca57` (this branch's point of departure) and was re-derived byte-for-byte unchanged after each of the two later merges of `main`, so it is not an artifact of one snapshot.

The seat's pre-measurement said "z.union across 66 files" — that is the file count, and it holds; the site count is 166, of which **32** qualify.

## What was pinned — 12 sites, three pins each

The three pins mirror PR #14975 exactly; ⛔ no second convention was invented for a sibling. That PR's pins were read first, and the same three questions are asked at every row:

1. **the rendered message names the key, the surface and the rename** — read through `formatZodError`, the real author-facing door, not the raw issue tree;
2. **branch selection is structural, not an accident of one fixture** — every fixture gives the object branch MORE THAN ONE issue (asserted, so a fixture cannot silently decay to a single-issue one), and the string arm's `expected string, received object` kind mismatch must NOT be rendered;
3. **the accept side is unmoved** — a bare string entry and a legal object entry both still parse.

| site | door | key | rename |
|---|---|---|---|
| `automation/state-machine.zod.ts:120` | `GuardRefSchema` | `parms` | → `params` |
| `automation/state-machine.zod.ts:231` | `StateNodeSchema.on` | `guard` | → `cond` |
| `automation/state-machine.zod.ts:292` | `StateMachineSchema.on` | `guard` | → `cond` |
| `automation/approval.zod.ts:791` | `ApprovalNodeConfigSchema.decisionOutputs` | `widget` | → `type` |
| `automation/flow-function.zod.ts:252` | `FlowFunctionEntrySchema` | `efect` | → `effect` |
| `data/field.zod.ts:1438` | `FieldSchema.lookupColumns` | `name` | → `field` |
| `data/field.zod.ts:1464` | `FieldSchema.dependsOn` | `local` | → `field` |
| `ui/chart.zod.ts:767` | `ChartGroupBySchema` | `granularity` | → `dateGranularity` |
| `ui/component.zod.ts:1181` | `RecordHighlightsField` | `field` | → `name` |
| `ui/view.zod.ts:1379` | `GanttQuickFilterSchema.options` | `title` | → `label` |
| `ui/view.zod.ts:1439` | `GanttConfigSchema.tooltipFields` | `name` | → `field` |
| `data/object.zod.ts:855` | `lifecycleOnlyWhenSchema` (class B) | `bogusKey` | none — see below |
| ⟲ `ui/view.zod.ts:2895` | `FormSectionSchema.fields` | `visibleWhenn` | ADR-0089 bullet |

⟲ The rename is asserted from a **literal per row**, no longer built from a `` `key` → `target` `` template. The template silently assumed one rendering; `ui/view.zod.ts:2895` prescribes its rename as an ADR-0089 **bullet** and carries no arrow at all, so a template would have forced that row to declare `rename: null` and drop a real prescription out of the pin — green, and measuring less than it claimed.

⭐ **The split the card predicted turned up again, twice.** `RecordHighlightsField` and `ActionRef`/`GuardRef` each already carried a careful **raw-shape** pin, and none of them carried a rendered-message one — exactly the state `devPlugins` was in. `ActionRef` alone had a rendered pin (the CONTROL case in `automation/state-machine.test.ts`); its sibling `GuardRef` shares the `it.each` table for the raw half but is NOT passed through `formatZodError` there, so it was uncovered. That asymmetry is now closed.

## Sites deliberately NOT pinned, and why

A population with declared exclusions is a measurement; a silent subset is not.

**⟲ Must-fix 2 — Class C: 17 sites, excluded, and the earlier reason for excluding them was false.** The old text said "no refusal is raised at all ... there is no author-visible message at them to regress." The first half is right — an **undeclared** key is stripped (`GroupByNodeSchema` and `BookNodeSchema` both accept a bogus key and parse it away, against the lit control `ChartGroupBySchema`, closed, which refuses and names the surface). ⛔ The second half is wrong. A wrong-typed or bad-enum **declared** key at a class-C site IS refused and IS rendered through this very descent — measured: `GroupByNodeSchema.safeParse({ field: 123 })` renders `✗ (root): Invalid input` then `✗ field: Invalid input: expected string, received number` with the string arm dropped; `{ dateGranularity: 'fortnight' }` and `ExpressionInputSchema` `{ dialect: 'cel', source: 5 }` behave the same.

The true claim, and the one the file now makes: these 17 have **no curated unknown-key prose to pin** — no surface phrase and no rename — so the pin shape this file applies has nothing to assert at them. Their rendered half is covered **generically** rather than per site, by `shared/error-map.test.ts` (`:226` nests a union inside a union with open `z.object` arms; `:307-329` walks four open-armed levels), which exercises the same descent on the same arm shape. Whether that generic coverage suffices, or whether these want per-site pins, is a scope question this PR does not settle. The scope choice was fine; certifying it with a false reason was not.

**⟲ Must-fix 3 — the 17 coordinates are now listed in the file header**, so the exclusion set is auditable without re-deriving it: `api/protocol.zod.ts:2853` · `data/data-engine.zod.ts:140` · `data/field-value.zod.ts:459` · `data/field-value.zod.ts:555` · `data/filter.zod.ts:405` · `data/query.zod.ts:200` · `data/query.zod.ts:537` · `shared/expression.zod.ts:178` · `shared/expression.zod.ts:242` · `shared/expression.zod.ts:349` · `shared/expression.zod.ts:384` · `system/book.zod.ts:31` · `system/book.zod.ts:48` · `system/metrics.zod.ts:430` · `system/tracing.zod.ts:347` · `ui/action.zod.ts:825` · `ui/component.zod.ts:1593`. A count and a class is not a report of what was deliberately not pinned.

**Class A — 2 of 14 already covered, not duplicated.** `devPlugins` by PR #14975's own file (`kernel/manifest-unknown-keys.test.ts`), `ActionRef` by `automation/state-machine.test.ts`.

**Class B — 1 site, pinned on the half it has.** `lifecycleOnlyWhenSchema` closes its two object arms with plain zod `.strict()` and carries no error map, so its refusal names the key and the path but no surface and no rename — `Unrecognized key: "bogusKey"`, zod's own wording. It rides the same union descent, so it is pinned on the key half. The message SPELLING is pinned per class (backticks for curated refusals, double quotes for zod's), so a row cannot pass on a message that merely contains the right letters.

So: **32** found, **15** have an unknown-key refusal to lose (14 class A + 1 class B), 2 of those were already covered elsewhere, **13 pinned here**, 17 excluded on the corrected reason above. `expect(SITES).toHaveLength(13)` certifies that population — which is exactly why the first pass getting it wrong mattered: at 12 it asserted, greenly and forever, that `ui/view.zod.ts:2895` was not a member.

## ⟳ Revision 3 — the self-contradiction, and a pin that could not fail

**⟳ Must-fix — the retracted sentence survived in the test body.** Revision 2 corrected the class-C reason in the header but left the CONTROL test 400 lines below still titled "a class-C (open) arm raises no refusal at all" and still saying "there is no author-visible message at that site to pin or to regress" — the exact sentence the header now calls untrue. The file asserted X in one place and not-X in another. Both now carry the header's narrow claim: no **unknown-key** refusal, no curated prose to pin, and a wrong-typed or bad-enum *declared* key IS refused and IS rendered through the same descent. Swept the whole file for the retracted phrasing; the only surviving occurrence is the narrow one.

**⟳ Declared increment — pin 2's `> 1` check was vacuous, and that is this card's own subject matter.** The clause counted `(union.errors ?? []).flat().length > 1` — every branch summed together. At a string-or-object site the string arm always contributes exactly one `invalid_type`, so the bound held however few issues the object arm raised. A pin that could not fail, certifying a structural property nobody had measured, inside the file written to stop exactly that.

⚠️ **Measured across all 13 rows rather than fixing only the row the reviewer probed** — and the answer is narrower than "vacuous at every two-arm site". With the clause counting the branch `selectUnionBranches` really picks, **11 of 13 rows already satisfied the claim**; exactly **two** did not:

| row | per-branch codes | selected-branch issues |
|---|---|---|
| `ui/view.zod.ts:2895` (added in rev 2) | `[["invalid_type"],["unrecognized_keys"]]` | 1 |
| `data/object.zod.ts:855` (class B) | `[["invalid_type"]×3,["unrecognized_keys"],["invalid_type","unrecognized_keys"]]` | 1 |

So the *clause* was vacuous everywhere, but the *fixtures* were honest at 11 of 13. `ui/view.zod.ts:2895`'s fixture now omits the required `field`, giving its object branch a genuine second issue (`[["invalid_type"],["invalid_type","unrecognized_keys"]]`).

**⟳ The fix is stronger than the bound it replaces.** Each row now DECLARES `selectedBranchIssues` and the count is asserted **exactly**, against the branch the policy actually selects — an exact count cannot be satisfied by an unrelated arm, and it fails in *either* direction when a fixture stops measuring what its row claims. Pin 2 additionally asserts the selected branch is the object arm (it carries `unrecognized_keys`), so a two-issue string arm could not stand in for it.

`data/object.zod.ts:855` declares **1**, with the reason at the row: its `$in` arm wins the fewest-issues tiebreak with a lone `unrecognized_keys`, so it cannot discriminate "the *whole* selected branch is rendered". Re-ordering that fixture is a separate open card and is ⛔ not done here — the count is declared so the gap is **visible instead of silent**, and a table-level assertion pins that exactly one row may carry the exemption and names which, so it cannot spread by copy-paste.

⟳ The header claims the bug made false — "every fixture gives the object branch MORE THAN ONE issue" and the `reject` doc — are corrected to describe what is actually asserted.

## Ablation — the whole point, since every deliverable is a pin

⟳ **Revision 3 ran two mutations, and one prediction was wrong — reported as observed, not as predicted.**

**MUT1** (the renderer's union descent forced empty). Predicted **unchanged at 27 red / 14 green**, on the reasoning that pin 2's new clauses call `selectUnionBranches` *directly* from the policy module, which MUT1 does not touch — they were renderer-independent before the change too. **Observed exactly that: `Tests 27 failed | 14 passed (41)`.** (Revision 1 was 25/13 of 38; revision 2's 27/14 was reproduced independently by the reviewer.)

**MUT4** (new — the *policy* stops ranking: `isKindMismatchOnly` filtering removed, every branch informative). This one targets the clauses MUT1 cannot reach. Predicted **13 red / 28 green** — pin 2 red at all 13, pin 1 green because the prescription would still be rendered.

⚠️ **Observed `Tests 24 failed | 17 passed (41)` — the prediction was wrong, and wrong in the informative direction.** Pin 1 reddened too (12 rows), which I had predicted would stay green. The mechanism: with kind-mismatch branches no longer dropped, the string arm (one issue, no unknown keys) ranks **best** on fewest-issues, so the object branch is not tied at the top and is never selected at all — the prescription is not rendered, so pin 1 fails alongside pin 2. Removing that filter does not add noise beside the prescription; it *replaces* the prescription with noise.

And **12 of 13, not 13**: the survivor is `data/object.zod.ts:855`, the row that declares `selectedBranchIssues: 1`. Its `$in` arm carries a lone `unrecognized_keys`, so it still wins the unknown-key tiebreak even unranked. ⇒ The exemption that row declares is now **demonstrated** rather than asserted — the one row that says it cannot discriminate is precisely the one that does not move.

The new row is shown to be capable of failing — ⛔ a row that cannot go red is the thing this card exists to prevent:

- the `FormSection.fields` row reddens on **both** pin 1 and pin 2;
- **zero** pin-1/pin-2 rows stayed green across all 13 sites, so every rendered pin discriminates.

The discrimination proof, in the same ablated run:

- `src/ui/view.test.ts` + `src/ui/component.test.ts` — **652/652 green, 0 failures.** `view.test.ts:3785-3803` is the pre-existing **raw-shape** pin for the newly added site, and `component.test.ts` carries `RecordHighlightsField`'s. Both sat green through a mutation that reddens 27 rendered pins — the split, demonstrated at the very site the review found.
- `src/kernel/manifest-unknown-keys.test.ts` — 6 failed / 21 passed (revision 1). All failures rendered-message pins; the `devPlugins` **raw-shape** pin directly above them stayed green.

⛔ No pin stayed green under a mutation that should break it. The 14 that stayed green are pin 3 and the table-length check, which do not read the renderer and are not claimed to.

Mechanics, per the bar:

- Mutation proven **on disk by occurrence counts**, never from an editor's exit code: anchor `const { selected, omitted } = selectUnionBranches` 1 → 0, injected marker 0 → 1, and `git diff --stat` non-empty (`1 file changed, 3 insertions(+), 1 deletion(-)`). The script refuses to proceed unless both counts land.
- Restore via `git checkout HEAD -- ABSOLUTE_PATH` under an `EXIT/INT/TERM` trap seeded from `git rev-parse --show-toplevel`, ⛔ never a bare `git checkout --`. Restoration proven by **blob equality against HEAD** — `8410fd41adca09eacb2f9d6cd88e5d8a4309b203` — plus `git diff HEAD` empty; an empty hash is treated as failure, not as nothing to compare. `git status --porcelain` is clean and nothing from the ablation is on this branch.
- The mutation needs no rebuild to take effect: the test imports `./error-map.zod` relatively, inside the same package, so it resolves to source and not through `dist`.

## Verification

Heavy runs through `scripts/pm/os-verify-lock.sh`; verdicts quoted from its own `VERDICT command-exit` line, never a bare `$?` and never read through a pipe.

- `pnpm --filter @objectstack/spec test` + `typecheck` — `VERDICT command-exit 0`, **473 files / 13406 tests passed** (revision 1); `typecheck` re-run green at revision 2, test-layer debt unchanged at 54 files / 259 errors.
- ⟳ The new file plus **four** neighbouring pin files at the final head `ba6e361e6f` — `VERDICT command-exit 0`, **5 files / 738 tests passed** (41 new). Pins file + `ui/view.test.ts` + `ui/component.test.ts` alone: **693/693**, matching the reviewer's own baseline count.
- ⟳ `typecheck` green at revision 3; test-layer debt unchanged at 54 files / 259 errors, so none of the revision-3 edits adds one.
- ⟳ Gate families re-derived at revision 3 and **byte-identical** to revisions 1 and 2 (same single changed path); all 76 re-run: 74 green, the same 2 NOT-MEASURED at exit 3.
- `pnpm --filter '@objectstack/spec^...' build && pnpm --filter @objectstack/spec build` — `VERDICT command-exit 0`.
- The new file is genuinely in the typecheck program rather than green over source nothing read: `tsc -p tsconfig.test.json --listFiles` reports **1** hit for it, against a lit control (`shared/error-map.zod.ts`, 1) and a negative control (0). It contributes **0** of the 259 ledgered test-layer errors, and `check:test-typecheck` exits 0.

**Gate families derived on the actual diff** — ⛔ no hand-built path list — with `node scripts/pm/dispatch-gates.mjs --commands --repo objectstack-ai/objectstack`, then reconciled with `--ran`:

```
✓ dispatch-gates --ran: 76 derived family(ies) accounted for
  — 74 run, 2 NOT-MEASURED (2 DERIVED from a recorded exit 3).
```

Exit codes were captured **before** any pipe and recorded per family as `COMMAND :: exit CODE`, so the NOT-MEASURED count is derived from the record rather than claimed by the runner. ⟲ Re-derived at revision 2: the changed-path set is the same single file, so the family set is byte-identical to revision 1's, and all 76 were re-run at the new head.

⚠️ ⟲ On the first re-run in the fresh revision-2 worktree, four spec gates exited **1** — `check:api-surface`, `check:browser-reachable-entries`, `check:dual-source-exports`, `check:entry-nameability`. Judged by substance rather than by the code, every one was refusing its own prerequisite: `packages/spec/dist` did not exist in that worktree, and each says so in its own words ("holds no `.d.ts` declarations — the package is not built ... a verdict now would be ... a FALSE GREEN"). ⛔ Not findings, and ⛔ not reportable as failing checks. `packages/spec` was built and all four then ran **green**. A prerequisite refusal does not always arrive as exit 3.

The two NOT-MEASURED are `check:dual-build-cjs-loads` and `check:type-check-debt`. Both print their own `PREREQUISITE NOT MET` and exit 3, and both need the **whole workspace** built (87 packages / 31 dependency closures respectively). ⛔ Recorded as NOT MEASURED — not as a red, and not as a pass. Judged by substance and not only by the code, as the bar requires: each names the missing `dist/` directories and says in its own words that nothing was measured. Four gates initially refused this way; two of them (`check:doc-formula-expressions`, `check:lean-entry-closure`) had cheap prerequisites, so `@objectstack/formula`, `@objectstack/lint` and `@objectstack/objectql` were built and both then ran **green** rather than being left unmeasured. CI builds fresh and measures the remaining two.

## Changeset — measured, not assumed

**None owed; `skip-changeset` applied.** The claim comment declined to assert this either way and asked for a measurement, so here it is, taken from the package's real publish instrument rather than by reading the whitelist:

```
npm pack --dry-run --json   (packages/spec)
  total files in the published tarball:   2011
  the new file:                           ABSENT
  any .test.ts at all:                    none
  LIT CONTROL src/**/*.zod.ts is shipped: ['src/shared/error-map.zod.ts']
```

`packages/spec`'s `files[]` admits `src/**/*.zod.ts`, so a source change here really would publish — that is the lit control, and it is why "test-only" could not be assumed. The diff is one `*.test.ts`, which the tarball excludes, so nothing released moves. `pnpm check:published-files` agrees, green.

## ⟲ Review record

A `CONTRACT_REVIEW_TIER` review of revision 1 returned **FAIL** on one substantive finding — the dropped site — plus two accuracy defects in the file header. All three are addressed above. The review independently confirmed, and this revision does not redo: the 166-site total, the class-A coordinates, the class-C count, the `46 → 0` control, `skip-changeset` (both the source-side `npm pack` half and the `dist` graph half), and revision 1's ablation numbers reproduced exactly, plus two further mutations of the reviewer's own.

Three findings the review filed as **cards or nits rather than blockers**, deliberately not acted on here: per-site rendered pins for class-C non-unknown-key refusals; re-ordering the class-B fixture so pin 2's whole-branch claim discriminates (the reviewer's MUT2 found that row green because its `unrecognized_keys` issue happens to be the branch's first issue — it does redden under MUT1, so it measures the rendered half, just not the whole-branch half); and the standing population guard. ⛔ None was decided unilaterally.

The header line that read as an enforced rule ("adding a string-or-object union ... adds a row here") is corrected to say the opposite plainly: nothing mechanically holds the table equal to the tree, `toHaveLength` pins the snapshot rather than the derivation, and the standing guard that would fix it is left to its own card rather than implied to exist.

## Acceptance notes — noted, not filed

- `packages/spec/src/ui/component.zod.ts:1179` points at a pin file that **does not exist**: it says `component-props-union-arm.test.ts` "pins it from this side", and that filename occurs exactly once in the repository — in that comment — and nowhere on disk. Lit controls: `state-machine.test.ts` and `view-union-diagnostics.test.ts` are each referenced the same way from a `.zod.ts` and each exist. It is a comment asserting a guard that was never there, which is a small instance of exactly what this card is about; the guard it describes now genuinely exists, as the `RecordHighlightsField` row of the new file. Not fixed here on purpose: `component.zod.ts` is a published file (`src/**/*.zod.ts`), so editing it would move this diff from "publishes nothing" to "publishes", trade the clean changeset measurement above for a judgement call, and put a prose edit inside a coverage diff. **Carrier: the next PR touching `component.zod.ts`.** Not filed as a card — it is neither a reproducible defect, nor a contract violation, nor a metadata-authoring trap.
- `StateNodeSchema.on` and `StateMachineSchema.on` are two textually duplicated `z.union([z.string(), TransitionSchema, z.array(TransitionSchema)])` expressions at two doors. Both are population members and both are pinned; whether the duplication should be one shared constant is a shape question this coverage PR deliberately does not open.
- A standing guard that re-derives the population from the tree and fails when a new string-or-object union with a closed arm appears unpinned would keep this gap from reopening. It is real machinery and a different card; this PR pins today's population and states the number instead.

## What is NOT here

⛔ No schema is reshaped — PR #14975 settled that question and this card explicitly is not a re-opening of it. `union-branch-policy.ts`, `ManifestSchema` and `formatZodError` are all untouched, and so is every `*.zod.ts` in the tree. ⛔ No behaviour changes. ⛔ `content/docs/releases/` untouched. Left as the maintainer's: ready-flip, enqueue, auto-merge, review.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MkQhmuuJAVDjmeWNixwDDH

---
_Generated by [Claude Code](https://claude.ai/code/session_01MkQhmuuJAVDjmeWNixwDDH)_


---
_Generated by [Claude Code](https://claude.ai/code)_