### PR TITLE
fix(cli): migrate-meta's semver-label assertion targets the Chain: line, not the whole stdout

### DIFF
--- a/packages/cli/test/migrate-meta.e2e.test.ts
+++ b/packages/cli/test/migrate-meta.e2e.test.ts
@@ -510,15 +510,32 @@ export default {
   });
 
   it("names this build's protocol major, in majors", async () => {
-    const stdout = await runMeta(['--from', String(PROTOCOL_MAJOR)], labelDir);
+    // `--to` is pinned to PROTOCOL_MAJOR deliberately: the unqualified default
+    // is CHAIN_TERMINUS_MAJOR (the highest major ANY migration step is
+    // registered for), which legitimately runs ahead of PROTOCOL_MAJOR once a
+    // future major's steps are pre-authored (see migrate/meta.ts). This case
+    // is specifically the "already at this runtime's own major" no-op chain,
+    // so it names both ends explicitly rather than riding a default that is
+    // designed to drift.
+    const stdout = await runMeta(['--from', String(PROTOCOL_MAJOR), '--to', String(PROTOCOL_MAJOR)], labelDir);
     expect(stdout).toContain(
       `Chain:  protocol ${PROTOCOL_MAJOR} → ${PROTOCOL_MAJOR} (this runtime implements protocol ${PROTOCOL_MAJOR})`,
     );
   }, 120_000);
 
   it('prints no padded protocol semver in the human output, under any label', async () => {
+    // Deliberately NOT pinning `--to` here: the default climbs to
+    // CHAIN_TERMINUS_MAJOR, which is exactly what exercises the real risk
+    // surface this test guards — a hop's semantic `why:` prose (which may
+    // legitimately CITE a past release's bare semver, e.g. "measured on
+    // 17.0.0 GA …") printed verbatim into stdout. The instrument must not
+    // confuse that citation with the mislabelled-runtime defect the docblock
+    // above describes, so it targets the version-label surface (the `Chain:`
+    // line / the word "runtime") instead of the whole transcript.
     const stdout = await runMeta(['--from', String(PROTOCOL_MAJOR)], labelDir);
-    expect(stdout).not.toContain(PROTOCOL_VERSION);
+    const chainLine = stdout.split('\n').find((line) => line.includes('Chain:'));
+    expect(chainLine, 'the Chain: line must be present to assert against').toBeTruthy();
+    expect(chainLine).not.toContain(PROTOCOL_VERSION);
     expect(stdout).not.toMatch(/runtime \d+\.\d+\.\d+/);
   }, 120_000);
 


### PR DESCRIPTION
Part of #17633 (nightly-filed `os-nightly-tiers` card; per the card's own text — "let the next nightly refresh this card" — closing is the nightly's job on green, not a keyword on this PR. No precedent found for a PR closing a nightly-filed `nightly-tiers: red on main` card by keyword: searched merged PRs and closed `domain:devx`+`priority:p1` issues for a prior instance of this recurring title; none exists yet, so this appears to be the first time it is fixed rather than re-filed. Flagging for the PM to confirm the relation is right).

## What / why

`packages/cli/test/migrate-meta.e2e.test.ts` — `os migrate meta` — the chain line names the protocol, not a package version:

