### PR TITLE
docs(spec): state the ADR-0053 D-D upper-bound rule in the date-macros header

### DIFF
--- a/.changeset/17333-date-macros-header-adr-0053.md
+++ b/.changeset/17333-date-macros-header-adr-0053.md
@@ -1,0 +1,49 @@
+---
+'@objectstack/spec': patch
+---
+
+`date-macros.zod.ts`'s module header states the ADR-0053 D-D upper-bound rule the platform implements, instead of the rule it replaced
+
+The header's "Out of scope" block told an author that on a `datetime` column
+`<= {current_year_end}` **stops at midnight on the 31st**, and prescribed the
+half-open `< {next_year_start}` as the fix. That is the pre-ADR-0053 reading.
+The platform rule has been the opposite since #3777: a bare `YYYY-MM-DD` used
+as an upper bound denotes the WHOLE day, compiled half-open to the next
+calendar day. It is stated once, in
+`packages/spec/src/data/calendar-day.ts` (ADR-0053 D-D), whose own operator
+table reads:
+
+| Operator | A bare `YYYY-MM-DD` on a `datetime` column means |
+|---|---|
+| `$gte` / `$gt` / `$lt` | that day's `00:00:00.000` — already correct as written |
+| `$lte`, a `$between` max, a `dateRange` end | the WHOLE day → compile `< nextUtcCalendarDay(day)` |
+
+and which `packages/spec/src/data/temporal-conformance.ts` pins cross-driver:
+the case *"datetime: bare-day `$lte` keeps the whole final day"* expects
+`d_mid` (09:15 on the boundary day) and `e_late` (21:40 on it) as members.
+
+**Why this header and not a note.** It is the doc comment on the vocabulary an
+AI author reaches for, and it is the one place in the tree that says what a
+`*_end` token does on the right-hand side of an operator. Both the old
+prescription and the correct spelling parse, run and return rows, so nothing
+downstream reports the mismatch — the author simply carries the wrong model
+into every later filter.
+
+**What the correction does.** The load-bearing first clause is kept verbatim: a
+`*_end` token IS the period's last calendar DAY. What follows now **cites**
+`calendar-day.ts` rather than restating the rule, so the two statements cannot
+drift apart again, and the half-open detour is refused by name for the reason
+it is now wrong — the widening is already applied.
+
+⛔ No behaviour changes. The diff is comment lines only; no schema, accept set,
+authorable key or published payload moves.
+
+**This is shipped, which is why it carries a changeset rather than
+`skip-changeset`.** `@objectstack/spec`'s published `files[]` lists
+`src/**/*.zod.ts`, so this file ships verbatim as source, and the header is the
+first thing in it.
+
+The generated reference page `content/docs/references/data/date-macros.mdx`
+carried the same sentence — it is rendered from this header and is marked
+AUTO-GENERATED — and is regenerated here with
+`pnpm --filter @objectstack/spec gen:schema && … gen:docs`.

--- a/content/docs/references/data/date-macros.mdx
+++ b/content/docs/references/data/date-macros.mdx
@@ -72,9 +72,20 @@ inside any single UI implementation.
   calendars) are defined by the resolver implementation; spec only
   freezes the **vocabulary**. One property is worth stating here
   because it is authored against: a `*_end` token is the period's
-  last calendar DAY (`{current_year_end}` → `2026-12-31`), so on a
-  `datetime` column `<= {current_year_end}` stops at midnight on the
-  31st. Filter a timestamp with the half-open `< {next_year_start}`.
+  last calendar DAY (`{current_year_end}` → `2026-12-31`). What a
+  bare day DENOTES once it lands on one side of an operator is a
+  separate contract, stated once in
+  `packages/spec/src/data/calendar-day.ts` (ADR-0053 D-D) and
+  deliberately not restated here: as an upper bound (`$lte`, a
+  `$between` max, a `dateRange` end) a bare day means the WHOLE
+  day, compiled half-open to the next calendar day, so
+  `<= {current_year_end}` reaches the final instant of Dec 31; as
+  `$gte` / `$gt` / `$lt` it means that day's `00:00:00.000`.
+  ⛔ Do NOT hand-write a half-open detour (`< {next_year_start}`)
+  to cover a period's last day on a `datetime` column: every
+  backend already applies the widening, and
+  `packages/spec/src/data/temporal-conformance.ts` pins it
+  cross-driver.
 
 <Callout type="info">
 **Source:** `packages/spec/src/data/date-macros.zod.ts`

