### PR TITLE
fix(cli): reach screen nodes inside ADR-0031 regions in `os i18n extract`

### DIFF
--- a/.changeset/17511-i18n-extract-region-screens.md
+++ b/.changeset/17511-i18n-extract-region-screens.md
@@ -1,0 +1,45 @@
+---
+'@objectstack/cli': patch
+---
+
+`os i18n extract` reaches a `screen` node nested inside an ADR-0031 flow region
+
+`walkScreenFlows` (`packages/cli/src/utils/i18n-extract.ts`) iterated
+`flow.nodes` flat, so a `type: 'screen'` node inside a region —
+`loop.config.body`, `parallel.config.branches[].nodes`,
+`try_catch.config.try` / `.catch`, nesting arbitrarily — was never reached. It
+emitted **no** `flows.NAME.screens.NODE_ID.title` / `.fields.*` skeleton entry
+and **no** coverage row.
+
+**Why that pairing is the defect and not just a missing translation.** A nested
+wizard step is a real screen: the executor pauses on it and the client receives
+its `ScreenSpec.nodeId`, so `translateFlow` overlays the bundle onto it and the
+key is live. With no entry emitted, a translator was never shown the key AND
+`os lint` / `pnpm check:i18n-coverage` had no row to demand — the gap was
+invisible to the mechanism built to report gaps. A green i18n gate on a tree
+whose nested steps render source-locale text was green because the surface was
+unreachable, not because the app was translated.
+
+The node universe now comes from a region-aware descent that reads the one
+shared declaration of WHERE a region lives, `FLOW_REGION_SLOTS_BY_TYPE` from
+`@objectstack/spec/automation` — the same table `packages/lint`'s
+`walkFlowNodes` reads. No local copy of the slot list is introduced: a second
+region table in a fourth package is the very shape this defect is an instance
+of.
+
+**Depth deliberately does not enter the key.** Entries stay
+`flows.NAME.screens.NODE_ID.*` at every depth, because `lookupFlowScreenCopy`
+is keyed by node id alone and the bundle schema knows nothing about depth; a
+region path segment would offer a key nothing resolves. A node id repeated at
+two depths therefore addresses one bundle slot and collapses to a single entry
+(first emission wins, outer before inner) — one slot can serve only one string,
+and the resolver overlays that string onto both nodes.
+
+Seeding is unchanged and applies at every depth: a screen `title` falls back to
+the node `label` (what `ScreenSpec.title` draws), and a field `label` falls back
+to its `name` as a *derived* seed, so the skeleton stays usable while the
+coverage gate demands no translation of a string nobody authored.
+
+⛔ No authorable key, bundle shape or export moves — an author who wrote a
+nested screen now gets scaffolding and a coverage row where both were silently
+absent. Existing keys are byte-unchanged.

--- a/packages/cli/src/utils/i18n-extract.ts
+++ b/packages/cli/src/utils/i18n-extract.ts
@@ -130,6 +130,7 @@ import {
   globalFilterKey,
   walkAddressedPageComponents,
 } from '@objectstack/spec/system';
+import { FLOW_REGION_SLOTS_BY_TYPE } from '@objectstack/spec/automation';
 import { DEFAULT_METADATA_TYPE_REGISTRY } from '@objectstack/spec/kernel';
 import { deriveFieldGroupLayout } from '@objectstack/spec/data';
 import { expandViewContainer, InlineLocaleMapSchema } from '@objectstack/spec/ui';
