### PR TITLE
docs(capabilities): drop unqualified `queue` approver from the shipped list

### DIFF
--- a/content/docs/capabilities/approvals.mdx
+++ b/content/docs/capabilities/approvals.mdx
@@ -1,14 +1,14 @@
 ---
 title: Approvals
-description: Eight ways to pick approvers, four decision modes including group sign-off, record locking, overdue escalation, and send-back-for-revision
+description: Seven ways to pick approvers, four decision modes including group sign-off, record locking, overdue escalation, and send-back-for-revision
 ---
 
 
 Discounts, contracts, spend — anything that needs a human "yes" becomes an approval step in a flow, replacing the group-chat shoulder tap with a tracked, enforceable decision.
 
-## Who approves — eight resolution styles
+## Who approves — seven resolution styles
 
-A specific person · everyone holding a position (e.g. sales managers) · the submitter's direct manager (needs a provisioned reporting chain — see below) · a team · a department (optionally including sub-departments) · organization leadership · **a person named on the record itself** (e.g. the "regional director" field) · a shared queue (first responder claims it).
+A specific person · everyone holding a position (e.g. sales managers) · the submitter's direct manager (needs a provisioned reporting chain — see below) · a team · a department (optionally including sub-departments) · organization leadership · **a person named on the record itself** (e.g. the "regional director" field).
 
 <Callout type="warn">
 **Routing to the submitter's manager needs a reporting chain you provide.** Unlike a position you

--- a/content/docs/capabilities/index.mdx
+++ b/content/docs/capabilities/index.mdx
@@ -15,7 +15,7 @@ If you are a developer, the [Build sections](/docs/data-modeling) cover the same
   <Card href="/docs/capabilities/views" title="Views — See Data Your Way" description="Nine lenses over the same records: table, kanban, calendar, gantt, map and more — plus saved filters and global search" />
   <Card href="/docs/capabilities/forms" title="Forms & Data Quality" description="Wizards, conditional fields, validation on save, legal stage transitions, public web-to-lead forms" />
   <Card href="/docs/capabilities/automation" title="Automation" description="Five trigger styles and visual flows: reminders, hand-offs, escalations, and scheduled work that runs itself" />
-  <Card href="/docs/capabilities/approvals" title="Approvals" description="Eight approver styles, four decision modes including group sign-off, locking, SLA escalation, send-back" />
+  <Card href="/docs/capabilities/approvals" title="Approvals" description="Seven approver styles, four decision modes including group sign-off, locking, SLA escalation, send-back" />
   <Card href="/docs/capabilities/permissions" title="Permissions — Who Sees What" description="Four layers from object capability to per-field visibility, five data-depth scopes, audit and explain" />
   <Card href="/docs/capabilities/analytics" title="Analytics & Dashboards" description="~20 chart families, period-over-period, runtime filters, TV display pages, reports and email digests" />
   <Card href="/docs/capabilities/ai" title="AI Under Governance" description="Ask questions and get charts; AI acts under the same permissions and audit as people; bring your own agent over MCP" />


### PR DESCRIPTION
Closes #17573

## What changed

`content/docs/capabilities/approvals.mdx` advertised `queue` ("a shared queue — first responder claims it") as one of eight shipped approver resolution styles. The runtime does not implement it: `packages/plugins/plugin-approvals/src/approval-service.ts:1714` — `if (type === 'queue')` — warns `"[approvals] approver type 'queue' is not implemented — the slot resolves to nobody (#3508)"`, and `packages/spec/src/automation/approval.zod.ts:204`/`:304` mark it `{ source: 'unsupported' }` / non-authorable. A `queue` entry authored today simply routes to nobody.

I re-measured these readings myself against `origin/main` (not cited from the PM dispatch comment):