--- a/packages/spec/src/data/date-macros.zod.ts
+++ b/packages/spec/src/data/date-macros.zod.ts
@@ -68,9 +68,18 @@ import { z } from 'zod';
  *   calendars) are defined by the resolver implementation; spec only
  *   freezes the **vocabulary**. One property is worth stating here
  *   because it is authored against: a `*_end` token is the period's
- *   last calendar DAY (`{current_year_end}` → `2026-12-31`), so on a
- *   `datetime` column `<= {current_year_end}` stops at midnight on the
- *   31st. Filter a timestamp with the half-open `< {next_year_start}`.
+ *   last calendar DAY (`{current_year_end}` → `2026-12-31`). What a
+ *   bare day then DENOTES on each side of an operator is not this
+ *   file's rule and is deliberately not restated here — it is the
+ *   platform-wide rule in `./calendar-day.ts` (ADR-0053 D-D): as an
+ *   upper bound (`$lte`, a `$between` max, a `dateRange` end) a bare
+ *   day means the WHOLE day, compiled half-open to the next calendar
+ *   day, so `<= {current_year_end}` reaches the final instant of Dec
+ *   31; as `$gte` / `$gt` / `$lt` it means that day's `00:00:00.000`.
+ *   ⛔ Do NOT hand-write a half-open detour (`< {next_year_start}`)
+ *   to cover the last day of a period on a `datetime` column: every
+ *   backend already applies that widening, and `./temporal-conformance.ts`
+ *   pins it cross-driver.
  */
 
 /** Single-point tokens — moments in time. */

--- a/packages/spec/src/data/date-macros.zod.ts
+++ b/packages/spec/src/data/date-macros.zod.ts
@@ -69,17 +69,19 @@ import { z } from 'zod';
  *   freezes the **vocabulary**. One property is worth stating here
  *   because it is authored against: a `*_end` token is the period's
  *   last calendar DAY (`{current_year_end}` → `2026-12-31`). What a
- *   bare day then DENOTES on each side of an operator is not this
- *   file's rule and is deliberately not restated here — it is the
- *   platform-wide rule in `./calendar-day.ts` (ADR-0053 D-D): as an
- *   upper bound (`$lte`, a `$between` max, a `dateRange` end) a bare
- *   day means the WHOLE day, compiled half-open to the next calendar
- *   day, so `<= {current_year_end}` reaches the final instant of Dec
- *   31; as `$gte` / `$gt` / `$lt` it means that day's `00:00:00.000`.
+ *   bare day DENOTES once it lands on one side of an operator is a
+ *   separate contract, stated once in
+ *   `packages/spec/src/data/calendar-day.ts` (ADR-0053 D-D) and
+ *   deliberately not restated here: as an upper bound (`$lte`, a
+ *   `$between` max, a `dateRange` end) a bare day means the WHOLE
+ *   day, compiled half-open to the next calendar day, so
+ *   `<= {current_year_end}` reaches the final instant of Dec 31; as
+ *   `$gte` / `$gt` / `$lt` it means that day's `00:00:00.000`.
  *   ⛔ Do NOT hand-write a half-open detour (`< {next_year_start}`)
- *   to cover the last day of a period on a `datetime` column: every
- *   backend already applies that widening, and `./temporal-conformance.ts`
- *   pins it cross-driver.
+ *   to cover a period's last day on a `datetime` column: every
+ *   backend already applies the widening, and
+ *   `packages/spec/src/data/temporal-conformance.ts` pins it
+ *   cross-driver.
  */
 
 /** Single-point tokens — moments in time. */


### PR DESCRIPTION
Part of #17333

- **Clause-②: no**

