### PR TITLE
docs(spec): ApproverType.describe() qualifies `manager` instead of offering it as a bare allowed value

### DIFF
--- a/.changeset/17579-approver-type-manager-describe.md
+++ b/.changeset/17579-approver-type-manager-describe.md
@@ -1,0 +1,43 @@
+---
+'@objectstack/spec': patch
+---
+
+`ApproverType` qualifies `manager` in its `.describe()` instead of offering it as a bare allowed value
+
+`ApproverType` carried **no** `.describe()` at all, so the generated reference
+page rendered `## ApproverType` with nothing but an `### Allowed Values` list:
+`manager` — the one rung an author cannot operate on a stock install — read
+exactly like the nine members that work. `{ type: 'manager' }` resolves
+`sys_user.manager_id`, and that column still has no product write surface
+(re-measured on this tree: the identity write guard's managed-update whitelist
+for `sys_user` is `{name, image, locale}`; the column carries `readonly: true`;
+no `packages/plugins/plugin-auth` source writes it). An author who chose it got
+a chain that passed `validate` and `lint` and then stalled on its first
+submission.
+
+The new describe says what is true about `manager` and **points** at the remedy
+rather than restating it: `MANAGER_ONLY_REMEDY` / `MANAGER_ONLY_ROUTES` in
+`packages/lint/src/validate-approval-approvers.ts` remain the single
+authoritative copy of the population routes, and that file's `DEPENDENCY`
+docblock now names this new string among the lines that go stale if the column
+ever gains a write surface. A pointer cannot drift into disagreement with what
+it points at, which is why no third copy of the 667-character remedy was added.
+
+⛔ No member is added, removed or renamed, and no behaviour changes: the enum's
+accept set is byte-identical and `check:api-surface` is green on the rebuilt
+`dist/*.d.ts`.
+
+**Why this ships, and why `patch`.** `@objectstack/spec`'s published `files[]`
+carries `dist`, `json-schema` and `src/**/*.zod.ts`, and the new string is
+measured in all three on the built tree — `dist/automation/index.js` and
+`.mjs` (2 files, against a lit control of an existing describe from the same
+module, also 2), four `json-schema/` documents (`ApproverType.json`,
+`ApprovalNodeApprover.json`, `ApprovalNodeConfig.json`, `objectstack.json`) and
+the shipped `approval.zod.ts` source. Prose only, no surface widening ⇒
+`patch`.
+
+The `packages/lint` half is a docblock comment and is deliberately **not**
+graded: that package publishes `dist` only, and the new sentence is absent from
+it (0 files) while a runtime string from the same source file is present in 4
+and a pre-existing comment from the same docblock is absent in 0 — so comments
+are stripped by construction and nothing published moves there.

--- a/content/docs/references/automation/approval.mdx
+++ b/content/docs/references/automation/approval.mdx
@@ -52,7 +52,7 @@ const result = ApprovalDecision.parse(data);
 
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
-| **type** | `Enum<'manager' \| 'position' \| 'department' \| 'team' \| 'field' \| 'expression' \| 'org_membership_level' \| 'role' \| 'user' \| 'queue'>` | ✅ |  |
+| **type** | `Enum<'manager' \| 'position' \| 'department' \| 'team' \| 'field' \| 'expression' \| 'org_membership_level' \| 'role' \| 'user' \| 'queue'>` | ✅ | Approval step approver type. `manager` is a directory-sync dependency rather than something an author configures here: it resolves the submitter's `sys_user.manager_id` at runtime, and that column has no product write surface, so until an operator populates it from outside the product a manager step resolves to nobody and the request waits. `os lint` reports that at authoring time as `approval-approvers-may-resolve-empty` and carries the graded population routes and the full remedy; the Approvals guide states the same remedy in prose. |
 | **value** | `string` | optional | User id / membership tier / position / team / department / field — per `type`; for `expression`, a CEL expression over `current.*` / `trigger.*` / `vars.*` |
 | **resolveAs** | `Enum<'user' \| 'department' \| 'position' \| 'team'>` | optional | How an `expression` result is expanded into approvers (default 'user') |
 | **group** | `string` | optional | Group label for per_group sign-off (e.g. "legal", "finance") |
@@ -81,7 +81,7 @@ const result = ApprovalDecision.parse(data);
 
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
-| **type** | `Enum<'manager' \| 'position' \| 'department' \| 'team' \| 'field' \| 'expression' \| …>` | ✅ |  |
+| **type** | `Enum<'manager' \| 'position' \| 'department' \| 'team' \| 'field' \| 'expression' \| …>` | ✅ | Approval step approver type. `manager` is a directory-sync dependency rather than something an author configures here: it resolves the submitter's `sys_user.manager_id` at runtime, and that column has no product write surface, so until an operator populates it from outside the product a manager step resolves to nobody and the request waits. `os lint` reports that at authoring time as `approval-approvers-may-resolve-empty` and carries the graded population routes and the full remedy; the Approvals guide states the same remedy in prose. |
 | **value** | `string` | optional | User id / membership tier / position / team / department / field — per `type`; for `expression`, a CEL expression over `current.*` / `trigger.*` / `vars.*` |
 | **resolveAs** | `Enum<'user' \| 'department' \| 'position' \| 'team'>` | optional | How an `expression` result is expanded into approvers (default 'user') |
 | **group** | `string` | optional | Group label for per_group sign-off (e.g. "legal", "finance") |
