### PR TITLE
docs(spec): state both roles of `aliases`, not only the gap it fills

### DIFF
--- a/.changeset/strict-object-aliases-two-roles.md
+++ b/.changeset/strict-object-aliases-two-roles.md
@@ -1,0 +1,15 @@
+---
+'@objectstack/spec': patch
+---
+
+Correct `aliases`' documented contract: it is not "only for what edit distance cannot reach".
+
+`strictObject`'s `aliases` option was documented as a universal in the three places an adopter reads — the module docblock in `shared/strict-object.ts`, the `StrictObjectOptions.aliases` JSDoc an editor shows on hover, and the same JSDoc on the published `strictUnknownKeyError`'s `StrictUnknownKeyErrorOptions.aliases` — all saying aliases are "semantic near-misses edit distance cannot reach". The word *cannot* denies the option's second job.
+
+The lookup is `aliases[aliasProbe(key)] ?? findClosestMatches(key, knownKeys, maxDistance, 1)[0]`: an alias is consulted **before** the distance fallback and wins outright. So an entry is equally right when distance *does* reach the key and answers with the wrong one — `hosts` is 2 edits from the declared `hooks` against a budget of `Math.max(2, Math.floor(5 / 3))` = 2, so on the plugin `permissions` block the entry is what keeps an author off lifecycle hooks.
+
+Neither role is rare, and the correction carries its own count rather than the hedge it replaces. Measured over every surface the `strictObject` registry records, 2026-09-11: **1910** alias entries, **1658** unreachable by distance, **252** reachable — 211 where the fallback would have answered identically, and **41** where it answers a different key the entry overrules.
+
+The failure mode the old sentence produced is precise and has a live carrier: an adopter with a reachable-but-wrong near-miss read "edit distance cannot reach", concluded `aliases` was not the tool for their case, and left the confident wrong suggestion in place.
+
+Prose only. No alias is added or removed, no schema, key list, strictness or error message changes, and `visibleWhen → visible` (verified still unreachable) stays as the proving case for the gap half.

