### PR TITLE
fix(lint)!: withdraw `absolute-colspan-discouraged` — its premise was measured false and its recommendation measured worse than the thing it warned about

### DIFF
--- a/.changeset/17328-colspan-rule-withdrawn.md
+++ b/.changeset/17328-colspan-rule-withdrawn.md
@@ -1,0 +1,39 @@
+---
+"@objectstack/lint": minor
+---
+
+fix(lint)!: `absolute-colspan-discouraged` is withdrawn — its premise was measured false in a browser, and the alternative it recommended measured worse than the thing it warned about (#17328)
+
+<!-- adr-0087: not-required (no-migration-prescription) nothing an author writes moves: `FormField.colSpan` is untouched in `packages/spec`, still parses, and every stored form view keeps its shape and its rendering. The only surface that moves is one exported TypeScript rule-id constant in `@objectstack/lint` plus the advisory finding it named — neither has a metadata representation, so `objectstack migrate meta` has nothing to reach and the ledger serves nobody affected. -->
+
+**BREAKING** — `@objectstack/lint` no longer exports `FORM_COLSPAN_ABSOLUTE`, and
+`validateFormLayout` no longer emits the `absolute-colspan-discouraged` finding. A
+TypeScript consumer that imported that constant (to suppress the rule, or to route it)
+stops compiling on the import, and the compiler names the site — a more precise channel
+than any release note. Authored metadata is untouched: `FormField.colSpan` is unchanged
+and still valid.
+
+The rule fired on **every** authored `colSpan`, `colSpan: 1` included, and asserted a
+rendering consequence: the form's column count is derived per surface (mobile 1 / modal 2
+/ page 3-4), so a fixed span "only aligns at one width". Measured in Chromium on a real
+authored 3-column section at all three of the widths that sentence names (390 / 720 /
+1700), that misalignment does not happen. The renderer emits one container-query-scoped
+span class clamped to the section's declared column count, so the cell starts at a real
+column boundary at every width and rendered overflow is 0px in every configuration —
+including `colSpan: 4` in a 3-column section, the case that would overflow if the clamp
+did not work. The clamp is precisely why the claim was false, and the rule's own file
+already recorded the clamp a few lines above the claim.
+
+The hint was the sharper defect. It steered authors to `span: 'full'`, which compiles to
+the same class as `colSpan: 4` (`@2xl:col-span-3`) and measures byte-identically: the rule
+warned about one spelling and recommended the other, and they are the same thing. At the
+modal width `span: 'full'` renders pixel-identical to authoring nothing at all, so an
+author who complied was left worse off than one who ignored it.
+
+With no authored `colSpan` shape left that misbehaves there was nothing to re-ground, so
+the rule is withdrawn rather than narrowed: `colSpan: 1` emits no class at all, a
+`colSpan` within the column count renders exactly as authored, and one above it clamps.
+Every test that pinned the rule's wording or its firing set was re-judged in place with
+the reason recorded, never deleted, and each re-judged pin is paired with a live finding
+on the same fixture so that a walk which stopped reaching the site could not pass as a
+withdrawal.

--- a/packages/lint/src/authoring-rule-wiring.test.ts
+++ b/packages/lint/src/authoring-rule-wiring.test.ts
@@ -596,10 +596,14 @@ describe('authoring-rule registry wiring (#4409)', () => {
       },
       {},
     );
