### PR TITLE
test(core, runtime): the retracted verb survived in two case titles — sweep it repo-wide instead of reading one file

### DIFF
--- a/.changeset/17147-retracted-verb-repo-wide.md
+++ b/.changeset/17147-retracted-verb-repo-wide.md
@@ -1,0 +1,11 @@
+---
+'@objectstack/core': patch
+---
+
+Sweep the retracted "enforces exactly the consented surface" phrasing repo-wide, not just in the file it shipped on.
+
+The #17147 pin read one file, and a post-merge sweep found what that missed: `artifact-granted-permissions.test.ts` carried the retracted sentence as a CASE TITLE — "a CONSENTED entry enforces exactly the consented surface" — beside a sibling titled "registered, and denies". Neither case asserts a refusal; both read a permission bag and check what it answers. But a case title is read as evidence (ADR-0033), and those two said the platform confines plugins while nothing on the tree queries the registry at all.
+
+Both titles now name what they assert, the file carries a verb-discipline note (`answers` / `registered` / `bound`; ⛔ never `enforces` / `denies` / `gates` / `refuses` / `blocks` until the seam exists), and the pin's negative assertion is a repo-wide `git grep` excluding only its own specimen — with an anti-vacuity limb so a broken scan cannot read as a clean one.
+
+No behaviour, no assertion semantics, and no accept/reject changes.