@@ -111,6 +111,8 @@ const result = ApprovalDecision.parse(data);
 ---
 
 ## ApproverType
+
+Approval step approver type. `manager` is a directory-sync dependency rather than something an author configures here: it resolves the submitter's `sys_user.manager_id` at runtime, and that column has no product write surface, so until an operator populates it from outside the product a manager step resolves to nobody and the request waits. `os lint` reports that at authoring time as `approval-approvers-may-resolve-empty` and carries the graded population routes and the full remedy; the Approvals guide states the same remedy in prose.
 
 ### Allowed Values
 

--- a/packages/lint/src/validate-approval-approvers.ts
+++ b/packages/lint/src/validate-approval-approvers.ts
@@ -139,6 +139,15 @@ const GROUP_ROUTED_TYPES = new Set(['position', 'team', 'department']);
  * a system-context write. Update them in the same change that opens the write
  * surface — and re-take the three grades above, which are readings of this
  * tree, not standing facts.
+ *
+ * Two other carriers assert the same fact and go stale with these strings, so
+ * the list is theirs too: the `manager` callout in
+ * `content/docs/automation/approvals.mdx`, and `ApproverType`'s `.describe()`
+ * in `packages/spec/src/automation/approval.zod.ts` (rendered verbatim into
+ * `content/docs/references/automation/approval.mdx`). Neither RESTATES the
+ * remedy — both point back here, which is why there is still exactly one copy
+ * to edit — but both assert that the column has no product write surface, and
+ * that is the sentence which stops being true.
  */
 // ⛔ The tracker ids stay in the comments above and never in this string:
 // `check:doc-authoring` Rule 3 — a runtime string reaches authors, operators and