`packages/spec/src/data/date-macros.zod.ts`'s module header, in its "Out of scope" block, still stated the **pre-ADR-0053** upper-bound rule: that on a `datetime` column `<= {current_year_end}` *stops at midnight on the 31st*, with the half-open `< {next_year_start}` prescribed as the correction. The platform has done the opposite since #3777. This is a **prose correction only** — comment lines in, comment lines out; no schema, accept set, authorable key or published payload moves.

## The three prerequisites, taken by state on `origin/main` (not from the card)

1. **The header still stated the stale rule.** Anchored by CONTENT, not by line: after whitespace flattening, `stops at midnight on the` = 1, `Filter a timestamp with the half-open` = 1 in the file at `origin/main`. Lit controls on the same flattened stream: `Out of scope` = 1, `DATE_MACRO_PARAM_RE` = 5. Dark controls (proving the authority was NOT yet cited): `ADR-0053` = 0, `calendar-day.ts` = 0, `nextUtcCalendarDay` = 0. Fabricated control = 0.
2. **`calendar-day.ts` still states the ADR-0053 D-D rule, operator table included** — this is the authority written against, and it is unchanged. Its table at `origin/main`:

   | Operator | A bare `YYYY-MM-DD` on a `datetime` column means |
   |---|---|
   | `$gte` / `$gt` / `$lt` | that day's `00:00:00.000` — already correct as written |
   | `$lte`, a `$between` max, a `dateRange` end | the WHOLE day → compile `< nextUtcCalendarDay(day)` |

3. **#17014's `DATE_RANGE_PRESET_MACRO_WINDOWS` correction landed**, so this header is the surviving stale statement and not a duplicate: `date-range-presets.ts` carries the convention block headed *"The convention, binding on every entry (#17014)"* and the corrected entries `today: ['{today}', '{today}']` / `yesterday: ['{yesterday}', '{yesterday}']`.

`premise_still_valid: true`.

## The correction, and what it is sourced to

The load-bearing first clause is kept verbatim — a `*_end` token IS the period's last calendar DAY. What follows now **cites** `packages/spec/src/data/calendar-day.ts` (ADR-0053 D-D) instead of restating the rule, so the two statements cannot drift apart again, and it refuses the half-open detour by name for the reason it is now wrong: the widening is already applied. `packages/spec/src/data/temporal-conformance.ts` is named as the cross-driver pin — its case *"datetime: bare-day `$lte` keeps the whole final day"* expects `d_mid` (09:15 on the boundary day) and `e_late` (21:40 on it) as members.

## Generator, not hand-edit

`content/docs/references/data/date-macros.mdx` is rendered from this header and is marked AUTO-GENERATED. It is regenerated with the repo's own tooling, never hand-edited:

```
pnpm --filter @objectstack/spec gen:schema && pnpm --filter @objectstack/spec gen:docs
```

The first run of `gen:docs` alone refused with a **prerequisite** message (`packages/spec/json-schema is missing` / later `is older than packages/spec/src`), and a second refusal after the wording was refined — both reported here rather than silently retried; neither is a red. `gen:schema` wrote no tracked file (`json-schema/` is a gitignored build artefact); `gen:docs` wrote exactly one: the mdx above.

## Changeset

`.changeset/17333-date-macros-header-adr-0053.md`, level **patch** on `@objectstack/spec`, committed (the gate reads it from git, so a working-tree edit would be invisible). `skip-changeset` is not available here because published content moves, measured rather than assumed:

- `@objectstack/spec`'s `files[]` lists `src/**/*.zod.ts`, so this file ships verbatim as source and the header is the first thing in it.
- The header also reaches the built declarations. On the built `dist/` (170 JS/d.ts files scanned, whitespace flattened): the new citation text (the backticked path `packages/spec/src/data/calendar-day.ts` followed by "(ADR-0053 D-D)") = 2 occurrences in 2 files (`dist/data/index.d.ts`, `dist/data/index.d.mts`), the stale `stops at midnight` = 0 across all 170, with the neighbouring control `Token resolution semantics` present at 2 and a fabricated control at 0.

⚠️ One probe in this set was **discarded and re-run**, reported rather than quietly retried: the first `dist` measurement used an anchor without backticks and read 0 for the new text in its own source file. That was a mistyped anchor, not an absence; the corrected anchor reads 2 / 1 as above.

## Verification