--- a/packages/core/src/security/granted-permissions-not-enforced.pin.test.ts
+++ b/packages/core/src/security/granted-permissions-not-enforced.pin.test.ts
@@ -62,6 +62,16 @@ const toRepoPath = (absolute: string) => relative(REPO_ROOT, absolute).split(sep
 /** The file that declares the enforcer, the secure context and every gate. */
 const HOME = toRepoPath(join(HERE, 'plugin-permission-enforcer.ts'));
 
+/** This file, so the repo-wide sweep below can exclude its own specimen. */
+const SELF = toRepoPath(fileURLToPath(import.meta.url));
+
+/**
+ * The retracted claim, as data. It shipped on the enforcer docblock and — found
+ * only by a post-merge sweep — as a case title in the runtime's seam test. Held
+ * once so the sweep and the single-file read cannot drift apart.
+ */
+const RETRACTED = 'enforces exactly the consented surface';
+
 /**
  * Generous on purpose: the scan costs tens of milliseconds, but a merge-queue
  * runner doing a full monorepo build at the same time can starve it, and a pin
@@ -169,8 +179,31 @@ describe('[#17147] the install-time granted permission set is registered, not en
     expect(
       text,
       'the retracted sentence must not come back beside the truthful one',
-    ).not.toContain('enforces exactly the consented surface');
+    ).not.toContain(RETRACTED);
   });
+
+  it('the retracted phrasing is absent from the WHOLE repo, not just its own file', () => {
+    // [#17147 follow-up] The single-file version above missed one: the runtime's
+    // own seam test carried `a CONSENTED entry enforces exactly the consented
+    // surface` as a CASE TITLE. Nothing in it asserted a refusal — it reads a
+    // permission bag and checks what the bag answers — but a case title is read
+    // as evidence (ADR-0033), and that one said the platform confines plugins.
+    // Found by a post-merge sweep, not by this pin, which is why the pin now
+    // sweeps instead of reading one file.
+    const offenders = gitGrep(RETRACTED).filter((p) => p !== SELF);
+
+    expect(
+      offenders,
+      'the retracted phrasing came back somewhere. It says the platform confines a plugin, '
+      + 'which it does not — see this file\'s header for the measurement, and use `answers` / '
+      + '`registered` / `bound` instead.',
+    ).toEqual([]);
+
+    // Anti-vacuity: this file itself carries the needle, so a scan that saw the
+    // tree must return at least SELF. An empty raw result means the scan is
+    // broken or the file is untracked, and `.filter` would hide both.
+    expect(gitGrep(RETRACTED), 'the scan did not even see this file').toContain(SELF);
+  }, SCAN_TIMEOUT_MS);
 
   it('registers a grant without gating anything — the behaviour the text describes', async () => {
     // Anti-vacuity for the prose above: assert the FACT, not only the sentence.

--- a/packages/runtime/src/security/artifact-granted-permissions.test.ts
+++ b/packages/runtime/src/security/artifact-granted-permissions.test.ts
@@ -14,6 +14,19 @@
 // asserted through the enforcer's OWN readback (`getPluginPermissions`), never
 // through the binding record alone — the binding record is what this module
 // says it did, the enforcer is what actually happened.
+//
+// ⛔ VERB DISCIPLINE (#17147). Every case here reads a permission BAG and
+// asserts what it ANSWERS. None of them asserts that anything was refused, and
+// none of them could: nothing on this tree queries the registry these entries
+// land in — `SecurePluginContext` has no production construction site, and the
+// fs/network gates have no caller at all. Two case titles here used to say
+// `enforces` and `denies`, and a case title is read as evidence (ADR-0033: an
+// AI author reading this file concludes the platform confines plugins and
+// writes a manifest expecting it). So: `answers`, `registered`, `bound` — ⛔
+// never `enforces`, `denies`, `gates`, `refuses` or `blocks` until the seam
+// exists. The measurement that decides when it does is pinned in
+// `@objectstack/core`'s `granted-permissions-not-enforced.pin.test.ts`, whose
+// negative assertion is repo-wide and covers this file too.
 
 import { describe, it, expect, vi } from 'vitest';
 import { createPluginPermissionEnforcer } from '@objectstack/core';
@@ -87,7 +100,7 @@ describe('#13457 — absent, `{}`, and consented are THREE states, never two', (
         expect(binding.unregistered).toEqual(['com.acme.crm', 'com.acme.reports']);
     });
 
-    it('a `{}` ENTRY is a consent record that consented to nothing — registered, and denies', () => {
+    it('a `{}` ENTRY is a consent record that consented to nothing — registered, and its bag answers NO to everything', () => {
         const e = enforcer();
         const binding = registerArtifactGrantedPermissions(
             artifact({ grantedPermissions: { 'com.acme.crm': {} } }),
@@ -106,7 +119,7 @@ describe('#13457 — absent, `{}`, and consented are THREE states, never two', (
         expect(perms!.canReadFile('/tmp/x')).toBe(false);
     });
 
-    it('a CONSENTED entry enforces exactly the consented surface and nothing beside it', () => {
+    it("a CONSENTED entry's bag ANSWERS yes to exactly the consented surface and nothing beside it", () => {
         const e = enforcer();
         registerArtifactGrantedPermissions(
             artifact({ grantedPermissions: { 'com.acme.crm': CONSENTED } }),


### PR DESCRIPTION
Follow-up to #17753, found by a post-merge sweep rather than by the pin that PR added. ⛔ #17147 stays OPEN — this PR is not its closer.

> ⚠️ Worded this way deliberately. The earlier phrasing put a closing keyword immediately before the number, and GitHub's reference parser matches the keyword plus the number and ignores the negation around it — so on #17753's merge the card was auto-closed as COMPLETED (reopened since; see that PR's body).

Clause-②: no — no new key lands on any published payload. Two test-case titles, one test header note, one widened assertion in a test file, one changeset.

## What the single-file pin missed

#17753's negative assertion read `plugin-permission-enforcer.ts` and checked the retracted sentence was gone from it. It was. But `packages/runtime/src/security/artifact-granted-permissions.test.ts` — the file #13457 added — carried the same phrasing as a **case title**:

> `it('a CONSENTED entry enforces exactly the consented surface and nothing beside it', …)`

next to a sibling titled `… — registered, and denies`.

**Neither case asserts a refusal, and neither could.** Both read a permission bag through `getPluginPermissions` and check what it *answers*; nothing on the tree queries that registry, because `SecurePluginContext` has no production construction site and the fs/network gates have no caller at all. A case title is read as evidence (ADR-0033) — those two told a reader the platform confines plugins, which is exactly the defect #17147 exists to remove, in the one place a `grep` for the *docblock* would never look.

## The fix, and why the pin changes shape

- Both titles now name what they assert: `bag ANSWERS yes to …` / `its bag answers NO to everything`.
- That file's header states the verb discipline out loud: **`answers` / `registered` / `bound`**, ⛔ never `enforces` / `denies` / `gates` / `refuses` / `blocks` until the seam exists — and points at the pin that decides when it does.
- `granted-permissions-not-enforced.pin.test.ts`'s negative assertion becomes a **repo-wide `git grep`** over the same pathspecs as its other sweeps, excluding only its own specimen. The needle is held once as `RETRACTED` so the sweep and the single-file read cannot drift apart.
- **Anti-vacuity limb:** the raw result must still *contain* this file's own specimen, so a scan that is broken or looking at nothing cannot pass as a clean repo — `.filter` alone would hide both.

**Ablated:** restoring the old case title turns the sweep red and names the offending file.

`check:cross-package-test-inputs` still OK (28 packages); `@objectstack/core` `test:repo` and `@objectstack/runtime` `src/security` both green (6 and 141 tests).

## The general lesson, recorded

A text pin that reads **one file** proves that file. This claim lived in six carriers across three repos, and the cheap correct shape was a sweep with an anti-vacuity control from the start.

Refs: #17147 · #13457 · PR #17753

🤖 Generated with [Claude Code](https://claude.com/claude-code)