--- a/packages/spec/src/automation/approval.zod.ts
+++ b/packages/spec/src/automation/approval.zod.ts
@@ -70,7 +70,33 @@ export const ApproverType = z.enum([
   // (see NON_AUTHORABLE_APPROVER_TYPES). Re-admit only together with a real
   // ownership-queue implementation (queue entity + membership + claim).
   'queue',
-]);
+])
+  // The generated reference page renders THIS string under `## ApproverType`;
+  // the JSDoc above the enum renders nowhere (`renderSchemaSection` prints
+  // `mainDef.description`, which only `.describe()` / `.meta({description})`
+  // fills). Until this string existed the page listed `manager` as a bare
+  // allowed value, so the one rung an author cannot operate on a stock install
+  // read exactly like the nine that work.
+  //
+  // ⛔ It POINTS at the remedy, it does not restate it. The remedy's single
+  // authoritative copy is `MANAGER_ONLY_REMEDY` / `MANAGER_ONLY_ROUTES` in
+  // `packages/lint/src/validate-approval-approvers.ts`, mirrored for readers by
+  // the Approvals guide; a third copy here would be one more line to keep in
+  // step, and a pointer cannot drift into disagreement with what it points at.
+  // That file's `⛔ DEPENDENCY` docblock now names this string among the lines
+  // that go stale if `manager_id` ever gains a product write surface.
+  //
+  // ⛔ Tracker ids stay out of the string itself — it reaches authors and
+  // generated surfaces, neither of whom can resolve one (`check:doc-authoring`
+  // Rule 3).
+  .describe(
+    'Approval step approver type. `manager` is a directory-sync dependency rather than something ' +
+    "an author configures here: it resolves the submitter's `sys_user.manager_id` at runtime, and " +
+    'that column has no product write surface, so until an operator populates it from outside the ' +
+    'product a manager step resolves to nobody and the request waits. `os lint` reports that at ' +
+    'authoring time as `approval-approvers-may-resolve-empty` and carries the graded population ' +
+    'routes and the full remedy; the Approvals guide states the same remedy in prose.',
+  );
 export type ApproverType = z.input<typeof ApproverType>;
 
 /**


### PR DESCRIPTION
Part of #17579

- **Clause-②: no** — this PR puts no new key on any published payload. `ApproverType`'s accept set is byte-identical (no member added, removed or renamed), `check:api-surface` is green on the rebuilt `dist/*.d.ts`, and `check:authorable-surface` left the checked-in artifacts untouched. The only new bytes are prose.

## What this changes

`ApproverType` carried **no `.describe()` at all**, so the generated reference page rendered `## ApproverType` with nothing but an `### Allowed Values` list. `manager` — the one rung an author cannot operate on a stock install — read exactly like the nine members that work.

- `packages/spec/src/automation/approval.zod.ts` — the enum gains a `.describe()` that qualifies `manager` and **points** at the remedy instead of restating it.
- `content/docs/references/automation/approval.mdx` — **regenerated**, never hand-edited (see the generator evidence below).
- `packages/lint/src/validate-approval-approvers.ts` — one paragraph added to the `DEPENDENCY` docblock above `MANAGER_ONLY_REMEDY`, naming the new describe among the lines that go stale if `manager_id` ever gains a write surface. The triage comment called this out as the part a round is most likely to skip; it is a comment only.

The describe, verbatim:

> Approval step approver type. `manager` is a directory-sync dependency rather than something an author configures here: it resolves the submitter's `sys_user.manager_id` at runtime, and that column has no product write surface, so until an operator populates it from outside the product a manager step resolves to nobody and the request waits. `os lint` reports that at authoring time as `approval-approvers-may-resolve-empty` and carries the graded population routes and the full remedy; the Approvals guide states the same remedy in prose.

**Route (iii), the triage default: it points, it does not restate.** `MANAGER_ONLY_REMEDY` / `MANAGER_ONLY_ROUTES` stay the single authoritative copy of the 667-character remedy. No third copy was written, so there is nothing new to keep in step — a pointer cannot drift into disagreement with what it points at. ⛔ No export was added to `packages/spec` (route (ii) was fenced).

## Prerequisite readings — taken by state on `origin/main` @ `ea2940d1c4`, not inherited from the card

**1. The `manager` describe.** ⚠️ **Correction to the card**: `ApproverType` had no `.describe()` to read unqualified — it had **none**. Its JSDoc (`approval.zod.ts:24-30`) renders nowhere: `renderSchemaSection` (`packages/spec/scripts/lib/schema-section.ts:328-330`) prints `mainDef.description`, which only `.describe()` / `.meta({description})` fills. Positive control that the mechanism is real: `HttpMethod`'s `.describe()` (`packages/spec/src/shared/http.zod.ts:45`) renders at `content/docs/references/shared/http.mdx:46`. The card's substance stands — the page sold `manager` unqualified — but the fix is a describe **added**, not a describe **edited**.

**2. The generated page.** `content/docs/references/automation/approval.mdx:113` is `## ApproverType`, `:115` is `### Allowed Values`, `:117` is the `manager` bullet — the exact window the card names. Its banner (`:6`) still reads `⚠️  AUTO-GENERATED — DO NOT EDIT. Run build-docs.ts to regenerate.` and the source callout (`:9-10`) still names `packages/spec/src/automation/approval.zod.ts`. Both hold.

**3. ⭐ `sys_user.manager_id` has no product write surface — re-measured, with the negative leg lit.**

A throwaway probe drove the identity write guard's real `beforeUpdate` handler in a user context, then was deleted (working tree verified clean afterwards); both legs went through the **same** handler:

```
PROBE legA surviving payload = {"id":"u1","name":"Keep"}      # manager_id stripped
PROBE legB surviving payload = {"id":"u1","locale":"zh-CN"}   # control survives intact
PROBE whitelist = ["name","image","locale"]
Test Files  2 passed (2)   Tests  29 passed (29)
```

- **Leg A (subject).** `{ id, name, manager_id }` came back as `{ id, name }` — `manager_id` never reaches the row. `{ id, manager_id }` alone is refused loudly: `PERMISSION_DENIED` / `403`.
- **Leg B (negative leg).** `locale` — a field that IS writable — passed the same probe unchanged. ⇒ the instrument is not a refusal that refuses everything.
- The landed pins the card cites are still exactly where it says: `identity-write-guard.test.ts:132` (`/Editable fields: name, image, locale/`) and `:186` (`getManagedUpdateWhitelist('sys_user')` equals `new Set(['name','image','locale'])`). Both green in the same run.

`readonly: true` on the column, with a discriminating control — `readonly` occurrences inside each field block of `packages/platform-objects/src/identity/sys-user.object.ts`:

| field | `readonly` occurrences |
|:--|--:|
| `manager_id` | **1** |
| `primary_business_unit_id` | 1 |
| `locale` (control — writable) | **0** |
| `name` (control — writable) | **0** |

No accepting route: across the **59** non-test `packages/plugins/plugin-auth/src/*.ts` files (enumerated with `git ls-tree`, not by grepping contents for a filename), `manager_id` occurs **5** times against a firing control of `phone_number` at **28** — and all 5 sit in `managed-extension-fields.ts` and `sys-user-writable-fields.ts`, both of which name the column only to record that it is **not** writable (`MANAGED_EXTENSION_EDITABLE_FIELDS.sys_user` is `new Set(['locale'])`). Counts are `grep -o | wc -l`, not `grep -c`.

⇒ **The premise holds. `premise_still_valid: true`.**

**4. What PR #17575 already fixed — not redone.** The `manager` callout in `content/docs/automation/approvals.mdx:65-87` and the qualification in `content/docs/capabilities/approvals.mdx:14-19` are both present and **untouched by this PR** (`git diff` names neither file).

## The page was regenerated, not hand-edited

```
$ pnpm --filter @objectstack/spec build           # required first (the dist caveat)
$ pnpm --filter @objectstack/spec check:generated
  ✗ check:docs   content/docs/references/**       # 1 of 15 stale — exactly the one predicted
$ pnpm --filter @objectstack/spec gen:docs
  ✅ Generated 222 files
$ git status --porcelain
   M content/docs/references/automation/approval.mdx     # 1 of the 222 changed
$ pnpm --filter @objectstack/spec check:generated
  ✓ All 15 generated artifacts are up to date.
```

The generator rewrote all 222 reference pages and exactly one moved. Beyond the `## ApproverType` section, the describe also reached the previously **blank** Description cells of the `type` rows in `ApprovalNodeApprover` and `ApprovalNodeConfig.approvers` — measured on the regenerated output, not predicted from the zod registry semantics (which read the other way).

## Verification

- `pnpm --filter @objectstack/spec check:generated` — **all 15 green**, including `check:api-surface`, `check:authorable-surface`, `check:docs`.
- **Derived gate family** — `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` over this diff: **100 families derived, 98 run green, 0 unrun, 2 NOT MEASURED**. Reconciled with `--ran` carrying each recorded exit code.
  - `pnpm check:dual-build-cjs-loads` and `pnpm check:lean-entry-closure` both exit **3 — PREREQUISITE NOT MET** (they load built entry points repo-wide and this worktree has no full `pnpm build`). ⛔ Recorded as NOT MEASURED, not as green; CI builds and runs both.
  - One run was **discarded and re-run rather than silently retried**: `check:skill-examples` first exited 1 for want of `packages/client-react/dist`, a prerequisite refusal, not a red. After `pnpm --filter @objectstack/client-react build` it is green — `✅ 258 prose examples type-check across 3 surface(s)`.
  - A second discarded run: `pnpm --filter … run test --concurrency=2` forwarded `--concurrency` into the vitest script and failed on flag parsing. Re-run correctly as `pnpm --workspace-concurrency=2 --filter … run test`.
- `pnpm --workspace-concurrency=2 --filter @objectstack/spec --filter @objectstack/lint run test` — spec **473 files / 13429 tests passed**, lint **103 files / 3747 tests passed**.
- `pnpm --workspace-concurrency=2 --filter @objectstack/spec --filter @objectstack/lint run typecheck` — exit 0, both test-layer debt ledgers held.
- `pnpm lint` (`eslint . --no-inline-config`, the whole repo) — **exit 0**. No narrowing was needed, so none is claimed.
- `pnpm check:nul-bytes` green, plus a direct control-character scan over the four touched files (`grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]'` → no match).

Heavy runs went through `scripts/pm/os-verify-lock.sh`; the verdicts above are its `VERDICT command-exit` lines, with each exit code captured before any pipe.

## Changeset

`.changeset/17579-approver-type-manager-describe.md` — **`@objectstack/spec`: `patch`**. The describe ships: `@objectstack/spec`'s `files[]` carries `dist`, `json-schema` and `src/**/*.zod.ts`, and the new string is measured in all three on the built tree — `dist/automation/index.js` + `.mjs` (**2** files, against a lit control of an existing describe from the same module, also **2**), four `json-schema/` documents, and the shipped `approval.zod.ts` source. Prose only, no surface widening ⇒ `patch`, not `minor`.

`@objectstack/lint` is deliberately **not** graded. It publishes `dist` only, and the new docblock sentence is absent from it (**0** files) while a runtime string from the same source file is present in **4** and a pre-existing comment from the same docblock is absent in **0** — comments are stripped by construction, so nothing published moves there.

## Out of scope

- ⛔ The `manager` enum member is **not** removed. Removing a member is a larger question and needs its own ruling.
- ⛔ No re-wording of PR #17575's callouts, no change to `ApproverType`'s shape, no touch to `plugin-auth` or the write guards, no export added to `packages/spec`.
- ⛔ `content/docs/releases/` untouched.
- ⚠️ Live coupling, unchanged by this PR: #16678 holds the open question of whether `manager_id` gains a product write surface. This wording is correct under every one of its options — the column still needs populating before `manager` resolves — and the `DEPENDENCY` docblock now lists this string among the lines that would need updating in the same change that opens such a surface.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MkQhmuuJAVDjmeWNixwDDH)_