### PR TITLE
fix(lint): `component-type-unknown` reports an EXACT retired component type, relaying the spec prescription

### DIFF
--- a/.changeset/issue-17595-retired-component-type-report.md
+++ b/.changeset/issue-17595-retired-component-type-report.md
@@ -1,0 +1,41 @@
+---
+'@objectstack/lint': patch
+---
+
+fix(lint): `component-type-unknown` reports an EXACT retired component type, relaying the spec's own prescription
+
+A retired component type is `isKnownComponentType` on purpose — its
+`ComponentPropsMap` row is kept so the props door can dispatch the retirement
+prescription — and this rule read that as "accepted". So a caller linting a
+**raw stack** got silence on a name `PageComponentSchema.type` refuses at the
+parse: the author's earliest feedback channel was the one that stayed quiet,
+and the refusal landed later, at the parse door, or in front of an end user.
+
+```
+FROM  validateComponentTypes({ pages: [{ … components: [{ type: 'element:filter' }] }] })
+      -> []                                   // silence, on a name the parser refuses
+
+TO    -> [{ rule: 'component-type-unknown', severity: 'error',
+            path: 'pages[0].regions[0].components[0].type',
+            message: '`element:filter` was removed in @objectstack/spec 17 (ADR-0049) …' }]
+```
+
+**No new prose.** The finding's `message` is the `RETIRED_PAGE_COMPONENT_TYPES`
+entry **verbatim** — the same string the enum error map and the kept props row
+already carry — pinned by byte equality in the rule's test, so the three doors
+cannot drift and a type retired tomorrow arrives reported on the day it lands.
+
+Two things deliberately unchanged: `isKnownComponentType` still answers `true`
+for a retired type (flipping it would MOVE the refusal out of the props door
+rather than add a report), and the typo suggester still never proposes a retired
+name.
+
+The new arm is judged **before** the reserved-namespace guard, because a
+retirement can take its namespace with it: `user:profile` was the `user:`
+namespace's only member, so `hasReservedComponentNamespace('user:profile')` is
+`false` and a check placed after that guard would have stayed silent on the
+member that has been refused longest.
+
+Measured before landing: **zero** authored instances of any retirement-map
+member across the in-repo page sources, with live component types as the lit
+control in the same query — so no existing authored stack turns red.

--- a/packages/lint/src/validate-component-types.test.ts
+++ b/packages/lint/src/validate-component-types.test.ts
@@ -9,6 +9,10 @@
  */
 import { describe, it, expect } from 'vitest';
 import {
+  hasReservedComponentNamespace,
+  RETIRED_PAGE_COMPONENT_TYPES,
+} from '@objectstack/spec/ui';
+import {
   validateComponentTypes,
   COMPONENT_TYPE_UNKNOWN,
 } from './validate-component-types.js';