--- a/docs/audits/2026-07-unknown-key-strictness-ledger.md
+++ b/docs/audits/2026-07-unknown-key-strictness-ledger.md
@@ -138,8 +138,13 @@ schema needs:
 lazySchema(() => strictObject({ surface, history, aliases?, guidance? }, { ...shape }))
 ```
 
-- `aliases` — semantic near-misses edit distance cannot reach (`visibleWhen` →
-  `visible`, `from` → `source`, `read` → `allowRead`).
+- `aliases` — curated near-miss answers, consulted before the distance fallback
+  and preferred over it, so the table carries both the near-misses distance
+  **cannot reach** (`visibleWhen` → `visible`, `from` → `source`, `read` →
+  `allowRead`) and the ones it **reaches and answers wrongly** (`hosts` →
+  `network`, 2 edits from the declared `hooks` against a budget of 2 — #16859).
+  Measured 2026-09-11 (#17361): of 1910 entries, 1658 unreachable, 211
+  reachable-and-agreeing, 41 overruling a wrong hit.
 - `guidance` — exact-key prescriptions: **tombstones for retired keys** (the
   rejection carries the upgrade — AGENTS.md Post-Task Checklist #3) and
   wrong-layer pointers (`apiOperations` is response-side; `objectName` belongs

--- a/packages/spec/src/shared/strict-object.ts
+++ b/packages/spec/src/shared/strict-object.ts
@@ -29,10 +29,30 @@
  * `aliases` and `guidance` stay hand-written, because they are the part that
  * carries judgement rather than transcription:
  *
- * - `aliases` — semantic near-misses edit distance cannot reach. The one that
- *   proves the category is `visibleWhen → visible`: ADR-0089 made `visibleWhen`
- *   the correct spelling on view/page, so an author borrowing it on a different
- *   surface is not making a typo, and only a human-written entry can catch it.
+ * - `aliases` — the curated answer for a semantic near-miss, a different *word*
+ *   for the same intent. It is consulted BEFORE the distance fallback and wins
+ *   outright (`aliases[aliasProbe(key)] ?? findClosestMatches(…)` in
+ *   `suggestions.zod.ts`), which is what gives it **two** jobs, not one:
+ *   - **filling a gap** — the near-miss distance cannot reach. The proving case
+ *     is `visibleWhen → visible`: ADR-0089 made `visibleWhen` the correct
+ *     spelling on view/page, so an author borrowing it on a different surface
+ *     is not making a typo, and only a human-written entry can catch it.
+ *   - **overruling a wrong hit** — the near-miss distance CAN reach, and
+ *     answers with the wrong key. The proving case is `hosts → network` on the
+ *     plugin `permissions` block (#16859): the budget is `max(2, len/3)` = 2
+ *     for a five-character key and `hosts` is exactly 2 from the declared
+ *     `hooks`, so without the entry the author is sent to lifecycle hooks on
+ *     the one block that also grants network access.
+ *
+ *   ⚠️ Neither job is the rare one, and this bullet claimed only the first
+ *   until #17361 measured it. Over every registered surface on 2026-09-11:
+ *   1910 alias entries, 1658 of them unreachable by distance and **252
+ *   reachable** — 211 where the fallback would have answered identically, and
+ *   **41 where it answers a different key** the entry overrules. ⛔ So do not
+ *   read this option as *only* for what distance cannot reach: that reading
+ *   tells an adopter holding a confident wrong suggestion — the case the
+ *   option is most needed for — that `aliases` is not their tool, which is
+ *   this campaign's own finding-7 shape (see {@link acceptsNothing}).
  * - `guidance` — tombstones for retired keys (the rejection must carry the
  *   upgrade) and wrong-layer pointers.
  *
@@ -114,8 +134,18 @@ export interface StrictObjectOptions {
   /** One sentence: what silently happened before this shape was closed. */
   history: string;
   /**
-   * Semantic near-misses edit distance cannot reach — a different *word* for
-   * the same intent, usually correct on a neighbouring surface.
+   * Curated answers for semantic near-misses — a different *word* for the same
+   * intent, usually correct on a neighbouring surface.
+   *
+   * Looked up BEFORE the edit-distance fallback and preferred over it, so an
+   * entry is the right tool in **both** directions: the word distance cannot
+   * reach (`visibleWhen → visible`), and the word distance *does* reach and
+   * gets WRONG (`hosts → network`, where `hosts` is 2 edits from the declared
+   * `hooks` against a budget of 2 — #16859). ⛔ Not "only for what distance
+   * cannot reach": that was this line until #17361, and it sends an author
+   * holding a confidently wrong suggestion away from the option that fixes it.
+   * Plain case / underscore slips still need no entry — the fallback folds
+   * those already, and a second spelling of a covered probe is a dead row.
    */
   aliases?: Readonly<Record<string, string>>;
   /**

--- a/packages/spec/src/shared/suggestions.zod.ts
+++ b/packages/spec/src/shared/suggestions.zod.ts
@@ -328,9 +328,15 @@ export interface StrictUnknownKeyErrorOptions {
   /**
    * Semantic near-misses: a different *word* for the same intent, usually
    * borrowed from a neighbouring schema or product where that word is correct.
-   * Edit distance cannot reach these, so they are named explicitly; plain
-   * case/underscore slips are left to {@link findClosestMatches}. Map keys are
-   * matched case-insensitively with `_` / `-` / space separators removed.
+   * Consulted BEFORE {@link findClosestMatches} and preferred over it, so an
+   * entry answers both the near-miss distance cannot reach AND the one it
+   * reaches and gets wrong — `hosts → network` is 2 edits from the declared
+   * `hooks` against a budget of 2, and the entry is what keeps the author off
+   * lifecycle hooks (#16859; this line asserted only the first half until
+   * #17361 measured 41 overruling entries across the spec). Plain
+   * case/underscore slips are still left to the fallback, which folds them.
+   * Map keys are matched case-insensitively with `_` / `-` / space separators
+   * removed.
    */
   aliases?: Readonly<Record<string, string>>;
   /**


### PR DESCRIPTION
Part of #17361

- **Clause-②: no**

Prose only. The diff adds no key to any published payload — every changed line in the two TypeScript files is inside a block comment (proof below).

## What was wrong

`strictObject`'s `aliases` was documented as a **universal** — *"semantic near-misses edit distance cannot reach"* — so an adopter holding a near-miss that distance **does** reach, and answers **wrongly**, reads the authority and concludes `aliases` is not their tool. That is the campaign's own finding-7 shape: this campaign's fix signposting the way into the failure mode it exists to kill.

The mechanism the sentence denies: the lookup is

```
aliases[aliasProbe(key)] ?? findClosestMatches(key, knownKeys, maxDistance, 1)[0]
```

so an alias is consulted **before** the distance fallback and **wins outright**. It therefore has two jobs, not one:

| role | proving case | why the fallback alone is not enough |
|---|---|---|
| fill a gap distance cannot reach | `visibleWhen` to `visible` | re-measured: no candidate within budget |
| overrule a hit distance gets WRONG | `hosts` to `network` (plugin `permissions`) | budget `max(2, floor(5/3))` = 2, `hosts` is exactly 2 from the declared `hooks` |

## Prerequisite readings — anchored by content on `origin/main` `d07fc178b9`, not by line and not from the card

Probe: whitespace flattened per file (a phrase can wrap across a line break), `edit[- ]?distance (cannot|can not|can.t) reach` **case-insensitive**, `grep -o | wc -l` over `git ls-files` (tracked only, so no built `dist/` in the population). 19 occurrences in 17 files. Dark control (a fabricated token) 0; lit control `strictObject(` 383.

1. **Both sentences still stand.** Module docblock and `StrictObjectOptions.aliases` JSDoc, both in `packages/spec/src/shared/strict-object.ts` — 2 occurrences in that file.
2. **The counter-example is still shipped and still reachable.** `hosts: 'network'` is live in `packages/spec/src/kernel/manifest.zod.ts`. Distance computed **independently**, in a standalone Python Levenshtein against the four declared keys `services` / `hooks` / `network` / `fs`: `hosts`-`hooks` = **2**, budget = **2** — inside. Controls from the same run: `filesystem`-`fs` = 8 (budget 3), `paths`-`fs` = 4 (budget 2), both outside, so the instrument returns both answers.
3. **A fourth site the card's table does not list.** The same universal is the hover text of the **published** factory's own option — `StrictUnknownKeyErrorOptions.aliases` in `shared/suggestions.zod.ts` — reached only because the site list was re-derived rather than trusted. Corrected here too.

## The census — the count, not a hedge

A correction that says aliases are *usually* unreachable, while more counter-examples ship, is a new false sentence. So every shipped alias was classified rather than sampled: the `strictObjectDeclarations()` registry was forced over every module under `packages/spec/src` (the `alias-integrity.test.ts` walk), and for each entry the real `findClosestMatches` was run against that surface's own `knownKeys` at that key's own budget.

| verdict | count |
|---|---|
| unreachable — distance returns nothing (the documented role) | 1658 |
| reachable, fallback agrees with the entry | 211 |
| **reachable, fallback answers a DIFFERENT key the entry overrules** | **41** |
| total entries / registered surfaces | 1910 / 384 |

Controls on the instrument: lit — `visibleWhen` (the docblock's own proving case) classifies, as `GAP`; dark — a fabricated alias token returns 0 rows. Source-side cross-check on tracked files only: 255 `aliases:` occurrences in 64 files, all inside `packages/spec`; no package outside `spec` calls `strictUnknownKeyError` at all.

⇒ `hosts` is **row 20 of 41**, not the only one. The corrected prose therefore names the overruling role as a **role**, and carries the measured count with its date rather than a word like "usually".

## What changed

- `packages/spec/src/shared/strict-object.ts` — module docblock: the `aliases` bullet now splits into the two roles, each with its proving case, plus the measured split and an explicit "do not read this as *only* for what distance cannot reach".
- `packages/spec/src/shared/strict-object.ts` — `StrictObjectOptions.aliases` JSDoc (the hover text): same correction, short form.
- `packages/spec/src/shared/suggestions.zod.ts` — `StrictUnknownKeyErrorOptions.aliases` JSDoc, the published factory's hover text (the re-derived fourth site).
- `docs/audits/2026-07-unknown-key-strictness-ledger.md` — the ledger's copy of the sentence. Its two cited examples (`from` to `source`, `read` to `allowRead`) were re-measured as still unreachable and kept.
- `.changeset/strict-object-aliases-two-roles.md` — `patch` on `@objectstack/spec` (a docblock ships in the published `.d.ts`).

⛔ No alias added or removed, no behaviour change, no key list, strictness or author-visible message touched.

## Verification

- **Comment-only proof**: every `+`/`-` line in the two TypeScript files matches a block-comment continuation; the detector fires on a synthetic code line (lit control), and finds nothing in the real diff.
- `pnpm --filter @objectstack/spec build` — exit 0, 34/34 declaration files.
- `pnpm --filter @objectstack/spec check:generated` — **all 15 generated artifacts up to date** (so nothing generated mirrors these docblocks; nothing was hand-edited).
- `pnpm --filter @objectstack/spec exec vitest run src/shared/` — 27 files, 567 tests, all pass.
- `pnpm --filter @objectstack/spec typecheck` — exit 0.
- `eslint --no-inline-config` over the **whole repo** — 6622 files, 0 errors (the union, not a narrowing).
- Derived gate families, `scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack`: **76 derived, 74 run green, 0 unrun**; reconciled with `--ran` carrying each recorded exit code. The 2 not measured are `check:dual-build-cjs-loads` and `check:lean-entry-closure` — both exit **3, PREREQUISITE NOT MET** (they read a whole-repo build). Exit 3 is a refusal, not a red; declared here and left to CI.
- Commit message grepped **before** the push: `#`, `Part of`, `Refs`, `Fixes`, `Closes`, `Resolves` → **0 each**, with lit controls `Co-authored-by` → 1 and `Claude-Session` → 1. The card relation is declared once, here in the body.

Measurements above are on the final commit, `d67cab8d2c`.

## 验收备注

Noted, not filed — three per-site copies of the same sentence that my census measured **false**, each outside this card's declared file face and each a different judgement call:

- `packages/objectql/src/validation/record-validator.ts` and `packages/spec/src/data/default-value-shape.ts` both cite *"edit distance cannot reach it (`latitude` to `lat`)"*. Measured: `latitude` has budget 2 and is 2 from the declared `altitude`, so the fallback reaches it and answers `altitude` — the alias is an **overrule**, and the cited example is the one that proves the opposite of what it is cited for. Successor: whoever next touches the location/address value-shape prose.
- `packages/spec/src/data/driver/turso.zod.ts` — *"Semantic near-misses only — the spellings edit distance cannot reach"* sits above a table containing `uri` to `url`, which the fallback reaches at distance 1 and answers identically. Harmless entry, false comment. Successor: whoever next touches the turso datasource schema.
- Checked and **true**, so nothing owed: the per-site claims in `ui/chart.zod.ts` (both tables), `data/object.zod.ts` and the hedged *"most of these"* in `data/authoring-key-lint.ts`.

⛔ Do not flip this out of draft, enqueue it, or arm auto-merge — the dispatching seat lands it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MkQhmuuJAVDjmeWNixwDDH)_