```
packages/plugins/plugin-approvals/src/approval-service.ts:1714  if (type === 'queue') {
packages/plugins/plugin-approvals/src/approval-service.ts:1716    `[approvals] approver type 'queue' is not implemented — the slot resolves to nobody (#3508)`,
  positive control, same file/scan shape: 'position' -> 4 hits
packages/spec/src/automation/approval.zod.ts:204   queue: { source: 'unsupported' },
packages/spec/src/automation/approval.zod.ts:304   queue: false,
```

## Fix — option (a): drop the item, correct the count

The card's acceptance item 1 offers a choice: drop the item and correct the count, or keep it and qualify it in place the way the developer page does. I chose **(a) drop**, because:

- `queue` isn't partially working with a caveat (like `manager`, which mostly works but needs a provisioned reporting chain) — it resolves to nobody, full stop, and is no longer offered for authoring at all (#3508). There is nothing left to sell on this page.
- This page is a one-sentence enumeration for a sales/business audience, not the place to carry the developer page's longer qualification (`content/docs/automation/approvals.mdx`) a second time.
- Dropping removes any claim — qualified or not — so nothing here can be misread as "shipped."

`manager`'s own wording is untouched — #16678 owns that half of the line and it's still in the decision box (open, `needs-user-decision`, unassigned), so it reads exactly as it did before.

## Send-back round: a fourth carrier, found by reverse-read

The first commit moved the count word in `approvals.mdx` (heading `:9`, frontmatter `description`) and dropped the list item, but left one carrier of the same "eight" claim untouched: the **section landing card** at `content/docs/capabilities/index.mdx:18` — `<Card ... title="Approvals" description="Eight approver styles, ...">` — which is the card the reader hits **before** the approvals page itself. The PM's send-back caught this; I re-measured it independently rather than trusting the send-back's grep, confirmed it on `origin/main`, and fixed it in a second commit that touches only that one `description` attribute on that one line — nothing else on the line or in the file.

**Reverse-read pass I ran on the two-file diff before pushing** (the question: which existing sentence in the tree does this change make false, beyond the one carrier already fixed?):

- `grep -rniE "eight approver|eight (ways|resolution) |approver styles"` across `content/`, `skills/`, `apps/` — after the two-file fix, zero hits anywhere in the tree (was 3, across the two files now both fixed).
- Numeral-spelled carriers (`8 approver`, `8 ways`, `8 resolution`, `approv.*\b8\b`) across `content/docs` — zero hits for the approver-count claim. (One unrelated false-positive: `content/docs/permissions/system-context.mdx:157` says "Approval actor / submitter / pending-approver checks bypassed (**8 sites**)" — a count of code call sites in an audit table, not a count of approver *styles*; not a carrier of this claim.)
- Enumeration-without-counting carriers: checked `skills/objectstack-automation/SKILL.md`'s "Approver Types" table, the one other place in the tree that lists the approver kinds. It already reads `queue` correctly — `"⛔ Declared but never resolved — the slot routes to nobody. Do not author"` — and carries no count word, so it was never a carrier and needed no change.
- Also checked `content/blog/` and `content/docs/getting-started/` for "eight" / "approver styles" — zero hits.

No further carriers found.

## Measurable check (card's item 5), re-scoped to both files

```
BEFORE (origin/main d07fc178b9):
  approvals.mdx:  grep -in "queue\|eight" -> 3 hits (description "Eight ways…", heading "eight resolution
                   styles", list "a shared queue (first responder claims it)")
  index.mdx:      grep -in "queue\|eight" -> 1 hit (landing card description "Eight approver styles")
AFTER (this branch, both commits):
  grep -in "queue\|eight" content/docs/capabilities/approvals.mdx content/docs/capabilities/index.mdx -> 0 hits
  grep -in "seven" content/docs/capabilities/approvals.mdx content/docs/capabilities/index.mdx -> 3 hits
    (approvals.mdx description, approvals.mdx heading, index.mdx landing card description)
```

Positive control satisfied on **each** file individually (both non-zero before), probe reads 0 across both files after, and the count word ("seven") now agrees with the 7 remaining list items on the approvals page and matches the landing card.

## Boundaries respected

Two files touched, both carriers of the *same* claim (the shipped-approver-style count for this one capability), not a widened surface:

- `content/docs/capabilities/approvals.mdx` — the page itself (heading, list, frontmatter description).
- `content/docs/capabilities/index.mdx:18` — the section landing card that quotes the same count as its own one-line summary of that page.

`content/docs/automation/approvals.mdx` (the reference sentence) and `packages/**` untouched. Neither file is generated: `content/docs/<tree>/` other than `references/`/`releases/` is hand-written per AGENTS.md's Documentation Guardrails table, so both were hand-edited directly. No implementation claim: this PR does not say `queue` should work — #3508 owns that.

## Gates

`content/docs/**` gate family, re-derived (not reused) on the two-file diff via `node scripts/pm/dispatch-gates.mjs --commands` at HEAD `23ba0dae77`. The derived command set is **identical** to the one-file run's — adding `capabilities/index.mdx` to the diff pulled in no new gate family — so the same 40 commands were re-run in full against the new tip:

```
pnpm check:doc-anchors · check:doc-authoring · check:docs-single-h1 · check:docs-redirects ·
check:docs-spec-enumerations · check:docs-transcript-drift · check:docs-audit-scope ·
check:nul-bytes · check:role-word · check:published-readme-links · check:watch-hint-literal ·
check:corpus-claim-drift · check:cross-package-test-inputs · check:driver-memory-census ·
check:react-page-adapter-contract · check:refd-timer-probe · check:skill-identifier-liveness ·
check:vendor-version-stamps

node scripts/check-doc-frontmatter.mjs · check-docs-section-name.mjs · check-section-landing-index.mjs ·
check-doc-route-spelling.mjs --advisory · check-ci-filter-parity.mjs · check-closing-keyword-parity.mjs (+self-test) ·
check-comment-mask-corpus.mjs · report-test-timings.mjs --self-test

pnpm --filter @objectstack/lint check:doc-formula-expressions · check:doc-security-posture
pnpm --filter @objectstack/spec check:docs · check:empty-state · check:liveness · check:skill-examples ·
check:strictness-ledger · check:variant-docs · check:yaml-examples
```

Ran/derived/NOT-MEASURED reconciliation: derived 40, ran 40, 0 NOT MEASURED, 0 UNRUN. All green, 0 findings against the two-file diff (`check:section-landing-index` and `check:docs-section-name` — the two gates that would plausibly notice a landing-page edit — both pass clean: 402 file(s), no nameless-section findings, 27 of 35 landing pages including this one declare no held index block).

## Changeset

`content/docs/**` ships only through the docs site (`apps/docs`, `"private": true`) — no workspace package's published `files[]` includes it (checked: grepped every `packages/*/package.json`'s `files` array, zero hits). `skip-changeset` applies; label applied.

Clause-②: no

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012GKcPZbMoGq7WPzKLfRBTU


---
_Generated by [Claude Code](https://claude.ai/code)_