- **`prints no padded protocol semver in the human output, under any label`** (the test the card's diagnosis names, `:519` pre-edit / `:521` the `not.toContain` line): `os migrate meta --from PROTOCOL_MAJOR` with no `--to` defaults `toMajor` to `CHAIN_TERMINUS_MAJOR` (18) — one major ahead of `PROTOCOL_MAJOR` (17) — because protocol-18 semantic migration entries are already pre-registered in `packages/spec/src/migrations/registry.ts` (by design: `CHAIN_TERMINUS_MAJOR = Math.max(PROTOCOL_MAJOR, ...MIGRATION_MAJORS)`, `packages/cli/src/commands/migrate/meta.ts:87`). Those entries' `why:` prose legitimately CITES the 17.0.0 GA release ("Measured on 17.0.0 GA end to end: …") and `os migrate meta`'s human output prints `why:` blocks verbatim, so the literal string `17.0.0` reaches stdout. The old assertion, `expect(stdout).not.toContain(PROTOCOL_VERSION)`, checked the WHOLE transcript and cannot tell that historical citation apart from the actual defect the test's own docblock (`:468-480`) describes — a bare padded semver printed in the Chain line's **version position**. Narrowed the assertion to that surface: pull out the `Chain:` line and assert `PROTOCOL_VERSION` is absent from it specifically, keeping the second half (`not.toMatch(/runtime \d+\.\d+\.\d+/)`) exactly as it was — already green, and still required by the docblock ("Both halves are asserted, because either one alone is satisfiable the wrong way").
- **`names this build's protocol major, in majors`**: re-measuring myself (not citing the card's diagnosis, which named only the test above) turned up a SECOND red in the same file, same describe block, same root cause: this case also omitted `--to`, so it silently rode the same `CHAIN_TERMINUS_MAJOR` default into a `17 → 18` chain instead of the `17 → 17` no-op it was written to assert (`Chain:  protocol 17 → 17 …` never appeared in `17 → 18` output). Its own name and position (the trivial "already at this runtime's own major" case, paired with the version-label docblock) is unambiguous about intent, so it now pins `--to PROTOCOL_MAJOR` explicitly rather than relying on a default that is deliberately designed to drift ahead as future-major migrations get pre-authored. This is a same-file, same-shape, test-only correction — not a widened surface.

Neither `packages/spec/src/migrations/**` (the data under test — the historical citations are real measurements and are not touched) nor `packages/cli/src/commands/migrate/meta.ts` (production code) is touched, per the card's own instruction and this card's acceptance criteria: the instrument was blind, not the record.

## Re-measurement (premise check, AGENTS.md rule 6)

Re-verified the diagnosis myself rather than citing the dispatch comment:
- `packages/spec/src/migrations/entries/semantic/18.ui-reference-rail-unknown-keys-refused.ts:21`, `18.admin-export-wildcard-removed.ts:24`, `18.stack-top-level-unknown-keys-refused.ts:19` each cite `17.0.0 GA` in their `why:` prose — confirmed by `grep`.
- The same four registry.ts copies at lines 5118 / 5523 / 9856 / 10617 — confirmed.
- `grep -rPn 'runtime \d+\.\d+\.\d+' packages/spec/src/migrations/` → 0 hits — confirmed the `not.toMatch` half was never the red half.
- **New finding beyond the card's diagnosis**: the card named only `:521`'s `not.toContain` assertion as red. Running the file unmodified showed **2 tests failing, not 1** (`Test Files 1 failed (1)` · `Tests 2 failed | 17 passed (19)`) — `names this build's protocol major, in majors` is also red, for the CHAIN_TERMINUS_MAJOR-vs-PROTOCOL_MAJOR reason above. Fixed both in this PR since both live in the file the card names and both must be green for the next nightly to actually go green on this file.

## Tests

**Leg 1 — unmodified tree, both `:521` assertions run SEPARATELY** (own script driving the real CLI once, applying each `expect` independently rather than letting vitest's first-failure abort hide the second):
```
=== leg A: not.toContain(PROTOCOL_VERSION) === FAIL (red)
=== leg B: not.toMatch(/runtime \d+\.\d+\.\d+/) === PASS (green)
```
Matches the diagnosis exactly: only the whole-stdout `toContain` half was ever red.

**Full file, unmodified tree**: `OS_TEST_TIERS=nightly pnpm --filter @objectstack/cli exec vitest run --project integration test/migrate-meta.e2e.test.ts` → `Test Files 1 failed (1)` · `Tests 2 failed | 17 passed (19)` (the two cases above).

**Full file, fixed tree**: same command → `Test Files 1 passed (1)` · `Tests 19 passed (19)`.

**Leg 2 — re-plant the original defect, prove the NEW assertion catches it** (AGENTS.md ablation discipline: mutate → prove on-disk → observe → revert with a trap, byte-verified): temporarily changed `packages/cli/src/commands/migrate/meta.ts`'s `printInfo` call from `` this runtime implements protocol ${PROTOCOL_MAJOR} `` to `` …${PROTOCOL_VERSION} `` (re-planting exactly the "bare padded semver in a version position" defect the docblock describes), confirmed the injection landed (`grep -c` = 1), ran the real edited test file against it:
```
× names this build's protocol major, in majors
× prints no padded protocol semver in the human output, under any label
× still says where the runtime stands when --to stops below this build's major
Tests  3 failed | 1 passed | 15 skipped (19)
```
The target case (`prints no padded protocol semver…`) goes RED as required — its narrowed `chainLine` assertion catches the re-planted defect exactly where the old whole-stdout assertion did, so the narrowing lost no detection power. Reverted via `git checkout HEAD -- THE-FILE`; `git hash-object` before/after match (`7af7441d…` both sides) and `git diff HEAD` is empty — `packages/cli/src/commands/migrate/meta.ts` carries no diff in this PR.

**Typecheck**: `pnpm --filter @objectstack/cli typecheck` → exit 0 (`tsc --noEmit` + `check:test-typecheck`, no new debt).

**Dependency closure build** (rule ①): `pnpm --filter '@objectstack/cli^...' build` → exit 0.

**Dispatch-gates**: `node scripts/pm/dispatch-gates.mjs --commands --repo objectstack-ai/objectstack` derived 48 families for this 1-file diff; ran all 48, reconciled with `--ran` → `48 derived, 48 run, 0 NOT-MEASURED, 0 UNRUN`. 47/48 exit 0; `pnpm check:dual-build-cjs-loads` exits 3 — `PREREQUISITE NOT MET` (reads built `dist/` for packages outside this diff's dependency closure — studio, client-react, the connectors, embedder-openai, knowledge-memory, etc. — none built here per the "definite scope" build rule). Recorded as NOT MEASURED, not a finding against this diff: nothing about it reads `packages/cli/test/**`.

Final commit: `b6d65a4d86`.

## Changeset

`packages/cli` is a published package, but its `files` is `["dist", "README.md", "CHANGELOG.md"]` (measured, `packages/cli/package.json`) — `test/**` never ships. `skip-changeset` label applied.

**Clause-②**: no (test assertion only; no contract surface moves — `packages/spec/src/migrations/**` and `meta.ts`'s output format are both untouched).

---
_Generated by [Claude Code](https://claude.ai/code/session_012GKcPZbMoGq7WPzKLfRBTU)_