### PR TITLE
docs(protocol): put the realtime subscribe fences on the shape SubscribeMessageSchema declares

### DIFF
--- a/content/docs/protocol/kernel/realtime-protocol.mdx
+++ b/content/docs/protocol/kernel/realtime-protocol.mdx
@@ -255,21 +255,45 @@ Subscribe to changes on a specific object:
 **Request:**
 ```json
 {
+  "messageId": "550e8400-e29b-41d4-a716-446655440000",
   "type": "subscribe",
-  "subscription_id": "sub_1",
-  "object": "task",
-  "events": ["created", "updated", "deleted"],
-  "filter": {
-    "assignee_id": "user_123"
+  "timestamp": "2024-01-16T14:30:00Z",
+  "subscription": {
+    "subscriptionId": "9f8c1e42-5b7a-4d33-9e10-6c2f8a91b4d7",
+    "events": ["data.record.created", "data.record.updated", "data.record.deleted"],
+    "objects": ["task"]
   }
 }
 ```
 
+**`SubscribeMessageSchema` declares exactly two things of its own** — `type: "subscribe"` and a
+`subscription` object — on top of the three `BaseWebSocketMessage` fields every message carries.
+Nothing else sits at the top level: the subscription's own fields live **inside** `subscription`
+(`EventSubscriptionSchema`), and they are camelCase.
+
 **Parameters:**