@@ -80,10 +84,9 @@ describe('leaves the declared vocabulary and the open arm alone', () => {
     // ComponentPropsMap rows that are NOT enum members: the measured
     // string-arm registrations that earned a row.
     'element:metadata_viewer',
-    // Retired at element grain with the row KEPT so the props gate dispatches
-    // the tombstones — the type stays accepted; the keys refuse (#9220 shape).
-    'element:filter',
-    'element:form',
+    // ⛔ The RETIRED types are deliberately NOT here — their kept
+    // `ComponentPropsMap` row makes them `isKnownComponentType`, and this rule
+    // used to read that as "accepted". They now have their own describe below.
     // The string-arm registration ledger (registered in objectui, row-less by
     // pinned decision).
     'record:line_items',
@@ -131,6 +134,96 @@ describe('leaves the declared vocabulary and the open arm alone', () => {
     expect(findings).toHaveLength(1);
     expect(findings[0].where).toBe('page "keyed_page" · nav:menue');
     expect(findings[0].message).toContain("'nav:menu'");
+  });
+});
+
+/**
+ * #17595 — the EXACT-name half of the retirement story.
+ *
+ * A retired type is `isKnownComponentType` on purpose (its `ComponentPropsMap`
+ * row is kept so the props door can dispatch the prescription), which is
+ * exactly what made this rule walk past it in silence while
+ * `PageComponentSchema.type` refuses the same name at the parse. Measured on
+ * both sides of the #17592 review: `element:filter` → no finding, before and
+ * after. This suite pins the report, and pins it BYTE-EQUAL to
+ * `RETIRED_PAGE_COMPONENT_TYPES` — the rule relays the spec's prescription, it
+ * does not author a second copy, so drift between the three doors is not
+ * expressible.
+ *
+ * Driven off the map rather than a restated list: a type retired tomorrow
+ * arrives here covered on the day it lands.
+ */
+describe('reports an EXACT retired component type, relaying the spec prescription (#17595)', () => {
+  // The `it.each` below is only a reading if the map is populated — a lit
+  // control for the loop itself, not decoration.
+  it('the retirement map is non-empty (control for the cases below)', () => {
+    expect(RETIRED_PAGE_COMPONENT_TYPES.size).toBeGreaterThan(0);
+  });
+
+  it.each([...RETIRED_PAGE_COMPONENT_TYPES.keys()])('flags %s', (type) => {
+    const findings = validateComponentTypes(page([{ type }]));
+    expect(findings).toHaveLength(1);
+    const f = findings[0];
+    expect(f.rule).toBe(COMPONENT_TYPE_UNKNOWN);
+    expect(f.severity).toBe('error');
+    expect(f.path).toBe('pages[0].regions[0].components[0].type');
+    expect(f.where).toBe(`page "p1" · ${type}`);
+    // Verbatim, not "contains": the relay is the contract.
+    expect(f.message).toBe(RETIRED_PAGE_COMPONENT_TYPES.get(type));
+    expect(f.hint).toContain(type);
+  });
+
+  /**
+   * The ordering pin. `RESERVED_COMPONENT_TYPE_NAMESPACES` is derived from the
+   * enum, and `user:profile` was the `user:` namespace's only member — so the
+   * namespace guard is FALSE for it and a retired-name check placed after that
+   * guard would report the two elements and stay silent on the member that has
+   * been refused longest. This asserts the reason, not just the outcome.
+   */
+  it('reaches `user:profile`, whose namespace left the reserved set with it', () => {
+    expect(hasReservedComponentNamespace('user:profile')).toBe(false);
+    const findings = validateComponentTypes(page([{ type: 'user:profile' }]));
+    expect(findings).toHaveLength(1);
+    expect(findings[0].message).toBe(RETIRED_PAGE_COMPONENT_TYPES.get('user:profile'));
+  });
+
+  it('reaches a retired type nested under a tab item, at its own path', () => {
+    const findings = validateComponentTypes(
+      page([
+        {
+          type: 'page:tabs',
+          properties: { items: [{ label: 'T', children: [{ type: 'element:form' }] }] },
+        },
+      ]),
+    );
+    expect(findings).toHaveLength(1);
+    expect(findings[0].path).toBe(
+      'pages[0].regions[0].components[0].properties.items[0].children[0].type',
+    );
+  });
+
+  it('stays silent on a source-authored page, like every other arm', () => {
+    const findings = validateComponentTypes({
+      pages: [
+        {
+          name: 'r1',
+          kind: 'react',
+          source: 'export default () => null',
+          regions: [{ name: 'main', components: [{ type: 'element:filter' }] }],
+        },
+      ],
+    });
+    expect(findings).toEqual([]);
+  });
+
+  it('does not re-author the prescription: no second copy of the guidance', () => {
+    // The hint is a located statement about the refusal, never a restatement
+    // of the map's own text (which would be the third copy the retirement
+    // explicitly forbids).
+    for (const [type, prescription] of RETIRED_PAGE_COMPONENT_TYPES) {
+      const f = validateComponentTypes(page([{ type }]))[0];
+      expect(f.hint).not.toContain(prescription);
+    }
   });
 });
 

--- a/packages/lint/src/validate-component-types.ts
+++ b/packages/lint/src/validate-component-types.ts
@@ -44,12 +44,54 @@
  * the authoring commands) and the ledgered `record:line_items`. An error gate
  * with zero live findings breaks no one and refuses the next `global:serch` at
  * the door instead of in front of a user.
