### PR TITLE
feat(spec): refuse a duration key whose JSDoc names a unit its describe does not

### DIFF
--- a/.changeset/15939-duration-unit-keys-jsdoc-divergence.md
+++ b/.changeset/15939-duration-unit-keys-jsdoc-divergence.md
@@ -1,0 +1,50 @@
+---
+'@objectstack/spec': patch
+---
+
+`check:duration-unit-keys` refuses a duration key whose JSDoc names a unit its describe does not
+
+The gate read a key's unit from `.describe()` and `.meta({ description })` only.
+A duration-shaped `z.number()` whose unit was written solely in the JSDoc block
+above it appeared in `--list` as a census row with `[prose: -]` and was never
+judged — and its own self-test pins *"a describe declared through
+`.meta({ description })` is READ — no exemption by blindness"*, which made the
+JSDoc blindness read as deliberate, measured coverage.
+
+**Ruled 2026-09-07 (decision batch #65).** JSDoc is developer commentary, not
+governed prose: `.describe()` is what `content/docs/references/**` renders and
+what rides into the published dist, and the JSDoc stops at the source file. So
+the gate does **not** start reading JSDoc as a unit channel — a unit written
+only there still has not satisfied the rule. What it now refuses is the
+DIVERGENCE: the JSDoc names a unit and the describe names none (or there is no
+describe at all), so the two channels disagree about whether this number's unit
+is written anywhere a reader can reach, and the channel that is silent is the
+published one. New rule `unit-in-jsdoc-not-in-describe`; the remedy is to move
+the unit into the describe, where the existing rule then puts it in the key
+name.
+
+⛔ **The JSDoc is read in exactly one direction: to refuse, never to satisfy.**
+A duration-shaped key with no unit in *either* channel is still listed and
+still not judged (the #14519 shape, unmoved). The new branch tests for a unit
+PRESENT in the JSDoc; it never tests for one absent from the describe, which is
+what would have made it the option the ruling declined.
+
+**Measured population delta on this tree: 0 → 21 offenders**, among an
+unchanged 211 duration-shaped numeric keys across 2433 source files. Every one
+was read rather than pattern-matched; none is a detector false positive. Three
+need only their describe corrected (the key name already carries `Ms`); the
+other eighteen name no unit in the key either, so each is a rename of a
+published key under an ADR-0087 conversion. ⛔ **No offender is exempted to
+reach green** — there is no baseline here by ruling, and the remediation is
+sequenced separately rather than hidden.
+
+**Two wrongly-recorded reasons repaired, both comment-only.** The blindness did
+not merely miss keys, it produced confident wrong prose about why they were
+missed: the retired-key entry for `SandboxConfig:process.timeout` and the
+burn-rate `window` pin comment in `metrics.test.ts` both said the neighbouring
+key was "outside the gate's population", when it is inside the census and
+outside the verdict — and its unit is not missing, only unpublished. Both now
+say that and name the JSDoc unit. `registry.ts` regenerated to mirror the
+entry; no pin assertion, title or body changed.
+
+⛔ No published key, accept set, default or runtime behaviour moves.

--- a/packages/spec/scripts/check-duration-unit-keys.ts
+++ b/packages/spec/scripts/check-duration-unit-keys.ts
@@ -67,6 +67,44 @@
  * talking about time. `--list` still prints the unit-nowhere keys so the
  * population stays visible; closing it is a describe-by-describe decision.
  *
+ * ⛔ "No unit anywhere" now means no unit in EITHER prose channel — see the
+ * JSDoc section below. A key whose describe is silent but whose JSDoc names a
+ * unit is not this shape at all: its unit IS written down, just not where the
+ * reader can see it, and that is the divergence class rather than this one.
+ *
+ * ## The SECOND prose channel: a JSDoc that names a unit the describe does not
+ *
+ * A key's unit can be written in two places, and only one of them is governed.
+ * `.describe()` / `.meta({ description })` is what `content/docs/references/**`
+ * renders and what rides into the published dist; the JSDoc block above the key
+ * is developer commentary that stops at the source file. Ruled 2026-09-07
+ * (decision batch #65, on #15939): JSDoc is NOT "prose" in the sense of this
+ * rule, so this gate does not read it as a unit channel — a key whose unit
+ * lives only in a JSDoc has NOT satisfied the rule, and option 1 of that card
+ * ("read the JSDoc too") was not adopted.
+ *
+ * What the ruling did adopt is the DIVERGENCE: when the JSDoc names a unit and
+ * the describe names none (or there is no describe at all), the two channels
+ * disagree about whether this number's unit is written down anywhere a reader
+ * can reach — and the channel that is silent is the published one. That is
+ * refused as `unit-in-jsdoc-not-in-describe`, and the remedy is to move the
+ * unit into the describe, where the rule above then applies and puts it in the
+ * key NAME.
+ *
+ * ⛔ SO THE JSDoc IS READ IN EXACTLY ONE DIRECTION: to refuse, never to
+ * satisfy. Nothing about the #14519 shape moves — a duration-shaped key with
+ * no unit in EITHER channel is still listed and still not judged. The
+ * divergence branch tests for a unit PRESENT in the JSDoc; it never tests for
+ * one absent from the describe, which is what would have made it option 1.
+ *
+ * Why the divergence is worth a refusal and the blindness was not: the card
+ * that filed it measured the cost. #15678 recorded in its changeset that
+ * `RuntimeConfig.resourceLimits.timeout` "names no unit anywhere in its prose"
+ * — and the JSDoc two lines above it says milliseconds. The blindness did not
+ * merely miss the key; it produced a confident, wrong, PINNED explanation of
+ * why it was missed. A gate that cannot see a channel writes falsehoods about
+ * it.
+ *
  * ## The two exemptions, DECLARED ON THE SCHEMA (#15676, ruling B)
  *
  * The rule governs every authored and every runtime-emitted duration MINUS two
@@ -304,6 +342,10 @@ export interface DurationKey {
   describe: string | undefined;
   /** units the describe prose names (canonical) */
   proseUnits: string[];
+  /** the JSDoc block written immediately above the key, when there is one */
+  jsdoc: string | undefined;
+  /** units that JSDoc block names (canonical) — read ONLY to refuse a divergence, never to satisfy the rule */
+  jsdocUnits: string[];
   /** units the key name carries (canonical) */
   keyUnits: string[];
   /** true when a sibling `unit` key sits on the same object literal */
@@ -320,7 +362,8 @@ export interface Finding {
   rule:
     | 'unit-in-prose-not-in-name'
     | 'name-unit-contradicts-prose'
-    | 'instant-unit-contradicts-schema';
+    | 'instant-unit-contradicts-schema'
+    | 'unit-in-jsdoc-not-in-describe';
   message: string;
 }
 
@@ -467,6 +510,31 @@ function concatLiteral(e: ts.Expression): string | undefined {
   return undefined;
 }
 
+/**
+ * The JSDoc block written immediately above a property — the SECOND prose
+ * channel, read only so a divergence can be refused (#15939, ruling 2026-09-07).
+ *
+ * Read through `ts.getJSDocCommentsAndTags`, not through a leading-comment scan,
+ * because the two differ exactly where it matters. A `//` line comment above a
+ * key is NOT a JSDoc block and must not be read as one, and — the hazard that
+ * would make this reader silently over-fire — an enclosing declaration's JSDoc
+ * must not be inherited by the first property of the object literal it
+ * introduces. Both are measured: a schema whose own docblock says
+ * "timeouts in milliseconds" contributes NOTHING to the bare `timeout` key
+ * declared first inside it, and the self-test pins that direction.
+ *
+ * The whole block's SOURCE TEXT is taken (leading asterisks, tags and all)
+ * rather than just the description: a unit named in an `@default 60 seconds`
+ * tag is the same divergence as one named in the summary line, and
+ * {@link unitsInProse}'s word-boundary matching is unbothered by the
+ * comment punctuation carried along with it.
+ */
+function jsdocTextOf(node: ts.Node, sf: ts.SourceFile): string | undefined {
+  const docs = ts.getJSDocCommentsAndTags(node).filter((d): d is ts.JSDoc => ts.isJSDoc(d));
+  if (docs.length === 0) return undefined;
+  return docs.map((d) => d.getText(sf)).join('\n');
+}
+
 /** Every numeric-chain property in one source text. */
 export function collectDurationKeys(fileName: string, code: string): DurationKey[] {
   const sf = ts.createSourceFile(fileName, code, ts.ScriptTarget.ES2022, /* setParentNodes */ true, ts.ScriptKind.TS);
@@ -486,12 +554,15 @@ export function collectDurationKeys(fileName: string, code: string): DurationKey
           // what every site in this tree writes, and where a key carries both,
           // the describe is the one an author reads at the declaration.
           const describe = describes.length ? describes[describes.length - 1] : metaDescription;
+          const jsdoc = jsdocTextOf(node, sf);
           out.push({
             file: fileName,
             line: sf.getLineAndCharacterOfPosition(node.getStart(sf)).line + 1,
             key: name,
             describe,
             proseUnits: unitsInProse(describe),
+            jsdoc,
+            jsdocUnits: unitsInProse(jsdoc),
             keyUnits: unitsInKey(name),
             valueUnitPair,
             durationShaped: isDurationShaped(name),
@@ -560,6 +631,32 @@ export function judge(site: DurationKey): Finding | undefined {
       };
     }
     return undefined;
+  }
+
+  // The DIVERGENCE class (#15939, ruling 2026-09-07, decision batch #65).
+  //
+  // Reached only when the describe named no unit at all — the branch above
+  // returns for every key whose describe did. A duration-shaped key whose
+  // JSDoc names a unit its describe does not is refused: the two prose
+  // channels disagree about whether this number's unit is written down, and
+  // the one that is published is the one that is silent.
+  //
+  // ⛔ The JSDoc is NEVER read as a way to SATISFY the rule — that was option
+  // 1 and it was not adopted. It is read in one direction only: to refuse.
+  // A key with no unit in EITHER channel stays "listed, not judged" (the
+  // #14519 shape), which is why this branch tests `jsdocUnits`, never the
+  // absence of `proseUnits` alone.
+  if (site.durationShaped && site.jsdocUnits.length > 0) {
+    return {
+      site,
+      rule: 'unit-in-jsdoc-not-in-describe',
+      message: `${where} — the JSDoc above the key names ${site.jsdocUnits.join('/')} but the describe names no unit`
+        + `${site.describe === undefined ? ' (there is no describe at all)' : ` (${JSON.stringify(site.describe)})`}. `
+        + 'The JSDoc is developer commentary; the describe is what `content/docs/references/**` publishes, so the '
+        + 'reader who most needs the unit is the one who cannot see it. Move the unit into the describe — the '
+        + 'existing rule then applies and the unit goes into the key NAME too, with an ADR-0087 conversion if the '
+        + 'key is published.',
+    };
   }
   return undefined;
 }
@@ -773,6 +870,88 @@ function selfTest(): number {
       return sites.length === 1 && sites[0].externalVocabulary === 'RFC 9111' && sites[0].proseUnits.join() === 'seconds';
     })());
 
+  // ── the DIVERGENCE class (#15939, ruling 2026-09-07, decision batch #65) ──
+  //
+  // The three POSITIVE CONTROLS are the three sites the card measured, reduced
+  // to their shape. They are the reason this class exists, so they are pinned
+  // here rather than described: if the reader ever stops seeing them, these
+  // cases go red instead of the population quietly shrinking by three.
+  //
+  // ⛔ The direction is load-bearing. The JSDoc is read ONLY to refuse, never
+  // to satisfy — option 1 (read JSDoc as a unit channel) was NOT adopted, and
+  // the case below that keeps a JSDoc-plus-describe key failing
+  // `unit-in-prose-not-in-name` is what stops this reader drifting into it.
+
+  expect('REFUSED (divergence): JSDoc names ms, describe names none → unit-in-jsdoc-not-in-describe',
+    rulesOf(`const S = z.object({\n  /**\n   * Execution timeout in milliseconds\n   */\n  timeout: z.number().int().min(0).optional().describe('Maximum execution time') });`)
+      .join() === 'unit-in-jsdoc-not-in-describe');
+  expect('REFUSED (divergence): JSDoc names seconds, describe names none → unit-in-jsdoc-not-in-describe',
+    rulesOf(`const S = z.object({\n  /**\n   * Window size in seconds\n   */\n  window: z.number().int().positive().describe('Window size') });`)
+      .join() === 'unit-in-jsdoc-not-in-describe');
+  expect('REFUSED (divergence): JSDoc names seconds and there is NO describe at all',
+    rulesOf(`const S = z.object({\n  /**\n   * Export interval in seconds\n   */\n  interval: z.number().int().positive().optional().default(60) });`)
+      .join() === 'unit-in-jsdoc-not-in-describe');
+
+  expect('compliant (negative control): the unit is in BOTH channels and in the name',
+    rulesOf(`const S = z.object({\n  /**\n   * Cache TTL in milliseconds\n   */\n  ttlMs: z.number().int().default(60_000).describe('Cache TTL in milliseconds') });`)
+      .join() === '');
+  expect('compliant: JSDoc names a unit the describe ALSO names — no divergence, nothing to refuse',
+    rulesOf(`const S = z.object({\n  /**\n   * Duration in milliseconds\n   */\n  durationMs: z.number().describe('Elapsed time in milliseconds') });`)
+      .join() === '');
+
+  // ⛔ The JSDoc never SATISFIES the rule. A key whose describe names the unit
+  // and whose name does not is still a rename, JSDoc or no JSDoc — otherwise
+  // this reader would have quietly implemented option 1 by the back door.
+  expect('the JSDoc does NOT satisfy the rule: describe names the unit, name does not → still unit-in-prose-not-in-name',
+    rulesOf(`const S = z.object({\n  /**\n   * Cache TTL in seconds\n   */\n  ttl: z.number().describe('Cache TTL in seconds') });`)
+      .join() === 'unit-in-prose-not-in-name');
+
+  // Unchanged by this class, and pinned again from the JSDoc side: no unit in
+  // EITHER channel stays a census row (the #14519 shape). The divergence
+  // branch tests for a unit IN the JSDoc, never for its absence in the describe.
+  expect('listed, not judged: a JSDoc that names no unit leaves the #14519 shape exactly where it was',
+    (() => {
+      const sites = collectDurationKeys('fixture.ts', `const S = z.object({\n  /**\n   * Session timeout\n   */\n  sessionTimeout: z.number().int().positive().default(3600).describe('Session timeout') });`);
+      return sites.length === 1 && sites[0].durationShaped && sites[0].jsdocUnits.length === 0 && judge(sites[0]) === undefined;
+    })());
+
+  // The two ways this reader could OVER-fire, both measured against the AST
+  // rather than assumed. Either one would manufacture offenders out of prose
+  // that is not attached to the key at all.
+  expect('a `//` line comment above a key is NOT a JSDoc block and is not read as one',
+    rulesOf(`const S = z.object({\n  // Execution timeout in milliseconds\n  timeout: z.number().describe('Maximum execution time') });`)
+      .join() === '');
+  expect('an ENCLOSING declaration\'s JSDoc is not inherited by the first property inside it',
+    rulesOf(`/**\n * The whole schema, timeouts in milliseconds\n */\nexport const S = z.object({ timeout: z.number().describe('Maximum execution time') });`)
+      .join() === '');
+
+  // The idiom suppressions that keep `unitsInProse` honest apply to this
+  // channel too — it is the SAME reader, deliberately, so a calendar position
+  // or a rate cannot become an offender by being written in a JSDoc instead.
+  expect('skipped in the JSDoc channel too: a calendar position is not a duration',
+    rulesOf(`const S = z.object({\n  /**\n   * Hour of the day (0-23)\n   */\n  windowHour: z.number().describe('Start hour') });`)
+      .join() === '');
+  expect('skipped in the JSDoc channel too: a rate is not a duration',
+    rulesOf(`const S = z.object({\n  /**\n   * Heartbeats per second\n   */\n  heartbeat: z.number().describe('Heartbeat rate') });`)
+      .join() === '');
+
+  expect('the divergence class is DURATION-SHAPED only: a non-duration name with a unit in its JSDoc is not refused',
+    rulesOf(`const S = z.object({\n  /**\n   * Sampled over 30 seconds\n   */\n  sampleCount: z.number().describe('Samples taken') });`)
+      .join() === '');
+  expect('exempt (i) survives the new class: an `EpochMs` instant with an ms JSDoc is not newly refused',
+    rulesOf(`const S = z.object({\n  /**\n   * Creation timestamp in milliseconds\n   */\n  createdAt: EpochMs });`)
+      .join() === '');
+  expect('REFUSED (ii) extends here: an `externalVocabulary` marker waives the RENAME, never the divergence',
+    rulesOf(`const S = z.object({\n  /**\n   * Maximum cache age in seconds\n   */\n  maxAge: z.number().meta({ externalVocabulary: 'HTTP Cache-Control max-age (RFC 9111)' }) });`)
+      .join() === 'unit-in-jsdoc-not-in-describe');
+
+  expect('a divergent site carries its JSDoc units in the census, not just in the verdict',
+    (() => {
+      const sites = collectDurationKeys('fixture.ts', `const S = z.object({\n  /**\n   * Window size in seconds\n   */\n  window: z.number().describe('Window size') });`);
+      return sites.length === 1 && sites[0].jsdocUnits.join() === 'seconds' && sites[0].proseUnits.length === 0
+        && sites[0].jsdoc !== undefined && sites[0].jsdoc.includes('Window size in seconds');
+    })());
+
   expect('a describe declared through `.meta({ description })` is READ — no exemption by blindness',
     rulesOf(`const S = z.object({ timeout: z.number().meta({ description: 'Timeout in milliseconds' }) });`)
       .join() === 'unit-in-prose-not-in-name');
@@ -894,6 +1073,7 @@ function main(argv: string[]): number {
   if (argv.includes('--list')) {
     for (const s of durationSites) {
       const marks = [
+        s.jsdocUnits.length ? ` [jsdoc: ${s.jsdocUnits.join('/')}]` : '',
         s.valueUnitPair ? ' [value/unit pair]' : '',
         s.instant ? ` [instant: ${INSTANT_ROOT}]` : '',
         s.externalVocabulary !== undefined ? ` [${EXTERNAL_VOCABULARY_META_KEY}: ${s.externalVocabulary}]` : '',

--- a/packages/spec/src/migrations/entries/retired-keys/18.kernel__SandboxConfig__process.timeout.ts
+++ b/packages/spec/src/migrations/entries/retired-keys/18.kernel__SandboxConfig__process.timeout.ts
@@ -5,9 +5,14 @@
 // `timeoutMs`; the value is unchanged. Tombstoned with `retiredKey()` inside
 // the live `process` block. ⚠️ Note for anyone grepping this file: the
 // neighbouring `RuntimeConfig.resourceLimits.timeout` is a DIFFERENT key whose
-// describe names no unit at all, so it is outside the gate's population and is
-// untouched here. No D2 conversion: a `SandboxConfig` is the isolation
-// argument a host or a plugin security manifest constructs, never a stack
-// collection member or a stored row. See
+// describe names no unit at all, so it is inside the gate's census and outside
+// its verdict, and is untouched here. ⚠️ Its unit is not missing, only
+// unpublished: the JSDoc two lines above it says milliseconds. That divergence
+// is what #15939 filed and what `check:duration-unit-keys` was ruled to refuse
+// (2026-09-07, decision batch #65) — so this key is a rename waiting on that
+// gate change, not a key that has nothing to fix.
+// No D2 conversion: a `SandboxConfig` is the isolation argument a host or a
+// plugin security manifest constructs, never a stack collection member or a
+// stored row. See
 // `kernel-plugin-security-durations-unit-in-key`.
 export const entry = 'kernel/SandboxConfig:process.timeout';

--- a/packages/spec/src/migrations/registry.ts
+++ b/packages/spec/src/migrations/registry.ts
@@ -12310,10 +12310,15 @@ export const RETIRED_KEYS_BY_MAJOR: Readonly<Record<number, readonly string[]>> 
     // `timeoutMs`; the value is unchanged. Tombstoned with `retiredKey()` inside
     // the live `process` block. ⚠️ Note for anyone grepping this file: the
     // neighbouring `RuntimeConfig.resourceLimits.timeout` is a DIFFERENT key whose
-    // describe names no unit at all, so it is outside the gate's population and is
-    // untouched here. No D2 conversion: a `SandboxConfig` is the isolation
-    // argument a host or a plugin security manifest constructs, never a stack
-    // collection member or a stored row. See
+    // describe names no unit at all, so it is inside the gate's census and outside
+    // its verdict, and is untouched here. ⚠️ Its unit is not missing, only
+    // unpublished: the JSDoc two lines above it says milliseconds. That divergence
+    // is what #15939 filed and what `check:duration-unit-keys` was ruled to refuse
+    // (2026-09-07, decision batch #65) — so this key is a rename waiting on that
+    // gate change, not a key that has nothing to fix.
+    // No D2 conversion: a `SandboxConfig` is the isolation argument a host or a
+    // plugin security manifest constructs, never a stack collection member or a
+    // stored row. See
     // `kernel-plugin-security-durations-unit-in-key`.
     'kernel/SandboxConfig:process.timeout',
     // #15678 (stack card 3/6 of #14478) — ruling B. `StartupOptions.timeout` said

--- a/packages/spec/src/system/metrics.test.ts
+++ b/packages/spec/src/system/metrics.test.ts
@@ -562,7 +562,12 @@ describe('metrics window and period lengths carry their unit (#15679)', () => {
     expect(MetricExportConfigSchema.parse({ type: 'prometheus', batch: { size: 500 } })
       .batch?.size).toBe(500);
     // The error-budget burn-rate `window` names no unit in its describe, so it is
-    // outside the gate population entirely and keeps its bare name.
+    // inside the gate's census and outside its verdict, and keeps its bare name.
+    // ⚠️ Its unit is not missing, only unpublished: the JSDoc above it says
+    // seconds. `check:duration-unit-keys` was ruled to refuse that divergence
+    // (2026-09-07, decision batch #65, on #15939), so this key is a rename
+    // waiting on that gate change — this pin asserts the CURRENT bare spelling
+    // and must be re-read, not trusted, when the rename lands.
     const slo = ServiceLevelObjectiveSchema.parse({
       ...sloBase,
       period: { type: 'rolling', durationSeconds: 2592000 },


### PR DESCRIPTION
Part of #15939

The `check:duration-unit-keys` widening, landing **last** as ruling A sequenced it. All seven remediation cards (#17780–#17786) have merged, so the population this rule adds is already remediated and the widened gate reads **zero offenders** on the merged tree.

## The ruling this executes

Option **2** of #15939, recorded 2026-09-07 (decision batch #65), maintainer 「同意」; sequencing set by **ruling A**, director seat 2026-09-11, maintainer 「同意」 (decision batch #115):

> **Ruling A.** Batch #65's direction stands (the gate refuses a duration key whose JSDoc names a unit its describe does not). Sequencing: the remediation lands **first, per file** … and PR **#17635** (the gate + self-test + the two corrected prose sites) lands **last**, into a tree it already reads as clean. ⛔ Not B (18 published-key renames in one PR); ⛔ C is gate weakening.

JSDoc is developer commentary and is **not** "prose" in the sense of the #14478 rule, so the gate does **not** start reading JSDoc as a unit channel — option 1 was explicitly not adopted. What it refuses is the **divergence**: a duration-shaped numeric key whose JSDoc names a unit and whose `.describe()` names none (or which has no describe at all).

⛔ **The JSDoc is read in exactly one direction: to refuse, never to satisfy.** A key with no unit in *either* channel is still listed and still not judged (the #14519 shape, unmoved). Two self-test cases pin that direction and neither was relaxed to reach zero:

```
✓ the JSDoc does NOT satisfy the rule: describe names the unit, name does not → still unit-in-prose-not-in-name
✓ listed, not judged: a JSDoc that names no unit leaves the #14519 shape exactly where it was
```

## What changed while this PR waited

Merged `origin/main` in (⛔ never rebased, never force-pushed — the branch is `os-bill`'s). Merge base **`b06b2db5c4`**, two commits past the `6d647858b7` the dispatch recorded; both land in `packages/spec/src/` and neither introduces an offender.

**The diff is now 4 files, not 5.** #17635's `metrics.test.ts` half was **obsolete, not merely conflicted**: #17783 rewrote the enclosing `it(...)`, moved the same correction into a narrowed header comment, and renamed the key itself. Verified by content rather than line number — the hunk's exact target text (`outside the gate population entirely and keeps its bare name`) returns **0** occurrences on the merged tree, while the bare phrase `outside the gate population entirely` returns **1**, now quoted as the *superseded* reading. Lit control `burn-rate` **2**, dark control (token invented at read time) **0**. That half is dropped; nothing is lost.

**`packages/spec/src/migrations/registry.ts` is generated and was NOT resolved textually.** It text-merged without a conflict, which is exactly the state AGENTS.md §10 says never to trust, so it was regenerated with `pnpm gen:migration-registry` and proved byte-identical to the merged bytes (blob `cef78f2140` before and after). `check:migration-registry` then read:

```
✓ src/migrations/registry.ts is current (215 semantic, 186 retired-key, 178 retired-def)
```

The only conflict was `metrics.test.ts`, resolved to main's side. `os-regen-merge.sh` stopped with *"✗ merge stopped on conflicts in NON-generated files — resolve those by hand"* — **correct for this merge**, since the sole conflict really was a hand-written file. The #18047 misclassification did not manifest here.

## The prose repair — one site, not two

The blindness did not merely miss keys, it produced confident wrong prose about why they were missed. One site still carried it. **The replacement text #17635 was carrying had itself gone stale** and would have landed already wrong: it described the neighbouring `RuntimeConfig.resourceLimits.timeout` as a key whose "describe names no unit at all", "inside the gate's census and outside its verdict", and "a rename waiting on that gate change". On this tree that key is **already renamed** — `timeoutMs … .describe('Maximum execution time in milliseconds')` at `plugin-security-advanced.zod.ts:316-317`, its tombstone at `:320`, its retirement prose at `:185`.

The note now repairs the *original* wrong reason without re-asserting a landed rename as pending, and points at the neighbour's own entry instead of restating its story. It spells no package version, so it does not join the `@objectstack/spec 18` class filed as #18040. `registry.ts` regenerated to mirror it. ⛔ No pin assertion, title or body changed.

The second site — the `metrics.test.ts` burn-rate pin — was corrected by #17783 when it renamed that key, so nothing is owed there.

## The gate reading, from the right instrument

⛔ `check:duration-unit-keys` on plain `main` proves nothing here: `main` carries the *old* gate. This is **this branch's widened gate on the merged tree**:

```
✓ check:duration-unit-keys — 211 duration-shaped numeric key(s) across 2482 source file(s) all carry
  their unit in the key name (or in a sibling `unit`, or under a declared exemption: 6 declared
  `EpochMs` instant(s), 11 declared `externalVocabulary` mirror(s)); zero offenders, no baseline.
                                                                                          exit 0
```

**A zero is only as good as the proof the instrument can still say non-zero.** Lit control, drawn a different way than the self-test — a real on-disk mutation of a real source file, not a synthetic fixture: the unit was stripped from `resourceLimits.timeoutMs`'s describe, leaving its JSDoc naming milliseconds. Blob `160ab186` → `b7d06799`, deleted anchor `0` / injected anchor `1`. The gate then:

```
✗ check:duration-unit-keys — 1 offender(s) among 211 duration-shaped numeric key(s) in 2482 source file(s)
  [unit-in-jsdoc-not-in-describe] packages/spec/src/kernel/plugin-security-advanced.zod.ts:316 `timeoutMs`
  — the JSDoc above the key names ms but the describe names no unit ("Maximum execution time").
                                                                                          exit 1
```

The **new** rule class fires, on the real tree walk, at the exact mutated key, with the census unchanged at 211/2482 — so only the verdict moved. Restored and proved restored by observed state: on-disk blob back to `160ab186`, `git diff HEAD` empty, working tree clean. The mutation ran under a `trap … EXIT INT TERM` with an absolute path.

**Population, measured here rather than relayed:** 18 renames each carrying a `retiredKey()` tombstone entry naming #15939 on `origin/main`, plus 3 describe-only corrections = **21**. Counted with an instrument independent of the gate (tombstone entry files), lit control 15 (`#15678` entries), dark control 0.

## Ruling A's objectui pre-check — inapplicable, and why

Ruling A requires a `git grep` of `objectui` at the pinned SHA before landing a **published-key rename** (AGENTS.md Post-Task Checklist step 4). **This PR renames nothing.** The 18 renames all landed in the seven remediation cards, each of which owed that check on its own landing. Measured here: every changed line under `packages/spec/src/` is a **comment** — the non-comment changed-line set is empty. So the check is inapplicable rather than done, and it is ⛔ not silently skipped.

## Verification

Heavy runs through `scripts/pm/os-verify-lock.sh` (`OS_VERIFY_LOCK_SLOT=issue-15939-dev`), verdicts quoted from the lock's own `VERDICT command-exit` line, ⛔ never a bare `$?`.

| check | result |
|:--|:--|
| `pnpm --filter '@objectstack/spec^...' build` | `VERDICT command-exit 0` — **empty closure** (`No projects matched`); `packages/spec` has no workspace dependencies, so this is a declared no-op, ⛔ not counted as a pass |
| `pnpm --filter @objectstack/spec build` | `VERDICT command-exit 0` (199s) — run before every gate that reads `dist/` |
| `pnpm --filter @objectstack/spec typecheck` | `VERDICT command-exit 0` — `tsc --noEmit` + `check:scripts-typecheck` + `check:test-typecheck` |
| `pnpm --filter @objectstack/spec test` | `VERDICT command-exit 0` — **476 files / 13578 tests passed** |
| `check:duration-unit-keys --self-test` | exit 0 — **156 cases, 0 failures**; the two one-directional pins quoted above intact |
| `check:duration-unit-keys` (widened, merged tree) | **exit 0, zero offenders**, + the lit/dark controls above |
| `check:migration-registry` | exit 0 — *"registry.ts is current (215 semantic, 186 retired-key, 178 retired-def)"* |
| `check:generated` | exit 0 — **all 15** generated artifacts up to date |
| `dispatch-gates.mjs --ran` | **82 derived, 81 run, 1 NOT-MEASURED, 0 UNRUN** |

Gate family derived **after** the merge and changeset existed, with `node scripts/pm/dispatch-gates.mjs --commands --repo objectstack-ai/objectstack`, and reconciled with `--ran` carrying a recorded exit code per family. Two prerequisites were built rather than counted green (`@objectstack/formula`, `@objectstack/lint`, `@objectstack/objectql`), after which `check:doc-formula-expressions` and `check:lean-entry-closure` both read exit 0.

**⊘ NOT MEASURED — declared, ⛔ not counted green:**

- `pnpm check:dual-build-cjs-loads` — **exit 3, `PREREQUISITE NOT MET`**: reads built output for 87 packages and needs a whole-repo `pnpm build`. That is CI's `Build Core`. Nothing was measured; this is neither a pass nor a finding.
- `pnpm check:pm-dispatch-gates` — **exit 124**, my own `timeout` kill at 560s under the container's foreground cap, ⛔ not a gate verdict. Its partial output showed no failing case, but no verdict line was reached. Note the reconciler derives NOT-MEASURED only from exit 3, so it counts this family as run; it is declared here instead.

The repo-wide farm (`pnpm lint` and the 48 artifact-roster, 11 wide-population and 5 path-scheduled CI families the derivation names as outside its total) is CI's run. This narrowing is declared, not silent.

## Changeset

`.changeset/15939-duration-unit-keys-jsdoc-divergence.md`, `@objectstack/spec: patch`. Rewritten against the merged tree: it had claimed a live *"0 → 21 offenders"* population delta and *"two wrongly-recorded reasons repaired"*, both false now that the remediation has landed and one of the two sites belongs to #17783. ⛔ No published key, accept set, default or runtime behaviour moves in this diff.

---

## Gate declaration for this PR

- **Clause-②: no**

**Why `no` is the honest answer for THIS diff**, re-measured after the merge: the four files are the gate script (`packages/spec/scripts/**`, not `src/**`), one comment-only prose repair, the regenerated migration registry mirroring it, and the changeset. Mechanically checked — **every changed line under `packages/spec/src/` is a comment**; the non-comment changed-line set is empty. No new exported symbol, no new key on a published payload, and no accept/reject outcome moved. What the diff does is make an existing gate refuse *more* inputs, which **narrows** the accept set; narrowing is the semantic face, never clause ②. `check:pm-widening-tells` reads exit 0.

⚠️ The path leg of the enqueue gate still fires (three of the paths are under `packages/spec/`), so an in-seat contract review at `CONTRACT_REVIEW_TIER` is owed before this may turn ready or enqueue. Scheduled, not waived — and this round ⛔ did not turn it ready, ⛔ did not enqueue it, and ⛔ did not touch `needs:contract-review`.

Prepared by the `os-dev` seat in session `session_015c5G6TmpMKgnusmTpD7Ntt`; merge commit `d9b3fd5a3d`, merge base `b06b2db5c4`.


---
_Generated by [Claude Code](https://claude.ai/code)_