### PR TITLE
feat(client): environments.delete gains purge and documents the two-step delete

### DIFF
--- a/.changeset/client-environments-delete-purge.md
+++ b/.changeset/client-environments-delete-purge.md
@@ -1,0 +1,18 @@
+---
+"@objectstack/client": minor
+---
+
+feat(client): `environments.delete` gains `purge` and documents the hosted control plane's two-step delete (#17636)
+
+The hosted control plane's `DELETE /api/v1/cloud/environments/:id` follows cloud ADR-0014: a live environment is **archived**, and only a second call with `?purge=1` on the now-archived environment tears it down. `?force=1` confirms a production environment and is never a purge. The SDK sent `force` only, so an SDK caller could archive an environment but never purge one.
+
+- `opts.purge?: boolean` sends `?purge=1`. It combines with `force`: a production environment is torn down with `{ force: true }`, then `{ force: true, purge: true }`. Calls that pass no options, or `force` alone, build exactly the URL they built before.
+- The return type declares the two answers the route actually sends, discriminated by `deleted`:
+  - archive: `{ environmentId, deleted: false, archived: true, purgeDeferred, retentionDays, warnings, message }`
+  - teardown: `{ environmentId, deleted: true, purged: true, warnings }`
+
+  Both members carry every key the old declaration named (`deleted`, `environmentId`, `warnings`), so existing reads still compile.
+- The JSDoc no longer describes a one-call cascade delete: a live environment is archived, `purge` acts only on an archived environment, `force` is the production confirmation, and a `failed` environment is torn down in one call.
+- `organizations.delete`'s JSDoc no longer claims that server-side hooks tear down the organization's environments. No hook does; delete each environment first.
+
+Graded `minor`: a purely additive widening of a published method's accepted options and declared answer (the "WHICH LEVEL" rule in `.github/workflows/pr-automation.yml`). Nothing is removed or renamed.

