### PR TITLE
docs(spec): state what the object-* blocks declare on record_picker filter docblock

### DIFF
--- a/.changeset/17475-record-picker-filter-docblock.md
+++ b/.changeset/17475-record-picker-filter-docblock.md
@@ -1,0 +1,31 @@
+---
+'@objectstack/spec': patch
+---
+
+`element:record_picker`'s `filter` docblock now says what the `object-*` blocks actually declare
+
+The docblock on `ElementRecordPickerPropsSchema.filter` (anchor:
+`Filter rules narrowing which records the picker offers`) carried a
+parenthetical claiming *"the four `object-*` blocks declare `filter` as
+`z.unknown()`, no orthography at all"*. Measured on the file itself: there is no
+`filter` key anywhere in `packages/spec/src/ui/component.zod.ts` declared
+`z.unknown()` — zero occurrences, against 61 occurrences of `z.unknown()` in the
+same file on the same instrument, so the zero is a reading and not a broken
+matcher. All eight Zod `filter` declarations in the file are
+`z.array(ViewFilterRuleSchema).optional()`; the one remaining `filter:` line is a
+`KeySetGuidance` prose entry, not a declaration.
+
+The `object-*` family in `ComponentPropsMap` has **six** entries. **Four** of
+them carry a `filter` door — `object-grid`, `object-metric`, `object-kanban`,
+`object-calendar` — and all four declare `z.array(ViewFilterRuleSchema)`. The
+other two, `object-form` and `object-master-detail-form`, declare no `filter`
+key at all. The corrected parenthetical states both numbers and names all six,
+and keeps the `#15449` citation, which is accurate as provenance for when those
+four doors moved onto the array form.
+
+**Why this is worth a patch rather than a silent tidy.** The sentence sat in the
+one docblock that tells an author what the sibling `filter` doors accept, and it
+told them those doors accept anything. The record form it thereby invited —
+`{ field: { $eq: ... } }`, the MongoDB-style shape this very docblock says the
+picker moved OFF — is refused at parse by all four. Prose only: no declaration
+moves and no accept set changes.