-    expect(findings.map((f) => f.rule).sort()).toEqual([
-      'absolute-colspan-discouraged',
-      'form-field-unknown',
-    ]);
+    // [#17328] RE-JUDGED, not deleted: the fixture used to earn a second rule
+    // id, `absolute-colspan-discouraged`, which was withdrawn after browser
+    // measurement falsified the misalignment it asserted. The `colSpan: 2` is
+    // left on the fixture on purpose — an entry-object field is the shape this
+    // adapter has to survive — and `form-field-unknown` still carries the whole
+    // point of the test: the registry entry's `run` really returns the finding
+    // a broken stack earns, on all three commands.
+    expect(findings.map((f) => f.rule).sort()).toEqual(['form-field-unknown']);
   });
 
   it('every ledger entry is still an exported rule', () => {

--- a/packages/lint/src/authoring-rules.ts
+++ b/packages/lint/src/authoring-rules.ts
@@ -1026,10 +1026,12 @@ export const AUTHORING_RULES: readonly AuthoringRule[] = [
     run: (stack) => validateSemanticRoles(stack),
   },
   // #2578 / #4449 — a form section's field reference that resolves to nothing
-  // (silently not rendered) and an absolute `colSpan` under a per-surface
-  // derived column count. Advisory: the renderer skips the unknown field and
-  // clamps the span, so nothing is broken — but each is almost certainly an
-  // authoring mistake, and until #4449 this rule ran on no command at all.
+  // (silently not rendered), and a `section.group` naming a field group the
+  // object does not declare. Advisory: the renderer skips the unknown field, so
+  // nothing is broken — but each is almost certainly an authoring mistake, and
+  // until #4449 this rule ran on no command at all. [#17328] It used to carry a
+  // third finding, `absolute-colspan-discouraged`; that one was withdrawn —
+  // `validate-form-layout.ts`'s module note carries the measurement.
   // Pure structured-metadata walk (no lazy dependency), so wiring it to all
   // three costs nothing measurable.
   {

--- a/packages/lint/src/index.ts
+++ b/packages/lint/src/index.ts
@@ -227,10 +227,17 @@ export {
 } from './validate-semantic-roles.js';
 export type { SemanticRoleFinding, SemanticRoleSeverity } from './validate-semantic-roles.js';
 
+// [#17328] `FORM_COLSPAN_ABSOLUTE` / `absolute-colspan-discouraged` was
+// WITHDRAWN, not renamed: browser measurement at all three surface widths
+// falsified the misalignment it asserted, and its recommended alternative
+// measured worse than the thing it warned about. The argument is in
+// `validate-form-layout.ts`'s module note. Removing the constant rather than
+// leaving it exported is deliberate: a rule id on the public surface reads as a
+// check the platform performs (Prime Directive #10), and the compiler is the
+// precise channel for telling a consumer that suppresses it.
 export {
   validateFormLayout,
   FORM_FIELD_UNKNOWN,
-  FORM_COLSPAN_ABSOLUTE,
   FORM_SECTION_GROUP_UNKNOWN,
 } from './validate-form-layout.js';
 export type { FormLayoutFinding, FormLayoutSeverity } from './validate-form-layout.js';

--- a/packages/lint/src/validate-form-layout.test.ts
+++ b/packages/lint/src/validate-form-layout.test.ts
@@ -5,7 +5,6 @@ import { defineStack, normalizeStackInput } from '@objectstack/spec';
 import {
   validateFormLayout,
   FORM_FIELD_UNKNOWN,
-  FORM_COLSPAN_ABSOLUTE,
   FORM_SECTION_GROUP_UNKNOWN,
 } from './validate-form-layout.js';
 
@@ -38,7 +37,7 @@ const groupedObjects = [
 ];
 
 describe('validateFormLayout (#2578)', () => {
-  it('is clean for a well-formed multi-column form (known fields, no colSpan)', () => {
+  it('is clean for a well-formed multi-column form (known fields)', () => {
     const stack = {
       objects,
       views: [
@@ -74,7 +73,19 @@ describe('validateFormLayout (#2578)', () => {
     expect(findings[0].path).toBe('views[0].sections[0].fields[1]');
   });
 
-  it('discourages absolute colSpan and steers to span', () => {
+  // [#17328] RE-JUDGED, not deleted. This test used to be the pin on the
+  // `absolute-colspan-discouraged` wording — it asserted the finding fired on
+  // `colSpan: 2` and that the hint said `span: 'full'`. Both halves were
+  // measured wrong in Chromium at the three surface widths the message named:
+  // the renderer clamps the span to the section's column count, so an absolute
+  // `colSpan` is grid-aligned at EVERY width (0px overflow in every
+  // configuration), and `span: 'full'` — the recommended alternative — compiles
+  // to the same class as `colSpan: 4` and renders pixel-identical to authoring
+  // nothing at the modal width. The rule was withdrawn. What the pin asserts
+  // now is that withdrawal, and it is deliberately PAIRED with a live finding
+  // on the same section: a bare `expect([])` here would keep passing if the
+  // walk stopped reaching this site at all.
+  it('[#17328] an absolute colSpan is no longer a finding — the rule was withdrawn', () => {
     const stack = {
       objects,
       views: [
@@ -85,14 +96,32 @@ describe('validateFormLayout (#2578)', () => {
         },
       ],
     };
-    const findings = validateFormLayout(stack);
-    expect(findings).toHaveLength(1);
-    expect(findings[0].rule).toBe(FORM_COLSPAN_ABSOLUTE);
-    expect(findings[0].hint).toContain("span: 'full'");
-    expect(findings[0].path).toBe('views[0].sections[0].fields[1].colSpan');
+    expect(validateFormLayout(stack)).toEqual([]);
+
+    // POSITIVE CONTROL on the identical shape: the walk does reach
+    // `sections[0].fields[1]`, so the empty result above is a verdict about
+    // `colSpan` and not about an unread site.
+    const reached = validateFormLayout({
+      objects,
+      views: [
+        {
+          name: 'contract_form',
+          data: { provider: 'object', object: 'contract' },
+          sections: [{ columns: 2, fields: ['name', { field: 'ghost_amount', colSpan: 2 }] }],
+        },
+      ],
+    });
+    expect(reached.map((f) => `${f.rule}@${f.path}`)).toEqual([
+      `${FORM_FIELD_UNKNOWN}@views[0].sections[0].fields[1]`,
+    ]);
   });
 
-  it('reports both rules for the same field independently', () => {
+  // [#17328] RE-JUDGED, not deleted. The same fixture used to earn TWO findings
+  // (`form-field-unknown` + `absolute-colspan-discouraged`). With the colSpan
+  // rule withdrawn the surviving assertion is the one that still carries
+  // information: a `colSpan` on an entry does not suppress, duplicate or
+  // relocate the reference finding the entry independently earns.
+  it('a colSpan on the entry does not disturb the reference finding it earns', () => {
     const stack = {
       objects,
       views: [
@@ -103,24 +132,34 @@ describe('validateFormLayout (#2578)', () => {
         },
       ],
     };
-    const rules = validateFormLayout(stack).map(f => f.rule).sort();
-    expect(rules).toEqual([FORM_COLSPAN_ABSOLUTE, FORM_FIELD_UNKNOWN].sort());
+    expect(validateFormLayout(stack).map((f) => `${f.rule}@${f.path}`)).toEqual([
+      `${FORM_FIELD_UNKNOWN}@views[0].sections[0].fields[0]`,
+    ]);
   });
 
+  // [#17328] RE-JUDGED, not deleted. The old assertion was
+  // `[FORM_COLSPAN_ABSOLUTE]` — the colSpan rule was the only thing that could
+  // still speak on an unresolvable binding, which is what made this test
+  // non-empty. With that rule withdrawn the verdict is `[]`, so the test is
+  // PAIRED with the same stack under a resolvable binding; otherwise a walk
+  // that stopped visiting orphan views entirely would look identical.
   it('skips reference-checking when the bound object cannot be resolved', () => {
-    const stack = {
+    const sections = [{ columns: 2, fields: ['whatever', { field: 'x', colSpan: 2 }] }];
+    expect(validateFormLayout({
       objects,
-      views: [
-        {
-          name: 'orphan_form',
-          data: { provider: 'object', object: 'does_not_exist' },
-          sections: [{ columns: 2, fields: ['whatever', { field: 'x', colSpan: 2 }] }],
-        },
-      ],
-    };
-    const findings = validateFormLayout(stack);
-    // No form-field-unknown (object unresolved), but colSpan is still flagged.
-    expect(findings.map(f => f.rule)).toEqual([FORM_COLSPAN_ABSOLUTE]);
+      views: [{ name: 'orphan_form', data: { provider: 'object', object: 'does_not_exist' }, sections }],
+    })).toEqual([]);
+
+    // POSITIVE CONTROL: the identical sections, bound to an object that DOES
+    // resolve, report both dangling names — so the silence above is the
+    // unresolved binding, not an unvisited site.
+    expect(validateFormLayout({
+      objects,
+      views: [{ name: 'bound_form', data: { provider: 'object', object: 'contract' }, sections }],
+    }).map((f) => `${f.rule}@${f.path}`)).toEqual([
+      `${FORM_FIELD_UNKNOWN}@views[0].sections[0].fields[0]`,
+      `${FORM_FIELD_UNKNOWN}@views[0].sections[0].fields[1]`,
+    ]);
   });
 
   it('ignores non-form views (no sections array)', () => {
@@ -295,9 +334,12 @@ describe('#6251 — the view CONTAINER ladder', () => {
         form: { data: { object: 'contract' }, groups: [{ fields: ['name', { field: 'ghost_g', colSpan: 3 }] }] },
       }],
     });
+    // [#17328] RE-JUDGED: the second row was the withdrawn
+    // `absolute-colspan-discouraged` finding on the same entry. The `colSpan: 3`
+    // is deliberately LEFT on the fixture — it is what proves the entry object
+    // shape is read here at all — but it no longer earns a row.
     expect(findings.map((f) => `${f.rule}@${f.path}`)).toEqual([
       `${FORM_FIELD_UNKNOWN}@views[0].form.groups[0].fields[1]`,
-      `${FORM_COLSPAN_ABSOLUTE}@views[0].form.groups[0].fields[1].colSpan`,
     ]);
   });
 
@@ -408,10 +450,13 @@ describe('#6251 — reachable on a REAL parsed app stack', () => {
 
   it('reports every planted defect on that stack — this is the assertion #6251 exists for', () => {
     const { value } = quietly(() => cliTierFor(structuredClone(appShape)));
+    // [#17328] RE-JUDGED: the third row was the withdrawn colSpan finding on
+    // the `ghost_named` entry. The other two rows are the ones #6251 exists for
+    // — one per container rung — and both still fire, so the traversal
+    // assertion this test carries is undiminished.
     expect(validateFormLayout(value!).map((f) => `${f.rule}@${f.path}`)).toEqual([
       `${FORM_FIELD_UNKNOWN}@views[0].form.sections[0].fields[2]`,
       `${FORM_FIELD_UNKNOWN}@views[0].formViews.create.sections[0].fields[1]`,
-      `${FORM_COLSPAN_ABSOLUTE}@views[0].formViews.create.sections[0].fields[1].colSpan`,
     ]);
   });
 
@@ -520,16 +565,26 @@ describe('#16168 — falls back to the container list binding', () => {
     })).toEqual([]);
   });
 
-  it('the colSpan rule is unconditional on the object binding — it already fired on a list-bound container before this fix', () => {
-    // Measured for the changeset: `absolute-colspan-discouraged` sits OUTSIDE
-    // the `known`-gated block (validate-form-layout.ts, the `(b)` comment) —
-    // it needs only `entry.colSpan != null`, never `objName` / `known`. So it
-    // was never actually dead on HotCRM's list-bound views; #16168 only fixes
-    // `form-field-unknown` and `form-section-group-unknown`.
-    const findings = validateFormLayout({
+  // [#17328] RE-JUDGED, not deleted. This was #16168's measurement that
+  // `absolute-colspan-discouraged` sat OUTSIDE the `known`-gated block — it
+  // needed only `entry.colSpan != null`, so it was never dead on HotCRM's
+  // list-bound views and #16168 only ever fixed the two reference rules. That
+  // rule is now withdrawn, so what the same fixture measures is the OTHER half
+  // of the same sentence: on a list-bound container a well-formed field with a
+  // `colSpan` is silent, while a dangling one is not — which is exactly the
+  // #16168 fix still holding, now with nothing riding alongside it.
+  it('[#17328] a list-bound container reports only its reference findings — the colSpan rule is gone', () => {
+    expect(validateFormLayout({
       objects,
       views: [listBoundContainer({ sections: [{ columns: 2, fields: [{ field: 'name', colSpan: 2 }] }] })],
-    });
-    expect(findings.map((f) => f.rule)).toEqual([FORM_COLSPAN_ABSOLUTE]);
+    })).toEqual([]);
+
+    // POSITIVE CONTROL — the #16168 fix itself: the same list-bound rung, a
+    // dangling reference, still reported. Without this the line above would
+    // pass on a container the walk never descends into.
+    expect(validateFormLayout({
+      objects,
+      views: [listBoundContainer({ sections: [{ columns: 2, fields: [{ field: 'ghost_lb', colSpan: 2 }] }] })],
+    }).map((f) => f.rule)).toEqual([FORM_FIELD_UNKNOWN]);
   });
 });

--- a/packages/lint/src/validate-form-layout.ts
+++ b/packages/lint/src/validate-form-layout.ts
@@ -3,27 +3,53 @@
 /**
  * Build-time form-layout diagnostics (#2578).
  *
- * Authored form views carry field references and column-layout hints that are
- * Zod-valid but can be silently wrong at render time — the "parsed, unmarked,
- * silently inert" shape ADR-0078 prohibits. This lint catches the two that
- * matter for multi-column, AI-authored forms, uniformly for `os build` /
- * `os validate`, MCP authoring and hand authors (ADR-0019).
+ * Authored form views carry field and field-group references that are Zod-valid
+ * but can be silently wrong at render time — the "parsed, unmarked, silently
+ * inert" shape ADR-0078 prohibits. This lint catches them uniformly for
+ * `os build` / `os validate`, MCP authoring and hand authors (ADR-0019).
  *
- * Both rules are warnings, not errors — nothing is fully broken (an unknown
- * field name is skipped; an over-wide colSpan is clamped) — but each is almost
- * certainly an authoring mistake worth surfacing at author time:
+ * Every rule here is a warning, not an error — nothing is fully broken (an
+ * unknown field name is skipped) — but each is almost certainly an authoring
+ * mistake worth surfacing at author time:
  *
  * - `form-field-unknown` — a section references a field that is not on the
  *   form's bound object, so the field silently does not render.
- * - `absolute-colspan-discouraged` — a field uses the absolute `colSpan`. Under
- *   a per-surface DERIVED column count (mobile 1 / modal 2 / page 3-4) a fixed
- *   span only lines up at the one width the author imagined; the renderer
- *   clamps it. The robust primitive is the relative `span: 'full'`.
+ * - `form-section-group-unknown` — see {@link FORM_SECTION_GROUP_UNKNOWN}.
+ *
+ * ## Retired: `absolute-colspan-discouraged` (#17328)
+ *
+ * It fired on EVERY authored `colSpan`, `colSpan: 1` included, and asserted a
+ * rendering consequence: "the form's column count is derived per surface
+ * (mobile 1 / modal 2 / page 3-4), so a fixed span only aligns at one width".
+ * Measured in Chromium on a real authored 3-column section at all three of the
+ * widths that sentence names (390 / 720 / 1700), the misalignment does not
+ * happen. The span is emitted as ONE container-query-scoped class clamped to
+ * the section's declared column count, so it is grid-aligned at every width and
+ * rendered overflow is 0px in every configuration — including `colSpan: 4` in a
+ * 3-column section, the case that would overflow if the clamp did not work. The
+ * clamp is the REASON the message was false, and this file's own note above
+ * already recorded the clamp: it contradicted itself.
+ *
+ * The hint was the sharper half. It steered authors to `span: 'full'`, and
+ * `span: 'full'` and `colSpan: 4` compile to the IDENTICAL class
+ * (`@2xl:col-span-3`) and measure byte-identically — the rule warned about one
+ * of them and recommended the other. At the modal width `span: 'full'` renders
+ * pixel-identical to writing nothing at all, so an author who complied was left
+ * worse off than one who ignored it.
+ *
+ * With no authored `colSpan` shape left that misbehaves there was nothing to
+ * re-ground, so the rule was WITHDRAWN rather than narrowed: `colSpan: 1` emits
+ * no class at all (inert), a `colSpan` within the column count renders exactly
+ * as authored, and one above it clamps. `colSpan` itself is untouched and still
+ * parses — only the diagnostic is gone. ⛔ Do not reintroduce a colSpan warning
+ * from source reading: it takes a browser measurement naming an authored shape
+ * that actually misrenders, and a positive control proving the probe fires on
+ * it.
  *
  * Scope: every form view reachable from a `views[]` entry — the entry itself
  * when it IS a bare form view, plus the container's default `form` and each
  * `formViews.<key>`, through the shared `view-walk.ts` ladder (#6381; see
- * {@link formViewSites} for why reading only the first shape left both rules
+ * {@link formViewSites} for why reading only the first shape left the rules
  * reporting clean on real app metadata, #6251). Forms embedded inside page
  * component trees are a follow-up — the walk deliberately stays shallow so it
  * never guesses at an arbitrary component's object binding.
@@ -42,7 +68,6 @@ import { formViewSites, viewObjectName } from './view-walk.js';
 import { recordsOf } from './object-graph.js';
 
 export const FORM_FIELD_UNKNOWN = 'form-field-unknown';
-export const FORM_COLSPAN_ABSOLUTE = 'absolute-colspan-discouraged';
 /**
  * [#13855] A section's `group` names a field group the bound object does not
  * declare. The reference form inherits the section's whole membership from that
@@ -195,24 +220,6 @@ export function validateFormLayout(stack: AnyRec): FormLayoutFinding[] {
                 hint:
                   `Fix the field name, or add "${fname}" to ${objName}. Section field ` +
                   `references must match the object's field names exactly.`,
-              });
-            }
-
-            // ── (b) absolute colSpan → steer to the surface-independent span ──
-            const colSpan = isRec(entry) ? entry.colSpan : undefined;
-            if (colSpan != null) {
-              findings.push({
-                severity: 'warning',
-                rule: FORM_COLSPAN_ABSOLUTE,
-                where,
-                path: `${fpath}.colSpan`,
-                message:
-                  `${viewName}: field "${fname ?? '?'}" sets absolute colSpan ${String(colSpan)} — ` +
-                  `the form's column count is derived per surface (mobile 1 / modal 2 / page 3-4), ` +
-                  `so a fixed span only aligns at one width`,
-                hint:
-                  `Prefer span: 'full' (whole row at any column count), or omit for auto ` +
-                  `width. The renderer clamps colSpan to the current column count.`,
               });
             }
           }


### PR DESCRIPTION
Clause-②: no

Closes #17328

## The decision: retire, not re-ground — and the evidence that decided it

Triage's ruling was "withdraw or re-ground the rule, and fix the hint", with the recommendation named as the harmful half. The choice between the two branches is settled by asking what a narrowed rule would still be warning about. Every candidate answer is empty:

| Authored shape | What #17328 measured | Is there anything to warn about? |
|:--|:--|:--|
| `colSpan: 1` | emits **zero** classes; byte-identical to the control at all three widths | No — wholly inert, yet it warned |
| `colSpan: 2` in a 2- or 3-column section | renders exactly 2 of 2 / 2 of 3; 0px overflow at every width | No — and it is the *only* spelling that expresses "two columns wide"; neither `span: 'full'` nor omitting it can |
| `colSpan: 4` in a 3-column section | clamps to `@2xl:col-span-3`; **0px overflow**, the case that would overflow if the clamp did not work | No |
| `span: 'full'` (the recommended alternative) | compiles to the **identical** class as `colSpan: 4` and measures byte-identically; at the modal width it is pixel-identical to authoring nothing | It is the one that misrenders — see the last section |

Overflow is **0px in every configuration at every width** in the card's table. With no authored shape that misbehaves, there is nothing left to re-ground, and a narrowed rule could not be given a positive control — the brief's own test for keeping it. **A rule that reports 0 and a rule correctly narrowed look identical on a clean tree**, so the honest branch is withdrawal.

The corollary matters for anyone tempted to soften the message instead: the rule warned about `colSpan: 4` and recommended `span: 'full'`, **and they are the same emitted class**. There is no wording that makes that coherent.

## Re-verification of the ruling's premise, on this branch's base (5ddd5d3f15)

Re-read first-hand rather than taken from the dispatch. All three hold, plus a fourth the card and triage did not name:

| Premise | Reading |
|:--|:--|
| fires on **every** authored `colSpan` | `validate-form-layout.ts:203` — `if (colSpan != null) {`, no further discrimination; `colSpan: 1` included |
| the message asserts a rendering consequence | `:210-213` — `…so a fixed span only aligns at one width` |
| the hint recommends `span: 'full'` | `:214-215` — `Prefer span: 'full' (whole row at any column count). The renderer clamps colSpan to the current column count.` |
| **the file contradicts itself** | `:13` — "an over-wide colSpan **is clamped**", one paragraph above the claim the clamp falsifies |
| **a third carrier, more authoritative than either** | `:18-21` — the module docblock repeats the same false premise *and* the same harmful recommendation |

## Reverse-read sweep — which existing sentences does this change make false?

Swept tree-wide with `git grep`. Reported in full, **including the zeros**.

**`only aligns at one width` (exact):** 1 hit — `validate-form-layout.ts:212`, the retired message itself. **Zero elsewhere in the tree.**

**`lines up at the one width`:** 3 hits — `validate-form-layout.ts:20` (the docblock carrier, rewritten here) and two `CHANGELOG.md` files. Changelogs are an immutable record of what a past release shipped and are not edited.

**`one width` (broad, 14 hits):** everything else is an unrelated sense — identifier column widths, SQL storage ceilings, string-family widths. One real hit: `skills/objectstack-ui/rules/navigation.md:139`. See "carriers left standing" below.

**`span: 'full'` (13 hits):** the two carriers in this file (both fixed); two `.changeset`/`CHANGELOG` history rows; `content/docs/ui/views.mdx` ×4; `packages/spec/src/ui/view.zod.ts:2494`; `skills/objectstack-ui/rules/navigation.md:136`; and three pure *fixtures* (`examples/app-showcase/.../task.view.ts:368`, `packages/lint/src/showcase-shape.fixtures.ts:298`, the test file) which assert nothing about width and are unaffected.

**`colSpan` tree-wide:** ~100 hits, almost all `*.form.ts` builtin form definitions **authoring** a colSpan — untouched and still valid, which is the point. The hits that *say something* about it are the ones tabled above.

**`FORM_COLSPAN_ABSOLUTE`:** after this change, zero code references — only tombstone comments in `validate-form-layout.ts`, `index.ts`, `authoring-rules.ts` and the re-judged tests.

**Two zeros worth stating as readings rather than silences:**
- `FORM_COLSPAN_ABSOLUTE` in any `.md` / `.mdx` outside `CHANGELOG.md`: **zero hits** — no README or doc page advertises the removed export, so nothing else had to move with it.
- Any importer of the constant outside `packages/lint/src`: **zero hits** — the only consumers were this package's own index and tests.

### Carriers left standing, deliberately — filed as #17670

The sweep found the same two false sentences in five more places outside this PR's fence: the `.describe()` on `FormField.colSpan` **and** on `FormField.span` in `packages/spec/src/ui/view.zod.ts` (which *generate* `content/docs/references/ui/view.mdx`), two hand-written docs pages, and `skills/objectstack-ui/rules/navigation.md` — a governed surface, and the prescriptive one an AI author reads first. Each is outside this card's land point and pulls in a different gate family (spec generated artifacts) or a human-merge surface. Filed unassigned as #17670 rather than fixed here or left unsaid.

`content/docs/releases/v12.mdx:73-76` and `:82` also name the rule; release notes are release-owned history and are correct as history. Not edited, not filed.

## What changed

- **`packages/lint/src/validate-form-layout.ts`** — the `(b)` emission block and the `FORM_COLSPAN_ABSOLUTE` constant are gone. The module docblock's colSpan bullet is replaced by a tombstone carrying the measurement, the reason the claim was false, the reason the recommendation was worse, and a standing instruction that reintroducing a colSpan warning takes a browser measurement plus a positive control — not source reading.
- **`packages/lint/src/index.ts`** — `FORM_COLSPAN_ABSOLUTE` is off the public surface, with the reason recorded at the export site: a rule id on the public surface reads as a check the platform performs (Prime Directive #10), and the compiler is the precise channel for telling a consumer that suppressed it.
- **`packages/lint/src/authoring-rules.ts`** — the registry comment described `validateFormLayout` as covering "an absolute `colSpan` under a per-surface derived column count". That becomes false with this change, so it is corrected in place (it now names the `section.group` rule it always ran and never mentioned).
- **Tests** — seven pins re-judged in place. None deleted.

`FormField.colSpan` in `packages/spec` is **untouched** and still parses. Only the diagnostic is gone.

## The pins: re-judged in place, never deleted

Each carries a comment saying what it used to assert, what changed and why. Each re-judged pin that would otherwise assert an empty result is **paired with a live finding on the same fixture**, because `expect([]).toEqual([])` would keep passing if the walk stopped reaching the site at all.

| Pin | Was | Is now |
|:--|:--|:--|
| `validate-form-layout.test.ts` "discourages absolute colSpan and steers to span" | **the** wording pin: hint contains `span: 'full'` | asserts the withdrawal, paired with a `form-field-unknown` on the identical `sections[0].fields[1]` |
| "reports both rules for the same field independently" | both rules on one entry | a `colSpan` on the entry does not suppress, duplicate or relocate the reference finding it earns |
| "skips reference-checking when the bound object cannot be resolved" | `[FORM_COLSPAN_ABSOLUTE]` — the colSpan rule was the only thing that could speak on an unresolvable binding | `[]`, paired with the identical sections under a resolvable binding reporting both dangling names |
| "reads the legacy `groups` bucket too" | 2 rows | 1 row; the `colSpan: 3` stays on the fixture — it is what proves the entry-object shape is read here |
| "reports every planted defect on that stack" (#6251) | 3 rows | 2 rows, one per container rung — the traversal assertion is undiminished |
| "the colSpan rule is unconditional on the object binding" (#16168) | the whole subject was the colSpan rule | the other half of the same sentence: a well-formed field with a `colSpan` on a list-bound container is silent, a dangling one is still reported — #16168's fix still holding, now with nothing riding alongside it |
| `authoring-rule-wiring.test.ts` "the form-layout rule really runs, and really finds something" | `['absolute-colspan-discouraged', 'form-field-unknown']` | `['form-field-unknown']`; the `colSpan: 2` stays on the fixture and the test's whole point — the registry entry's `run` returns a real finding on all three commands — is carried intact |

## Verification

- `pnpm --filter '@objectstack/lint^...' build` — exit 0.
- `pnpm --filter @objectstack/lint test` — **101 files / 3724 passed, 5 skipped**, exit 0.
- `pnpm --filter @objectstack/lint typecheck` — exit 0 (`tsc --noEmit` + `check:test-typecheck`).
- `pnpm lint` (`eslint . --no-inline-config`, the whole repo, not narrowed) — exit 0.
- Gate families derived with `scripts/pm/dispatch-gates.mjs` against the real change set and reconciled with `--ran`: **59 derived, 56 run green, 0 unrun**, 3 NOT MEASURED at **exit 3 / PREREQUISITE NOT MET** (`check:dual-build-cjs-loads`, `check:lean-entry-closure`, `check:type-check-debt` — each needs the whole-repo build closure; declared to CI). `check:docs-transcript-drift` first exited 3 for the same reason and passes after `pnpm --filter '@objectstack/lint...' build`.
- Changeset gates green on the committed changeset: `check-adr-0087-registration` (accepted the `no-migration-prescription` disposition), `check-changeset-no-major`, `check-empty-changeset`, `check-changeset-fixed`.
- All readings above taken at `70e35f4beb`.

### Reverse verification (one-time ablation, not left on the tree)

Prediction before running: **red**. Re-emitting the withdrawn finding was injected into the committed source; the mutation was proved on disk by marker count and by `git hash-object` differing from the `HEAD` blob (`8ddaf813…` against `0c354a4d…`), and the two test files were run against the mutated source.

Result: **7 failed / 48 passed** — every one of the seven re-judged pins goes red, and nothing else does. So the pins assert the withdrawal, not nothing.

Restore leg: `git checkout HEAD -- packages/lint/src/validate-form-layout.ts` under an `EXIT INT TERM` trap using absolute paths, verified by blob hash equal to `HEAD` (`0c354a4d…`) **and** an empty `git diff HEAD` — not by an exit code.

## AGENTS.md Post-Task Checklist item 4 — does this removal break the pinned sibling checkout?

This PR removes a published export (`FORM_COLSPAN_ABSOLUTE` from `@objectstack/lint`), which is exactly the class item 4 names. **The `Console Pin Gate` job does not answer it on this PR**, and that is not a pass:

- The job is gated `if: ${{ !cancelled() && needs.filter.outputs.console != 'false' }}` (`.github/workflows/ci.yml`, the `console-pin` job). The `console` paths-filter lists exactly seven paths — `.objectui-sha`, `scripts/build-console.sh`, `scripts/check-console-sha.mjs`, `scripts/check-console-injection.mjs`, `scripts/console-spec-probes.mjs`, `scripts/assert-console-spec-injection.mjs`, `.github/workflows/ci.yml`. **No path under `packages/` is among them**, so a `packages/lint` diff never triggers it, and a skipped check reads as success in branch protection. On this question CI is **NOT MEASURED**.
- ⛔ The filter was deliberately **not** touched. Manufacturing a trigger is not a measurement.

So it was measured directly instead, on the pinned tree.

### The tree that was read

`.objectui-sha` at this PR's head is `53ded82bf7a494f54e344e19099dbf00854b8694`. Fetched exactly as `scripts/build-console.sh` mode 3 does (`git init` + `fetch --depth 1 origin` at that SHA from `https://github.com/objectstack-ai/objectui.git`), checked out detached. `git rev-parse HEAD` equals the pin; **6409 tracked files**.

### Reading 1 — what the pinned sibling imports, zeros included

Identical probe (`git grep -F` on the symbol), same tree, absent symbols beside their positive controls:

| Symbol | Hit lines | Files |
|:--|--:|--:|
| `FORM_COLSPAN_ABSOLUTE` | **0** | **0** |
| `absolute-colspan-discouraged` | **0** | **0** |
| `validateFormLayout` | **0** | **0** |
| `FORM_FIELD_UNKNOWN` | **0** | **0** |
| `FORM_SECTION_GROUP_UNKNOWN` | **0** | **0** |
| `PAGE_SOURCE_CLASSNAME` — positive control | 3 | 1 |
| `validatePageSourceStyling` — positive control | 4 | 2 |
| `validateCapabilityReferences` — positive control | 6 | 4 |
| `validateSecurityPosture` — positive control | 5 | 2 |

The controls are not arbitrary: **the pinned sibling really does depend on `@objectstack/lint`** — `apps/console/package.json:94` and `packages/app-shell/package.json:85` both declare `"@objectstack/lint": "^17.0.0"` — so the zeros above are a reading taken on a tree where this exact package is demonstrably present and imported, not on an empty clone.

Every site that reaches into the package, exhaustively — five, and only four symbols between them:

- `apps/console/src/__tests__/sdui-preview-page-source-styling.test.ts:28` — `import { validatePageSourceStyling, PAGE_SOURCE_CLASSNAME } from '@objectstack/lint';`
- `packages/app-shell/src/preview/capabilityLint.ts:50` — `await import('@objectstack/lint')`, feature-detecting `validateCapabilityReferences` and nothing else
- `packages/app-shell/src/preview/securityPostureLint.ts:94` — `await import('@objectstack/lint')`, feature-detecting `validateSecurityPosture` and nothing else
- two comment references in `apps/console/vite.config.ts`

**Namespace / wildcard imports of `@objectstack/lint`: 0 hits** — so there is no `import * as lint` whose dynamic member read a grep for the symbol could miss. The two dynamic sites read two named functions, by name, and both are still exported here (checked against the export list in `packages/lint/src/index.ts`, not against a comment that merely mentions the name).

### Reading 2 — the gate could not see this change even if the symbol were there

`scripts/build-console.sh` injects exactly two framework packages into the pinned build. Those two `export` lines are the only ones in the whole script:

- `:171` `export OBJECTSTACK_CLIENT_DIST="$CLIENT_PKG"`
- `:215` `export OBJECTSTACK_SPEC_DIST="$SPEC_PKG"`

`@objectstack/lint` is not injected. The pinned tree is installed with `pnpm install --frozen-lockfile --prefer-offline --prod=false` against `registry.npmjs.org`, and objectui's own lockfile resolves `'@objectstack/lint@17.2.0'` — a published, immutable version. **No change to this repo's `packages/lint` working tree can move what the Console Pin Gate builds against**, at PR time or at merge time.

### Verdict

Item 4 is satisfied without a sibling fix and without a pin bump: the pinned sibling does not import the removed symbol, and the gate resolves the package from npm rather than from this tree. **This ships alone.** `.objectui-sha` is untouched — that pin belongs to #17429, not to this PR.

**Declared NOT MEASURED:** the `Console Pin Gate` build itself was not executed locally — it installs objectui's full dependency tree and CI allows it 45 minutes, beyond this session's foreground budget. What is reported above is the two readings that decide item 4's question, not a substitute build. If a reviewer wants the build run anyway, its trigger is a `.objectui-sha` touch, which is #17429's to make.

## Changeset — measured, not defaulted

`@objectstack/lint` ships `files: ["dist", "README.md", "CHANGELOG.md"]`, and this change moves what `dist` contains: one export is gone and one class of finding is no longer emitted. A changeset is genuinely owed; `skip-changeset` is **not** applicable and no such label is applied. Graded `minor` with a `**BREAKING**` banner, per this repo's launch-window convention (`major` is refused by `check-changeset-no-major`; breaking-ness is carried by the banner plus the ADR-0087 disposition, not by the level). Disposition: `not-required (no-migration-prescription)` — nothing an author writes moves, and the one surface that does move has no metadata representation for `objectstack migrate meta` to reach.

## Clause-②

`Clause-②: no`, as the claiming seat judged on the card. Nothing here widens a contract: a lint warning is withdrawn, `packages/spec/src/**` is untouched, and the rule's severity was `warning` throughout. One thing the seat asked to be told: **this implementation removes a public export** (`FORM_COLSPAN_ABSOLUTE` from `@objectstack/lint`). It adds no new export and no new rule constant — the movement is strictly subtractive — but the line is the seat's to re-judge, not mine.

## New evidence for the PM: the `span: 'full'` half

Not filed here, and no objectui change attempted — this session's repository access is `objectstack-ai/objectstack` only. Two readings from this branch worth having when that half is triaged:

1. The misrender is **recommended by the spec itself**, not only by the retired lint hint: `packages/spec/src/ui/view.zod.ts:2494` describes `span: 'full'` as "whole row at any column count" and tells authors to "prefer this over the absolute `colSpan`". That `.describe()` is the source the public reference docs are generated from, so the recommendation outlives this PR by a wide margin (carried in #17670).
2. The shape of the defect is visible in the emitted class without reading objectui's source: `span: 'full'` and `colSpan: 4` both compile to `@2xl:col-span-3` — a hard-coded span of the declared maximum gated at the **top** breakpoint only. So `span: 'full'` is not "relative" in the emitted CSS at all; it is an absolute span of 3 with a single container-query gate, which is exactly why it collapses to one column of two at the modal width. Whatever the fix is, "full" needs a class at each breakpoint, not one at the last.

## 验收备注

- `packages/cli/test/build-warning-truncation-notice.test.ts:65,131` uses the string `absolute-colspan-discouraged` as **synthetic fixture data** for a warning-truncation test; it constructs the findings by hand and asserts nothing about this rule. Nothing there becomes false, so it is left alone rather than pulling `packages/cli` into this diff. Noted, not filed.
- The `(a)` / `(c)` comment labels inside `validateFormLayout` now have a gap where `(b)` was. The labels are referenced from test comments, so they are left stable rather than renumbered. Noted, not filed.
- `packages/lint`'s own module docblock said "the two that matter" while three rule ids existed (`form-section-group-unknown` was added later and documented only on its constant). Corrected as a side effect of the rewrite, since the sentence had to be rewritten anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012GKcPZbMoGq7WPzKLfRBTU