### PR TITLE
docs(adr-0025): the granted permission set is REGISTERED at load and enforces nothing — §3.7 said the opposite (#17147)

### DIFF
--- a/docs/adr/0025-plugin-package-distribution.md
+++ b/docs/adr/0025-plugin-package-distribution.md
@@ -1,6 +1,6 @@
 # ADR-0025: Plugin Package Distribution (Code + Dependencies)
 
-**Status**: Proposed — partially implemented (2026-07-16 audit): the `.osplugin` artifact format and `os plugin build`/`sign`/`publish` CLI landed; the install flow (§3.5), `sys_plugin`/`sys_plugin_version`/`sys_plugin_installation` registry (§3.8), and install-time consent remain unimplemented.
+**Status**: Proposed — partially implemented (2026-09-12 audit, superseding 2026-07-16): the `.osplugin` artifact format and `os plugin build`/`sign`/`publish` CLI landed. **Install-time permission consent landed for PACKAGE installs** — the console disclosure panel, `sys_package_installation.granted_permissions`, re-consent on a widening upgrade, `EnvironmentArtifactSchema.grantedPermissions`, and `PluginPermissionEnforcer.registerGrantedPermissions` at load — but it is **registered-only and enforces nothing** (§3.7, #17147). The code-plugin half of the install flow (§3.5 steps 4–7: download / verify / materialize / load) and the `sys_plugin`/`sys_plugin_version`/`sys_plugin_installation` registry (§3.8) remain unimplemented: measured on `9bd4344e4` there is no `os plugin install` command, no `.osplugin` loader, and no runtime path on which a distributed plugin's code executes — an environment artifact carries `sys_package_version.manifest_json` and never the blob.
 **Deciders**: ObjectStack Protocol Architects
 **Builds on**: [ADR-0003](./0003-package-as-first-class-citizen.md) (package + versioned releases), [ADR-0004](./0004-cloud-multi-kernel.md) (cloud multi-kernel), [ADR-0010](./0010-metadata-protection-model.md) (L1/L2/L3 protection), [ADR-0016](./0016-studio-package-authoring-and-publish.md) (package authoring & publish, local export/import)
 **Consumers**: `@objectstack/core` (kernel, plugin-loader, security), `@objectstack/runtime` (sandbox, marketplace install), `@objectstack/cli`, `@objectstack/spec/system` (ObjectStackManifest), `@objectstack/spec/cloud`, `../objectui` (Studio)
@@ -277,9 +277,34 @@ enforces this at publish time (an unverified publisher cannot ship `runtime:
   counter-signs on approval. Host ships trusted root keys; verify the chain at
   install (§3.5 step 4) **and** at load (§3.5 step 7).
 - **Permissions.** New manifest `permissions` block → install-time consent →
-  granted set → `PluginPermissionEnforcer` (service/hook/file/network already
-  enforced). Principle of least privilege; all denials logged (existing
-  behavior).
+  granted set → `PluginPermissionEnforcer`. Principle of least privilege; all
+  denials logged.
+
+  > **Landed as far as REGISTRATION, and no further (2026-09-12, #17147).** The
+  > parenthetical here used to read *"(service/hook/file/network already
+  > enforced)"*. It was never true of the granted set, and two of the four
+  > classes have no enforcement surface at all. Measured on `9bd4344e4`:
+  >
+  > - the consent record is persisted by the control plane
+  >   (`sys_package_installation.granted_permissions`) and re-consent is forced
+  >   on a widening upgrade — **live**, §3.8 as written;
+  > - it reaches the runtime on `EnvironmentArtifactSchema.grantedPermissions`
+  >   and `AppPlugin.init()` hands each entry to
+  >   `PluginPermissionEnforcer.registerGrantedPermissions` — **live** (#13457);
+  > - **nothing queries that registry.** `enforceServiceAccess` and
+  >   `enforceHookTrigger` are reachable only through `SecurePluginContext`,
+  >   which has zero production construction sites; `enforceFileRead`,
+  >   `enforceFileWrite` and `enforceNetworkRequest` are called by nothing at
+  >   all, `SecurePluginContext` included.
+  >
+  > ⇒ the granted set records what was consented to and **refuses no
+  > operation**. Per-plugin context construction — §3.5 step 7's *"wraps
+  > `PluginContext` with the enforcer scoped to the granted set"* — is the
+  > materialize seam that maintainer ruling `5486840233` assigns to this ADR's
+  > install-flow design work and forbids improvising elsewhere; it is tracked as
+  > **#17147** and is not built. The measurement is pinned in
+  > `packages/core/src/security/granted-permissions-not-enforced.pin.test.ts`,
+  > which goes red the day it is — delete this note in that PR.
 - **Config.** RETIRED 2026-08-27 (#11982, ADR-0049 enforce-or-remove;
   maintainer ruling, decision-inbox batch 5). `PluginConfigValidator` /
   `createPluginConfigValidator` and `PluginMetadata.configSchema` were removed:


### PR DESCRIPTION
## ⛔ Governed surface — stays DRAFT for maintainer merge

`docs/adr/**` is a governed surface (Prime Directive #14). This PR is **not** queued, **not** armed for auto-merge, and is **not** flipped out of draft. It is split out of **#17753** precisely so that PR's code / spec / test / generated-docs half can land the ordinary way.

⛔ #17147 stays OPEN — this PR is not its closer either. See #17753 for why the card stays open.

> ⚠️ Worded this way deliberately. The earlier phrasing put a closing keyword immediately before the number, and GitHub's reference parser matches the keyword plus the number and ignores the negation around it — so on #17753's merge the card was auto-closed as COMPLETED (reopened since; see that PR's body).

## ⚠️ CI state before you merge — one red remains, and it is advisory

| check | state | why |
|---|---|---|
| `Check Changeset` | **cleared** | This PR releases nothing (one file under `docs/adr/`), so the gate's own prescription applies: the `skip-changeset` label, applied live. ⛔ An empty-frontmatter changeset is explicitly not a third option (#5471). |
| `Part-of PR must not also close its card` | **red, and staying red** | RULE 2 only: the single commit on this branch ends `Refs #17147`, and that rule forbids **any** card-relation trailer in a commit message. RULE 3 (the body half) is clear — the body carries no closing keyword, verified with the gate's own regex. |

The Part-of red is **not** a required context (absent from the required-context registry; its workflow subscribes to no `merge_group` event), `Refs` lands as a reference and moves **no** card, and the gate's own log states that the repair is ⛔ never a history rewrite. So it is a red to read, not to act on. Nothing else is outstanding.

## The two corrections

**§3.7 Permissions** carried the parenthetical *"(service/hook/file/network already enforced)"*. Measured on `9bd4344e4`:

| | |
|---|---|
| persisted consent record + re-consent on a widening upgrade | ✅ live, §3.8 as written |
| artifact carriage + `AppPlugin.init()` → `registerGrantedPermissions` | ✅ live (#13457) |
| anything that **queries** the registry | ❌ `enforceServiceAccess` / `enforceHookTrigger` reachable only via `SecurePluginContext` (zero production construction sites); `enforceFileRead` / `enforceFileWrite` / `enforceNetworkRequest` called by **nothing at all** |

The bullet now states that split and names §3.5 step 7's per-plugin context as the **materialize seam** ruling `5486840233` assigns to this ADR's own install-flow design work — tracked as #17147, deliberately not built here.

**The Status line** is stale in the *other* direction: the 2026-07-16 audit says install-time consent is unimplemented, and it has since landed for package installs. Replaced with a 2026-09-12 audit that separates what landed (consent, carriage, registration) from what did not — no `os plugin install`, no `.osplugin` loader, and no runtime path on which a distributed plugin's code executes; an environment artifact carries `sys_package_version.manifest_json` and never the blob.

## Related

- **#17753** — the framework half: four shipped sentences corrected, generated docs regenerated, and `granted-permissions-not-enforced.pin.test.ts`, which pins the measurement and **goes red the day the seam lands**. That pin's failure message names this note; delete the §3.7 block in the same PR.
- **objectstack-ai/objectui#9235** — the console consent panel, which told the installer the same thing.
- **#13458** — Phase 2 stays `Blocked-by: #17147`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