--- a/packages/client/src/environments-delete-two-step.test.ts
+++ b/packages/client/src/environments-delete-two-step.test.ts
@@ -1,0 +1,217 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * `client.environments.delete` under the hosted control plane's two-step
+ * delete (cloud ADR-0014) — #17636.
+ *
+ * ## The producer, measured
+ *
+ * `DELETE /api/v1/cloud/environments/:id` is served by `objectstack-ai/cloud`,
+ * `packages/service-cloud/src/routes/environment-lifecycle.ts`, read at cloud
+ * `eeac7b22` (cloud#2188). The route reads two query flags, `force` and
+ * `purge`, independently, and a 200 carries exactly one of two bodies:
+ *
+ *   archive  — a live environment whatever the flags, or an archived one
+ *              without `purge`:
+ *              `{ environmentId, deleted: false, archived: true,
+ *                 purgeDeferred, retentionDays, warnings: [], message }`
+ *   teardown — an archived environment with `purge`, or a `failed` one:
+ *              `{ environmentId, deleted: true, purged: true, warnings }`
+ *
+ * Every other outcome is a non-2xx error envelope, which this client's
+ * `fetch` wrapper throws — it never reaches the declared return type.
+ *
+ * ## What each pin asserts
+ *
+ * - The URL for every combination of the two options. `force` and `purge` are
+ *   independent confirmations and a production teardown needs both on ONE
+ *   call, so a builder that let one option shadow the other would leave that
+ *   teardown unreachable from the SDK.
+ * - Both 200 bodies relay untouched, key for key.
+ * - A refusal rejects, carrying the envelope's `code` and the response status.
+ * - The TYPE pins: the declared answer is the discriminated union of the two
+ *   bodies, no more and no less. They are compiled — `tsconfig.test.json`
+ *   includes `src/**` and the package's `typecheck` script names it — so each
+ *   `@ts-expect-error` is a real check.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { ObjectStackClient } from './index';
+
+type EnvironmentsNamespace = ObjectStackClient['environments'];
+type DeleteAnswer = Awaited<ReturnType<EnvironmentsNamespace['delete']>>;
+type DeleteOptions = NonNullable<Parameters<EnvironmentsNamespace['delete']>[1]>;
+
+/**
+ * The archive answer. `deleted: false` selects it, and each key is declared at
+ * its wire type: assigning into typed locals is the pin, so a key weakened to
+ * optional or retyped goes red here rather than in a caller.
+ */
+export function archiveAnswerDeclaresItsKeys(answer: DeleteAnswer): void {
+    if (answer.deleted) return;
+    const environmentId: string = answer.environmentId;
+    const archived: true = answer.archived;
+    const purgeDeferred: boolean = answer.purgeDeferred;
+    const retentionDays: number = answer.retentionDays;
+    const warnings: string[] = answer.warnings;
+    const message: string = answer.message;
+    void [environmentId, archived, purgeDeferred, retentionDays, warnings, message];
+    // @ts-expect-error an archive tears nothing down; the archive answer carries no `purged`
+    void answer.purged;
+}
+
+/** The teardown answer. `deleted: true` selects it, and it carries none of the archive-only keys. */
+export function teardownAnswerDeclaresItsKeys(answer: DeleteAnswer): void {
+    if (!answer.deleted) return;
+    const environmentId: string = answer.environmentId;
+    const purged: true = answer.purged;
+    const warnings: string[] = answer.warnings;
+    void [environmentId, purged, warnings];
+    // @ts-expect-error the teardown answer carries no `archived`
+    void answer.archived;
+    // @ts-expect-error the teardown answer carries no `purgeDeferred`
+    void answer.purgeDeferred;
+    // @ts-expect-error the teardown answer carries no `retentionDays`
+    void answer.retentionDays;
+    // @ts-expect-error the teardown answer carries no `message`
+    void answer.message;
+}
+
+/** The three keys the previous declaration named sit on BOTH members, so a read written against it still compiles. */
+export function previouslyDeclaredKeysStayReadable(answer: DeleteAnswer): void {
+    const deleted: boolean = answer.deleted;
+    const environmentId: string = answer.environmentId;
+    const warnings: string[] = answer.warnings;
+    void [deleted, environmentId, warnings];
+}
+
+/** `force` and `purge` are both declared options and may be passed together. */
+export function bothOptionsAreDeclared(): void {
+    const productionTeardown: DeleteOptions = { force: true, purge: true };
+    void productionTeardown;
+}
+
+/** A client whose `fetch` answers one canned response. */
+function clientAnswering(status: number, body: unknown) {
+    const fetchMock = vi.fn().mockResolvedValue({
+        ok: status >= 200 && status < 300,
+        status,
+        statusText: status === 200 ? 'OK' : 'Conflict',
+        json: async () => body,
+        headers: new Headers(),
+    });
+    const client = new ObjectStackClient({ baseUrl: 'http://localhost:3000', fetch: fetchMock });
+    return { client, fetchMock };
+}
+
+const ARCHIVED = {
+    environmentId: 'env_1',
+    deleted: false,
+    archived: true,
+    purgeDeferred: false,
+    retentionDays: 30,
+    warnings: [],
+    message: 'Environment archived (soft-deleted).',
+};
+
+const TORN_DOWN = {
+    environmentId: 'env_1',
+    deleted: true,
+    purged: true,
+    warnings: ['attachment storage sweep failed: timeout'],
+};
+
+describe('client.environments.delete — the two-step delete (cloud ADR-0014)', () => {
+    const CASES: Array<{ opts: DeleteOptions | undefined; query: string }> = [
+        { opts: undefined, query: '' },
+        { opts: {}, query: '' },
+        { opts: { force: false, purge: false }, query: '' },
+        { opts: { force: true }, query: '?force=1' },
+        { opts: { force: true, purge: false }, query: '?force=1' },
+        { opts: { purge: true }, query: '?purge=1' },
+        { opts: { force: false, purge: true }, query: '?purge=1' },
+        { opts: { force: true, purge: true }, query: '?force=1&purge=1' },
+    ];
+
+    for (const { opts, query } of CASES) {
+        const label = opts === undefined ? 'no options' : JSON.stringify(opts);
+        it(`${label} → DELETE …/environments/env_1${query}`, async () => {
+            const { client, fetchMock } = clientAnswering(200, { success: true, data: ARCHIVED });
+
+            await client.environments.delete('env_1', opts);
+
+            expect(fetchMock).toHaveBeenCalledTimes(1);
+            expect(fetchMock.mock.calls[0][0]).toBe(`http://localhost:3000/api/v1/cloud/environments/env_1${query}`);
+            expect(fetchMock.mock.calls[0][1].method).toBe('DELETE');
+        });
+    }
+
+    it('encodes the id and keeps both flags after it', async () => {
+        const { client, fetchMock } = clientAnswering(200, { success: true, data: TORN_DOWN });
+
+        await client.environments.delete('env/1 x', { force: true, purge: true });
+
+        expect(fetchMock.mock.calls[0][0]).toBe(
+            'http://localhost:3000/api/v1/cloud/environments/env%2F1%20x?force=1&purge=1',
+        );
+    });
+
+    it('relays the archive answer key for key, and `deleted: false` narrows to it', async () => {
+        const { client } = clientAnswering(200, { success: true, data: ARCHIVED });
+
+        const answer = await client.environments.delete('env_1');
+
+        expect(Object.keys(answer).sort()).toEqual([
+            'archived', 'deleted', 'environmentId', 'message', 'purgeDeferred', 'retentionDays', 'warnings',
+        ]);
+        if (answer.deleted) throw new Error('expected the archive answer');
+        expect(answer.archived).toBe(true);
+        expect(answer.purgeDeferred).toBe(false);
+        expect(answer.retentionDays).toBe(30);
+        expect(answer.warnings).toEqual([]);
+    });
+
+    it('relays a deferred purge: a LIVE environment asked to purge is archived with `purgeDeferred: true`', async () => {
+        const { client } = clientAnswering(200, { success: true, data: { ...ARCHIVED, purgeDeferred: true } });
+
+        const answer = await client.environments.delete('env_1', { purge: true });
+
+        if (answer.deleted) throw new Error('expected the archive answer');
+        expect(answer.archived).toBe(true);
+        expect(answer.purgeDeferred).toBe(true);
+    });
+
+    it('relays the teardown answer key for key, and `deleted: true` narrows to it', async () => {
+        const { client } = clientAnswering(200, { success: true, data: TORN_DOWN });
+
+        const answer = await client.environments.delete('env_1', { purge: true });
+
+        expect(Object.keys(answer).sort()).toEqual(['deleted', 'environmentId', 'purged', 'warnings']);
+        if (!answer.deleted) throw new Error('expected the teardown answer');
+        expect(answer.purged).toBe(true);
+        expect(answer.warnings).toEqual(['attachment storage sweep failed: timeout']);
+    });
+
+    it('rejects a refusal instead of resolving it: a production environment deleted without `force`', async () => {
+        const { client } = clientAnswering(409, {
+            success: false,
+            error: {
+                code: 'RESOURCE_CONFLICT',
+                message: 'This is the organization\'s production environment. Re-run with force to delete it.',
+                httpStatus: 409,
+            },
+        });
+
+        await expect(client.environments.delete('env_prod')).rejects.toMatchObject({
+            code: 'RESOURCE_CONFLICT',
+            httpStatus: 409,
+        });
+    });
+
+    it('anti-vacuity: the type pins above are real bindings in this module', () => {
+        expect(typeof archiveAnswerDeclaresItsKeys).toBe('function');
+        expect(typeof teardownAnswerDeclaresItsKeys).toBe('function');
+        expect(typeof previouslyDeclaredKeysStayReadable).toBe('function');
+        expect(typeof bothOptionsAreDeclared).toBe('function');
+    });
+});

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -2915,17 +2915,73 @@ export class ObjectStackClient {
     },
 
     /**
-     * Cascade-delete an environment: cleans up credential/member/package_installation
-     * rows, releases the physical database via the provisioning adapter, and
-     * removes the `sys_environment` row. Default environments require `force: true`.
+     * Delete an environment — `DELETE /api/v1/cloud/environments/:id` — in the
+     * hosted control plane's TWO steps (cloud ADR-0014): no live environment is
+     * ever one call from irreversible destruction.
+     *
+     * 1. **Archive.** A live environment (active, provisioning, suspended, …) is
+     *    archived, whatever the flags. Its row and data are retained and it stays
+     *    recoverable until the retention window (`retentionDays`) ends, when the
+     *    control plane reclaims it. An archived environment deleted again without
+     *    `purge` stays archived and gets the same answer. The answer is
+     *    `deleted: false, archived: true`.
+     * 2. **Purge.** `purge: true` on an environment that is ALREADY archived tears
+     *    it down now, irreversibly — dependent rows, the physical database,
+     *    domains and attachments. The answer is `deleted: true, purged: true`.
+     *    `purge` on a live environment is deferred, never honoured: that call
+     *    archives it and answers `purgeDeferred: true`; delete again with `purge`
+     *    to tear it down.
+     *
+     * A `failed` environment (provisioning never completed) is torn down in ONE
+     * call, with or without `purge`.
+     *
+     * `force` and `purge` are independent confirmations; neither implies the
+     * other. `force: true` confirms the organization's PRODUCTION environment
+     * (for a legacy row with no `environment_type`, its default environment). It
+     * is required on every delete of one — the archiving call and the purging
+     * call — and it is never a purge: tearing down a production environment is
+     * `{ force: true }`, then `{ force: true, purge: true }`.
+     *
+     * Refusals reject instead of resolving (read `err.httpStatus` / `err.code`):
+     * `409` for a production environment without `force` and for a system
+     * environment, `404` for an id the caller cannot see, `403` for an
+     * organization member who is neither an owner/admin nor the environment's
+     * creator.
+     *
+     * The resolved value is one of the route's two 200 answers, discriminated by
+     * `deleted`; each member declares exactly the keys that answer carries.
      */
-    delete: async (id: string, opts?: { force?: boolean }) => {
-      const qs = opts?.force ? '?force=1' : '';
+    delete: async (id: string, opts?: { force?: boolean; purge?: boolean }) => {
+      const params = new URLSearchParams();
+      if (opts?.force) params.set('force', '1');
+      if (opts?.purge) params.set('purge', '1');
+      const qs = params.toString();
       const res = await this.fetch(
-        `${this.baseUrl}/api/v1/cloud/environments/${encodeURIComponent(id)}${qs}`,
+        `${this.baseUrl}/api/v1/cloud/environments/${encodeURIComponent(id)}${qs ? `?${qs}` : ''}`,
         { method: 'DELETE' },
       );
-      return this.unwrapResponse<{ deleted: boolean; environmentId: string; warnings: string[] }>(res);
+      return this.unwrapResponse<
+        | {
+            environmentId: string;
+            deleted: false;
+            archived: true;
+            /** `true` when `purge` was asked of a LIVE environment: it was archived instead — delete again with `purge`. */
+            purgeDeferred: boolean;
+            /** Days the archived environment is retained before the control plane reclaims it. */
+            retentionDays: number;
+            /** Always empty on an archive. */
+            warnings: string[];
+            /** The control plane's account of what happened and what to do next. */
+            message: string;
+          }
+        | {
+            environmentId: string;
+            deleted: true;
+            purged: true;
+            /** Best-effort cleanup steps that failed after the teardown itself succeeded. */
+            warnings: string[];
+          }
+      >(res);
     },
 
     /**
@@ -3577,8 +3633,11 @@ export class ObjectStackClient {
      * NOT the bare id string the vendor's OpenAPI stub declares.
      *
      * better-auth removes the organization row, all members, and all
-     * pending invitations. Project teardown (per-project DBs, etc.) is
-     * handled server-side by hooks attached to the organization plugin.
+     * pending invitations. It deletes NO environment and releases no
+     * environment database — no organization-plugin hook tears environments
+     * down. On the hosted control plane, delete each of the organization's
+     * environments first with {@link ObjectStackClient.environments}`.delete`
+     * (archive, then `purge`), then delete the organization.
      */
     delete: async (organizationId: string): Promise<OrganizationWire> => {
       const route = this.getRoute('auth');


### PR DESCRIPTION
Fixes #17636

Clause-②: no — an optional client option plus a doc and return-type correction; no `packages/spec/src/**` file is touched and no contract accept/reject behaviour changes.

## What changed

`@objectstack/client`, `packages/client/src/index.ts`:

- **`environments.delete(id, opts)`** gains `opts.purge?: boolean`, sent as `?purge=1`. It is independent of `force` (`?force=1`) and both may be passed on one call. The query string is built with `URLSearchParams`, so every combination yields `''`, `?force=1`, `?purge=1` or `?force=1&purge=1`. A call with no options, or with `force` alone, builds the same URL as before.
- **JSDoc** rewritten for the hosted control plane's two-step delete (cloud ADR-0014):
  - a live environment is archived (retained, recoverable within `retentionDays`);
  - `purge` tears down only an already-archived environment, and is deferred on a live one (`purgeDeferred: true`);
  - `force` is the production confirmation, required on both calls for a production environment, and never a purge;
  - a `failed` environment is torn down in one call;
  - refusals reject: 409 for production without `force` or a system environment, 404, 403.
- **Return type** is now the discriminated union of the route's two 200 answers (rows 11 and 13 below), keyed by `deleted`. The three keys the old declaration named (`deleted`, `environmentId`, `warnings`) sit on both members, so existing reads still compile.
- **`organizations.delete` JSDoc** no longer claims that hooks on the organization plugin tear down the organization's environments. No such hook exists (evidence under acceptance item 5). JSDoc only; no behaviour change.

Also added: the test file `packages/client/src/environments-delete-two-step.test.ts`, and the changeset `.changeset/client-environments-delete-purge.md`, graded `minor` (an additive widening of a published method, per the "WHICH LEVEL" rule).

## Server truth — `objectstack-ai/cloud` at `eeac7b22b` (cloud#2188), read from `origin/main`

All paths are under `packages/service-cloud/src/`.

- **Route:** `routes/environment-lifecycle.ts:1930-1945`. Bare line numbers below are in this file.
- **Flags:** `isDeleteFlagSet` (`:1711-1712`, accepts `true`, `1`, `'true'` and `'1'`) reads `req.query.force` and `req.query.purge` (`:1940-1941`).
- **Envelopes:** a success goes through `ok()`, which is `{ success: true, data }` (`cloud-artifact-helpers.ts:107`). A failure goes through `fail()`, which is `{ success: false, error: { code, message, httpStatus } }` (`cloud-artifact-helpers.ts:141`); the client's `fetch` wrapper throws it.

| # | Condition | Status | Body (`data` for a 200) | Where |
|---|---|---|---|---|
| 1 | no caller | 401 | `fail` | `routes/types.ts:200`, reached from `:1931` |
| 2 | empty id | 400 | `fail` | `:1933` |
| 3 | unknown id | 404 | `fail` | `:1935` |
| 4 | environment has no `organization_id` | 409 | `fail` | `:1326` (gate `assertEnvAdminOrCreator`, `:1312`) |
| 5 | control driver unavailable, in the gate | 503 | `fail` | `:1329` |
| 6 | caller is not a member of the environment's organization | 404 | `fail`, same words as row 3 | `:1338` |
| 7 | member who is not owner/admin/creator | 403 | `fail` | `:1347` |
| 8 | system environment | 409 | `fail` | `:1769-1771` |
| 9 | production environment without `force` | 409 | `fail` | `:1773-1778` |
| 10 | archive path, metadata CAS fails | 503, 500, 404 or 409 | `fail` | `:1799`, from `:639`, `:656`, `:660`, `:666` |
| 11 | **archive**: a live environment (any flags), or an archived one without `purge` | 200 | `{ environmentId, deleted: false, archived: true, purgeDeferred, retentionDays, warnings: [], message }` | `:1822-1839` |
| 12 | teardown path, provisioning service unavailable | 503 | `fail` | `:1843-1844` |
| 13 | **teardown**: an archived environment with `purge`, or a `failed` one | 200 | `{ environmentId, deleted: true, purged: true, warnings }` | `:1886` |
| 14 | teardown throws | 409 if the message names a system or default environment, else 500 | `fail` | `:1887-1891` |

Notes on the table:

- **Production (row 9):** decided by `classifyEnvironmentType` (`plan-entitlements.ts:767`), which uses the explicit `environment_type`, else the legacy `is_default`.
- **Archive answer (row 11):** `purgeDeferred` is the `purge` flag (`:1818`), and `retentionDays` is `ENV_RETENTION_DAYS`, which is 30 (`environment-deletion-policy.ts:32`).
- **Mode selection:** `decideEnvironmentDeletionMode` (`environment-deletion-policy.ts:44`). A `failed` environment tears down (`:49`); an `archived` one tears down only with `purge` (`:53`); anything else archives (`:57`).
- **Cloud's own pins agree:** `test/environment-delete-route-two-step.test.ts` lines 325, 343, 355, 384, 397, 403, 416, 429 and 444.

Only rows 11 and 13 are 200s, so together they are the whole declared return type.

## Acceptance, item by item

All runs are at `0dc866618`.

1. **`purge` sends `?purge=1`, combines with `force`, and every combination is tested.**
   - Cases: eight option shapes (`undefined`, `{}`, the four true/false pairs, and the two single-flag spellings), plus an id-encoding case.
   - Run: `pnpm --filter @objectstack/client exec vitest run --maxWorkers=2 --reporter=verbose src/environments-delete-two-step.test.ts` gave `Tests 14 passed (14)`.
   - Ablation, from the committed state: deleting the `params.set('purge', '1')` line gave `Tests 4 failed | 10 passed (14)` (the three purge cases and the encoding case). It was then restored with `git checkout HEAD --` and proven byte-identical to the HEAD blob `a2631376`.
2. **The JSDoc follows the two-step semantics.** See the `environments.delete` diff:
   - archive, recoverable within `retentionDays`;
   - `purge` only on an archived environment, deferred on a live one;
   - `force` is the production confirmation, never a purge;
   - a `failed` environment is torn down in one call.
3. **The return type carries exactly the server's fields.** It is the union of rows 11 and 13.
   - Type pins in the test file: typed-local assignments for every declared key; `@ts-expect-error` on `purged` for an archive; `@ts-expect-error` on `archived`, `purgeDeferred`, `retentionDays` and `message` for a teardown.
   - The file is inside the `tsconfig.test.json` program: `tsc -p tsconfig.test.json --noEmit --listFiles` exits 0 and lists it once.
   - Ablation: deleting `retentionDays: number;` from the archive member made `tsc` exit 2, with `TS2339` at `environments-delete-two-step.test.ts(55,42)` and `(170,23)`. It was then restored to the HEAD blob.
4. **Docs page.** No page documents this method, so there is nothing to sync.
   - `grep -rn "environments.delete"` over `content/`, `apps/docs/`, `skills/` and `packages/client/README.md` gives 0 hits.
   - `content/docs/api/client-sdk.mdx` names the environments namespace only in passing (lines 18 and 158).
5. **`organizations.delete`.**
   - It calls better-auth's `POST /api/v1/auth/organization/delete`, not cloud's `DELETE /api/v1/cloud/organizations/:id`. The cloud route is the one that answers 409 while environments remain (`routes/environment-crud.ts:872` and `:905`), and it is ledgered as an SDK `gap` (`cloud-route-ledger.ts:340`).
   - The JSDoc nevertheless claimed that organization-plugin hooks tear down environments. No such hook exists: plugin-auth's `organizationHooks` (`packages/plugins/plugin-auth/src/auth-manager.ts:2951`) declares none for delete, and `git grep "beforeDeleteOrganization\|afterDeleteOrganization"` finds 0 hits in this repo's `packages/**/src` and in cloud's `packages/*/src`.
   - The false sentence is replaced. No other method was touched.

## Gates

**Declared unlocked mode.** `scripts/pm/os-verify-lock.sh` found no usable `flock` on this host (macOS), so every locked run below printed `VERDICT command-exit N · UNLOCKED (declared)`: nothing was serialized.

| Command | Verdict |
|---|---|
| `pnpm exec turbo run build --filter=@objectstack/client --concurrency=2` | `Tasks: 33 successful, 33 total` · `VERDICT command-exit 0` |
| `pnpm --filter @objectstack/client test` | `Test Files 42 passed (42)` · `Tests 506 passed (506)` · `VERDICT command-exit 0` |
| `pnpm --filter @objectstack/client typecheck` | `check:test-typecheck: OK`, 0 file(s) / 0 error(s) · `VERDICT command-exit 0` |
| `pnpm check:nul-bytes` | `check-nul-bytes: OK (scanned 8386 text file(s)`, no raw control bytes |
| `pnpm check:adr-0087-registration` | `this PR adds no declared-breaking changeset (1 non-breaking changeset(s) seen)` |
| `node scripts/check-changeset-no-major.mjs` | `This diff introduces no major bump`; the level axis is not applicable locally (no `pull_request` payload) |
| `pnpm --filter @objectstack/spec run check:skill-examples`, after building `@objectstack/client-react` | `258 prose examples type-check across 3 surface(s)` |
| eslint, narrowed (below) | 2 files · 0 errors · 0 warnings |

`node scripts/pm/dispatch-gates.mjs --commands` derived **60** families from the three changed paths. All 60 were run and recorded with exit codes. The `--ran` reconciliation reads: `60 derived famil(ies) accounted for — 58 run, 2 NOT-MEASURED`.

**NOT MEASURED.** Each gate below refused with its own `PREREQUISITE NOT MET`, exit 3:
- `pnpm check:dual-build-cjs-loads`: it reads every workspace package's `dist/`. 35 packages are unbuilt here, and building them is a whole-workspace build, which this dispatch excludes because the box is shared.
- `pnpm check:type-check-debt`: `--re-measure` needs the whole `packages/*` closure built (same exclusion). The client test-layer program was measured directly instead, and compiles with the new file in it (acceptance item 3).

**Narrowed lint.** Repo-wide `pnpm lint` belongs to CI. The narrowed run was `eslint --no-inline-config --format json packages/client/src/index.ts packages/client/src/environments-delete-two-step.test.ts`, which exited 0.
1. Population: both paths came back as linted results, so `eslint.config.mjs` ignores neither.
2. Count, from the JSON output: 2 files, 0 errors, 0 warnings.
3. Invariance: `eslint.config.mjs` enables no type-aware linting (no `parserOptions.project`, no `projectService`), so this diff cannot move any untouched file's verdict.

## Acceptance notes

- **Premise divergence (acceptance item 5).** The dispatch took `organizations.delete` to be the cloud route that answers 409. The SDK method is a different route, better-auth's. Its JSDoc was corrected for its own false claim, not for the 409 behaviour.
- noted, not filed: cloud's route-ledger note for `DELETE /api/v1/cloud/environments/:id` (`cloud-route-ledger.ts:185`) says the SDK method sends `force` only. That goes stale once this lands and cloud pins past it. Carrier: the cloud pin bump that picks this up.
- noted, not filed: on cloud, deleting an already-archived environment again without `purge` re-runs the archive branch. It re-stamps `archived_at`, which restarts the retention clock, and writes another audit row, while `environment-deletion-policy.ts` calls that case an idempotent no-op. It is never destructive. Recorded for the cloud owner of `environment-lifecycle.ts`.
- noted, not filed: the SDK still has no archive or restore method (cloud's ledger rows for those routes are `gap`). Out of scope.

---
_Generated by [Claude Code](https://claude.ai/code/session_c5c0ce54-bb9c-478c-9e5b-cf44b80d4569)_