-- `subscription_id`: Client-generated unique ID for this subscription
-- `object`: Object name to subscribe to
-- `events`: Array of events to listen for (default: all)
-- `filter`: Optional filter (same syntax as HTTP API filters)
+- `messageId`: UUID for this message (`BaseWebSocketMessage`)
+- `timestamp`: ISO 8601 datetime the message was sent (`BaseWebSocketMessage`)
+- `subscription.subscriptionId`: **UUID** identifying the subscription — the schema declares
+  `z.string().uuid()`, so an opaque handle like `"sub_1"` does not parse
+- `subscription.events`: array of event **patterns**, not bare verbs — lowercase dot notation with
+  wildcards (`"data.record.*"`, `"*.created"`). The platform-checked vocabulary is the closed
+  `DataEventType` / `BulkDataEventType` enums (`packages/spec/src/api/events.zod.ts`), whose members
+  are `data.record.created` / `data.record.updated` / `data.record.deleted` and their bulk siblings
+- `subscription.objects`: optional **array** of object names to filter events by (`["account",
+  "contact"]`) — plural, and an array even for a single object
+- `subscription.channels`: optional array of channel names for scoped subscriptions
+- `subscription.filters`: optional, and **declared `unknown`** — see the callout below
+
+<Callout type="warn">
+  ⛔ **`filters` is declared but not enforced — it is not "the same syntax as HTTP API filters".**
+  `EventSubscriptionSchema.filters` is `z.unknown()`, and no runtime evaluates a payload filter:
+  `matchesSubscription` (`@objectstack/service-realtime`) matches on object name and event type
+  only. A subscription carrying `filters` therefore **receives every event its patterns match** —
+  the extra conditions are silently ignored, in the permissive direction. The key is typed
+  `unknown` deliberately, because validating a shape nothing reads would imply an enforcement that
+  does not exist (objectui#2945). Narrow with `objects` and `events`, and re-check on the client.
+</Callout>
 
 **Success Response:**
 
@@ -378,10 +402,18 @@ Stop receiving events for a subscription:
 **Request:**
 ```json
 {
+  "messageId": "b3d1a77e-4c62-4f0b-9a55-1d8e2f6c0b34",
   "type": "unsubscribe",
-  "subscription_id": "sub_1"
+  "timestamp": "2024-01-16T14:35:00Z",
+  "request": {
+    "subscriptionId": "9f8c1e42-5b7a-4d33-9e10-6c2f8a91b4d7"
+  }
 }
 ```
+
+`UnsubscribeMessageSchema` nests its payload under `request` (`UnsubscribeRequestSchema`), whose one
+field is `subscriptionId` — a UUID, and the same UUID the subscribe message declared. Note the key
+is **not** the `subscription` of a subscribe message: the two envelopes use different wrappers.
 
 **Response:** the same `ack` envelope as a subscribe acknowledgement — there is no `unsubscribed`
 type either.
@@ -398,47 +430,67 @@ type either.
 
 ### Subscribe to Specific Record
 
-Watch a single record for changes:
+Watch a single record for changes — **narrowed on the client**, because the declared subscription
+has no record-level field:
 
 **Request:**
 ```json
 {
+  "messageId": "c1f4b9a2-6e78-4a31-bb05-9d3e7c2a1f80",
   "type": "subscribe",
-  "subscription_id": "sub_2",
-  "object": "task",
-  "record_id": "task_456",
-  "events": ["updated", "deleted"]
+  "timestamp": "2024-01-16T14:40:00Z",
+  "subscription": {
+    "subscriptionId": "2a6d5f14-8b90-4c27-a3e1-7f05b8d29c46",
+    "events": ["data.record.updated", "data.record.deleted"],
+    "objects": ["task"]
+  }
 }
 ```
+
+<Callout type="warn">
+  ⛔ **There is no `recordId` on a subscription, and no `record_id` anywhere in the protocol.**
+  `EventSubscriptionSchema` declares exactly `subscriptionId`, `events`, `objects`, `filters` and
+  `channels` — the narrowest scope the contract can express is **object + event pattern**. This
+  page used to show a top-level `record_id`, which no schema declares and no runtime reads.
+  Subscribe at object scope as above and compare the incoming event's own record identity on the
+  client; `filters` cannot do it for you (see the callout under **Subscribe to Object Events**).
+</Callout>
 
 **Use case:** Detail pages that need to reflect live changes to the currently viewed record.
 
 ### Subscribe to Query Results
 
-Subscribe to a dynamic set of records matching a query:
+Subscribe to a dynamic set of records matching a query — again **narrowed on the client**, because
+the declared subscription carries no query:
 
 **Request:**
 ```json
 {
+  "messageId": "d8e0c3b5-1f47-4d92-8a6c-5b4e9f210a73",
   "type": "subscribe",
-  "subscription_id": "sub_3",
-  "object": "task",
-  "query": {
-    "filter": {
-      "status": "todo",
-      "assignee_id": "user_123"
-    },
-    "sort": "-priority"
-  },
-  "events": ["created", "updated", "deleted"]
+  "timestamp": "2024-01-16T14:45:00Z",
+  "subscription": {
+    "subscriptionId": "6b3c9e07-2d54-4f18-9c8a-0e7d1b5a4632",
+    "events": ["data.record.created", "data.record.updated", "data.record.deleted"],
+    "objects": ["task"]
+  }
 }
 ```
 
-**Behavior:**
-- Receive `created` events when records matching query are created
-- Receive `updated` events when subscribed records change
-- Receive `deleted` events when subscribed records are deleted
-- Automatically receive events when records enter/exit the query filter
+<Callout type="warn">
+  ⛔ **There is no `query` on a subscription either, and no server-side query membership tracking.**
+  A top-level `query` object appeared on this page but is declared nowhere: `EventSubscriptionSchema`
+  has no such field, and the only payload-shaped key it does have — `filters` — is `unknown` and
+  unenforced. Nothing computes whether a record entered or left a result set, so a server cannot
+  send you an "entered/exited" signal it does not track.
+</Callout>
+
+**Behavior at object scope** — what the declared subscription above actually delivers:
+- Receive `data.record.created` events for every `task` the subscription's patterns match
+- Receive `data.record.updated` events for every `task` that changes
+- Receive `data.record.deleted` events for every `task` that is deleted
+- Evaluate query membership **on the client**: apply the predicate to each event and derive the
+  enter/exit transitions yourself by comparing against the set you are already holding
 
 **Example:** Task enters subscription:
 ```json
@@ -625,20 +677,26 @@ class ObjectStackClient {
   }
   
   resubscribe() {
-    this.subscriptions.forEach((config, id) => {
-      this.send({ ...config, subscription_id: id });
+    this.subscriptions.forEach((subscription, id) => {
+      this.send({ type: 'subscribe', subscription: { ...subscription, subscriptionId: id } });
     });
   }
-  
-  subscribe(config) {
-    const id = `sub_${Date.now()}`;
-    this.subscriptions.set(id, config);
-    this.send({ ...config, type: 'subscribe', subscription_id: id });
+
+  subscribe(subscription) {
+    // `subscriptionId` is declared `z.string().uuid()` — not an opaque handle.
+    const id = crypto.randomUUID();
+    this.subscriptions.set(id, subscription);
+    this.send({ type: 'subscribe', subscription: { ...subscription, subscriptionId: id } });
     return id;
   }
-  
+
   send(message) {
-    this.ws.send(JSON.stringify(message));
+    // Every message carries the three `BaseWebSocketMessage` fields.
+    this.ws.send(JSON.stringify({
+      messageId: crypto.randomUUID(),
+      timestamp: new Date().toISOString(),
+      ...message,
+    }));
   }
 }
 
@@ -654,10 +712,14 @@ Real-time subscriptions respect object-level and row-level permissions:
 **Scenario:** User subscribes to all tasks:
 ```json
 {
+  "messageId": "e5a7d210-3c86-4b4f-9017-8f2c6d3b5a19",
   "type": "subscribe",
-  "subscription_id": "sub_1",
-  "object": "task",
-  "events": ["created", "updated"]
+  "timestamp": "2024-01-16T14:50:00Z",
+  "subscription": {
+    "subscriptionId": "9f8c1e42-5b7a-4d33-9e10-6c2f8a91b4d7",
+    "events": ["data.record.created", "data.record.updated"],
+    "objects": ["task"]
+  }
 }
 ```
 


### PR DESCRIPTION
Part of #17184 — the **second half**. The first half (the four undeclared message types) landed as #17700; this PR does not revisit it.

- **Clause-②: no** — this PR puts no new key on any published payload.

`packages/spec/src/api/websocket.zod.ts` is **byte-unchanged**: blob `3348dd76745b61e83801e2e8bae48c6756c5a69c` on both sides (`git rev-parse HEAD:<path>` vs `git hash-object <path>`, and an empty `git diff HEAD -- <path>`). Prose only, one file.

## The defect

Six subscribe/unsubscribe sites carried every subscription field at the **top level**, in snake_case, where the declared contract nests them and spells them camelCase. `SubscribeMessageSchema` (`websocket.zod.ts:278`–`:281`) declares exactly `type: 'subscribe'` plus a `subscription` object, on top of the three `BaseWebSocketMessage` fields; `EventSubscriptionSchema` (`:102`–`:117`) declares `subscriptionId` / `events` / `objects` / `filters` / `channels`. A fence copied verbatim parses against no schema in the file.

The mismatch is **not one thing**, and each axis was verified separately:

| page (top level) | declared | axes |
|:--|:--|:--|
| `subscription_id` | `subscription.subscriptionId` | nesting + snake/camel + **`z.string().uuid()`, so `"sub_1"` does not parse** |
| `object`, a string | `subscription.objects`, an array | nesting + singular/plural + scalar/array |
| `filter` | `subscription.filters` | nesting + singular/plural |
| `events: ["created", …]` | `z.array(EventPatternSchema)` | bare verbs vs patterns — `DataEventType` publishes `data.record.created` |
| *absent* | `messageId`, `timestamp` | **both required by `BaseWebSocketMessage`** — an axis not in the card |

### Two page keys map to nothing at all

`record_id` and `query` are declared **nowhere** in the protocol. The narrowest scope the contract can express is object + event pattern, so those two sections now say so and move the narrowing to the client rather than showing fields no schema carries.

### Second, independent defect in the same bullet list

The page described `filter` as *"Optional filter (same syntax as HTTP API filters)"*. The schema's docblock (`:106`–`:115`) says the opposite in as many words — *"⚠️ **NOT YET ENFORCED** — no runtime evaluates a payload filter. `matchesSubscription` matches on object name and event type only … a subscription carrying `filters` receives every event its patterns match."* The page promised enforcement the contract explicitly disclaims; it now carries that disclaimer.

## Fence census — the round's first deliverable

Enumerated on this tree, **not** inherited from the dispatch's page-wide counts.

| # | line (pre) | section | type | top-level keys |
|--:|--:|:--|:--|:--|
| 1 | 256–266 | Subscribe to Object Events | `subscribe` | `type`, `subscription_id`, `object`, `events`, `filter` |
| 2 | 379–384 | **Unsubscribe** | `unsubscribe` | `type`, `subscription_id` |
| 3 | 404–412 | Subscribe to Specific Record | `subscribe` | `type`, `subscription_id`, `object`, `record_id`, `events` |
| 4 | 421–435 | Subscribe to Query Results | `subscribe` | `type`, `subscription_id`, `object`, `query`, `events` |
| 5 | 655–662 | Permission Enforcement | `subscribe` | `type`, `subscription_id`, `object`, `events` |
| 6 | 679–689 | **Client Reconnection (JS)** | `subscribe` | `type`, `subscription_id` (+ `sub_${Date.now()}`) |

⭐ The card named **four** sections. The census found **six** sites: **Unsubscribe** (#2) and the **JS client snippet** (#6) were not on the card's list. #6 was also missed by a first pass that matched only JSON `"type": "subscribe"` — it uses the single-quoted JS form, and the census was widened to catch it.

After the edit all six carry exactly `messageId` / `type` / `timestamp` / `subscription` (or `request` for unsubscribe).

## Fork verdict: **(a) the page is wrong** — every fence

Producer evidence on this tree, all six fences landing on the same verdict:

- `SubscribeMessageSchema`, `UnsubscribeMessageSchema` and `EventSubscriptionSchema` have **zero** consumers outside `packages/spec`'s own declaration, its unit test and the type-alias pin.
- `IRealtimeService.handleUpgrade` is deliberately unimplemented platform-wide — `service-realtime/src/no-channel-route.pin.test.ts:49` asserts it **is not a function**.
- `subscription_id` → **0** across **6120** tracked `packages/**` source files (no `dist/`), with four lit controls on the same corpus and the same call: `subscriptionId` **40**, `eventTypes` **27**, `handleUpgrade` **18**, `EventSubscriptionSchema` **13**.
- The 660 `record_id` hits are the generic DB-column convention: **zero** files carry both `record_id` and `WebSocket`.

Nothing produces or consumes a WebSocket subscribe message, so no top-level field on one can be real. Reading (b) — the schema is incomplete — would need a producer, and there is none.

**objectui: reported, not counted.** All WS-subscription probes return 0 there, but the schema-side control is also dark (`subscriptionId` 0, `EventSubscription` 0) — only the generic `useState` (2262) lights, which proves the corpus is real source and nothing more. A zero whose control does not light is not a reading. `cloud` is not checked out here: **NOT MEASURED**.

## Verification

- **40/40** derived gates green, on a clean full re-run after the builds. Gate family derived mechanically via `node scripts/pm/dispatch-gates.mjs --commands --repo objectstack-ai/objectstack` (it reads the change set from the merge base itself), not hand-listed.
- Five gates first returned `PREREQUISITE NOT MET` / "build first" (exit 3 and exit 1) — **NOT MEASURED, not red**. After building `@objectstack/lint...`, `@objectstack/spec` and `@objectstack/client-react...` all five are green. Exit codes captured **before** any pipe.
- MDX compiles: `pnpm exec fumadocs-mdx` exit 0.
- No generated or tracked artifact moved — `authorable-surface.base.json` included. `git status --porcelain` shows exactly one file.
- No control characters: `check:nul-bytes` exit 0, plus a direct `grep -naP` sweep of the edited file.

## `skip-changeset`, and a conflict with the dispatch to flag

⚠️ **The dispatch asked for a patch changeset; this PR carries none, and the label instead.** Reporting rather than silently choosing:

- `content/docs/**` ships in **no** published package's `files[]` — 0 of 70 publishable packages mention `content/` or `docs/` there, with all 70 shipping `dist` as the positive control.
- `@objectstack/docs`, which owns the page, is `private: true` — there is no publishable package to bump. Naming any other package would ship a release note for a package this PR does not touch.
- **Precedent on the identical surface**: #17700, the first half of this very card, merged with no changeset.

By the standing criterion — nothing published moves — this is the textbook `skip-changeset` case, which `lint.yml` states in those words. Happy to add a changeset if the maintainer reads it the other way.

## Scope

Confined to the subscribe/unsubscribe fences and their Parameters bullet lists. ⛔ Not `websocket.zod.ts`, ⛔ not the message-type sections #17700 corrected, ⛔ not `content/docs/releases/`, ⛔ no other page.

One finding deliberately left out and filed separately: the `type: "event"` fences on this same page carry top-level `subscription_id` / `event` / `data` / `changes` / `reason` where `EventMessageSchema` declares `subscriptionId` / `eventName` / `payload` / `userId` and no `changes` or `reason`. Same defect class, different message family — it is not this round's declared face, and it is not silently widened into.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MkQhmuuJAVDjmeWNixwDDH

---
_Generated by [Claude Code](https://claude.ai/code/session_01MkQhmuuJAVDjmeWNixwDDH)_