### PR TITLE
test(spec): correct the row-update positive control's data-API path

### DIFF
--- a/packages/spec/src/ui/action-row-update.test.ts
+++ b/packages/spec/src/ui/action-row-update.test.ts
@@ -153,7 +153,7 @@ describe('#14092 — `operation: \'update\'` + `patch` is accepted (the bulk def
 
   it('positive control — the api and script forms are untouched by the new refinements', () => {
     expect(ActionSchema.safeParse({
-      name: 'revoke', label: 'Revoke', type: 'api', target: '/api/v1/sys_api_key/{id}',
+      name: 'revoke', label: 'Revoke', type: 'api', target: '/api/v1/data/sys_api_key/${ctx.recordId}',
       method: 'PATCH', bodyExtra: { revoked: true }, recordIdParam: 'id',
     }).success).toBe(true);
     expect(ActionSchema.safeParse({ name: 'run', label: 'Run', target: 'runThing' }).success).toBe(true);


### PR DESCRIPTION
Fixes #15099

**Clause-②: no** — re-derived from what this ships, not inherited. The diff is one string literal inside a `.test.ts`. No accept set moves (`target` is `z.string().optional()` and `ActionSchema` is untouched), no authorable key is added or removed, no closed-set member, no published export, no registry entry. C5 widening tells: none.

## What changed

One line — `packages/spec/src/ui/action-row-update.test.ts:156`, the **positive control** of the row-level declarative-write suite:

```diff
-      name: 'revoke', label: 'Revoke', type: 'api', target: '/api/v1/sys_api_key/{id}',
+      name: 'revoke', label: 'Revoke', type: 'api', target: '/api/v1/data/sys_api_key/${ctx.recordId}',
```

Two things were wrong with the old spelling, and both are corrected:

1. **The `/data` segment.** The shipped data door is `PATCH {apiBase}/data/:object/:id` — `getApiBasePath()` composed with `crud.dataPrefix`, whose default is `/data` (`packages/spec/src/api/rest-server.zod.ts:312`). The fixture omitted it.
2. **The placeholder convention.** `target` documents `${param.X}` / `${ctx.X}` interpolation (`action.zod.ts:985-1003`); a bare `{id}` is `newTabUrl`'s convention and is never substituted here — the `method` docblock says so in as many words.

The new value is byte-identical in shape to the corrected twin at `packages/spec/src/ui/action.zod.ts:1403`, which PR #15098 landed.

## Direction

Taken from the newest triage comment, quoted rather than paraphrased:

> ⚠️ ⛔ Do not "fix" this by making the schema validate data-API paths. That would be a new refusal on a published schema, not this card. **Correct the control's spelling.**

The card's alternative — replace the value with something obviously illustrative — was **not** taken. That option was licensed only on a measurement that correcting the spelling is *actively misleading*, and the measurement says the opposite: after this change the fixture agrees byte-for-byte with its twin docblock at `action.zod.ts:1403`, and no source file under `packages/**` spells the pre-fix shape any more — the sole surviving occurrence is the `CHANGELOG.md` historical record. A reader grepping `sys_api_key` for a worked example now finds one answer instead of two.

## Premise, falsified on this branch's own merge base (`f721ef0ff2`)

Readings taken on the source tree at the merge base, before any build. Occurrence counts, not line counts — `grep -o ... | wc -l`, because `grep -c` counts lines and would have made these readings void.

| reading | measured |
|---|---|
| `/api/v1/sys_api_key` across `packages/**` before the fix | **2** — `action-row-update.test.ts:156` and `packages/spec/CHANGELOG.md:8775` |
| lit control on the same corpus, same command shape: `/api/v1/data/sys_api_key` | **12** occurrences across 7 files ⇒ the reading above is a reading, not an empty corpus |
| `sys_api_key` occurrences inside the edited file | **1** ⇒ one string, one site |
| `target`'s schema | `z.string().optional()` — no path validation |

`packages/spec/CHANGELOG.md:8775` is a historical record and is **not** rewritten. It is the only place the old spelling survives, and a changelog is true about the past.

## The ablation this card owed: the fixture is INERT to the assertion

Three legs, same command, same file, same suite. Every mutation and every restore proven **by state** — `git hash-object` against the HEAD blob and an empty `git diff HEAD` — never by an exit code. The mutating script carried `trap restore EXIT INT TERM` with an absolute path, and each mutation was confirmed on disk by an anchored `grep -c` of both the injected and the removed text before the run.

```
HEAD blob for packages/spec/src/ui/action-row-update.test.ts = 09871ea6859d4f7de5f25ab0e6467579c40da2cb

LEG 0  BASELINE at HEAD (the corrected fixture)
       on-disk hash 09871ea685... == HEAD blob
       Test Files  1 passed (1)      Tests  31 passed (31)          exit 0

LEG 1  ABLATION — target := 'ABSURD::::not-a-url::::@@@@/nowhere/{{{'
       anchor BEFORE: old=1 new=0   AFTER: old=0 new=1
       on-disk hash 4f9a15b689... != HEAD blob   (the mutation really landed)
       Test Files  1 passed (1)      Tests  31 passed (31)          exit 0   ⇒ INERT
       RESTORE PROVEN BY STATE: hash=09871ea685... == HEAD blob; git diff HEAD empty

LEG 2  LIT CONTROL — type: 'api' := 'NOT_AN_ACTION_TYPE' in the SAME test
       anchor BEFORE: old=1 new=0   AFTER: old=0 new=1
       on-disk hash 085f8a7edd... != HEAD blob
       × positive control — the api and script forms are untouched by the new refinements
       Test Files  1 failed (1)      Tests  1 failed | 30 passed (31)   exit 1   ⇒ CAN redden
       RESTORE PROVEN BY STATE: hash=09871ea685... == HEAD blob; git diff HEAD empty
```

Leg 1 paired with leg 2 is the proof: an absurd path leaves 31/31 green, while breaking a value the same test actually asserts reddens exactly that test. Nothing pins the path string, so the card's premise stands and this is a commit rather than a report. It is also why this sat unnoticed: a positive control teaches with the authority of a passing test, and this one could never have failed.

Both legs restored; the working tree is clean and no ablation artifact is committed.

## Changeset: measured, not asserted — `skip-changeset`

The card *argued* the fixture does not publish. Measured on the built package rather than inferred from the glob:

- `npm pack --dry-run --json` on a freshly built `@objectstack/spec` enumerates **2011** files. `src/ui/action-row-update.test.ts` is **absent**; so is every other `.test.ts` (0 of 2011).
- Lit control on that same enumeration: its published twin `src/ui/action.zod.ts` **is** present ⇒ the absence above is a reading, not an empty corpus.
- Content, not just filenames: a token unique to the edited file (`the api and script forms are untouched`) scores **0** occurrences across all 2011 published files, while a control token from published source (`Supports ${param.X} and ${ctx.X} interpolation`) scores **61** on the same corpus. No generated artifact — `json-schema`, `api-surface`, `spec-changes.json`, `llms.txt`, `prompts`, `liveness`, `dist` — re-authors the test file's content.
- The one published occurrence of the old spelling is `CHANGELOG.md`, the historical record this PR deliberately does not touch.

Nothing already published moves ⇒ no changeset.

## Verification

Run on the final commit `2b266a8ced`.

| check | result |
|---|---|
| `pnpm --filter @objectstack/spec exec vitest run --project local src/ui/action-row-update.test.ts` | 1 file / **31 tests** passed |
| `pnpm --filter @objectstack/spec test` | **472** test files / **13368** tests passed |
| `pnpm --filter @objectstack/spec typecheck` | exit 0 — all three legs (`tsc --noEmit`, `check:scripts-typecheck`, `check:test-typecheck`) |
| the edited file is really in the typecheck program | `tsc -p tsconfig.test.json --listFiles` names it **1x** (control: 126 `src/ui/` files in the same program) — so the typecheck above is not silently excluding it |
| `pnpm exec turbo run build --filter=@objectstack/spec --filter=@objectstack/formula --filter=@objectstack/lint` | 4/4 successful; wrote no tracked file |
| `pnpm lint` (repo-wide, `eslint . --no-inline-config`) | exit 0 — the full population, so no narrowing argument is needed |
| `pnpm check:nul-bytes` | OK — 8338 text files scanned, no raw control bytes |
| derived gate families (`scripts/pm/dispatch-gates.mjs --commands`) | **76** derived; `--ran` reconciles **71 run green, 5 NOT MEASURED, 0 unrun** |

The dependency-closure build (`@objectstack/spec^...`) is empty — `packages/spec` has no workspace dependencies — so that leg is vacuous here and the package was built directly instead.

**Declared to CI, NOT MEASURED locally (exit 3, `PREREQUISITE NOT MET`, each needs the whole repo built):** `check:dts-closure`, `check:dual-build-cjs-loads`, `check:lean-entry-closure`, `check:sourcemap-no-sources-content`, `check:type-check-debt`. Six further gates first read as non-zero for the same reason and are green after the build: `check:api-surface`, `check:browser-reachable-entries`, `check:dual-source-exports`, `check:entry-nameability`, `check:exported-any`, `check:doc-formula-expressions`. None is recorded as a red.

## 验收备注

Fences held. `ActionSchema` is untouched; `packages/spec/CHANGELOG.md` is untouched; the three sibling rounds' surfaces (`zod-issues-to-fields.ts`, `search-fields.ts`, `contracts/**`) are untouched. The live fence on this file was checked directly: the edit is the `target` literal in a `.success` positive control, not a union-branch author-visible message pin — the message-pinning assertions elsewhere in the file are unchanged.

No out-of-scope findings were filed. One observation, noted and deliberately not filed: `recordIdParam: 'id'` sits beside the corrected `target` in the same fixture and is equally inert to the assertion, but it is a separate key with its own meaning rather than part of the path, so correcting it was outside the licensed diff and there is no evidence it is wrong. Carrier if it ever matters: whichever PR next revisits this fixture — currently none.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MkQhmuuJAVDjmeWNixwDDH)_