+ *
+ * ## The EXACT-name arm: a retired type, reported with the spec's own words
+ *
+ * A type the vocabulary RETIRED is `isKnownComponentType` — deliberately, so
+ * the kept `ComponentPropsMap` row keeps carrying the prescription at the props
+ * door — and it was therefore the one reserved-namespace string this rule
+ * walked past in silence, while `PageComponentSchema.type` refuses it by name
+ * at the parse. Lint saying "the stack is fine" about a name the parser then
+ * refuses is the declared-not-enforced shape inverted: the author's EARLIEST
+ * feedback channel was the one that stayed quiet. So the arm below reports it,
+ * and the reported text is `RETIRED_PAGE_COMPONENT_TYPES`'s own entry —
+ * relayed verbatim, never re-authored, so this file cannot drift from the enum
+ * error map and the kept props row that carry the same string. The pin is byte
+ * equality against the map (`validate-component-types.test.ts`), which is also
+ * what makes a member retired tomorrow arrive here already covered.
+ *
+ * ⛔ `isKnownComponentType` is NOT the seam for this. Flipping it would MOVE
+ * the refusal out of the props door instead of ADDING a report here, and would
+ * strip the retired row of the dispatch that makes its prescription reachable.
+ *
+ * ### Why the arm runs BEFORE the namespace guard
+ *
+ * `RESERVED_COMPONENT_TYPE_NAMESPACES` is derived from the enum, and a
+ * retirement can take the namespace out with the member: `user:profile` was the
+ * `user:` namespace's ONLY member, so since its removal
+ * `hasReservedComponentNamespace('user:profile')` is `false` — measured, not
+ * assumed — and a retired-type check placed after that guard would report the
+ * two elements and stay silent on exactly the member that has been refused
+ * longest. Retirement is an EXACT-name fact and needs no namespace claim to be
+ * true, so it is judged first. The guard keeps its own job unchanged for every
+ * other string: what is outside a reserved namespace and not retired is the
+ * open arm's declared story and stays untouched.
+ *
+ * The corpus this arm landed on was measured the way severity was: zero
+ * authored instances of any retirement-map member across the in-repo page
+ * sources (`examples/**`, `packages/platform-objects/src/pages/**`), with live
+ * types as the lit control in the same query. Every in-tree occurrence of a
+ * retired name is the map itself, a tombstone prescription, conversion or
+ * migration registry data, a test, or prose. ⚠️ That reading covers authored
+ * config-file metadata only — the same scope limit the rule's `surfaceReason`
+ * records for stored tenant rows.
  */
 
 import {
   hasReservedComponentNamespace,
   isKnownComponentType,
   KNOWN_COMPONENT_TYPE_CANDIDATES,
+  RETIRED_PAGE_COMPONENT_TYPES,
 } from '@objectstack/spec/ui';
 import { findClosestMatches, formatSuggestion } from '@objectstack/spec/shared';
 import { walkPageComponents, type AnyRec } from './page-walk.js';