--- a/packages/spec/src/ui/component.zod.ts
+++ b/packages/spec/src/ui/component.zod.ts
@@ -2200,8 +2200,12 @@ export const ElementRecordPickerPropsSchema = lazySchema(() => strictObject({
    * `ViewFilterRule` ARRAY form, `[{ field, operator, value }, ...]`, the one
    * filter orthography the map's array-declared `filter` doors share
    * (`record:related_list`, its nested Add-affordance picker, and — since
-   * #12039 Key 2 — `element:number`; the four `object-*` blocks declare
-   * `filter` as `z.unknown()`, no orthography at all — #15449). Until #14406
+   * #12039 Key 2 — `element:number`; and, since #15449, the four `filter`
+   * doors of the six-entry `object-*` family — `object-grid`,
+   * `object-metric`, `object-kanban` and `object-calendar` — each of which
+   * declares this same `z.array(ViewFilterRuleSchema)`, while that family's
+   * remaining two entries, `object-form` and `object-master-detail-form`,
+   * declare no `filter` key at all). Until #14406
    * this entry alone still said `FilterConditionSchema`, the MongoDB-style
    * record form: the last record-form `filter` in `ComponentPropsMap` after
    * the ui#6206 ruling (2026-08-25, Option B, verbatim 「同意」: one filter


### PR DESCRIPTION
Part of #17475

- **Clause-②: no**

Correcting one parenthetical in the `filter` docblock on `ElementRecordPickerPropsSchema`. Prose only: no declaration moves, no accept set changes, no schema is touched.

## The falsified sentence

The docblock (anchored by content: `Filter rules narrowing which records the picker offers`, never by line — the block moves) claimed:

> the four `object-*` blocks declare `filter` as `z.unknown()`, no orthography at all — #15449

## Re-measured on `origin/main`, not inherited from the card

The card's census is from `fd62a66b7c`; this branch was cut from `76c9fab30c` and then merged `origin/main` at `bc2bf01c8a`. Every number below was taken again on that tree.

**1. Census — occurrences, not lines** (`grep -o | wc -l`, on `git show origin/main:packages/spec/src/ui/component.zod.ts` so no built `dist/` is in the population):

| probe | occurrences |
|---|---|
| `filter: z.unknown()` — **dark** | **0** |
| `z.unknown()` — **lit control**, same file, same instrument | **61** |
| `ViewFilterRuleSchema` — **lit control** | **14** |

The lit controls come back non-zero on the same instrument and the same file, so the dark zero is a reading and not a matcher that finds nothing.

Eight Zod `filter` declarations exist in the file and **all eight** are `z.array(ViewFilterRuleSchema).optional()` (lines 1122, 1158, 1853, 2229, 2490, 2704, 2772, 2882 on `origin/main`). A ninth `filter:` line, at 1460, is a `KeySetGuidance` prose string — not a declaration. The card's `grep -n '^  filter:'` reading of 7 is the two-space-indent subset of the same set.

**2. The `object-*` block count — measured, not copied.** The docblock says *four*. The family is **six**:

| `ComponentPropsMap` key | schema | `filter` door |
|---|---|---|
| `object-grid` | `ObjectGridPropsSchema` | `z.array(ViewFilterRuleSchema).optional()` |
| `object-metric` | `ObjectMetricPropsSchema` | `z.array(ViewFilterRuleSchema).optional()` |
| `object-kanban` | `ObjectKanbanPropsSchema` | `z.array(ViewFilterRuleSchema).optional()` |
| `object-calendar` | `ObjectCalendarPropsSchema` | `z.array(ViewFilterRuleSchema).optional()` |
| `object-form` | `ObjectFormPropsSchema` | **none declared** |
| `object-master-detail-form` | `ObjectMasterDetailFormPropsSchema` | **none declared** |

So "four" is right as a count of `filter` doors and wrong as a count of the family — and the sentence gave no way to tell which it meant. The file's own header says so independently: `#7751 then GREW the map by the object-* block family -- six entries`. The corrected prose states **both** numbers and names all six blocks.

**3. #17166 / PR #17473 landed and did fence this key out.** `7aae0050bb docs(spec): name all five exportOptions members on object-grid, not two (#17473)` is an ancestor of `origin/main` (`git merge-base --is-ancestor` exit 0 — positive ancestry, which is self-certifying even on this shallow checkout). Its diff to `component.zod.ts` touches **zero** lines containing `filter` or `object-*`. Unpaid work, not a duplicate.

**4. Wrap-across-line-break handled.** Under a naive whitespace flatten the target sentence reads **0** in the source — because a JSDoc block carries a leading `*` on every line. Stripping the comment prefix before collapsing gives **1**. That zero was a mistyped anchor, not an absence, and the edit was anchored on the contiguous two-line span with a uniqueness assertion (`hits !== 1` aborts).

## The correction

The parenthetical now folds the four `filter` doors into the enumeration of array-declared doors it belongs in, keeps the `#15449` citation as provenance for when they moved, and names the two blocks that carry no `filter` key at all.

## Generated pages: verified on this tree, with a live control

`pnpm --filter @objectstack/spec gen:docs` regenerates 222 files and leaves the tree **clean** — a comment docblock is not a `.describe()`, so `content/docs/references/**` does not move.

That clean reading is admissible because the instrument was shown to swing the other way. Positive control, `trap`-restored: a marker was appended to a neighbouring `.describe()` string on the same schema, proven on disk (`grep -c` 0 → 1; blob hash `d81a58da6c` → `e341d20797`), then `gen:schema` + `gen:docs` were re-run — `content/docs/references/ui/component.mdx` went **modified**. Restored with `git checkout HEAD -- ...`, hash back to `d81a58da6c`, `gen:schema` + `gen:docs` re-run from the restored source, `git status --porcelain` empty.

A first attempt at that control is reported rather than hidden: it exited **1** on a prerequisite refusal (`packages/spec/json-schema is older than packages/spec/src`), which measured nothing and was discarded, not retried in silence.

## Why a changeset, measured rather than assumed

`@objectstack/spec` `files[]` ships `dist` and `src/**/*.zod.ts`. After a build, the corrected sentence is present in **2** published dist files (`dist/ui/index.js`, `dist/ui/index.mjs`) and the old falsified fragment in **0**; the lit control (the sibling `.describe()` prose) hits the same 2 files. The docblock ships. `patch` on `@objectstack/spec`.

## Verification

Run at `567cb419f8`, tree clean.

- `pnpm --filter @objectstack/spec build` — `VERDICT command-exit 0`.
- `pnpm --filter '@objectstack/spec^...' build` — **empty run**: `No projects matched the filters`. `packages/spec` has no workspace dependencies, so the closure leg measured nothing and is reported as such.
- `pnpm --filter @objectstack/spec typecheck` — `VERDICT command-exit 0`; `check:test-typecheck: OK — 54 file(s) / 259 error(s) / 144 pinned signature(s) held`.
- `pnpm --filter @objectstack/spec test` — `VERDICT command-exit 0`; `Test Files 473 passed (473)`, `Tests 13429 passed (13429)`.
- `pnpm lint` (`eslint . --no-inline-config`, the repo-wide population) — exit 0. Run whole, at this HEAD, so no narrowing is claimed and none needs defending.
- **Derived gate families**, via `node scripts/pm/dispatch-gates.mjs --commands --repo objectstack-ai/objectstack` (change set taken by the script from the merge base, not hand-listed): **76 derived, 75 run green, 1 NOT MEASURED, 0 unrun**, reconciled with `--ran` carrying a recorded exit code per family.

Two families were re-run rather than reported from a misinvocation:

- `check:doc-formula-expressions` first exited **3** — `PREREQUISITE NOT MET`, unbuilt `@objectstack/formula` / `@objectstack/lint`. Nothing was measured. After building both: exit **0**.
- `check:react-declaration-parity` first exited **1** with `MANIFEST is not set — this gate did NOT run`. Re-run as CI runs it (`MANIFEST="$PWD/sdui.manifest.json" ... --baseline react-declaration-parity.baseline.json --strict`): exit **0**, `no new DECLARATION divergence vs accepted baseline`.
- `check:lean-entry-closure` first exited **3** on an unbuilt `@objectstack/objectql`. After building it: exit **0**.

**NOT MEASURED, declared:** `pnpm check:dual-build-cjs-loads` exits **3** — `PREREQUISITE NOT MET`, 48 packages have no `dist/`; clearing it is a repo-wide `pnpm build`, which is CI's run and not this round's. Recorded as exit 3, never as a pass.

## Known red: `Part-of PR must not also close its card`

⚠️ **Self-inflicted and, on an already-pushed branch, not clearable by any author action** — reported rather than worked around.

Commit `6f2d6d9ac` carries `Part of #17475` in its **message**. The contract puts the card relation in the PR **body** only; a commit carries no card trailer. I wrote it into both, and pushed before the guard ran.

`scripts/check-partof-closing-keyword.mjs`, reproduced locally against this PR's own commit list and body, exits 1 and states the remedy itself:

> ⛔ The repair is NOT a history rewrite. Amend, rebase and force-push are forbidden in this repository and this gate never asks for one. […] **BRANCH ALREADY PUSHED** — no author action clears this red […] the only thing that would remove it is the rewrite forbidden above.

Three facts from the gate's own text, so this can be read rather than acted on: the check is **advisory** at the branch-protection layer (absent from the required-context registry; its workflow subscribes to no `merge_group` event); the trailer's spelling is `Part of`, which **lands as a reference and moves no card**; and the card relation is carried by the PR body regardless. ⛔ I did not amend, rebase or force-push, and ⛔ I did not reword the body to hide it.

It also sits **outside** the derived gate total above: `dispatch-gates --ran` names the path-scheduled CI jobs as a separate class from the 76 families it derives, and this is one of them.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MkQhmuuJAVDjmeWNixwDDH


---
_Generated by [Claude Code](https://claude.ai/code)_