@@ -1547,6 +1548,84 @@ function walkDatasets(config: any, out: ExpectedEntry[]): void {
 const SCREEN_NODE_TYPE = 'screen';
 
 /**
+ * Depth ceiling for the region recursion, mirroring the ceiling the spec-side
+ * walks use (`conversions/walk.ts`, `automation/control-flow.zod.ts`) and for
+ * the same reason: a stack handed to `defineStack` is hand-built objects rather
+ * than parsed JSON, so a region that contains itself is reachable and would
+ * otherwise be unbounded recursion on the extract path.
+ */
+const MAX_REGION_DEPTH = 32;
+
+/**
+ * Every flow node of one flow, container FIRST and depth-first — **including
+ * the nodes nested inside ADR-0031 structured regions** (`loop.config.body`,
+ * `parallel.config.branches[]`, `try_catch.config.try`/`.catch`), to any depth.
+ *
+ * **WHERE a region lives is imported, never restated.**
+ * {@link FLOW_REGION_SLOTS_BY_TYPE} (`@objectstack/spec/automation`) is the one
+ * declaration of that fact, and `automation/region-slots.ts` is explicit that
+ * the *table* is the shared thing while the *walks* are deliberately not merged
+ * — they take different inputs and yield different units (a graph, a
+ * copy-on-write rewrite, a node with a diagnostic path). This pass is a fourth
+ * unit again: it collects nodes to harvest KEYS from, rewriting nothing. So it
+ * reads that table exactly as `packages/lint`'s `walkFlowNodes` does, and a
+ * local copy of the slot list — the defect this walker's own card is an
+ * instance of, one package over — is what the import exists to prevent.
+ *
+ * ⚠️ The region-bearing descent could NOT be imported: `mapFlowNodeList`
+ * (`spec/conversions/walk.ts`) is reachable from no `exports` subpath of
+ * `@objectstack/spec` by deliberate design — its docblock says so and
+ * `packages/spec/api-surface/*.json` lists none of its symbols — and
+ * `packages/lint`'s `walkFlowNodes` is not exported from that package's entry
+ * either. Both would have to widen a package's public surface to be reused
+ * here, so the shared table is the whole of what can honestly be shared.
+ *
+ * A value that is not region-shaped passes through untouched: `config` is an
+ * open record and `body` in particular is also an ordinary key elsewhere (an
+ * `http` node's request payload), so the shape is checked, never assumed.
+ */
+function collectFlowNodesDeep(nodes: unknown): any[] {
+  const out: any[] = [];
+
+  const visit = (list: unknown, depth: number): void => {
+    if (!Array.isArray(list) || depth > MAX_REGION_DEPTH) return;
+    for (const node of list) {
+      if (!node || typeof node !== 'object' || Array.isArray(node)) continue;
+      out.push(node);
+
+      // Keyed off the node's own `type` through the Map, never an object
+      // literal: `type` is author-controlled and an open namespace (ADR-0018),
+      // so a lookup on a plain object would resolve `'constructor'` through
+      // `Object`'s prototype chain and hand this walk something that is not a
+      // slot list.
+      const slots = typeof node.type === 'string' ? FLOW_REGION_SLOTS_BY_TYPE.get(node.type) : undefined;
+      if (!slots) continue;
+      const config = node.config;
+      if (!config || typeof config !== 'object' || Array.isArray(config)) continue;
+
+      for (const { key, arity } of slots) {
+        const raw = (config as any)[key];
+        if (arity === 'many') {
+          // `parallel`: an array of regions, each with its own `nodes`.
+          if (!Array.isArray(raw)) continue;
+          for (const branch of raw) visitRegion(branch, depth + 1);
+        } else {
+          visitRegion(raw, depth + 1);
+        }
+      }
+    }
+  };
+
+  const visitRegion = (region: unknown, depth: number): void => {
+    if (!region || typeof region !== 'object' || Array.isArray(region)) return;
+    visit((region as any).nodes, depth);
+  };
+
+  visit(nodes, 0);
+  return out;
+}
+
+/**
  * Emit the screen-flow copy surface (#7646, resolver landed in #11287).
  *
  * **The hole this closes.** A `type: 'screen'` flow is a wizard the user
@@ -1588,6 +1667,29 @@ const SCREEN_NODE_TYPE = 'screen';
  * A screen node whose `waitForInput` is `false` is deliberately NOT skipped:
  * `translateFlow` overlays every screen node, and a walker that skipped one
  * would re-open the extractable-but-ungated gap in miniature.
+ *
+ * **Every screen node, at any DEPTH** (#17511). The node universe comes from
+ * {@link collectFlowNodesDeep}, not from `flow.nodes` flat: a `type: 'screen'`
+ * node inside an ADR-0031 region is a real screen — the executor pauses on it
+ * and the client receives its `ScreenSpec.nodeId` — so `translateFlow` overlays
+ * it and the bundle key is live for it. The flat walk reached the container and
+ * stopped, which was the same extractable-but-ungated gap the paragraph above
+ * refuses, one level in and worse: with no entry emitted there is no skeleton
+ * key for a translator to fill AND no coverage row to demand it, so the hole
+ * was invisible to the mechanism built to report holes.
+ *
+ * **Depth does not enter the key, on purpose.** The entry stays
+ * `flows.<flow>.screens.<node_id>.…` at every depth because that is what the
+ * resolver reads: `lookupFlowScreenCopy(bundle, flowName, nodeId)` is keyed by
+ * node id alone and, as `translateFlow`'s docblock puts it, "the bundle schema
+ * is keyed by node id and knows nothing about depth". A path segment for the
+ * region would offer a key nothing resolves — precisely the producer/consumer
+ * drift the imported key face exists to prevent. Consequence for a node id
+ * REPEATED at two depths: both screens address one bundle slot, so
+ * {@link dedupeByPath} collapses them to a single entry, first emission wins,
+ * and the walk is outer-before-inner so which one that is stays deterministic.
+ * That is not a loss — one slot can serve only one string, and the resolver
+ * overlays that string onto both nodes.
  */
 function walkScreenFlows(config: any, out: ExpectedEntry[]): void {
   const flows: any[] = Array.isArray(config?.flows) ? config.flows : [];
@@ -1601,7 +1703,7 @@ function walkScreenFlows(config: any, out: ExpectedEntry[]): void {
     // keeps a label-less flow from seeding an empty string anyway.
     pushOptional(out, ['flows', flowName, 'label'], flow.label, 'flow', scope);
 
-    const nodes: any[] = Array.isArray(flow.nodes) ? flow.nodes : [];
+    const nodes: any[] = collectFlowNodesDeep(flow.nodes);
     for (const node of nodes) {
       if (!node || typeof node !== 'object' || node.type !== SCREEN_NODE_TYPE) continue;
       const nodeId = typeof node.id === 'string' && node.id.length > 0 ? node.id : undefined;

--- a/packages/cli/test/i18n-flow-screen-coverage.test.ts
+++ b/packages/cli/test/i18n-flow-screen-coverage.test.ts
@@ -308,3 +308,281 @@ describe('`os i18n extract` scaffolds the flows skeleton', () => {
     expect((filtered.bundles.en as any).objects).toBeUndefined();
   });
 });
+
+// ── objectstack#17511 — the same hole, one region deep ────────────────────
+//
+// Everything above walks `flow.nodes` at the TOP level only, which is what the
+// walker did: `FlowNode.config` carries ADR-0031 regions (`loop.config.body`,
+// `parallel.config.branches[].nodes`, `try_catch.config.try`/`.catch`, nesting
+// arbitrarily), and a `type: 'screen'` node inside one is a real screen — the
+// executor pauses on it and the client receives its `ScreenSpec.nodeId`, so
+// `translateFlow` overlays it (#11745 / PR #17521) and the bundle key is live.
+//
+// The flat walk reached the container and stopped, so the nested step got NO
+// skeleton entry and NO coverage row. That pairing is why the defect outranks
+// "untranslated": a missing coverage row reads as "nothing to do here", so the
+// gap was invisible to the very mechanism built to report gaps — a silent zero
+// rather than a visible failure, the same shape as the #11485 census above one
+// level in.
+//
+// ## The lit control lives in the fixture, not next to it
+//
+// `welcome` below is a TOP-level screen, reached by the old flat walk too. It
+// is in the same flow as the nested ones on purpose: without it, a green on the
+// nested keys could be read as "the fixture loaded and the walk ran", and a red
+// could be read as "the fixture never loaded at all". With it, the two
+// explanations separate — the control asserts the harness, the nested keys
+// assert the descent.
+
+/**
+ * One flow carrying a screen in EVERY region slot the table declares, and at
+ * three different depths, so a descent that handles `loop` but forgets
+ * `parallel`'s array-of-regions arity fails on a named key rather than on a
+ * count.
+ *
+ *   welcome          depth 0   (the lit control)
+ *   pick_region      depth 1   loop.config.body
+ *   accept_terms     depth 2   parallel.config.branches[0]
+ *   card_details     depth 3   try_catch.config.try
+ *   payment_failed   depth 3   try_catch.config.catch
+ */
+const nestedOnboarding = {
+  name: 'onboarding',
+  label: 'Onboarding',
+  type: 'screen',
+  nodes: [
+    { id: 'welcome', type: 'screen', label: 'Welcome', config: { title: 'Welcome aboard' } },
+    {
+      id: 'per_region',
+      type: 'loop',
+      label: 'For each region',
+      config: {
+        body: {
+          nodes: [
+            {
+              id: 'pick_region',
+              type: 'screen',
+              label: 'Pick Region Step',
+              config: {
+                title: 'Pick a region',
+                fields: [{ name: 'region_code', label: 'Region' }, { name: 'notes' }],
+              },
+            },
+            {
+              id: 'fan_out',
+              type: 'parallel',
+              config: {
+                branches: [
+                  {
+                    name: 'legal',
+                    nodes: [{ id: 'accept_terms', type: 'screen', config: { title: 'Accept the terms' } }],
+                  },
+                  {
+                    name: 'billing',
+                    nodes: [
+                      {
+                        id: 'guard_payment',
+                        type: 'try_catch',
+                        config: {
+                          // No `config.title`: the executor draws the node label
+                          // for a nested screen exactly as for a top-level one.
+                          try: { nodes: [{ id: 'card_details', type: 'screen', label: 'Card Details' }] },
+                          catch: { nodes: [{ id: 'payment_failed', type: 'screen', config: { title: 'Payment failed' } }] },
+                        },
+                      },
+                    ],
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    },
+  ],
+  edges: [],
+};
+
+/** The #11485 tree shape, with the nested wizard as its only flow. */
+const nestedTree = (flowTranslations?: Record<string, unknown>) => ({
+  i18n: { defaultLocale: 'en', supportedLocales: ['en', 'zh-CN'] },
+  objects: [{ name: 'crm_lead', label: 'Lead', fields: { company: { label: 'Company' } } }],
+  flows: [nestedOnboarding],
+  translations: [
+    {
+      'zh-CN': {
+        objects: { crm_lead: { label: '线索', fields: { company: { label: '公司' } } } },
+        ...(flowTranslations ? { flows: flowTranslations } : {}),
+      },
+    },
+  ],
+});
+
+describe('a screen inside an ADR-0031 region (#17511)', () => {
+  it('harvests every nested screen, at every region slot and depth', () => {
+    // The exact face, so a key that should NOT exist fails here too. Eight of
+    // these ten were absent before the descent landed; `flows.onboarding.label`
+    // and `screens.welcome.title` are the two the flat walk already reached.
+    expect(flowKeys({ flows: [nestedOnboarding] }).sort()).toEqual([
+      'flows.onboarding.label',
+      'flows.onboarding.screens.accept_terms.title',
+      'flows.onboarding.screens.card_details.title',
+      'flows.onboarding.screens.payment_failed.title',
+      'flows.onboarding.screens.pick_region.fields.notes.label',
+      'flows.onboarding.screens.pick_region.fields.notes.placeholder',
+      'flows.onboarding.screens.pick_region.fields.region_code.label',
+      'flows.onboarding.screens.pick_region.fields.region_code.placeholder',
+      'flows.onboarding.screens.pick_region.title',
+      'flows.onboarding.screens.welcome.title',
+    ]);
+  });
+
+  it('gives the coverage gate a row for the nested step, not just the top-level one', () => {
+    const zh = userIssues(computeI18nCoverage(nestedTree())).filter((i) => i.locale === 'zh-CN');
+    const keys = zh.map((i) => i.key);
+
+    // The control: present before this card, and still present.
+    expect(keys).toContain('flows.onboarding.screens.welcome.title');
+    // The rows that did not exist — one per region slot the table declares.
+    expect(keys).toContain('flows.onboarding.screens.pick_region.title');
+    expect(keys).toContain('flows.onboarding.screens.pick_region.fields.region_code.label');
+    expect(keys).toContain('flows.onboarding.screens.accept_terms.title');
+    expect(keys).toContain('flows.onboarding.screens.card_details.title');
+    expect(keys).toContain('flows.onboarding.screens.payment_failed.title');
+    // Attributed to the flow bucket, so `os lint` renders `i18n/missing-flow`.
+    for (const issue of zh) expect(issue.source).toBe('flow');
+    // The object surface IS translated: the whole report is the wizard.
+    expect(keys.filter((k) => !k.startsWith('flows.'))).toEqual([]);
+  });
+
+  it('seeds a nested screen exactly as a top-level one, never more narrowly', () => {
+    const entries = collectExpectedEntries({ flows: [nestedOnboarding] });
+    const at = (key: string) => entries.find((e) => e.path.join('.') === key);
+
+    // `title` falls back to the node `label` — `ScreenSpec.title` is
+    // `config.title ?? node.label` at every depth, so the nested screen owes
+    // the same demand as `summary` does at the top level.
+    expect(at('flows.onboarding.screens.card_details.title')).toMatchObject({
+      sourceValue: 'Card Details',
+      inline: 'Card Details',
+      source: 'flow',
+    });
+    // A nested field's `label` falls back to its `name` as a DERIVED seed:
+    // usable skeleton, no demand for a string nobody authored. Getting this
+    // wrong is how a region-aware walk starts failing the gate on machine ids.
+    expect(at('flows.onboarding.screens.pick_region.fields.notes.label')).toMatchObject({
+      sourceValue: 'notes',
+      inline: undefined,
+    });
+    const gated = computeI18nCoverage(nestedTree()).issues.map((i) => i.key);
+    expect(gated).not.toContain('flows.onboarding.screens.pick_region.fields.notes.label');
+    // And the authored one IS demanded.
+    expect(at('flows.onboarding.screens.pick_region.fields.region_code.label')).toMatchObject({
+      sourceValue: 'Region',
+      inline: 'Region',
+    });
+  });
+
+  it('scaffolds the nested drill into a bundle the strict schema accepts', () => {
+    const result = extractTranslations({ flows: [nestedOnboarding] }, { locales: ['en', 'zh-CN'] });
+    const en = result.bundles.en as any;
+    const zh = result.bundles['zh-CN'] as any;
+
+    expect(en.flows.onboarding.screens.card_details.title).toBe('Card Details');
+    expect(en.flows.onboarding.screens.accept_terms.title).toBe('Accept the terms');
+    // The translator's empty slots for the nested steps — the vocabulary that
+    // did not exist in the skeleton at all before this card.
+    expect(zh.flows.onboarding.screens.payment_failed.title).toBe('');
+    // Keyed by node id at the TOP of `screens`, flat: depth is not in the key,
+    // because `lookupFlowScreenCopy` is keyed by node id and knows nothing
+    // about depth. A region segment here would offer a key nothing reads.
+    expect(Object.keys(en.flows.onboarding.screens).sort()).toEqual([
+      'accept_terms',
+      'card_details',
+      'payment_failed',
+      'pick_region',
+      'welcome',
+    ]);
+    expect(TranslationDataSchema.safeParse(en).success).toBe(true);
+  });
+
+  it('goes quiet once the nested steps are translated', () => {
+    const report = computeI18nCoverage(
+      nestedTree({
+        onboarding: {
+          label: '入职',
+          screens: {
+            welcome: { title: '欢迎' },
+            pick_region: { title: '选择区域', fields: { region_code: { label: '区域' } } },
+            accept_terms: { title: '接受条款' },
+            card_details: { title: '银行卡信息' },
+            payment_failed: { title: '支付失败' },
+          },
+        },
+      }),
+    );
+
+    expect(userIssues(report)).toEqual([]);
+  });
+
+  it('reads the region TABLE, so a `body` that is not a region slot stays unwalked', () => {
+    // `config` is an open record and `body` is an ordinary key elsewhere — an
+    // `http` node's request payload. `http` owns no slot in
+    // `FLOW_REGION_SLOTS_BY_TYPE`, so a screen-shaped object sitting in its
+    // payload is data, not a flow node, and must not become a bundle key.
+    // This is what consulting the table buys over walking every `body`.
+    expect(
+      flowKeys({
+        flows: [
+          {
+            name: 'callout',
+            label: 'Callout',
+            nodes: [
+              {
+                id: 'post',
+                type: 'http',
+                config: { body: { nodes: [{ id: 'not_a_screen', type: 'screen', config: { title: 'Payload' } }] } },
+              },
+            ],
+          },
+        ],
+      }),
+    ).toEqual(['flows.callout.label']);
+  });
+
+  it('collapses a node id repeated at two depths onto its one bundle slot', () => {
+    // The bundle addresses a screen by node id alone, so two screens sharing an
+    // id share one slot — one string is all the resolver can overlay onto both.
+    // `dedupeByPath` therefore keeps ONE entry, and the walk being
+    // outer-before-inner makes which one deterministic.
+    const entries = collectExpectedEntries({
+      flows: [
+        {
+          name: 'dup',
+          label: 'Dup',
+          nodes: [
+            { id: 'step', type: 'screen', config: { title: 'Outer' } },
+            { id: 'wrap', type: 'loop', config: { body: { nodes: [{ id: 'step', type: 'screen', config: { title: 'Inner' } }] } } },
+          ],
+        },
+      ],
+    }).filter((e) => e.path.join('.') === 'flows.dup.screens.step.title');
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({ sourceValue: 'Outer' });
+  });
+
+  it('terminates on a region that contains itself', () => {
+    // A stack handed to `defineStack` is hand-built objects, so a self
+    // -referencing region is reachable; the depth ceiling is what keeps this a
+    // finite walk rather than a stack overflow on the extract path.
+    const loop: any = { id: 'spin', type: 'loop', config: { body: { nodes: [] } } };
+    loop.config.body.nodes.push(loop);
+
+    expect(
+      flowKeys({
+        flows: [{ name: 'cyclic', label: 'Cyclic', nodes: [loop, { id: 'real', type: 'screen', config: { title: 'Reached' } }] }],
+      }).sort(),
+    ).toEqual(['flows.cyclic.label', 'flows.cyclic.screens.real.title']);
+  });
+});


### PR DESCRIPTION
Fixes #17511

Clause-②: no

<sub>Declared by the dispatching `domain:cli` PM seat (session `session_01TSf4DV7ziu4V5j73e46b7c`), matching the claim comment on #17511. Verified against the DIFF, not the card: the extractor now reaches screen nodes it was always meant to reach, emitting keys under the **already-declared** `flows.NAME.screens.NODE_ID.*` shape — no new key shape, no new error code (0 added upper-case code literals), and no change to what INPUT is accepted (a nested screen was always legal to author; only the walker failed to see it). `check-i18n-coverage` confirms the ratchet does not move.</sub>

`walkScreenFlows` (`packages/cli/src/utils/i18n-extract.ts`) iterated `flow.nodes` flat, so a `type: 'screen'` node nested inside an ADR-0031 region — `loop.config.body`, `parallel.config.branches[].nodes`, `try_catch.config.try` / `.catch`, nesting arbitrarily — was never reached. It emitted **no** `flows.NAME.screens.NODE_ID.title` / `.fields.*` skeleton entry and **no** coverage row.

That pairing is the defect, not the missing translation: a translator was never shown the key AND the coverage gate had no row to demand, so the hole was invisible to the mechanism built to report holes. A silent zero.

## Premise check — both the card and its triage comment are stale, so neither is quoted

- The card's triage comment (18:28Z) says #11745 is `pm:dispatched`. **It is `closed`/`completed`**, landed as PR #17521. Verified myself rather than cited from the comment. The region walk this card reuses therefore already exists on `main`; there was no moving target and no sibling pin to register.
- "Do not fold into #11745" still holds — different package, different unit, and it is closed.

Everything else in the card re-measured true at `7d350a46`, with fresh lit controls (see below).

## The dispatch assumption that turned out FALSE, and what it changed

The dispatch flagged one assumption as unmeasured: *"`mapFlowNodeList` is importable from `packages/cli` without a new dependency edge."* **It is not**, and this is the one finding worth reading before the diff:

- `packages/spec/src/conversions/index.ts` re-exports `types` / `registry` / `apply` / `stored` only — **not `walk.js`**.
- `walk.ts`'s own docblock states the boundary deliberately: *"Deliberately NOT re-exported from `conversions/index.js` … `walk.ts` reaches no `exports` subpath of the package (`packages/spec/api-surface/*.json` lists none of its symbols), and that is the boundary that keeps this a repair rather than a widening of the package's public surface."*
- Confirmed mechanically: `mapFlowNodeList` appears in **no** file under `packages/spec/api-surface/`.
- `packages/lint`'s `walkFlowNodes` (`src/flow-walk.ts`) is **also** not exported from that package's entry (`src/index.ts` / `src/runtime.ts`).

So neither landed descent is reachable across a package boundary, and making one reachable means editing `packages/spec` or `packages/lint` — outside this card's file surface, and `packages/spec` is the spec seat's unconditionally. Deep-importing past the boundary was ruled out by the dispatch and is not done here.

## The route taken, and why it is not a second region table

The card's own "Shape of the fix" authorises exactly this: *"either through the spec-side slot table or by whichever walker `packages/cli` already depends on."* The slot table **is** reachable — `FLOW_REGION_SLOTS_BY_TYPE` is exported from `@objectstack/spec/automation` and recorded at `packages/spec/api-surface/automation.json:116` — so the node universe now comes from a local descent that reads that one table.

This is the architecture `automation/region-slots.ts` declares, not a deviation from it:

> The **walks** are deliberately NOT merged: they take different inputs … yield different units (a graph, a node, a rewritten tree) … Only the fact they all need — *this* table — is shared.

`packages/lint/src/flow-walk.ts:51` reaches the table the same way, from outside `packages/spec`. `walk.ts:175`'s "one implementation" is scoped to the per-flow descent *inside* `packages/spec`, which is why `walk.ts` refuses to publish itself. No copy of the slot list is introduced — the thing this card is an instance of one package over.

The lookup goes through the `Map`, never an object literal: `node.type` is author-controlled and an open namespace (ADR-0018), so an object lookup would resolve `'constructor'` through the prototype chain. A `MAX_REGION_DEPTH` of 32 mirrors both spec-side walks, because a `defineStack` tree is hand-built objects and a self-containing region is reachable.

## Depth does not enter the key — the key-path question the dispatch asked

Entries stay `flows.NAME.screens.NODE_ID.*` at **every** depth, because that is what the resolver reads: `lookupFlowScreenCopy(bundle, flowName, nodeId)` is keyed by node id alone, and `translateFlow`'s docblock says the bundle schema *"is keyed by node id and knows nothing about depth"*. A region segment in the key would offer a key nothing resolves — the exact producer/consumer drift the imported key face exists to prevent.

**A node id repeated at two depths** therefore addresses one bundle slot, and the existing `dedupeByPath` collapses it to a single entry, first emission wins; the walk is outer-before-inner so which one wins is deterministic. That is not a loss: one slot can serve only one string, and the resolver overlays that string onto both nodes. Pinned.

Seeding is identical at every depth, not narrower — `title` falls back to the node `label` (what `ScreenSpec.title` draws) and a field `label` falls back to its `name` as a **derived** seed, so the skeleton stays usable while the gate demands no translation of a string nobody authored. Both pinned, because getting the second wrong is how a region-aware walk starts failing the gate on machine identifiers.

## Acceptance — the named criterion, with the lit control in the same fixture

`nestedOnboarding` carries a screen in **every** slot the table declares, at four depths, and a top-level screen as the control:

| node | depth | slot |
|:--|:--|:--|
| `welcome` | 0 | — (the lit control) |
| `pick_region` | 1 | `loop.config.body` |
| `accept_terms` | 2 | `parallel.config.branches[0]` |
| `card_details` | 3 | `try_catch.config.try` |
| `payment_failed` | 3 | `try_catch.config.catch` |

Pins assert the exact key face (eight of the ten keys were absent before), that the coverage gate gains a row per nested screen attributed to the `flow` bucket, that the skeleton still parses under `strictObject`, and the negative half — an `http` node's `config.body` is **not** walked, since `http` owns no slot, which is what consulting the table buys over walking every `body`.

### Reverse verification

Reverting the one line to the flat walk, with the mutation proven on disk (anchor counts 1→0 and 0→1, blob hash differing from HEAD) and restored by `git checkout HEAD -- ...` verified against the HEAD blob hash and an empty `git diff HEAD`:

```
Test Files  1 failed (1)
     Tests  4 failed | 17 passed (21)
   × harvests every nested screen, at every region slot and depth
   × gives the coverage gate a row for the nested step, not just the top-level one
   × seeds a nested screen exactly as a top-level one, never more narrowly
   × scaffolds the nested drill into a bundle the strict schema accepts
```

Predicted direction was "goes red" and that is what it did. The 17 that stayed green include the pre-existing #11485 suite and the pins measuring collision handling, cycle termination and table consultation — properties the descent does not decide. The subject resolves through a **relative** import into `src/`, so no `dist` rebuild is involved in the ablation.

## Verification

- **Closure build** `turbo build --filter '@objectstack/cli^...'` — `Tasks: 56 successful, 56 total`, exit 0. Full `pnpm build` afterwards: `73 successful, 73 cached`.
- **Typecheck** `pnpm --filter @objectstack/cli typecheck` — `tsc --noEmit` plus `check:test-typecheck: OK`, exit 0.
- **Unit tier** `vitest run --project unit` — `Test Files 195 passed (195)`, `Tests 2708 passed (2708)`. The `integration` tier is declared to CI: the diff touches no integration-layer file and no spawn entry point.
- **Gate floor** re-derived on the final 3-path diff with `scripts/pm/dispatch-gates.mjs`, every command redirected with `$?` captured **before** any pipe: `62 derived, 62 run, 0 NOT-MEASURED, 0 UNRUN` — a *derived* zero, all 62 records carrying an exit code and none of them 3.
  - Four gates first returned **exit 3 — `PREREQUISITE NOT MET`, "NOTHING was measured"** (`check:i18n`, `check:i18n-coverage`, `check:i18n-walk-parity`, `check:dual-build-cjs-loads`): they read built output that did not exist yet. Recorded as unmeasured, the prerequisite closures each gate names were built, and all four re-run green:
    - `check-i18n-bundles: OK (9 package(s) — all bundles in sync, no undeclared authoring keys).`
    - `check-i18n-coverage: OK (13 config(s), 621 baselined untranslated string(s), none new).`
    - `check-i18n-walk-parity: 11 declared group(s), 8 walked, 3 exempted — every declared group has an extractor face.`
    - `check:dual-build-cjs-loads — 104 published require entry point(s) across 67 package(s) load` (floors held).
  - `check-undeclared-dep-imports` — the gate the dispatch flagged as most likely to bite the import — exit 0. `@objectstack/cli` already declares `@objectstack/spec`, and `@objectstack/spec/automation` is a published subpath, so **no new dependency edge**.
- **`pnpm lint`** (the standing `dispatch-gates` blind spot) delivered as a **declared narrowing**, with all three readings:
  1. population read from ESLint's own config resolution (`isPathIgnored` over every tracked lintable file): **6612 in scope, 0 ignored** — not a guess;
  2. files linted read from `--format json` output: **2**, 0 errors / 0 warnings, exit 0;
  3. invariance: `eslint.config.mjs` states in its own header that this repo *"never enables type-aware linting (no `parserOptions.project`, no typed `@typescript-eslint` rules) for ANY file, test or not"* — measured there with a positive control, and confirmed independently (every `parserOptions` occurrence carries only `ecmaVersion` / `sourceType`). Each file is linted in isolation, so this diff cannot move the verdict on any of the 6610 untouched files.

  The whole-repo run stays CI's, as the repo-scan rule assigns it.

A `patch` changeset is included: `@objectstack/cli` publishes `dist`, and the extractor's emitted output changes.

## Acceptance notes (out of scope, filed nowhere)

- **`packages/lint`'s `walkFlowNodes` is not exported from `@objectstack/lint`.** `i18n-extract.ts` already imports `walkPageComponents` from that package, so the CLI consuming a lint walker is established practice, and publishing this one would let two consumers share a descent rather than a table. Noted, not filed: it is a surface-widening proposal for the lint seat, not a defect — the runtime rejects nothing and no declared contract is broken. Successor: whoever next needs a region-aware node walk outside `packages/spec`.
- **The dispatch's file surface names `packages/cli/src/` for the tests**, but every sibling i18n-extract pin lives in `packages/cli/test/` (eight files). The new pins were added to `packages/cli/test/i18n-flow-screen-coverage.test.ts` — this card's own surface — rather than stranded in `src/` away from their siblings; that file also already carries the `vi.mock` of the liveness ledger that makes a `flows` **coverage row** observable at all, which the acceptance criterion requires. Declared as a deviation in the report.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TSf4DV7ziu4V5j73e46b7c)_

---
_Generated by [Claude Code](https://claude.ai/code)_