All at `9f2225f55b`.

- **Gate families derived, not guessed:** `node scripts/pm/dispatch-gates.mjs --commands --repo objectstack-ai/objectstack` → 100 commands. **98 run green.** It flagged a STALE TREE warning for one derivation input (`scripts/pm/check-clause2-carriers.mjs`); re-derived after `git fetch origin main` and the 100-command list is byte-identical.
- **NOT MEASURED (1), not a red:** `pnpm check:dual-build-cjs-loads` exits 3 — it reads built output of 34 packages that have no `dist/` here and needs a repo-wide `pnpm build`; that is CI's run.
- **Five gates first came back as prerequisite refusals and were re-run green after building their prerequisites** (`@objectstack/lint`, `@objectstack/formula`, `@objectstack/client-react`): `check:doc-formula-expressions` and `check:doc-security-posture` (exit 3), `@objectstack/spec check:skill-examples` (**exit 1**, a refusal that did NOT arrive as exit 3), `check:docs-transcript-drift` (exit 3), `check:lean-entry-closure` (exit 3). Every exit code was captured before any pipe.
- **Named family green:** `pnpm --filter @objectstack/spec check:docs` exit 0; also `check:generated`, `check:authorable-surface`, `check:api-surface`, `check:doc-anchors`, `check:doc-authoring`, `check:docs-spec-enumerations`, `check:spec-docblock-symbol-anchors`, `check:nul-bytes`, `check:changeset-no-major --base origin/main`, `check:empty-changeset --base origin/main` — all exit 0.
- **Package:** `pnpm --filter @objectstack/spec build` exit 0; `typecheck` exit 0; `test` exit 0 — **473 test files, 13429 tests passed**. The dependency closure (`@objectstack/spec^...`) is empty: `@objectstack/spec` declares no workspace dependencies.
- **Repo-wide lint:** `pnpm lint` (`eslint . --no-inline-config`) exit 0 — run in full, so no narrowing needs declaring.
- **Control characters:** `grep -naP` over the edited source for the C0/C1 set returns exit 1 (no matches), exit code captured before any pipe.

An earlier `test` attempt returned the lock's `exit 99` (queue-timeout, **NOT MEASURED**); it was resumed under the same `OS_VERIFY_LOCK_SLOT` and is the green run reported above. All build/test runs went through `scripts/pm/os-verify-lock.sh`.

## 验收备注 — out of scope, noted for the seat

A flattened, tree-wide census over 8,179 tracked source blobs at `origin/main` (lit control `current_year_end` = 24 occurrences in 11 files; fabricated control = 0) found the stale statement at **four** sites. Two are in this PR (the header and its generated page). The other two are different files with different owners and are deliberately **not** touched here:

- `packages/core/src/utils/filter-tokens.ts` — a module header section literally titled *"Period `_end` is the last calendar DAY, not the last instant"*, stating that `<= {current_year_end}` *excludes everything after midnight on the 31st*, that authors *want* `< {next_year_start}`, and that widening the bound is *"not something the resolver may quietly fix"*. Different package, different published surface.
- `skills/objectstack-query/rules/filters.md` — *"`<= {current_year_end}` stops at midnight on the 31st. Use the half-open `< {next_year_start}` for timestamps."* Hand-written (no AUTO-GENERATED marker), and `skills/**` is a governed surface with its own line/token ratchet, so it is emphatically not a rider.

Both contradict the same declared contract in `calendar-day.ts`. They are reported to the PM seat for filing rather than filed from here: the repository-scoped issue **search** path is 403 for this session (`sessions are bound to their configured repositories`) and the MCP `search_issues` fallback returned `API rate limit already exceeded`, so a repo-wide duplicate check could not be completed. The partial reading that did complete: one REST page over open `domain:spec` issues (100 returned, the card reports ~104 open) — `filter-tokens` = 0, `objectstack-query` = 0, with lit controls `date-macros` = 1 and `ADR-0053` = 1 (both #17333 itself) and a fabricated control = 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MkQhmuuJAVDjmeWNixwDDH

---
_Generated by [Claude Code](https://claude.ai/code/session_01MkQhmuuJAVDjmeWNixwDDH)_