### PR TITLE
docs(spec): correct `ManifestSchema.version`'s prerelease `@example` to a value its regex accepts

### DIFF
--- a/.changeset/issue-17461-manifest-version-example.md
+++ b/.changeset/issue-17461-manifest-version-example.md
@@ -1,0 +1,34 @@
+---
+'@objectstack/spec': patch
+---
+
+`ManifestSchema.version`'s TSDoc no longer documents an `@example` its own regex refuses
+
+The key documented two examples and accepted only one:
+
+```
+@example "1.0.0"          -> /^\d+\.\d+\.\d+$/ accepts
+@example "2.1.0-beta.1"   -> /^\d+\.\d+\.\d+$/ REFUSES
+```
+
+An author who copied the second example verbatim got a `ZodError` out of
+`ManifestSchema.parse`. The prerelease example is corrected to `"2.1.0"`, a
+value the regex accepts.
+
+**Nothing published moves except the comment.** The regex, the
+`.describe('Package version (semantic versioning)')` string and the prose
+`(major.minor.patch)` are byte-identical; no accept set, authorable key or
+runtime behaviour changes. `@objectstack/spec` ships `src/**/*.zod.ts` in its
+`files[]`, so this TSDoc line is itself published — which is why it carries a
+changeset rather than `skip-changeset`.
+
+**The refusal was already the settled reading, which is why this is a comment
+fix and not a schema change.** Three artifacts agreed before this change and
+still agree: the regex, the prose `(major.minor.patch)`, and
+`manifest.test.ts`, which pins `'1.0.0-beta'` in `invalidVersions` on purpose.
+Only the `@example` line dissented, so it was the artifact in error. Widening
+the accept set to admit prerelease or build metadata would contradict that pin
+and is deliberately NOT done here.
+
+`PluginSchema.version` accepts a different grammar today; the two keys are
+deliberately different and are not reconciled by this change.

--- a/packages/spec/src/kernel/manifest.zod.ts
+++ b/packages/spec/src/kernel/manifest.zod.ts
@@ -317,7 +317,7 @@ export const ManifestSchema = strictObject({
    * Package version following semantic versioning (major.minor.patch).
    *
    * @example "1.0.0"
-   * @example "2.1.0-beta.1"
+   * @example "2.1.0"
    */
   version: z.string().regex(/^\d+\.\d+\.\d+$/).describe('Package version (semantic versioning)'),
   


### PR DESCRIPTION
Fixes #17461

- **Clause-②: no** — this PR puts no new key on any published payload.

## What changed

One TSDoc line on `ManifestSchema.version` (`packages/spec/src/kernel/manifest.zod.ts`):

```
-   * @example "2.1.0-beta.1"
+   * @example "2.1.0"
```

The key documented two examples and its own regex accepted only one. Reproduced on this branch's base, no build needed:

```
$ node -e "const re=/^\d+\.\d+\.\d+$/; for (const v of ['1.0.0','2.1.0-beta.1']) console.log(re.test(v), JSON.stringify(v))"
true "1.0.0"
false "2.1.0-beta.1"
```

An author copying the second documented example verbatim got a `ZodError` out of `ManifestSchema.parse`. The corrected value is accepted: `re.test('2.1.0')` is `true`.

## Why the comment was the artifact in error, not the regex

Three artifacts agreed on the refusal before this change and still agree afterwards:

| artifact | says | touched here |
|:---|:---|:---|
| `version: z.string().regex(...)` | refuses a prerelease suffix | no — byte-identical |
| prose `following semantic versioning (major.minor.patch)` | major.minor.patch only | no — byte-identical |
| `manifest.test.ts` `invalidVersions` pins `'1.0.0-beta'` | refusal is deliberate | no — not in the diff |

Only the `@example` line dissented, so it is an editing residue in the TSDoc. **Widening the regex to admit prerelease or build metadata is deliberately NOT done here** — it would contradict a test that pins the refusal on purpose and would enlarge a published schema's accepted set. `PluginSchema.version` (#17070) accepts a different grammar today; the two keys are deliberately different and are not reconciled here.

## Verification

Commands and their own verdict lines, all at `dfcb1592`:

- `pnpm --filter @objectstack/spec build` — `VERDICT command-exit 0` (under `scripts/pm/os-verify-lock.sh`)
- `pnpm --filter @objectstack/spec typecheck && pnpm --filter @objectstack/spec test` — `VERDICT command-exit 0`; `Test Files 473 passed (473)`, `Tests 13435 passed (13435)`
- `pnpm --filter @objectstack/spec exec vitest run --maxWorkers=2 src/kernel/manifest.test.ts` — `EXIT=0`, `Test Files 1 passed (1)`, `Tests 41 passed (41)` — the pinned `invalidVersions` case still passes, unchanged
- `pnpm --filter @objectstack/spec check:generated` — `✓ All 15 generated artifacts are up to date`, including `check:docs`. The `@example` line is not extracted into `content/docs/references/**`: measured at 0 occurrences there, with the neighbouring `.describe()` string `Package version (semantic versioning)` at 12 in the same tree as the lit control.
- `pnpm exec eslint . --no-inline-config --format json` — exit 0 over **6636 files**, 0 errors, 0 warnings. Repo-wide, not narrowed.
- Derived gate family (`node scripts/pm/dispatch-gates.mjs --commands --repo objectstack-ai/objectstack`): **76 derived, 73 run green, 3 NOT MEASURED**. The three exited 3 — `PREREQUISITE NOT MET`, each refusing because a whole-repo `pnpm build` is absent for packages this diff does not touch: `check:doc-formula-expressions`, `check:dual-build-cjs-loads`, `check:lean-entry-closure`. Declared to CI, which builds everything. Reconciled with `--ran`.

## Published reach

`@objectstack/spec` ships `src/**/*.zod.ts` in its `files[]`, so the edited line is itself published, and the TSDoc is also emitted into the built declarations. Measured on `packages/spec/dist` after the build: corrected `@example "2.1.0"` at **16** occurrences, old `@example "2.1.0-beta.1"` at **0**, with the untouched neighbour `@example "1.0.0"` at **16** as the lit control. Hence a changeset (`patch`, `@objectstack/spec`) rather than `skip-changeset`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MkQhmuuJAVDjmeWNixwDDH)_