### PR TITLE
fix(driver-turso): remote mode materializes every declared object-level index (#17609)

### DIFF
--- a/.changeset/driver-turso-remote-declared-indexes.md
+++ b/.changeset/driver-turso-remote-declared-indexes.md
@@ -1,0 +1,21 @@
+---
+'@objectstack/driver-turso': patch
+---
+
+fix(driver-turso): remote mode materializes every declared object-level index, not only field-level `unique` (#17609)
+
+## What was wrong
+
+In remote mode (`libsql://` / `https://`), `TursoDriver` provisions tables through `RemoteTransport`, and the only index DDL that path could emit came from field-level `unique`. An object's declared `indexes: [...]` — unique or not — had no consumer there, so no remote database ever carried one. The local face (`SqlDriver`) created all of them, so nothing failed and no local test noticed: on a remote tenant database `sys_notification_delivery` (five declared indexes) and `sys_job_queue` (three) held only their primary-key autoindex, and the delivery claim query answered every poll with a full table scan (`SCAN sys_notification_delivery` + `USE TEMP B-TREE FOR ORDER BY`).
+
+## What changes
+
+- Remote mode now creates **every** declared index: field-level `unique` plus the object's own `indexes`, unique and non-unique, including `unique: 'organization'` with its NULL-safe `COALESCE(<tenant>, '__global__')` key part. Names and keys come from the same shared normalizers `SqlDriver` and the drift differ use (`uniqueIndexesFromFields`, `normalizeDeclaredIndex`, `buildIndexName`), so both faces land the same index set — pinned by a new local/remote parity suite that compares `sqlite_master` on both.
+- New tables get their indexes in the same batch as `CREATE TABLE`.
+- **Existing tables are retrofitted on the next schema sync** with `CREATE [UNIQUE] INDEX IF NOT EXISTS`. No row is read-modified or rewritten.
+- An index the retrofit cannot create is reported once at `error`, naming the index, the table and the database's own cause. A declared `unique` index over rows that already violate it is **not** forced and no data is repaired: de-duplicate the key's values and re-run schema sync.
+- Steady-state cost goes down: a sync now reads the existing index names once (one statement, folded into the column-probe batch it already sends) and issues no index DDL when every declared index exists. Before, every boot re-sent one `CREATE UNIQUE INDEX IF NOT EXISTS` per field-level unique index on an existing table.
+
+## Upgrading
+
+Nothing to change in metadata or configuration. The first kernel build after upgrading creates the missing indexes on each existing remote database — on a large table that one build pays the index build time. Watch the boot log for `could not create the declared` lines at `error`: each names an index that is still absent and why.

--- a/packages/drivers/driver-turso/src/remote-transport-unsafe-identifier-envelope.test.ts
+++ b/packages/drivers/driver-turso/src/remote-transport-unsafe-identifier-envelope.test.ts
@@ -10,7 +10,7 @@
  * where an identifier is INLINED into SQL (SQLite cannot bind one): `object`,
  * `field` and the `groupBy` field / output key in `aggregate`, the table and
  * column names in `syncSchema` / `syncSchemasBatch` / `buildCreateTableSQL`,
- * and the index name and columns in `syncUniqueIndexes`. It threw a bare
+ * and the index name and columns in `buildDeclaredIndexDDL`. It threw a bare
  * `Error` — no `code`, no `status` — so `mapDataError`
  * (`packages/rest/src/error-response.ts`) reached none of its classifying
  * branches, fell through to its sanitised terminal and served a **500**. A

--- a/packages/drivers/driver-turso/src/remote-transport-unsafe-identifier-envelope.test.ts
+++ b/packages/drivers/driver-turso/src/remote-transport-unsafe-identifier-envelope.test.ts
@@ -10,7 +10,7 @@
  * where an identifier is INLINED into SQL (SQLite cannot bind one): `object`,
  * `field` and the `groupBy` field / output key in `aggregate`, the table and
  * column names in `syncSchema` / `syncSchemasBatch` / `buildCreateTableSQL`,
- * and the index name and columns in `buildDeclaredIndexDDL`. It threw a bare
+ * and the index key columns in `buildDeclaredIndexDDL`. It threw a bare
  * `Error` — no `code`, no `status` — so `mapDataError`
  * (`packages/rest/src/error-response.ts`) reached none of its classifying
  * branches, fell through to its sanitised terminal and served a **500**. A
@@ -57,9 +57,12 @@
  * a separate card and stays open. [#14235] That card has since landed: the
  * `groupBy` OUT KEY position is ESCAPED rather than refused now, so its case
  * below asserts the quoted emission instead of a refusal — every OTHER
- * position named above (`object`, `field`, the `groupBy` FIELD, the DDL table,
- * column and index names) is untouched and still refuses with this envelope,
- * and the accept-set `describe` below still drives the `groupBy` FIELD.
+ * position named above (`object`, `field`, the `groupBy` FIELD, the DDL table
+ * and column names, the index key columns) is untouched and still refuses with
+ * this envelope, and the accept-set `describe` below still drives the `groupBy`
+ * FIELD. [#17609] An author-declared index NAME moved the same way, for the
+ * same reason — escaped, not refused; pinned in
+ * `turso-local-remote-declared-index-parity.test.ts`.
  *
  * ## Reverse verification — direction predicted BEFORE it was run
  *

--- a/packages/drivers/driver-turso/src/remote-transport.ts
+++ b/packages/drivers/driver-turso/src/remote-transport.ts
@@ -46,9 +46,17 @@ import type { DriverQuery } from '@objectstack/spec/contracts';
 // face creates are byte-identical to the ones `SqlDriver` creates locally and
 // the ones the drift differ looks for, so the two faces cannot fork on what the
 // declaration meant (#6203, which this driver has already paid for twice).
+//
+// [#17609] …and what an object's declared `indexes: [...]` become, through the
+// same normalizer `SqlDriver.syncDeclaredIndexes` and the drift differ read
+// (`normalizeDeclaredIndex`). Until then only the field-level half above was
+// imported, so every object-level index — unique or not — had no consumer on
+// this face and never reached a remote database at all.
 import {
   uniqueIndexesFromFields,
+  normalizeDeclaredIndex,
   organizationKeyPartSql,
+  type DeclaredIndexInput,
   type ExpectedIndex,
 } from '@objectstack/driver-sql';
 import { nanoid } from 'nanoid';
@@ -62,6 +70,23 @@ const DEFAULT_ID_LENGTH = 16;
  * Columns created unconditionally by syncSchema — skip when iterating fields.
  */
 const BUILTIN_COLUMNS = new Set(['id', 'created_at', 'updated_at']);
+
+/**
+ * [#17609] Every index name the database already carries — ONE statement for a
+ * whole schema sync, read beside the column probe. SQLite index names are
+ * unique per database, so a name hit is the same "already exists" answer
+ * `SqlDriver.syncDeclaredIndexes` reads from its own per-table introspection;
+ * `IF NOT EXISTS` on the DDL still absorbs a concurrent creator.
+ */
+const EXISTING_INDEX_NAMES_SQL = `SELECT name FROM sqlite_master WHERE type='index'`;
+
+/** [#17609] One declared index, resolved to the DDL that materializes it. */
+interface PlannedIndex {
+  name: string;
+  table: string;
+  unique: boolean;
+  sql: string;
+}
 
 /**
  * Pattern for valid SQL identifiers (table and column names).
@@ -1142,16 +1167,21 @@ export class RemoteTransport {
    * `error` class, and routing it through the `warn` sink would file it under
    * exactly the level the rule exists to keep readable.
    *
-   * Absent, the degradation is not lost: {@link syncUniqueIndexes} still skips
-   * the index and the condition resurfaces as the enveloped refusal in
-   * {@link upsert}. `TursoDriver` wires this to `logger.error` at construction,
+   * [#17609] A declared NON-unique index that could not be created is the same
+   * class for the same reason: every query keeps answering, correctly, while
+   * each one scans the table — nothing is visibly wrong, and the cost arrives
+   * as read volume.
+   *
+   * Absent, the degradation is not lost: {@link retrofitDeclaredIndexes} still
+   * skips the index, and a missing UNIQUE resurfaces as the enveloped refusal
+   * in {@link upsert}. `TursoDriver` wires this to `logger.error` at construction,
    * the same way it wires the connect factory and the temporal column rule.
    */
   private durabilitySink: ((message: string) => void) | null = null;
 
   /**
-   * Register where this transport reports a declared constraint it could not
-   * materialize (#8413). See {@link durabilitySink} for why it is not the
+   * Register where this transport reports a declared index it could not
+   * materialize (#8413, #17609). See {@link durabilitySink} for why it is not the
    * diagnostic sink.
    */
   setDurabilitySink(sink: (message: string) => void): void {
@@ -1822,7 +1852,7 @@ export class RemoteTransport {
   async syncSchema(object: string, schema: any): Promise<void> {
     await this.ensureConnected();
 
-    const objectDef = schema as { name: string; fields?: Record<string, any> };
+    const objectDef = schema as { name: string; fields?: Record<string, any>; indexes?: unknown };
     const tableName = object;
     this.assertSafeIdentifier(tableName);
 
@@ -1835,11 +1865,11 @@ export class RemoteTransport {
 
     if (!exists) {
       await this.client!.execute(this.buildCreateTableSQL(tableName, objectDef));
-      // [#8413] The table was created empty microseconds ago, so its unique
-      // indexes cannot fail on existing data — no isolation needed, and any
-      // error here is a real DDL fault that should surface.
-      for (const sql of this.buildUniqueIndexDDL(tableName, objectDef, this.materializedColumns(objectDef))) {
-        await this.client!.execute(sql);
+      // [#8413 · #17609] The table was created empty microseconds ago, so its
+      // declared indexes cannot fail on existing data — no isolation needed,
+      // and any error here is a real DDL fault that should surface.
+      for (const index of this.buildDeclaredIndexDDL(tableName, objectDef, this.materializedColumns(objectDef))) {
+        await this.client!.execute(index.sql);
       }
     } else {
       // ALTER TABLE — add missing columns
@@ -1862,10 +1892,15 @@ export class RemoteTransport {
           materialized.add(name);
         }
       }
-      // [#8413] The retrofit leg — this table may already hold the duplicates
-      // the missing constraint admitted, so it is isolated and reported, never
-      // forced. See {@link syncUniqueIndexes}.
-      await this.syncUniqueIndexes(this.buildUniqueIndexDDL(tableName, objectDef, materialized));
+      // [#8413 · #17609] The retrofit leg — this table may already hold the
+      // duplicates a missing UNIQUE admitted, so it is isolated and reported,
+      // never forced, and an index the database already carries is not
+      // re-issued. See {@link retrofitDeclaredIndexes}.
+      const planned = this.buildDeclaredIndexDDL(tableName, objectDef, materialized);
+      if (planned.length > 0) {
+        const existing = await this.client!.execute(EXISTING_INDEX_NAMES_SQL);
+        await this.retrofitDeclaredIndexes(this.missingIndexes(planned, existing.rows));
+      }
     }
   }
 
@@ -1888,11 +1923,15 @@ export class RemoteTransport {
   /**
    * Batch-synchronize multiple object schemas using batched libsql calls.
    *
-   * Collects all DDL statements (CREATE TABLE / ALTER TABLE ADD COLUMN)
-   * for every schema and uses `client.batch()` to minimize network
-   * round-trips. The process may perform up to three batch calls:
-   * one to introspect existing tables, one to introspect columns for
-   * existing tables, and one to apply DDL statements.
+   * Collects all DDL statements (CREATE TABLE / ALTER TABLE ADD COLUMN /
+   * CREATE INDEX) for every schema and uses `client.batch()` to minimize
+   * network round-trips. The process may perform up to four batch calls: one
+   * to introspect existing tables, one to introspect the existing tables'
+   * columns together with the index names the database already carries, one to
+   * apply DDL statements, and — only when an existing table is missing a
+   * declared index — one to retrofit those indexes. Once every declared index
+   * exists (the steady state of every boot after the first) the fourth call is
+   * not made and no index DDL is sent (#17609).
    *
    * This method does not implement an internal fallback to sequential
    * `syncSchema()`. Any fallback behavior is expected to be handled
@@ -1930,45 +1969,52 @@ export class RemoteTransport {
     const ddlStatements: InStatement[] = [];
 
     for (const { object, schema } of newSchemas) {
-      const objectDef = schema as { name: string; fields?: Record<string, any> };
+      const objectDef = schema as { name: string; fields?: Record<string, any>; indexes?: unknown };
       ddlStatements.push(this.buildCreateTableSQL(object, objectDef));
-      // [#8413] Rides the SAME batch, immediately behind its own CREATE TABLE
-      // (order matters — the index cannot precede the table). A brand-new table
-      // is empty, so these cannot fail on existing data and need none of the
-      // isolation the retrofit leg below gets: they belong in the batch, and
-      // cost this path zero extra round trips.
-      ddlStatements.push(
-        ...this.buildUniqueIndexDDL(object, objectDef, this.materializedColumns(objectDef)),
-      );
+      // [#8413 · #17609] Every declared index — field-level `unique` and the
+      // object's own `indexes`, unique or not — rides the SAME batch,
+      // immediately behind its own CREATE TABLE (order matters — the index
+      // cannot precede the table). A brand-new table is empty, so these cannot
+      // fail on existing data and need none of the isolation the retrofit leg
+      // below gets: they belong in the batch, and cost this path zero extra
+      // round trips.
+      for (const index of this.buildDeclaredIndexDDL(object, objectDef, this.materializedColumns(objectDef))) {
+        ddlStatements.push(index.sql);
+      }
     }
 
-    // [#8413] Existing tables' unique indexes are collected here and applied
-    // AFTER the main batch — they must follow their table's `ALTER TABLE ADD
-    // COLUMN` (the column may be brand new), and they must not share a
-    // transaction with it: on a libsql `write` batch one statement's failure
-    // rolls back every other statement in the batch, so a single table holding
-    // duplicates would silently undo the schema sync of every OTHER object in
-    // the boot. That is the blast radius the separation exists to prevent.
-    const retrofitStatements: string[] = [];
+    // [#8413 · #17609] Existing tables' missing declared indexes are collected
+    // here and applied AFTER the main batch — they must follow their table's
+    // `ALTER TABLE ADD COLUMN` (the column may be brand new), and they must not
+    // share a transaction with it: on a libsql `write` batch one statement's
+    // failure rolls back every other statement in the batch, so a single table
+    // holding duplicates would silently undo the schema sync of every OTHER
+    // object in the boot. That is the blast radius the separation exists to
+    // prevent.
+    let retrofit: PlannedIndex[] = [];
 
-    // Phase 2b: for existing tables, introspect columns in one batch
+    // Phase 2b: for existing tables, introspect columns — and, as the LAST
+    // statement of the same read batch, every index name the database already
+    // carries (#17609), so the retrofit re-issues only what is missing. That
+    // one statement is the whole steady-state cost of index sync: it adds no
+    // round trip, and it does not grow with the number of declared indexes.
     if (existingSchemas.length > 0) {
       const pragmaStmts: InStatement[] = existingSchemas.map((s) => ({
         sql: `PRAGMA table_info("${s.object}")`,
         args: [],
       }));
-      const pragmaResults = await this.client!.batch(pragmaStmts, 'read');
+      const introspection = await this.client!.batch([...pragmaStmts, EXISTING_INDEX_NAMES_SQL], 'read');
+      const planned: PlannedIndex[] = [];
 
       for (let i = 0; i < existingSchemas.length; i++) {
         const { object, schema } = existingSchemas[i];
-        const objectDef = schema as { name: string; fields?: Record<string, any> };
-        if (!objectDef.fields) continue;
+        const objectDef = schema as { name: string; fields?: Record<string, any>; indexes?: unknown };
 
-        const existingColumns = new Set(pragmaResults[i].rows.map((r: any) => r.name));
+        const existingColumns = new Set(introspection[i].rows.map((r: any) => r.name));
         const materialized = new Set<string>(BUILTIN_COLUMNS);
         for (const c of existingColumns) materialized.add(String(c));
 
-        for (const [name, field] of Object.entries(objectDef.fields)) {
+        for (const [name, field] of Object.entries(objectDef.fields ?? {})) {
           if (existingColumns.has(name)) continue;
           const type = (field as any).type || 'string';
           if (type === 'formula') continue;
@@ -1978,8 +2024,9 @@ export class RemoteTransport {
           materialized.add(name);
         }
 
-        retrofitStatements.push(...this.buildUniqueIndexDDL(object, objectDef, materialized));
+        planned.push(...this.buildDeclaredIndexDDL(object, objectDef, materialized));
       }
+      retrofit = this.missingIndexes(planned, introspection[existingSchemas.length].rows);
     }
 
     // Phase 3: execute all DDL in a single batch
@@ -1987,10 +2034,11 @@ export class RemoteTransport {
       await this.client!.batch(ddlStatements, 'write');
     }
 
-    // Phase 4 [#8413]: retrofit the existing tables' declared unique indexes,
-    // outside the batch above for the blast-radius reason stated at its
-    // declaration. Failures here are reported, never forced and never repaired.
-    await this.syncUniqueIndexes(retrofitStatements);
+    // Phase 4 [#8413 · #17609]: retrofit the existing tables' missing declared
+    // indexes, outside the batch above for the blast-radius reason stated at
+    // its declaration. Failures here are reported, never forced and never
+    // repaired.
+    await this.retrofitDeclaredIndexes(retrofit);
   }
 
   async dropTable(object: string): Promise<void> {
@@ -2043,7 +2091,7 @@ export class RemoteTransport {
    * identifier — `object`, `field` and the `groupBy` `outKey` in
    * {@link RemoteTransport.aggregate}, the table and column names in
    * `syncSchema` / `syncSchemasBatch` / `buildCreateTableSQL`, and the index
-   * name and columns in `syncUniqueIndexes` — so the envelope is decided once
+   * name and columns in `buildDeclaredIndexDDL` — so the envelope is decided once
    * for all of them. See {@link unsafeIdentifierError} for which envelope and
    * why. The predicate and the message are unchanged.
    */
@@ -2122,8 +2170,23 @@ export class RemoteTransport {
   }
 
   /**
-   * [#8413] The UNIQUE indexes a schema's field-level `unique` declarations ask
-   * for, as executable DDL.
+   * [#8413 · #17609] Every index an object's metadata declares, as executable
+   * DDL: field-level `unique` (tenancy-aware) PLUS the object's own
+   * `indexes: [...]`, unique or not.
+   *
+   * # One answer, three readers
+   *
+   * The set is composed from the two shared normalizers that
+   * `SqlDriver.syncDeclaredIndexes` and the drift differ's `expectedIndexes`
+   * compose — `uniqueIndexesFromFields` for field-level `unique`,
+   * `normalizeDeclaredIndex` for each declared entry — so the index NAME
+   * (`buildIndexName`, or the author's own `name`) and the KEY this face
+   * creates are the ones the local face creates and the differ looks for.
+   * Nothing about naming, scope or key order is decided here. Until #17609 only
+   * the first normalizer was read, so every object-level index had no consumer
+   * on this face and no remote database carried one — `sqlite_master` on a
+   * production tenant held the primary-key autoindexes and nothing else, and
+   * the hot polling tables answered every claim query with a full scan.
    *
    * # Why a companion index and not an inline `UNIQUE` column constraint
    *
@@ -2134,51 +2197,57 @@ export class RemoteTransport {
    *  1. **Retrofit.** SQLite cannot add a column constraint to an existing
    *     table — `ALTER TABLE` has no `ADD CONSTRAINT`, so an inline `UNIQUE`
    *     reaches an already-created table only through a full table rebuild
-   *     (create-copy-drop-rename). A `CREATE UNIQUE INDEX` is a single
-   *     statement that touches no row. Since the tables this defect has been
-   *     filling with duplicates all already exist, the inline form would have
-   *     made the fix unreachable exactly where it is needed.
-   *  2. **Parity.** `SqlDriver` materializes field-level `unique` as a UNIQUE
-   *     INDEX (`syncDeclaredIndexes`), never inline. Matching it means the two
-   *     faces converge on the same index NAME (`buildIndexName`) and the same
-   *     key, so `sqlite_master` on a remote database and on a local one read
-   *     alike — and the drift differ, which looks for those names, does not
-   *     report a remote database as drifted from its own declaration.
+   *     (create-copy-drop-rename). A `CREATE [UNIQUE] INDEX` is a single
+   *     statement that touches no row. Since the tables these indexes were
+   *     missing from all already exist, the inline form would have made the
+   *     fix unreachable exactly where it is needed.
+   *  2. **Parity.** `SqlDriver` materializes every declared index as an INDEX,
+   *     never inline, so `sqlite_master` on a remote database and on a local
+   *     one read alike — and the drift differ, which looks for those names,
+   *     does not report a remote database as drifted from its own declaration.
    *
    * # NULL semantics are inherited, not chosen here
    *
    * SQL UNIQUE is NULL-distinct, so rows with a NULL in the key stay mutually
-   * unconstrained; the tenant-scoped arm gets the NULL-SAFE key part
+   * unconstrained; an organization-scoped unique gets the NULL-SAFE key part
    * (`COALESCE(<tenant>, '__global__')`) from the shared helper for the reason
    * ADR-0120 D3 records. Neither rule is re-decided here.
    *
    * Columns that were never materialized (a virtual `formula` field) are
    * skipped rather than emitted — the same choice `SqlDriver.syncDeclaredIndexes`
    * makes, and for the same reason: DDL naming a column that does not exist
-   * fails the whole sync over an index nothing could have used.
+   * fails the whole sync over an index nothing could have used. A name declared
+   * twice is emitted once, as the local face creates it once.
    */
-  private buildUniqueIndexDDL(
+  private buildDeclaredIndexDDL(
     tableName: string,
-    objectDef: { fields?: Record<string, any>; tenancy?: any },
+    objectDef: { fields?: Record<string, any>; tenancy?: any; indexes?: unknown },
     materializedColumns: Set<string>,
-  ): string[] {
+  ): PlannedIndex[] {
     const tenantField = this.tenantFieldResolver ? this.tenantFieldResolver(objectDef) : null;
     const expected: ExpectedIndex[] = uniqueIndexesFromFields(
       tableName,
       objectDef.fields ?? {},
       tenantField,
     );
+    const declared = Array.isArray(objectDef.indexes) ? (objectDef.indexes as DeclaredIndexInput[]) : [];
+    for (const entry of declared) {
+      const normalized = normalizeDeclaredIndex(tableName, entry, tenantField);
+      if (normalized) expected.push(normalized);
+    }
 
-    const statements: string[] = [];
+    const planned: PlannedIndex[] = [];
+    const emitted = new Set<string>();
     for (const index of expected) {
       const missing = index.columns.filter((c) => !materializedColumns.has(c));
       if (missing.length > 0) {
         this.diagnosticSink?.(
-          `[RemoteTransport] skipping declared unique index on "${tableName}" — ` +
+          `[RemoteTransport] skipping declared index "${index.name}" on "${tableName}" — ` +
             `column(s) not materialized: ${missing.join(', ')}`,
         );
         continue;
       }
+      if (emitted.has(index.name)) continue;
       this.assertSafeIdentifier(index.name);
       for (const column of index.columns) this.assertSafeIdentifier(column);
 
@@ -2186,69 +2255,98 @@ export class RemoteTransport {
       const parts = index.columns.map((c) =>
         nullSafe.has(c) ? organizationKeyPartSql(`"${c}"`) : `"${c}"`,
       );
-      // `IF NOT EXISTS` is what makes every sync after the first a no-op
-      // server-side, so re-syncing an object costs a statement rather than an
-      // error — and it is also what makes the per-statement retry in
-      // {@link syncUniqueIndexes} safe under EITHER libsql batch semantic
+      // `IF NOT EXISTS` is what makes a concurrent creator (two instances
+      // booting against one database) a no-op rather than an error — and it is
+      // also what makes the per-statement retry in
+      // {@link retrofitDeclaredIndexes} safe under EITHER libsql batch semantic
       // (transactional: nothing was applied; non-transactional: re-applying is
       // a no-op).
-      statements.push(
-        `CREATE UNIQUE INDEX IF NOT EXISTS "${index.name}" ON "${tableName}" (${parts.join(', ')})`,
-      );
+      planned.push({
+        name: index.name,
+        table: tableName,
+        unique: index.unique,
+        sql:
+          `CREATE ${index.unique ? 'UNIQUE ' : ''}INDEX IF NOT EXISTS "${index.name}" ` +
+          `ON "${tableName}" (${parts.join(', ')})`,
+      });
+      emitted.add(index.name);
     }
-    return statements;
+    return planned;
   }
 
   /**
-   * [#8413] Materialize unique indexes against a table that ALREADY EXISTS —
-   * the retrofit path, and the one that can legitimately fail.
+   * [#17609] The planned indexes the database does not already carry, by name —
+   * the remote twin of the `existing.has(name)` skip in
+   * `SqlDriver.syncDeclaredIndexes`. `rows` is the answer to
+   * {@link EXISTING_INDEX_NAMES_SQL}.
+   */
+  private missingIndexes(planned: PlannedIndex[], rows: ReadonlyArray<unknown>): PlannedIndex[] {
+    const existing = new Set(rows.map((row) => String((row as { name?: unknown }).name)));
+    return planned.filter((index) => !existing.has(index.name));
+  }
+
+  /**
+   * [#8413 · #17609] Materialize declared indexes against tables that ALREADY
+   * EXIST — the retrofit path, and the one that can legitimately fail.
    *
    * ⛔ **This must never repair data, and never gives up quietly.** Creating a
    * UNIQUE index over a table that already holds duplicates fails, and those
-   * duplicates are precisely what this defect has been producing. Deleting,
+   * duplicates are precisely what a missing constraint admits. Deleting,
    * merging or rewriting any of those rows is a destructive migration and an
-   * operator's decision — never a side effect of a driver booting. So the only
-   * two outcomes here are *the index now exists* and *the index does not exist
-   * and somebody was told at `error`*, which is the level AGENTS.md's
-   * degradation rule requires for a declared constraint that is not enforced:
-   * from the outside nothing looks wrong, and the loss surfaces a release later.
+   * operator's decision — never a side effect of a driver booting. A plain
+   * index cannot fail on data, but it can still fail (a server-side limit, a
+   * timeout on a large table). So the only two outcomes here are *the index
+   * now exists* and *the index does not exist and somebody was told at
+   * `error`*, which is the level AGENTS.md's degradation rule requires: DDL the
+   * metadata declares did not run, and from the outside nothing looks wrong —
+   * a missing UNIQUE keeps admitting duplicates, a missing access path keeps
+   * answering every query by scanning the table. Both surface a release later,
+   * the second one as read volume.
    *
-   * Reporting it is not the whole remedy, and is not meant to be — the operator
-   * with duplicates also gets {@link refuseUnbackedConflictTarget} on any
-   * `conflictKeys` upsert against the same table, which is a refusal at the
-   * moment of use rather than a log line at boot.
+   * Reporting a missing UNIQUE is not the whole remedy, and is not meant to be
+   * — the operator with duplicates also gets {@link refuseUnbackedConflictTarget}
+   * on any `conflictKeys` upsert against the same table, which is a refusal at
+   * the moment of use rather than a log line at boot.
    *
-   * **Round-trip cost, stated rather than hidden** (#7099 asked which trips are
-   * already paid): the happy path is ONE extra batch per sync that touches an
-   * existing table, and only when that table declares a unique field at all.
-   * The per-statement fallback runs only after a batch has already failed, i.e.
-   * only on a database that really does have a violated constraint — so the
-   * cost of precision is paid by the deployment that needs the diagnosis, not
-   * by every boot.
+   * **Round-trip cost, stated rather than hidden:** `planned` holds only the
+   * indexes the database does not already carry — both callers filter by name
+   * first — so the steady state issues NO statement here and no round trip. A
+   * boot that does have indexes to add pays ONE batch for all of them. The
+   * per-statement fallback runs only after that batch has failed, i.e. only on
+   * a database where some index really is unbuildable, so the cost of naming
+   * the culprit is paid by the deployment that needs the diagnosis, not by
+   * every boot. On a transactional libsql `write` batch one failure rolls back
+   * its siblings as well; the fallback is also what lands those.
    */
-  private async syncUniqueIndexes(statements: string[]): Promise<void> {
-    if (statements.length === 0) return;
+  private async retrofitDeclaredIndexes(planned: PlannedIndex[]): Promise<void> {
+    if (planned.length === 0) return;
     try {
-      await this.client!.batch(statements, 'write');
+      await this.client!.batch(planned.map((index) => index.sql), 'write');
       return;
     } catch {
       // The batch told us SOMETHING failed, not which. Re-issue one at a time
       // so the report names the index an operator has to act on — `IF NOT
       // EXISTS` makes the ones that already succeeded no-ops either way.
     }
-    for (const sql of statements) {
+    for (const index of planned) {
       try {
-        await this.client!.execute(sql);
+        await this.client!.execute(index.sql);
       } catch (e) {
+        const cause = e instanceof Error ? e.message : String(e);
         this.durabilitySink?.(
-          `[RemoteTransport] could not create the declared unique index — ` +
-            `${sql}. The constraint is NOT enforced on this table: existing rows already ` +
-            `violate it (the duplicates this face accepted while it emitted no UNIQUE at all), ` +
-            `or the index is otherwise unbuildable. Nothing looks broken from the outside and ` +
-            `duplicates will keep accumulating. Fix by de-duplicating the column's existing ` +
-            `values and re-running schema sync — this driver deliberately does NOT rewrite ` +
-            `stored rows to force the index through. Until then a conflictKeys upsert on this ` +
-            `table is refused rather than crashing. Cause: ${e instanceof Error ? e.message : String(e)}`,
+          index.unique
+            ? `[RemoteTransport] could not create the declared unique index "${index.name}" on ` +
+                `"${index.table}" — ${index.sql}. The constraint is NOT enforced on this table: existing rows ` +
+                `already violate it (duplicates this face accepted while the index was absent), or the index is ` +
+                `otherwise unbuildable. Nothing looks broken from the outside and duplicates will keep ` +
+                `accumulating. Fix by de-duplicating the key's existing values and re-running schema sync — this ` +
+                `driver deliberately does NOT rewrite stored rows to force the index through. Until then a ` +
+                `conflictKeys upsert on this table is refused rather than crashing. Cause: ${cause}`
+            : `[RemoteTransport] could not create the declared index "${index.name}" on "${index.table}" — ` +
+                `${index.sql}. Every query this index exists to serve is answered by scanning the whole table ` +
+                `instead: nothing looks broken from the outside and results stay correct, but each such read ` +
+                `costs a full scan that grows with the table. Fix the cause below and re-run schema sync — the ` +
+                `next schema sync retries it, and no row is touched either way. Cause: ${cause}`,
         );
       }
     }

--- a/packages/drivers/driver-turso/src/remote-transport.ts
+++ b/packages/drivers/driver-turso/src/remote-transport.ts
@@ -2091,7 +2091,7 @@ export class RemoteTransport {
    * identifier — `object`, `field` and the `groupBy` `outKey` in
    * {@link RemoteTransport.aggregate}, the table and column names in
    * `syncSchema` / `syncSchemasBatch` / `buildCreateTableSQL`, and the index
-   * name and columns in `buildDeclaredIndexDDL` — so the envelope is decided once
+   * key columns in `buildDeclaredIndexDDL` — so the envelope is decided once
    * for all of them. See {@link unsafeIdentifierError} for which envelope and
    * why. The predicate and the message are unchanged.
    */
@@ -2142,6 +2142,9 @@ export class RemoteTransport {
    * `alias` is escaped rather than concatenated.
    *
    * ⛔ NOT for column references — those keep {@link assertSafeIdentifier}.
+   *
+   * [#17609] It also spells a declared index NAME in
+   * {@link buildDeclaredIndexDDL}: one name, never a reference.
    */
   private aliasIdentifierSql(alias: string): string {
     return `"${String(alias).replace(/"/g, '""')}"`;
@@ -2248,8 +2251,14 @@ export class RemoteTransport {
         continue;
       }
       if (emitted.has(index.name)) continue;
-      this.assertSafeIdentifier(index.name);
+      // The KEY columns are references and stay gated. The index NAME is not a
+      // reference but one name by definition — the class #14113 escapes for an
+      // alias rather than refuses. It is the one position here an author types
+      // freely (`IndexSchema.name` is any string, and the local face quotes
+      // whatever it is given), so refusing it would fail this face's WHOLE
+      // schema sync over a declaration the other face accepts.
       for (const column of index.columns) this.assertSafeIdentifier(column);
+      const nameSql = this.aliasIdentifierSql(index.name);
 
       const nullSafe = new Set(index.nullSafeColumns ?? []);
       const parts = index.columns.map((c) =>
@@ -2266,7 +2275,7 @@ export class RemoteTransport {
         table: tableName,
         unique: index.unique,
         sql:
-          `CREATE ${index.unique ? 'UNIQUE ' : ''}INDEX IF NOT EXISTS "${index.name}" ` +
+          `CREATE ${index.unique ? 'UNIQUE ' : ''}INDEX IF NOT EXISTS ${nameSql} ` +
           `ON "${tableName}" (${parts.join(', ')})`,
       });
       emitted.add(index.name);

--- a/packages/drivers/driver-turso/src/turso-driver.ts
+++ b/packages/drivers/driver-turso/src/turso-driver.ts
@@ -689,7 +689,9 @@ export class TursoDriver extends SqlDriver {
       // DURABILITY degradation, not a functional one: writes keep succeeding,
       // reads keep returning rows, and the only thing that changed is that a
       // constraint the metadata declares is not enforced — the "looks normal
-      // from the outside" shape AGENTS.md grades at `error`. It is a SEPARATE
+      // from the outside" shape AGENTS.md grades at `error`. [#17609] A declared
+      // PLAIN index it could not create lands here too, for the same reason:
+      // every query still answers, by scanning the table. It is a SEPARATE
       // sink from the `warn` one above precisely so this class does not have to
       // share a level with the diagnostics that are merely informative.
       this.remoteTransport.setDurabilitySink((message) =>

--- a/packages/drivers/driver-turso/src/turso-local-remote-declared-index-parity.test.ts
+++ b/packages/drivers/driver-turso/src/turso-local-remote-declared-index-parity.test.ts
@@ -292,7 +292,7 @@ function countingClient(inner: Client): { client: Client; calls: Array<{ via: 'e
 }
 
 const INDEX_DDL = /^\s*CREATE\s+(UNIQUE\s+)?INDEX\b/i;
-const INDEX_NAME_READ = /sqlite_master/i;
+const INDEX_NAME_READ = /FROM\s+sqlite_master\s+WHERE\s+type\s*=\s*'index'/i;
 
 /** The durability channel (`logger.error`) and the diagnostic one (`logger.warn`), captured. */
 function captureLogs(driver: TursoDriver) {

--- a/packages/drivers/driver-turso/src/turso-local-remote-declared-index-parity.test.ts
+++ b/packages/drivers/driver-turso/src/turso-local-remote-declared-index-parity.test.ts
@@ -40,8 +40,10 @@
  * on `service-messaging` or `platform-objects`. `os17609_scoped` covers what
  * those two do not: a tenant column, a field-level `unique` scoped by it, a
  * declared `unique: 'organization'` (NULL-safe key part), an explicit
- * `unique: 'global'`, an author-named index, and an index over a virtual
- * `formula` field that neither face may materialize.
+ * `unique: 'global'`, two author-named indexes — one of them no SQL
+ * identifier at all (a space and a double quote), which both faces must
+ * accept — and an index over a virtual `formula` field that neither face may
+ * materialize.
  */
 
 import { describe, it, expect, afterEach, vi } from 'vitest';
@@ -143,6 +145,7 @@ const SCOPED: ObjectDef = {
     { fields: ['external_id'], unique: 'global' },
     { fields: ['region', 'slug'] },
     { name: 'os17609_scoped_by_region', fields: ['region'] },
+    { name: 'os17609 scoped-by "slug"', fields: ['slug'] },
     { fields: ['total'] },
   ],
 };
@@ -176,6 +179,7 @@ const EXPECTED_NAMES: Record<string, string[]> = {
     buildIndexName(SCOPED.name, ['external_id'], true),
     buildIndexName(SCOPED.name, ['region', 'slug'], false),
     'os17609_scoped_by_region',
+    'os17609 scoped-by "slug"',
     `sqlite_autoindex_${SCOPED.name}_1`,
   ].sort(),
 };
@@ -197,6 +201,9 @@ const withoutDeclaredIndexes = (o: ObjectDef): ObjectDef => {
 };
 
 type Row = Record<string, unknown>;
+
+/** A SQL identifier, quoted — the fixture carries an index name that is not a bare identifier. */
+const quoteIdent = (id: string) => `"${id.replace(/"/g, '""')}"`;
 type Query = (sql: string, args?: unknown[]) => Promise<Row[]>;
 
 interface IndexShape {
@@ -222,7 +229,7 @@ async function indexShapes(query: Query, table: string): Promise<IndexShape[]> {
     const expressions = [
       ...String(master?.sql ?? '').matchAll(/COALESCE\(\s*[`"]?(\w+)[`"]?\s*,\s*'([^']*)'\s*\)/gi),
     ].map((m) => `COALESCE(${m[1]}, '${m[2]}')`);
-    const keys = (await query(`PRAGMA index_xinfo("${name}")`))
+    const keys = (await query(`PRAGMA index_xinfo(${quoteIdent(name)})`))
       .filter((k) => Number(k.key) === 1)
       .sort((a, b) => Number(a.seqno) - Number(b.seqno))
       .map((k) => (Number(k.cid) === -2 ? (expressions.shift() ?? '<expression>') : String(k.name)));
@@ -234,7 +241,8 @@ async function indexShapes(query: Query, table: string): Promise<IndexShape[]> {
       keys,
     });
   }
-  return out.sort((a, b) => a.name.localeCompare(b.name));
+  // Code-unit order, the same order `EXPECTED_NAMES`' `.sort()` uses.
+  return out.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
 }
 
 const indexNames = async (query: Query, table: string) => (await indexShapes(query, table)).map((i) => i.name);

--- a/packages/drivers/driver-turso/src/turso-local-remote-declared-index-parity.test.ts
+++ b/packages/drivers/driver-turso/src/turso-local-remote-declared-index-parity.test.ts
@@ -1,0 +1,501 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * [#17609] ONE `TursoDriver`, ONE index set — an object's declared
+ * `indexes: [...]` materialized on BOTH faces and read back off
+ * `sqlite_master`, the two readings held against each other.
+ *
+ * # What was broken
+ *
+ * Remote mode (`libsql://`) provisions tables through
+ * `RemoteTransport.syncSchemasBatch`, and every index DDL that file could emit
+ * came from field-level `unique` alone. An object's declared `indexes` —
+ * unique or not — had no consumer on that path, so on every remote tenant
+ * database the hot tables carried only their primary-key autoindex:
+ * `sys_notification_delivery` declares five indexes and had none, and its
+ * claim query full-scanned the table on every dispatcher tick. The local face
+ * (`SqlDriver.syncDeclaredIndexes`) created all of them, so no local suite
+ * could see it; the loss surfaced as row-read volume, not as a failure.
+ *
+ * # Why a parity file
+ *
+ * The same lesson `turso-local-remote-unique-parity.test.ts` records: a
+ * per-face suite cannot fail on the DIFFERENCE between faces, and the
+ * difference is the defect. So each pin here drives one object set through
+ * BOTH faces and compares what physically landed — index names, uniqueness,
+ * origin and key parts (NULL-safe organization expressions included) — rather
+ * than asserting either face against a literal. Each parity pin is ANCHORED
+ * by names computed through the shared `buildIndexName`, because two faces
+ * that both lost every index would agree perfectly.
+ *
+ * The remote face here is the real `@libsql/client` over `file::memory:`,
+ * not the better-sqlite3 stub: a libsql `write` batch is transactional, and
+ * the retrofit's failure disposition depends on exactly that semantic.
+ *
+ * # The fixtures
+ *
+ * `sys_notification_delivery` and `sys_job_queue` are the two tables the card
+ * measured on production, reproduced here as SHAPES — their fields and their
+ * `indexes` verbatim — because this package does not (and should not) depend
+ * on `service-messaging` or `platform-objects`. `os17609_scoped` covers what
+ * those two do not: a tenant column, a field-level `unique` scoped by it, a
+ * declared `unique: 'organization'` (NULL-safe key part), an explicit
+ * `unique: 'global'`, an author-named index, and an index over a virtual
+ * `formula` field that neither face may materialize.
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { createClient, type Client, type InStatement } from '@libsql/client';
+import { Field } from '@objectstack/spec/data';
+import { buildIndexName } from '@objectstack/driver-sql';
+import { TursoDriver } from './turso-driver.js';
+
+type ObjectDef = {
+  name: string;
+  fields: Record<string, any>;
+  indexes?: Array<{ name?: string; fields: string[]; unique?: boolean | 'global' | 'organization' }>;
+};
+
+const DELIVERY: ObjectDef = {
+  name: 'sys_notification_delivery',
+  fields: {
+    id: Field.text({ label: 'Delivery ID', required: true, readonly: true }),
+    notification_id: Field.text({ label: 'Notification Event', required: true, maxLength: 255 }),
+    recipient_id: Field.text({ label: 'Recipient User', required: true, maxLength: 255 }),
+    channel: Field.text({ label: 'Channel', required: true, maxLength: 64 }),
+    topic: Field.text({ label: 'Topic' }),
+    digest_key: Field.text({ label: 'Digest Key', maxLength: 331 }),
+    payload: Field.json({ label: 'Payload' }),
+    status: Field.select(['pending', 'in_flight', 'success', 'failed', 'dead', 'suppressed'], {
+      label: 'Status',
+      required: true,
+      defaultValue: 'pending',
+    }),
+    attempts: Field.number({ label: 'Attempts', defaultValue: 0 }),
+    partition_key: Field.number({ label: 'Partition Key', defaultValue: 0 }),
+    claimed_by: Field.text({ label: 'Claimed By' }),
+    claimed_at: Field.number({ label: 'Claimed At (ms)' }),
+    next_attempt_at: Field.number({ label: 'Next Attempt At (ms)' }),
+    last_attempted_at: Field.number({ label: 'Last Attempted At (ms)' }),
+    error: Field.textarea({ label: 'Error' }),
+    created_at: Field.datetime({ label: 'Created At', readonly: true }),
+    updated_at: Field.datetime({ label: 'Updated At' }),
+  },
+  indexes: [
+    { fields: ['notification_id', 'recipient_id', 'channel'], unique: true },
+    { fields: ['status', 'partition_key', 'next_attempt_at'] },
+    { fields: ['status', 'claimed_at'] },
+    { fields: ['notification_id'] },
+    { fields: ['digest_key', 'status', 'next_attempt_at'] },
+  ],
+};
+
+const JOB_QUEUE: ObjectDef = {
+  name: 'sys_job_queue',
+  fields: {
+    id: Field.text({ label: 'Message ID', required: true, readonly: true }),
+    queue: Field.text({ label: 'Queue', required: true, maxLength: 255 }),
+    idempotency_key: Field.text({ label: 'Idempotency Key', required: false, maxLength: 255 }),
+    payload_json: Field.textarea({ label: 'Payload (JSON)', required: false }),
+    metadata_json: Field.textarea({ label: 'Metadata (JSON)', required: false }),
+    status: Field.select(['pending', 'running', 'completed', 'failed', 'dlq'], {
+      label: 'Status',
+      required: true,
+      defaultValue: 'pending',
+    }),
+    priority: Field.number({ label: 'Priority', required: false, defaultValue: 100 }),
+    attempts: Field.number({ label: 'Attempts', required: false, defaultValue: 0 }),
+    max_attempts: Field.number({ label: 'Max Attempts', required: false, defaultValue: 3 }),
+    backoff_type: Field.select(['fixed', 'exponential'], {
+      label: 'Backoff',
+      required: false,
+      defaultValue: 'exponential',
+    }),
+    backoff_delay_ms: Field.number({ label: 'Backoff Base (ms)', required: false, defaultValue: 1000 }),
+    backoff_max_delay_ms: Field.number({ label: 'Backoff Cap (ms)', required: false }),
+    scheduled_for: Field.datetime({ label: 'Scheduled For', required: false }),
+    locked_by: Field.text({ label: 'Locked By', required: false, maxLength: 255 }),
+    locked_until: Field.datetime({ label: 'Locked Until', required: false }),
+    last_error: Field.textarea({ label: 'Last Error', required: false }),
+    completed_at: Field.datetime({ label: 'Completed At', required: false }),
+    created_at: Field.datetime({ label: 'Created At', required: true, readonly: true }),
+    updated_at: Field.datetime({ label: 'Updated At', required: false }),
+  },
+  indexes: [
+    { fields: ['queue', 'status', 'scheduled_for'] },
+    { fields: ['idempotency_key', 'queue'] },
+    { fields: ['status'] },
+  ],
+};
+
+const SCOPED: ObjectDef = {
+  name: 'os17609_scoped',
+  fields: {
+    organization_id: { type: 'text', maxLength: 64 },
+    code: { type: 'text', maxLength: 64, unique: true },
+    slug: { type: 'text', maxLength: 64 },
+    external_id: { type: 'text', maxLength: 64 },
+    region: { type: 'text', maxLength: 64 },
+    total: { type: 'formula', expression: 'region' },
+  },
+  indexes: [
+    { fields: ['slug'], unique: 'organization' },
+    { fields: ['external_id'], unique: 'global' },
+    { fields: ['region', 'slug'] },
+    { name: 'os17609_scoped_by_region', fields: ['region'] },
+    { fields: ['total'] },
+  ],
+};
+
+const OBJECTS = [DELIVERY, JOB_QUEUE, SCOPED];
+
+/** The card's claim query, verbatim. */
+const CLAIM_SQL =
+  `SELECT id FROM sys_notification_delivery WHERE status = 'pending' AND partition_key = ? ` +
+  `AND next_attempt_at <= ? ORDER BY next_attempt_at LIMIT 50`;
+
+/** The index names each fixture must carry — through the SHARED namer, never a second spelling. */
+const EXPECTED_NAMES: Record<string, string[]> = {
+  [DELIVERY.name]: [
+    buildIndexName(DELIVERY.name, ['notification_id', 'recipient_id', 'channel'], true),
+    buildIndexName(DELIVERY.name, ['status', 'partition_key', 'next_attempt_at'], false),
+    buildIndexName(DELIVERY.name, ['status', 'claimed_at'], false),
+    buildIndexName(DELIVERY.name, ['notification_id'], false),
+    buildIndexName(DELIVERY.name, ['digest_key', 'status', 'next_attempt_at'], false),
+    `sqlite_autoindex_${DELIVERY.name}_1`,
+  ].sort(),
+  [JOB_QUEUE.name]: [
+    buildIndexName(JOB_QUEUE.name, ['queue', 'status', 'scheduled_for'], false),
+    buildIndexName(JOB_QUEUE.name, ['idempotency_key', 'queue'], false),
+    buildIndexName(JOB_QUEUE.name, ['status'], false),
+    `sqlite_autoindex_${JOB_QUEUE.name}_1`,
+  ].sort(),
+  [SCOPED.name]: [
+    buildIndexName(SCOPED.name, ['organization_id', 'code'], true),
+    buildIndexName(SCOPED.name, ['organization_id', 'slug'], true),
+    buildIndexName(SCOPED.name, ['external_id'], true),
+    buildIndexName(SCOPED.name, ['region', 'slug'], false),
+    'os17609_scoped_by_region',
+    `sqlite_autoindex_${SCOPED.name}_1`,
+  ].sort(),
+};
+
+const CLAIM_INDEX = buildIndexName(DELIVERY.name, ['status', 'partition_key', 'next_attempt_at'], false);
+const DEDUP_INDEX = buildIndexName(DELIVERY.name, ['notification_id', 'recipient_id', 'channel'], true);
+
+/** A fresh copy per sync — neither face may see a definition the other one mutated. */
+const fresh = (o: ObjectDef): ObjectDef => ({
+  ...o,
+  fields: Object.fromEntries(Object.entries(o.fields).map(([k, v]) => [k, { ...v }])),
+  ...(o.indexes ? { indexes: o.indexes.map((i) => ({ ...i, fields: [...i.fields] })) } : {}),
+});
+
+/** The same object as the pre-fix remote face provisioned it: no object-level indexes. */
+const withoutDeclaredIndexes = (o: ObjectDef): ObjectDef => {
+  const { indexes: _dropped, ...rest } = fresh(o);
+  return rest;
+};
+
+type Row = Record<string, unknown>;
+type Query = (sql: string, args?: unknown[]) => Promise<Row[]>;
+
+interface IndexShape {
+  name: string;
+  unique: boolean;
+  partial: boolean;
+  origin: string;
+  /** Key parts in order; an expression part is its normalized COALESCE text. */
+  keys: string[];
+}
+
+/**
+ * What physically landed for one table, read the same way off either face:
+ * `PRAGMA index_list` for name / uniqueness / origin / partiality,
+ * `PRAGMA index_xinfo` for the key columns, and the stored `CREATE` text for
+ * expression parts (whose column name `index_xinfo` reports as NULL).
+ */
+async function indexShapes(query: Query, table: string): Promise<IndexShape[]> {
+  const out: IndexShape[] = [];
+  for (const row of await query(`PRAGMA index_list("${table}")`)) {
+    const name = String(row.name);
+    const [master] = await query(`SELECT sql FROM sqlite_master WHERE type = 'index' AND name = ?`, [name]);
+    const expressions = [
+      ...String(master?.sql ?? '').matchAll(/COALESCE\(\s*[`"]?(\w+)[`"]?\s*,\s*'([^']*)'\s*\)/gi),
+    ].map((m) => `COALESCE(${m[1]}, '${m[2]}')`);
+    const keys = (await query(`PRAGMA index_xinfo("${name}")`))
+      .filter((k) => Number(k.key) === 1)
+      .sort((a, b) => Number(a.seqno) - Number(b.seqno))
+      .map((k) => (Number(k.cid) === -2 ? (expressions.shift() ?? '<expression>') : String(k.name)));
+    out.push({
+      name,
+      unique: Number(row.unique) === 1,
+      partial: Number(row.partial) === 1,
+      origin: String(row.origin),
+      keys,
+    });
+  }
+  return out.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+const indexNames = async (query: Query, table: string) => (await indexShapes(query, table)).map((i) => i.name);
+
+const cleanups: Array<() => Promise<void> | void> = [];
+afterEach(async () => {
+  for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
+});
+
+async function localFace(): Promise<{ driver: TursoDriver; query: Query }> {
+  const driver = new TursoDriver({ url: ':memory:' });
+  await driver.connect();
+  expect(driver.transportMode).toBe('local');
+  cleanups.push(() => driver.disconnect());
+  return { driver, query: async (sql, args) => (await driver.execute(sql, args ?? [])) as Row[] };
+}
+
+async function remoteFace(client: Client = createClient({ url: 'file::memory:' })): Promise<{
+  driver: TursoDriver;
+  query: Query;
+}> {
+  const driver = new TursoDriver({ url: 'libsql://declared-index-parity.turso.io', client });
+  await driver.connect();
+  expect(driver.transportMode).toBe('remote');
+  cleanups.push(() => driver.disconnect());
+  return {
+    driver,
+    query: async (sql, args) => (await client.execute({ sql, args: (args ?? []) as any[] })).rows as unknown as Row[],
+  };
+}
+
+/** Every statement the driver hands the client, in order, with the call that carried it. */
+function countingClient(inner: Client): { client: Client; calls: Array<{ via: 'execute' | 'batch'; sql: string[] }> } {
+  const calls: Array<{ via: 'execute' | 'batch'; sql: string[] }> = [];
+  const sqlOf = (s: InStatement) => (typeof s === 'string' ? s : s.sql);
+  const client = new Proxy(inner, {
+    get(target, prop) {
+      if (prop === 'execute') {
+        return (stmt: InStatement, ...rest: unknown[]) => {
+          calls.push({ via: 'execute', sql: [sqlOf(stmt)] });
+          return (target.execute as (...a: unknown[]) => unknown).call(target, stmt, ...rest);
+        };
+      }
+      if (prop === 'batch') {
+        return (stmts: InStatement[], ...rest: unknown[]) => {
+          calls.push({ via: 'batch', sql: stmts.map(sqlOf) });
+          return (target.batch as (...a: unknown[]) => unknown).call(target, stmts, ...rest);
+        };
+      }
+      const value = Reflect.get(target, prop, target);
+      return typeof value === 'function' ? value.bind(target) : value;
+    },
+  });
+  return { client, calls };
+}
+
+const INDEX_DDL = /^\s*CREATE\s+(UNIQUE\s+)?INDEX\b/i;
+const INDEX_NAME_READ = /sqlite_master/i;
+
+/** The durability channel (`logger.error`) and the diagnostic one (`logger.warn`), captured. */
+function captureLogs(driver: TursoDriver) {
+  const logger = (driver as unknown as { logger: { warn: (m: string) => void; error: (m: string) => void } }).logger;
+  return {
+    error: vi.spyOn(logger, 'error').mockImplementation(() => undefined),
+    warn: vi.spyOn(logger, 'warn').mockImplementation(() => undefined),
+  };
+}
+
+describe('[#17609] declared object-level indexes land identically on both TursoDriver faces', () => {
+  it('a fresh database carries the same index set — names, uniqueness, origin and key parts', async () => {
+    const local = await localFace();
+    const remote = await remoteFace();
+
+    await local.driver.initObjects(OBJECTS.map(fresh));
+    await remote.driver.initObjects(OBJECTS.map(fresh));
+
+    for (const { name } of OBJECTS) {
+      const localShapes = await indexShapes(local.query, name);
+      const remoteShapes = await indexShapes(remote.query, name);
+      // Names first, for a readable diff; then the whole shape.
+      expect(remoteShapes.map((i) => i.name), name).toEqual(localShapes.map((i) => i.name));
+      expect(remoteShapes, name).toEqual(localShapes);
+      // The anchor: agreement alone is satisfied by both faces losing them together.
+      expect(localShapes.map((i) => i.name), name).toEqual(EXPECTED_NAMES[name]);
+    }
+
+    // The tenant key part is the NULL-safe expression on both faces, not the bare column.
+    const scoped = await indexShapes(remote.query, SCOPED.name);
+    expect(scoped.find((i) => i.name === buildIndexName(SCOPED.name, ['organization_id', 'slug'], true))).toEqual(
+      expect.objectContaining({ unique: true, keys: ["COALESCE(organization_id, '__global__')", 'slug'] }),
+    );
+  });
+
+  it('the single-object `syncSchema` path lands the same set as the batch path', async () => {
+    const local = await localFace();
+    const remote = await remoteFace();
+
+    for (const o of OBJECTS) {
+      await local.driver.initObjects([fresh(o)]);
+      await remote.driver.syncSchema(o.name, fresh(o));
+    }
+    for (const { name } of OBJECTS) {
+      expect(await indexShapes(remote.query, name), name).toEqual(await indexShapes(local.query, name));
+    }
+  });
+
+  it('retrofits every declared index onto tables that already exist — and changes no row', async () => {
+    const local = await localFace();
+    const { client, calls } = countingClient(createClient({ url: 'file::memory:' }));
+    const remote = await remoteFace(client);
+
+    // The production state: tables the pre-fix remote face provisioned, holding rows.
+    await remote.driver.initObjects(OBJECTS.map(withoutDeclaredIndexes));
+    expect(await indexNames(remote.query, DELIVERY.name)).toEqual([`sqlite_autoindex_${DELIVERY.name}_1`]);
+    expect(await indexNames(remote.query, JOB_QUEUE.name)).toEqual([`sqlite_autoindex_${JOB_QUEUE.name}_1`]);
+    for (let i = 0; i < 3; i++) {
+      await remote.driver.create(DELIVERY.name, {
+        notification_id: `n${i}`,
+        recipient_id: 'u1',
+        channel: 'inbox',
+        status: 'pending',
+        partition_key: i,
+        next_attempt_at: 1000 + i,
+      });
+      await remote.driver.create(JOB_QUEUE.name, { queue: 'q', status: 'pending', idempotency_key: `k${i}` });
+    }
+    const snapshot = async () => ({
+      delivery: await remote.query(`SELECT * FROM "${DELIVERY.name}" ORDER BY id`),
+      jobs: await remote.query(`SELECT * FROM "${JOB_QUEUE.name}" ORDER BY id`),
+      changes: (await remote.query('SELECT total_changes() AS n'))[0].n,
+    });
+    const before = await snapshot();
+
+    calls.length = 0;
+    await remote.driver.initObjects(OBJECTS.map(fresh));
+    const retrofitDdl = calls.flatMap((c) => c.sql).filter((s) => INDEX_DDL.test(s));
+
+    // ⛔ Zero data change: the same rows, byte for byte, and no row-level write at all.
+    expect(await snapshot()).toEqual(before);
+    // `IF NOT EXISTS` on every retrofit statement — a concurrent boot creating the same index is a no-op.
+    expect(retrofitDdl.length).toBeGreaterThan(0);
+    for (const sql of retrofitDdl) expect(sql).toMatch(/\bINDEX IF NOT EXISTS\b/i);
+
+    await local.driver.initObjects(OBJECTS.map(fresh));
+    for (const { name } of OBJECTS) {
+      expect(await indexShapes(remote.query, name), name).toEqual(await indexShapes(local.query, name));
+      expect(await indexNames(remote.query, name), name).toEqual(EXPECTED_NAMES[name]);
+    }
+  });
+
+  it('steady state costs zero index DDL — one index-name read, riding a round trip the sync already pays', async () => {
+    const { client, calls } = countingClient(createClient({ url: 'file::memory:' }));
+    const remote = await remoteFace(client);
+    await remote.driver.initObjects(OBJECTS.map(fresh));
+
+    // A whole kernel build's `initObjects`, once every index exists.
+    calls.length = 0;
+    await remote.driver.initObjects(OBJECTS.map(fresh));
+    const boot = calls.flatMap((c) => c.sql);
+    expect(boot.filter((s) => INDEX_DDL.test(s))).toEqual([]);
+
+    // The DDL seam alone, measured exactly: N table probes (one batch) + N column
+    // probes and ONE index-name read (one batch) — two round trips, 2N + 1 statements,
+    // independent of how many indexes the objects declare.
+    calls.length = 0;
+    await remote.driver.syncSchemasBatch(OBJECTS.map((o) => ({ object: o.name, schema: fresh(o) })));
+    const N = OBJECTS.length;
+    expect(calls.map((c) => c.via)).toEqual(['batch', 'batch']);
+    expect(calls.flatMap((c) => c.sql)).toHaveLength(2 * N + 1);
+    expect(calls[1].sql.filter((s) => INDEX_NAME_READ.test(s))).toHaveLength(1);
+    expect(calls[1].sql.filter((s) => /^PRAGMA table_info/i.test(s))).toHaveLength(N);
+  });
+
+  it('serves the delivery claim query from the declared index — the same plan on both faces', async () => {
+    const local = await localFace();
+    const remote = await remoteFace();
+    await local.driver.initObjects([fresh(DELIVERY)]);
+    await remote.driver.initObjects([fresh(DELIVERY)]);
+
+    const plan = async (query: Query) =>
+      (await query(`EXPLAIN QUERY PLAN ${CLAIM_SQL}`, [0, 0])).map((r) => String(r.detail)).join('\n');
+    const remotePlan = await plan(remote.query);
+
+    expect(remotePlan).toContain(
+      `SEARCH sys_notification_delivery USING INDEX ${CLAIM_INDEX} (status=? AND partition_key=? AND next_attempt_at<?)`,
+    );
+    expect(remotePlan).not.toMatch(/SCAN sys_notification_delivery/);
+    expect(remotePlan).toBe(await plan(local.query));
+  });
+});
+
+describe('[#17609] a declared index the retrofit cannot create is reported at `error`, never forced', () => {
+  it('an object-level UNIQUE over existing duplicates: not created, named on the durability channel, no row repaired', async () => {
+    const remote = await remoteFace();
+    await remote.driver.initObjects([withoutDeclaredIndexes(DELIVERY)]);
+    // The duplicates a table with no dedup index accepted.
+    for (const attempt of [1, 2]) {
+      await remote.driver.create(DELIVERY.name, {
+        notification_id: 'n1',
+        recipient_id: 'u1',
+        channel: 'email',
+        status: 'pending',
+        attempts: attempt,
+      });
+    }
+    const logs = captureLogs(remote.driver);
+
+    await expect(remote.driver.initObjects([fresh(DELIVERY)])).resolves.toBeUndefined();
+
+    const names = await indexNames(remote.query, DELIVERY.name);
+    // The unique index is absent — and the four plain ones DID land, although a libsql
+    // `write` batch rolls back every statement beside the one that failed.
+    expect(names).not.toContain(DEDUP_INDEX);
+    expect(names).toEqual(EXPECTED_NAMES[DELIVERY.name].filter((n) => n !== DEDUP_INDEX));
+
+    // Reported once, on the `error` channel, naming the index and carrying SQLite's own cause.
+    const reports = logs.error.mock.calls.map((c) => String(c[0])).filter((m) => m.includes(DEDUP_INDEX));
+    expect(reports).toHaveLength(1);
+    expect(reports[0]).toContain(DELIVERY.name);
+    expect(reports[0]).toMatch(/UNIQUE constraint failed/i);
+    expect(logs.warn.mock.calls.some((c) => String(c[0]).includes(DEDUP_INDEX))).toBe(false);
+
+    // ⛔ Nothing repaired: both duplicates are still there.
+    expect((await remote.query(`SELECT COUNT(*) AS n FROM "${DELIVERY.name}"`))[0].n).toBe(2);
+  });
+
+  it('a PLAIN index the server refuses: named on the durability channel with its cause; the rest still land', async () => {
+    const inner = createClient({ url: 'file::memory:' });
+    const refused = (sql: string) => INDEX_DDL.test(sql) && sql.includes(`"${CLAIM_INDEX}"`);
+    const refusal = () => Object.assign(new Error('SQLITE_FULL: database or disk is full'), { code: 'SQLITE_FULL' });
+    const client = new Proxy(inner, {
+      get(target, prop) {
+        if (prop === 'execute') {
+          return async (stmt: InStatement) => {
+            if (refused(typeof stmt === 'string' ? stmt : stmt.sql)) throw refusal();
+            return target.execute(stmt);
+          };
+        }
+        if (prop === 'batch') {
+          return async (stmts: InStatement[], mode?: 'write' | 'read' | 'deferred') => {
+            if (stmts.some((s) => refused(typeof s === 'string' ? s : s.sql))) throw refusal();
+            return target.batch(stmts, mode);
+          };
+        }
+        const value = Reflect.get(target, prop, target);
+        return typeof value === 'function' ? value.bind(target) : value;
+      },
+    });
+    const remote = await remoteFace(client);
+    await remote.driver.initObjects([withoutDeclaredIndexes(DELIVERY)]);
+    const logs = captureLogs(remote.driver);
+
+    await expect(remote.driver.initObjects([fresh(DELIVERY)])).resolves.toBeUndefined();
+
+    const names = await indexNames(remote.query, DELIVERY.name);
+    expect(names).not.toContain(CLAIM_INDEX);
+    expect(names).toEqual(EXPECTED_NAMES[DELIVERY.name].filter((n) => n !== CLAIM_INDEX));
+
+    const reports = logs.error.mock.calls.map((c) => String(c[0])).filter((m) => m.includes(CLAIM_INDEX));
+    expect(reports).toHaveLength(1);
+    expect(reports[0]).toContain(DELIVERY.name);
+    expect(reports[0]).toContain('SQLITE_FULL');
+  });
+});


### PR DESCRIPTION
Closes #17609

Clause-②: no — the driver now materializes indexes the metadata already declares; `packages/spec/src/**` is untouched, and no export, schema key or accepted/refused authoring input changes.

## Premise, verified against `origin/main` @ `3ef96b471` before any edit

- Remote mode: `TursoDriver.initObjects` → `RemoteTransport.syncSchemasBatch`. Every index DDL in `remote-transport.ts` came from `buildUniqueIndexDDL` → `uniqueIndexesFromFields` (field-level `unique` only); emit sites `:1841` / `:1868` / `:1941` / `:1981`, sole template `:2196`. Confirmed as the card states.
- No other remote path creates declared indexes: `git grep` finds no other `CREATE INDEX` in `driver-turso/src`, and nothing outside `driver-sql` calls an index-sync method.
- One correction: `SqlDriver.syncDeclaredIndexes` is at `sql-driver.ts:12464` on that commit, not `:9812`. Nothing else in the premise moved.
- Reproduced locally before the fix: the new parity suite, run on base + test file only (`bd207df81`), was **7 failed / 7**; the remote face held only `sqlite_autoindex_sys_notification_delivery_1` and planned the claim query as `SCAN sys_notification_delivery` + `USE TEMP B-TREE FOR ORDER BY`.

## What changes

Only `packages/drivers/driver-turso` (plus a changeset). **`driver-sql` is not modified** — the remote face imports the already-exported `normalizeDeclaredIndex` beside `uniqueIndexesFromFields` / `organizationKeyPartSql`.

- **`buildDeclaredIndexDDL`** (replaces `buildUniqueIndexDDL`): field-level `unique` via `uniqueIndexesFromFields` plus each declared entry via `normalizeDeclaredIndex` — the same two normalizers `SqlDriver.syncDeclaredIndexes` and `expectedIndexes` compose. Names come from `buildIndexName` (or the author's `name`); keys include the NULL-safe `COALESCE(organization_id, '__global__')` part for `unique: 'organization'`. No naming or keying rule is re-implemented. Emits `CREATE [UNIQUE] INDEX IF NOT EXISTS`. Unmaterialized columns (virtual `formula`) are skipped with a diagnostic, as locally.
- **New tables**: every declared index rides the `CREATE TABLE` batch — no extra round trip.
- **Existing tables (retrofit)**: the existing column-probe read batch gains ONE statement, `SELECT name FROM sqlite_master WHERE type='index'`. Only indexes whose name is absent are issued, in one `write` batch kept outside the main DDL batch (the blast-radius separation of the field-level unique retrofit is preserved). No row is written.
- **`retrofitDeclaredIndexes`** (replaces `syncUniqueIndexes`): batch → on failure, per statement → each failure goes to the durability sink (`logger.error`) naming index, table, DDL and the database's own cause. A unique index over existing duplicates is not forced and no row is repaired. A plain index that fails is reported the same way, with its consequence (full scans).
- **`syncSchema`** (single-object path) behaves the same.
- **Author-declared index names are escaped, not refused.** `IndexSchema.name` is any string and the local face quotes whatever it is given; holding it to `SAFE_IDENTIFIER` would have failed the remote face's whole schema sync — every object in the boot — over a declaration the other face accepts. An index name is one name, never a reference: the class `aliasIdentifierSql` already escapes. Key columns stay gated. Corpus at `3ef96b471`: 85 files declare `indexes: [`, 0 author-given names are non-identifiers, so nothing in-tree changes behaviour.

## Acceptance evidence

All pins live in `packages/drivers/driver-turso/src/turso-local-remote-declared-index-parity.test.ts`. Local face = `new TursoDriver({ url: ':memory:' })` (the `SqlDriver` path). Remote face = `new TursoDriver({ url: 'libsql://…', client })` with the **real** `@libsql/client` over `file::memory:` — not the better-sqlite3 stub, because a libsql `write` batch is transactional and the failure disposition depends on it (measured: one unique failure in a write batch rolls back a plain `CREATE INDEX` in the same batch).

Fixtures: `sys_notification_delivery` and `sys_job_queue` shapes (fields + `indexes` verbatim from `service-messaging` / `platform-objects`), and `os17609_scoped` — tenant column, field-level `unique` scoped by it, `unique: 'organization'`, `unique: 'global'`, two author-named indexes (one containing a space and a double quote), and an index over a `formula` field.

### 1 — every declared index, same name and key; new tables in batch; retrofit `IF NOT EXISTS`, zero data change

- `a fresh database carries the same index set — names, uniqueness, origin and key parts`: per table, `PRAGMA index_list` + `PRAGMA index_xinfo` + the stored COALESCE text, local vs remote, deep-equal — anchored to `buildIndexName`-computed sets so two faces that both lost every index cannot pass:
  - `sys_notification_delivery` (6, the card's local count): `idx_sys_notification_delivery_ad1bb657`, `idx_sys_notification_delivery_b3081700`, `idx_sys_notification_delivery_notification_id`, `idx_sys_notification_delivery_status_claimed_at`, `uniq_sys_notification_delivery_f5f71821`, `sqlite_autoindex_sys_notification_delivery_1`
  - `sys_job_queue` (4, the card's local count): `idx_sys_job_queue_queue_status_scheduled_for`, `idx_sys_job_queue_idempotency_key_queue`, `idx_sys_job_queue_status` + `sqlite_autoindex_sys_job_queue_1`
  - `os17609_scoped`: `uniq_os17609_scoped_organization_id_code` (field-level, NULL-safe), `uniq_os17609_scoped_organization_id_slug` (`organization`, NULL-safe), `uniq_os17609_scoped_external_id` (`global`, verbatim), `idx_os17609_scoped_region_slug` + `os17609_scoped_by_region`, `os17609 scoped-by "slug"`, `sqlite_autoindex_os17609_scoped_1`; the `formula` index is absent on both faces
- `the single-object syncSchema path lands the same set as the batch path`
- `retrofits every declared index onto tables that already exist — and changes no row`: tables provisioned without object-level indexes and holding rows; the next `initObjects` leaves every row byte-identical and `total_changes()` unchanged, every retrofit statement is `IF NOT EXISTS`, and the resulting shapes equal the local face's.

### 2 — failures are not silent

- `an object-level UNIQUE over existing duplicates: not created, named on the durability channel, no row repaired`: two rows share `(notification_id, recipient_id, channel)`. `initObjects` resolves; the dedup index is absent while the four plain indexes land (the transactional batch rolled them back — the per-statement fallback lands them); exactly one `logger.error` report names the index and table and carries `UNIQUE constraint failed`; nothing on `warn`; both duplicate rows remain.
- `a PLAIN index the server refuses: named on the durability channel with its cause; the rest still land`: an injected `SQLITE_FULL` for the claim index → exactly one `logger.error` report naming it with the cause; the other four declared indexes land.

### 3 — parity test

The suite above: 7 pins, both faces, `sqlite_master` compared, covering both hot-table shapes.

### 4 — boot cost

- `steady state costs zero index DDL — one index-name read, riding a round trip the sync already pays`: a second `initObjects` over existing indexes sends **0** index DDL statements. `syncSchemasBatch` alone, measured exactly: **2 round trips (`batch`, `batch`), 2N + 1 statements** (N = 3 objects → 7), independent of how many indexes are declared (14 here). The index-name read is the last statement of the batch that already carries the N `PRAGMA table_info` probes.
- Before, the same seam sent **2N + U statements over 3 round trips** every boot when U > 0 (U = field-level unique indexes on existing tables, re-sent as `CREATE UNIQUE INDEX IF NOT EXISTS`); the red base run shows that statement re-sent for `uniq_os17609_scoped_organization_id_code`. Applied to the card's tenant A shape (100 tables, 4 field-level uniques) that formula gives 204 statements / 3 round trips before and 201 / 2 after — arithmetic from the measured formula, not a production reading.
- The one-time cost moves to the first build after upgrade: each existing remote database builds its missing indexes once.

### 5 — `EXPLAIN QUERY PLAN` on the remote face

Pinned in `serves the delivery claim query from the declared index — the same plan on both faces` (asserts `SEARCH … USING INDEX`, no `SCAN`, plan text equal to local). Captured from the built package, real `@libsql/client` over `file::memory:`, one database across both steps:

```text
EXPLAIN QUERY PLAN SELECT id FROM sys_notification_delivery WHERE status='pending' AND partition_key=? AND next_attempt_at<=? ORDER BY next_attempt_at LIMIT 50

remote — table as provisioned without object-level indexes (the pre-fix physical state):
  indexes: sqlite_autoindex_sys_notification_delivery_1
  SCAN sys_notification_delivery
  USE TEMP B-TREE FOR ORDER BY
remote — next initObjects on the SAME database with this fix (retrofit):
  indexes: idx_sys_notification_delivery_ad1bb657, idx_sys_notification_delivery_b3081700, idx_sys_notification_delivery_notification_id, idx_sys_notification_delivery_status_claimed_at, sqlite_autoindex_sys_notification_delivery_1, uniq_sys_notification_delivery_f5f71821
  SEARCH sys_notification_delivery USING INDEX idx_sys_notification_delivery_b3081700 (status=? AND partition_key=? AND next_attempt_at<?)
local — reference:
  indexes: (identical to the retrofitted remote set)
  SEARCH sys_notification_delivery USING INDEX idx_sys_notification_delivery_b3081700 (status=? AND partition_key=? AND next_attempt_at<?)
```

## Reverse verification

Directions predicted before each run. The suite imports `./turso-driver.js` from `src`, so the mutated `src/remote-transport.ts` is what ran (the local face's `@objectstack/driver-sql` resolves to its built dist, which no leg touched). Each leg: marker counted on disk before the run; restore by `git checkout HEAD --`, proven by the blob hash equalling HEAD's and an empty `git diff HEAD`.

- Base + test only (`bd207df81`): **7 failed / 7**. Fix (`6da2d2684`): **7 passed**.
- Final HEAD `6241e6e51`, three ablations of `src/remote-transport.ts`:
  - **A** — `missingIndexes` returns every planned index (no existing-name skip). Predicted 1 failed | 6 passed, only the steady-state pin. Observed **1 failed | 6 passed**: `steady state costs zero index DDL…`.
  - **B** — the retrofit fallback's durability report silenced. Predicted 2 failed | 5 passed, both failure-report pins. Observed **2 failed | 5 passed**: exactly those two.
  - **C** — the index name spelled raw (a bare double-quoted name) instead of escaped. Predicted 4 failed | 3 passed: every pin that syncs `os17609_scoped`, whose quote-bearing index name breaks the raw statement, and none of the three that sync only `sys_notification_delivery`. Observed **4 failed | 3 passed**: fresh database, `syncSchema` path, retrofit, steady state.
  - Every leg: marker counted once on disk before the run; restored blob `90cf0ed7` equals HEAD's; `git diff HEAD` empty afterwards.

## Local verification (HEAD `6241e6e51`)

Exit codes were captured before any pipe; each reading quotes the gate's own verdict line.

**Package — `@objectstack/driver-turso`**

- `pnpm --filter @objectstack/driver-turso test` — exit 0: **52 files, 1243 tests passed**.
- `pnpm --filter @objectstack/driver-turso typecheck` — exit 0. `tsc --listFiles` counts all 52 test files, the new suite among them.
- `pnpm --filter @objectstack/driver-turso build` — exit 0: `check-dts-emitted: @objectstack/driver-turso - 1/1 declared declaration file(s) present.`
- Dependency closure, at `3ef96b471` before any edit: `pnpm turbo run build --filter=@objectstack/driver-turso^... --concurrency=2` — 7 successful, 0 cached.
- `@objectstack/driver-sql` is not modified, so no `driver-sql` test / build / typecheck is owed.

**Lint — a declared narrowing, with its proof** (the repo-wide `pnpm lint` is CI's run)

- `pnpm exec eslint --no-inline-config --format json` over the 4 touched `.ts` files — exit 0. The JSON reports 4 files, 0 errors, 0 warnings, and no ignore notice on any of them, so all 4 are inside eslint's own lint population.
- Invariance: `eslint.config.mjs` never enables type-aware linting — it says so itself (no `parserOptions.project`, no typed `@typescript-eslint` rules) — so this diff cannot move a verdict in any untouched file. The fifth changed path is the changeset (Markdown, not linted).

**Derived gates** — `node scripts/pm/dispatch-gates.mjs --commands` on this tree derives 62 commands. Also run: the 4 roster gates it flags under this PR's own directories (`check-changeset-fixed`, `check:authz-resolver`, `check:error-code-casing`, `check:filter-alias-parity`) and `check:durability-log-level`.

- **68 exit 0.** Among them:
  - `pnpm check:durability-log-level` — `35 durability-critical catch seam(s), all loud, rethrowing or propagating to the caller`.
  - `pnpm check:nul-bytes` — `OK (scanned 8367 text file(s) … no raw ASCII control bytes)`.
  - `pnpm check:cross-package-test-inputs` — `28 package(s) read outside themselves, all declared` (the new suite reads nothing outside its package).
  - `pnpm check:test-source-alias`, `pnpm check:type-source-resolution`, `pnpm check:object-def-param-keys`, `pnpm check:driver-conformance`, `pnpm check:published-files` — OK.
  - `pnpm check:type-check-coverage` — `76/80 workspace packages type-checked`.
  - `node scripts/check-adr-0087-registration.mjs --base origin/main` — `this PR adds no declared-breaking changeset (1 non-breaking changeset(s) seen)`; `node scripts/check-empty-changeset.mjs --base origin/main` — `No empty-frontmatter changeset introduced`.
  - `node scripts/check-changeset-no-major.mjs --base origin/main` — exit 0, but locally it printed `no pull_request payload was available to read a declaration from`: the `Clause-②` limb reads this PR body, which only CI can hand it.
  - `pnpm check:lean-entry-closure` — first run exit 3 (`PREREQUISITE NOT MET`: no built `objectql`); after `pnpm turbo run build --filter=@objectstack/objectql --concurrency=2` (15 tasks, all cached) re-run exit 0: `2 published condition(s) measured from a real load … Admitted set held exactly (15 packages)`.
  - `pnpm check:dts-closure` and `pnpm check:sourcemap-no-sources-content` — exit 0 over the packages built in this worktree (driver-turso among them), not the whole repo.
- **2 NOT MEASURED** (exit 3, `PREREQUISITE NOT MET` — the gates' own words: neither a pass nor a failure):
  - `pnpm check:dual-build-cjs-loads` — reads every package's built output; 78 packages have no `dist/` here. It needs a full `pnpm build`, which this seat did not run beside another seat's build. CI builds first.
  - `pnpm check:type-check-debt` — `--re-measure` needs built type entry points for 24 workspace dependencies of the ledgered packages; same reason. `driver-turso` is not in that ledger.
- Reconciliation: `node scripts/pm/dispatch-gates.mjs --ran` over a record carrying every command as `command :: exit N` — `62 derived famil(ies) accounted for — 60 run, 2 NOT-MEASURED (2 DERIVED from a recorded exit 3)`, 0 unrun. Derived on this tree, 2 commits behind `origin/main` `0918c4411`; the tool reports none of those commits touched what the derivation reads.
- `dispatch-gates` also names what no local command covers, all NOT MEASURED here and owned by CI: 5 families whose argv takes a workflow value, 5 path-scheduled CI jobs (Test Core, Temporal Conformance, Dogfood Regression Gate, Dogfood Verify CLI, Build Core), 11 wide-population families and 45 roster families.

**Lock:** every `scripts/pm/os-verify-lock.sh` call ended `VERDICT … UNLOCKED (declared)` — a macOS host with no `flock` — so the shared verify lock was never taken and nothing was serialized.

## Acceptance notes

- `os-verify-lock.sh` ran in **declared UNLOCKED mode** on every locked command: the host is macOS with no `flock`, so the shared verify lock was never taken and nothing was serialized.
- `driver-sql` is untouched, so no `driver-sql` test/build/typecheck is owed; its built dist (from the closure build) is what the local face ran.
- The two hot-table fixtures are shapes copied from their object files, not imports: `driver-turso` does not depend on `service-messaging` or `platform-objects`. If those objects' `indexes` change, this suite keeps pinning driver parity, not those objects' current declarations.
- #17610 and #17611 remain open; this PR only makes each claim statement an index lookup.

---

_Generated by [Claude Code](https://claude.ai/code/session_c5c0ce54-bb9c-478c-9e5b-cf44b80d4569)_