@@ -93,6 +135,26 @@ export function validateComponentTypes(stack: AnyRec): ComponentTypeFinding[] {
     for (const { component, path } of walkPageComponents(page, `pages[${pi}]`)) {
       const type = strName(component.type);
       if (!type) continue;
+
+      // EXACT-name arm, judged before the namespace guard (header: `user:`
+      // stopped being a reserved namespace when its only member was retired).
+      // The message IS the map's entry — relayed, never re-authored.
+      const prescription = RETIRED_PAGE_COMPONENT_TYPES.get(type);
+      if (prescription !== undefined) {
+        findings.push({
+          severity: 'error',
+          rule: COMPONENT_TYPE_UNKNOWN,
+          where: `page "${pageName}" · ${type}`,
+          path: `${path}.type`,
+          message: prescription,
+          hint:
+            `Apply the prescription above: \`${type}\` is a retired component type, refused by ` +
+            'name at the parse door (`PageComponentSchema.type`), so this page cannot validate or ' +
+            'publish while the node is present.',
+        });
+        continue;
+      }
+
       if (!hasReservedComponentNamespace(type)) continue; // the open arm's half — deliberately untouched
       if (isKnownComponentType(type)) continue;
 


### PR DESCRIPTION
Fixes #17595

`component-type-unknown` now reports an **exact** retired component type, carrying the
`RETIRED_PAGE_COMPONENT_TYPES` prescription verbatim.

- **Clause-②: no** — this PR puts no new key on any published payload.

## The defect

A retired type is `isKnownComponentType` on purpose — the `ComponentPropsMap` row is kept so
the props door can dispatch the retirement prescription — and this rule read that as
"accepted". So a caller linting a **raw stack** got silence on a name
`PageComponentSchema.type` refuses at the parse. The author's earliest feedback channel was
the one that stayed quiet; the refusal then landed at the parse door, or in front of an end
user. Reproduced on this branch's base before any edit, through the rule itself:

```
user:profile     reservedNS=false known=true  typeFindings=0  propsFindings=1 [component-props-invalid]
element:filter   reservedNS=true  known=true  typeFindings=0  propsFindings=0
element:form     reservedNS=true  known=true  typeFindings=0  propsFindings=0
global:serch     reservedNS=true  known=false typeFindings=1  propsFindings=0  ... LIT CONTROL
```

## The census that gated this landing

Triage made the direction conditional on one number: **how many authored instances of each
retirement-map member exist in-tree** — 「all zero ⇒ the new finding is free. Land it.」 A
crude `git grep` does not answer it, so the count was taken twice, both ways over **tracked
files only** (no `dist/` is tracked and none was present, so no build output is in scope).

**1. Every raw occurrence, classified.** Occurrences counted with `grep -o | wc -l`, never
`grep -c` (which counts lines):

| member | total occ | docs/CHANGELOG/changeset | tests + ledgers | spec vocabulary machinery + prescriptions | conversion/migration registries | lint comments | **authored page nodes** |
|---|---|---|---|---|---|---|---|
| `user:profile` | 50 | 14 | 22 | 14 | 0 | 0 | **0** |
| `element:filter` | 149 | 48 | 29 | 26 | 44 | 2 | **0** |
| `element:form` | 152 | 41 | 36 | 21 | 48 | 2 | **0** |
| `record:details` *(lit control)* | 233 | 102 | 50 | 11 | 18 | 10 | **6, in 4 authored page files** |

The control is what makes the three zeros a reading: run through the identical buckets, a
live component type leaves a residue outside every exclusion — `examples/app-showcase/src/ui/pages/{project-detail,settings,task-detail}.page.ts`
and `packages/platform-objects/src/pages/sys-user.page.ts`. The exclusions therefore do not
swallow authored page nodes, and the three retired members have an empty residue.

**2. The authored-page corpus, directly.** `examples/**` + `packages/platform-objects/src/pages/**`
+ the three tracked JSON stacks that carry page components — 261 tracked files:

```
user:profile 0 · element:filter 0 · element:form 0
record:details 15 · record:highlights 7 · page:tabs 9      ... LIT CONTROLS, same command
```

**Verdict: zero authored instances of any retirement-map member.** No existing authored stack
turns red, so this is a rule change and not a migration.

## What changed

The new arm relays the map — the finding's `message` **is** `RETIRED_PAGE_COMPONENT_TYPES`'s
entry, pinned by byte equality in the test, so this file cannot drift from the enum error map
and the kept props row that carry the same string, and a type retired tomorrow arrives
reported on the day it lands (the suite is driven off the map's keys, not a restated list).

It is judged **before** the reserved-namespace guard. That is not stylistic: a retirement can
take its namespace with it. `user:profile` was the `user:` namespace's only member, and
`RESERVED_COMPONENT_TYPE_NAMESPACES` is derived from the enum, so
`hasReservedComponentNamespace('user:profile')` is `false` — measured, above — and a check
placed after that guard would have reported the two elements and stayed silent on exactly the
member that has been refused longest.

Fences honoured: `isKnownComponentType` is untouched (flipping it would MOVE the refusal out
of the props door rather than add a report); the typo-suggestion path is untouched and still
never proposes a retired name; no third copy of the prescription is authored, and a test
asserts the hint does not restate it.

## Verification

All commands run on the pushed head, in a dedicated worktree.

| what | command | result |
|---|---|---|
| dependency closure | `pnpm --filter '@objectstack/lint^...' build` | `VERDICT command-exit 0` |
| the rule's own suite | `vitest run src/validate-component-types.test.ts` | 35 passed |
| lint package, whole | `pnpm --filter @objectstack/lint test` | 101 files, 3741 passed, 5 skipped, `command-exit 0` |
| consumer of the rule set | cli `test/generate-scaffold-validates.test.ts` (unit tier) | 18 passed |
| derived gate family | `scripts/pm/dispatch-gates.mjs --commands` → 30 commands | 30/30 exit 0 |
| control bytes | `node scripts/check-nul-bytes.mjs` | OK, 8436 files |
| eslint, repo-wide | `eslint . --no-inline-config --format json` | 6636 files linted, 0 errors, 0 warnings |

Behaviour after the change, same probe as above: all three members report once, `message`
byte-equal to the map, at the node's own path; `record:details`, `mcp:connect-agent` and
`flex` still yield nothing; `element:fitler` / `element:frm` still propose no retired name;
a `kind: 'react'` source-authored page stays silent.

**`pnpm --filter @objectstack/lint typecheck` exits 1 in this worktree, for a reason that is
not this diff and reproduces at the base commit.** The source layer is clean
(`tsc --noEmit` exit 0). The test layer reports exactly the 6 `TS6059` errors the
shrink-only ledger already records, in two files this PR never touches, and none in anything
it does touch. The wrapper reds because `check-test-typecheck.mts` keeps a quoted span of 32
characters or fewer verbatim in a signature: this worktree's `rootDir` path is 31 characters,
so it survives where the ledger recorded it masked. Controls: the same command at the base
commit `431c7571` reds identically, and the primary checkout's path is 40 characters. CI's
checkout path is longer still. Recorded as an out-of-scope finding, not repaired here.

## Acceptance notes

- **The `validateComponentProps` asymmetry survives this PR.** On `{ properties: {} }`,
  `user:profile` still produces a `COMPONENT_PROPS_INVALID` finding and the two elements still
  produce nothing — measured before and after, unchanged. This PR equalises the **type** door,
  where all three now report identically; the props door is a different rule and was left
  alone rather than widened into. Already recorded on the card.
- **No sweep for sibling silences in other lint rules was run**, per the card's own declared
  scope limit. Nothing here asserts that surface is clean.
- The rule's registration comment claims a 0-finding in-repo corpus; the census above keeps
  that claim true.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MkQhmuuJAVDjmeWNixwDDH)_