### PR TITLE
fix(tooling): count MEMBERS, not directories, in the dispatcher gate's workspace-glob pin

### DIFF
--- a/scripts/check-dispatcher-error-vocabulary.mjs
+++ b/scripts/check-dispatcher-error-vocabulary.mjs
@@ -405,13 +405,19 @@ const PENDING_REGISTRATION_ALLOWANCE = Object.freeze({
  * not red — set well below the 70 measured when this landed.
  *
  * ⚠️ ⛔ THE FLOOR ALONE CANNOT CATCH A LOST GLOB, and saying otherwise would be
- * the same false comfort this gate exists to refuse. Measured on this tree, per
- * workspace glob: `packages/*` 31, `packages/services/*` 16,
- * `packages/plugins/*` 15, `packages/drivers/*` 5, `examples/*` 5,
- * `packages/qa/*` 4, `packages/connectors/*` 4, `packages/apps/*` 3,
- * `packages/triggers/*` 3, `packages/adapters/*` 1, `apps/*` 1 — 88 members
- * before the published filter. Losing the LARGEST glob entirely still leaves 57,
- * comfortably over any floor low enough not to red on ordinary churn — and
+ * the same false comfort this gate exists to refuse. ⭐ The numbers below are
+ * the PUBLISHED population — the one this floor is a floor ON. An earlier
+ * revision of this paragraph counted DIRECTORIES (`packages/*` 31, 88 in all),
+ * which is a different quantity from the one the floor reads, so the margin it
+ * reported flattered the floor by ten. Measured on this tree, per workspace
+ * glob: `packages/*` 23, `packages/services/*` 16, `packages/plugins/*` 15,
+ * `packages/drivers/*` 5, `packages/connectors/*` 4, `packages/apps/*` 3,
+ * `packages/triggers/*` 3, `packages/adapters/*` 1, and `packages/qa/*`,
+ * `apps/*`, `examples/*` 0 each (every member under those three is private) —
+ * 70 published members, out of 80 manifest-carrying member directories and 88
+ * directories before the manifest filter. Losing the LARGEST glob entirely
+ * still leaves 47 — comfortably over any floor low enough not to red on
+ * ordinary churn, but a margin of 7, not the 17 the directory count implied. And
  * `expandWorkspaceGlob` returns `[]` for a glob whose parent directory is gone,
  * SILENTLY. So `packages/*` could vanish, taking `packages/spec` with it, and a
  * floor of 40 would not notice.
@@ -423,7 +429,36 @@ const PENDING_REGISTRATION_ALLOWANCE = Object.freeze({
 const PUBLISHED_SOURCE_FACE_FLOOR = 40;
 
 /**
- * [#16649] Every non-exclusion workspace glob that expands to NOTHING.
+ * [#17145] The expansion this pin means by "member": the directories a glob
+ * resolves to that actually carry a `package.json`.
+ *
+ * ⛔ NOT `expandWorkspaceGlob` raw. Eight of this workspace's 88 directories are
+ * CATEGORY directories holding no manifest at all — all eight under `packages/`:
+ * adapters, apps, connectors, drivers, plugins, qa, services, triggers. So a raw
+ * expansion counts a thing that is not a member and the pin's own message ("NO
+ * member") says something the pin did not measure. The failure that hides in
+ * the gap is the realistic one: members move one level deeper,
+ * `pnpm-workspace.yaml` does not follow, the parent still exists, the glob
+ * still resolves to category directories — and the pin stays quiet while every
+ * member under it has left the published face. Measured before this filter
+ * landed: `content/*` (two directories, neither a member) was accepted silently.
+ *
+ * ⛔ And NOT the PUBLISHED filter either, which would be the wrong correction in
+ * the other direction: three live globs (`packages/qa/*`, `apps/*`,
+ * `examples/*`) enumerate real members of which none is published, so a
+ * published-filtered pin reds on a healthy tree. "Member" is pnpm's word and
+ * the manifest is pnpm's test; publication is the FLOOR's question, below.
+ *
+ * @param {string} root
+ * @param {string} glob
+ * @returns {string[]} repo-relative member directories, unsorted
+ */
+function expandWorkspaceMembers(root, glob) {
+  return expandWorkspaceGlob(root, glob).filter((dir) => existsSync(join(root, dir, 'package.json')));
+}
+
+/**
+ * [#16649] Every non-exclusion workspace glob that expands to NO MEMBER.
  *
  * Zero on this tree, and that is the whole point: a glob expanding to nothing
  * is either a directory that moved without `pnpm-workspace.yaml` following it,
@@ -432,7 +467,9 @@ const PUBLISHED_SOURCE_FACE_FLOOR = 40;
  * cleanup. Both are worth a red, and neither is visible in a member COUNT.
  *
  * `readGlobs` / `expand` are injected so `--self-test` can drive a workspace
- * this repo does not have.
+ * this repo does not have. ⚠️ Every caller that drives it over the LIVE tree
+ * passes {@link expandWorkspaceMembers} — production and `--self-test` reading
+ * two different populations is the defect #17145 carded, not a spare knob.
  */
 export function emptyWorkspaceGlobs({ readGlobs, expand }) {
   return readGlobs()
@@ -5755,21 +5792,45 @@ function selfTest() {
       'an EXCLUSION glob expands to nothing by definition and is not a finding (control)');
     ok(emptyWorkspaceGlobs({
       readGlobs: () => readWorkspaceGlobs(ROOT),
-      expand: (g) => expandWorkspaceGlob(ROOT, g),
+      expand: (g) => expandWorkspaceMembers(ROOT, g),
     }).length === 0,
       'the LIVE workspace has a glob that expands to nothing — the production run refuses on this too');
-    // The measurement that says the floor alone is not enough, held against the
-    // live tree rather than left as a claim in a comment.
+    // [#17145] The same expansion, shown to be the MANIFEST-filtered one and not
+    // the raw directory listing. Without this the two could drift apart again
+    // silently, which is the whole defect: a glob resolving only to category
+    // directories is a lost population, and the raw expansion calls it healthy.
+    ok(expandWorkspaceMembers(ROOT, 'packages/*').length < expandWorkspaceGlob(ROOT, 'packages/*').length,
+      'packages/* resolves to directories that carry no manifest, so the manifest filter is load-bearing here ' +
+        '— if these two ever agree, this case is no longer proving the pin counts members');
+    ok(emptyWorkspaceGlobs({
+      readGlobs: () => ['content/*'],
+      expand: (g) => expandWorkspaceMembers(ROOT, g),
+    }).join(',') === 'content/*',
+      'a LIVE glob resolving only to manifest-less directories (content/blog, content/docs) is reported by ' +
+        'name — before #17145 the raw expansion accepted it silently, which is how members can move one ' +
+        'level deeper with pnpm-workspace.yaml left behind and nothing red');
+    // [#17145] The measurement that says the floor alone is not enough, held
+    // against the live tree — and computed on the PUBLISHED population, which is
+    // the one PUBLISHED_SOURCE_FACE_FLOOR is a floor on. Computing it on
+    // directories (88/31) compares the margin of one quantity against the floor
+    // of another and the agreement is coincidental.
     {
+      const readManifest = (rel) => readFileSync(join(ROOT, rel), 'utf8');
       const perGlob = readWorkspaceGlobs(ROOT)
         .filter((g) => !isExclusionGlob(g))
-        .map((g) => expandWorkspaceGlob(ROOT, g).length);
+        .map((g) => derivePublishedFaces({ dirs: expandWorkspaceMembers(ROOT, g), readManifest }).length);
       const total = perGlob.reduce((a, b) => a + b, 0);
+      // The decomposition has to BE the floor's population, or the margin below
+      // is arithmetic over a set nothing else reads. Two globs overlapping would
+      // double-count here and inflate it; `live` is deduplicated, this is not.
+      ok(total === live.length,
+        `the per-glob published counts sum to ${total} but the live published face enumerates ` +
+          `${live.length} — the margin below would be computed over a population the floor never reads`);
       ok(total - Math.max(...perGlob) > PUBLISHED_SOURCE_FACE_FLOOR,
-        `losing the largest workspace glob would leave ${total - Math.max(...perGlob)} member(s), which is ` +
-          `BELOW the floor of ${PUBLISHED_SOURCE_FACE_FLOOR} — if this ever flips, the floor really would ` +
-          'catch a lost glob and PUBLISHED_SOURCE_FACE_FLOOR\'s docblock is stale. It is asserted in the ' +
-          'direction that keeps the per-glob pin necessary, not in the direction that flatters the floor');
+        `losing the largest workspace glob would leave ${total - Math.max(...perGlob)} published member(s), ` +
+          `which is BELOW the floor of ${PUBLISHED_SOURCE_FACE_FLOOR} — if this ever flips, the floor really ` +
+          'would catch a lost glob and PUBLISHED_SOURCE_FACE_FLOOR\'s docblock is stale. It is asserted in ' +
+          'the direction that keeps the per-glob pin necessary, not in the direction that flatters the floor');
     }
 
     // Registration is the way out: a registered code derives no site at all.
@@ -5899,7 +5960,7 @@ function main() {
   // members than any survivable floor can detect (see PUBLISHED_SOURCE_FACE_FLOOR).
   const emptyGlobs = emptyWorkspaceGlobs({
     readGlobs: () => readWorkspaceGlobs(ROOT),
-    expand: (glob) => expandWorkspaceGlob(ROOT, glob),
+    expand: (glob) => expandWorkspaceMembers(ROOT, glob),
   });
   if (emptyGlobs.length > 0) {
     throw new Error(
@@ -5943,7 +6004,8 @@ function main() {
     `${registered.size} registered codes (${ledger.size} ledger + ${standard.size} standard); ` +
     `${sites.length} unregistered code-stamping site(s) found; ${declared.length} classified.\n` +
     `  [#16649] the published face: ${publishedFaces.length} published member(s), each contributing its ` +
-    `src/ (floor ${PUBLISHED_SOURCE_FACE_FLOOR}, and every workspace glob checked non-empty — the floor ` +
+    `src/ (floor ${PUBLISHED_SOURCE_FACE_FLOOR}, and every workspace glob checked to hold at least one ` +
+    `manifest-carrying member — the floor ` +
     `alone cannot see a lost glob), holding ${publishedSites.length} stamp site(s); plus the stricter ` +
     `spec face, ${specSites.length} site(s) under ${SPEC_SOURCE_FACE}. Every one of them is ` +
     `'foreign-vocabulary' or 'runtime-pinned' — any other verdict there is a finding: those trees ship in ` +


### PR DESCRIPTION
Fixes #17145

`emptyWorkspaceGlobs` expanded each workspace glob with the raw `expandWorkspaceGlob`, which
enumerates **directories**. The floor it exists to supplement, `PUBLISHED_SOURCE_FACE_FLOOR`,
is a floor on `derivePublishedFaces` — **published members**. Two different populations, so the
self-test that justified the pin was green against a quantity nothing else in the file reads,
and the agreement between them was coincidental.

- **Clause-②: no** — this PR puts no new key on any published payload.

## The premise, re-measured on this head

Measured per glob on `e2a68648ee`, all three populations in one command:

| glob | directories | manifest-carrying members | published members |
|:--|--:|--:|--:|
| `packages/*` | 31 | 23 | 23 |
| `packages/services/*` | 16 | 16 | 16 |
| `packages/plugins/*` | 15 | 15 | 15 |
| `packages/drivers/*` | 5 | 5 | 5 |
| `examples/*` | 5 | 5 | 0 |
| `packages/qa/*` | 4 | 4 | 0 |
| `packages/connectors/*` | 4 | 4 | 4 |
| `packages/apps/*` | 3 | 3 | 3 |
| `packages/triggers/*` | 3 | 3 | 3 |
| `packages/adapters/*` | 1 | 1 | 1 |
| `apps/*` | 1 | 1 | 0 |
| **total** | **88** | **80** | **70** |

`derivePublishedFaces` over the whole tree independently returns **70**, the same number the
production run prints. The eight directories that carry no manifest are all under `packages/`:
adapters, apps, connectors, drivers, plugins, qa, services, triggers.

So the margin the self-test asserted was `88 − 31 = 57 > 40` where the floor's own margin is
`70 − 23 = 47 > 40` — a real margin of **7**, not the 17 the docblock claimed. The card's
premise holds in full, and the assertion **still holds** once the populations are made to agree,
so nothing here required moving the floor.

⭐ A reading only counts if a control could have come back the other way. In the same command:
all three totals are non-zero, and the red control below fires.

## What changed

1. **`expandWorkspaceMembers`** — one shared expansion (`expandWorkspaceGlob` filtered by
   `existsSync(package.json)`), used by **both** the production run and the live self-test case,
   so they cannot drift apart again. The pin's message "expand to NO member" is now true of what
   the pin measured.
2. **The margin assertion computes on the published population**, plus a new case pinning that
   the per-glob decomposition **sums to the live published face** — without it, two overlapping
   globs would double-count and inflate the margin over a set nothing else reads.
3. **The floor's docblock carries the published numbers** (`packages/*` 23, total 70, margin 47),
   records the directory reading it replaced, and records that three live globs publish nothing —
   which is the reason the pin filters on the **manifest** and not on publication.

⛔ Deliberately **not** the published filter. Three live globs (`packages/qa/*`, `apps/*`,
`examples/*`) enumerate real members of which none is published, so a published-filtered pin
reds on a healthy tree. "Member" is pnpm's word and the manifest is pnpm's test; publication is
the floor's question. Both readings are now cases in the self-test.

## Ablation — the gate is shown to fail, twice

**Leg 1: the pin.** `content/*` appended to `pnpm-workspace.yaml` (two directories, neither a
member — the shape the card measured as silently accepted):

```
node scripts/check-dispatcher-error-vocabulary.mjs          PROD_EXIT=1
  "pnpm-workspace.yaml declares 1 glob(s) that expand to NO member: content/*"
node scripts/check-dispatcher-error-vocabulary.mjs --self-test   SELFTEST_EXIT=1
```

On the **same** mutated tree, under the pre-fix raw expansion:

```
PRE-FIX  (raw dirs)  empty globs: []            => gate would be GREEN
POST-FIX (manifest)  empty globs: ["content/*"] => gate is RED
non-zero control, content/* raw dirs: 2
```

⇒ the fix is load-bearing; the old gate would have passed either way.

**Leg 2: the population swap.** With `PUBLISHED_SOURCE_FACE_FLOOR` mutated 40 → 47 (the exact
published margin), `main()` stays green (70 ≥ 47) so **only** the assertion moves:

```
SELFTEST_EXIT=1
  "losing the largest workspace glob would leave 47 published member(s), which is BELOW the floor of 47"
pre-fix directory computation at the same floor: total 88, largest 31, margin 57 => GREEN
```

⇒ swapping the population, not merely the pin, is what carries the guarantee.

**Restore, proved by hash, not assumed.** Both legs ran under a `trap ... EXIT INT TERM` with
absolute paths, and both restores were verified against the HEAD blob hash:

```
pnpm-workspace.yaml   HEAD c554761e93 / after c554761e93   RESTORE_BYTE_IDENTICAL=yes
the gate script       HEAD 5f03734933 / after 5f03734933   RESTORE_BYTE_IDENTICAL=yes
git diff HEAD -- pnpm-workspace.yaml : empty
```

`pnpm-workspace.yaml` is **not** in this PR's diff. Leg 2 mutated an already-committed file, so
the restore had a commit to return to.

## The other three items on the card, graded

- **Item 2 (the assertion's population)** — part of the substantive defect, **fixed** above.
- **Item 3 (the docblock's numbers: 31 → 23, 88 → 80/70, 57 → 47)** — **fixed**, and not cosmetic:
  the docblock is the sentence the assertion exists to keep true, so leaving it at the directory
  reading would leave the file asserting one quantity and explaining another.
- **Item 4 (PR #17056's body: the same wrong figures, 80 vs 88 self-contradiction, "five
  precedents" where the head has six, and the claim that the earlier review's 23 was a miscount)**
  — **history, not work**, exactly as the card records it. A merged PR body cannot be rewritten,
  and commit `0292e14f7`'s "31 of 88 members" will not be force-pushed. The card is the correction
  of record; this PR does not widen its diff to chase it.

## Changeset — measured, not assumed: none owed

`skip-changeset`. Nothing published moves:

- **Subject** — `scripts/check-dispatcher-error-vocabulary.mjs` lies under **none** of the 70
  published members (npm packs only from a package root, so no member's `files[]` can reach it),
  and the only package that contains it is the repo root, `@objectstack/spec-monorepo`, which is
  `private: true`.
- **Positive control** — `npm pack --dry-run --json` in `packages/spec` lists **200** shipped
  `src/**/*.zod.ts` entries out of 270, so the instrument does report shipped files.
- **Negative control** — that same list contains **0** test files, though 425 `*.test.ts` exist
  in `packages/spec/src` on disk. The instrument discriminates; it is not answering "yes" to
  everything.
- No published source imports this script; the two references to it under `packages/` are its
  path named in comments (`packages/runtime/src/dispatcher-error-vocabulary.ts`) and in a test's
  comment, neither an import, so no build inlines the changed bytes.

## Verification (all on the pushed head `e2a68648ee`)

- `pnpm check:dispatcher-error-vocabulary` — exit 0; self-test **10 shapes + 351 assertions OK**
  (348 before: the three new cases).
- **32 of 32** derived gate families run, **0 NOT-MEASURED, 0 UNRUN** —
  `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack --ran ...` reconciles with
  every command carrying a recorded exit code, all 0. Derivation re-run after a fresh
  `git fetch origin main`.
- `pnpm exec eslint . --no-inline-config --format json` over the **whole repo** — exit 0,
  **6639 files**, 0 errors, 0 warnings. The union, not a narrowing.
- Control-character self-scan on the changed file: no matches, with the probe lit on a planted
  0x0B to prove the grep fires.
- No card relation in the commit message (`check:commit-card-trailers` green at pre-push; bare
  stems counted separately — the one `fix` hit is the `fix(tooling)` conventional prefix, and the
  message contains zero `#NNN` tokens).

---
_Generated by [Claude Code](https://claude.ai/code/session_01MkQhmuuJAVDjmeWNixwDDH)_