### PR TITLE
docs(spec): `navigation.view` stops promising a view selection nothing performs

### DIFF
--- a/.changeset/16885-navigation-view-declared-not-resolved.md
+++ b/.changeset/16885-navigation-view-declared-not-resolved.md
@@ -1,0 +1,45 @@
+---
+'@objectstack/spec': patch
+---
+
+`ListViewSchema.navigation.view`'s description stops promising view selection the stack never performs
+
+`NavigationConfigSchema.view` described itself as *"Name of the form view to use
+for details (e.g. `summary_view`, `edit_form`)"*. Measured against
+`@objectstack/spec` source and the `objectui` checkout this repo pins in
+`.objectui-sha`, no reader resolves an authored view name:
+
+- The key's **only** read is `useNavigationOverlay`
+  (`packages/react/src/hooks/useNavigationOverlay.ts`). It binds
+  `const view = navigation?.view` and then passes that string as the **second
+  argument of `onNavigate`** — the slot whose other producers are navigation
+  **mode** tokens (`'new_window'`, and the `'view'` literal the `??` supplies).
+- The hook also re-exports it on `NavigationOverlayState.view`, and **no
+  consumer reads that member** — while its siblings on the same returned object
+  (`width`, `isOverlay`, `mode`, `selectedRecord`) are read at roughly twenty
+  sites, which is the lit control that makes the zero a reading.
+- Every `formViews` read in that tree is `formViews?.default`. None is keyed by
+  an authored view name, so no resolution path exists for this key to reach.
+- One shipped consumer types that second argument `'view' | 'edit'` and
+  branches on both with **no fallback arm**, so an authored name there matches
+  neither branch and the row click does nothing.
+
+The key is therefore worse than ignored: the value travels, and it lands in a
+slot that means something else. The description now says that, carries the
+repo's existing `[EXPERIMENTAL — not enforced]` marker, and tells authors to
+leave the key unset.
+
+⛔ **No accept set moves.** `view` is still `z.string().optional()`; every
+document that parsed before parses now, with identical issues and identical
+output. Nothing is retired, renamed, constrained, or newly resolved — the
+enforce-or-remove decision (ADR-0049) is still open on #16885, and this change
+deliberately does not take it.
+
+**This is shipped, which is why it carries a changeset rather than
+`skip-changeset`.** `@objectstack/spec`'s published `files[]` ships both `dist`
+and `src/**/*.zod.ts`. Measured on the rebuilt artifact: the corrected sentence
+is present in 22 built bundles and in the published source file, the old
+sentence is absent from all of them, a sibling `describe()` that ships
+(`Disable standard navigation entirely`) lit the same probe at 22 as the
+positive control, and a test-only `it()` title lit `src` but not `dist` as the
+negative control.

--- a/content/docs/references/ui/view.mdx
+++ b/content/docs/references/ui/view.mdx
@@ -914,7 +914,7 @@ View filter rule
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | **mode** | `Enum<'page' \| 'drawer' \| 'modal' \| 'split' \| 'popover' \| 'new_window' \| 'none'>` | optional (default: `"page"`) |  |
-| **view** | `string` | optional | Name of the form view to use for details (e.g. "summary_view", "edit_form") |
+| **view** | `string` | optional | [EXPERIMENTAL — not enforced] Intended as the name of a form view to open for details (e.g. "summary_view", "edit_form"), but no reader resolves an authored view name: the one read forwards this string into the renderer's navigation-ACTION argument (the slot that otherwise carries the mode token), where a consumer with a closed action vocabulary matches no branch and the row click does nothing. Authoring it selects no view — leave it unset until enforce-or-remove (ADR-0049) is decided for this key. |
 | **preventNavigation** | `boolean` | optional (default: `false`) | Disable standard navigation entirely |
 | **openNewTab** | `boolean` | optional (default: `false`) | Force open in new tab (applies to page mode) |
 | **size** | `Enum<'auto' \| 'sm' \| 'md' \| 'lg' \| 'xl' \| 'full'>` | optional (default: `"auto"`) | Overlay size bucket for drawer/modal detail: 'auto' (default — renderer derives from field count + viewport; AI writes nothing) or a coarse override sm/md/lg/xl/full. Prefer this over the pixel `width`; page mode ignores it. |
@@ -1159,7 +1159,7 @@ Tab configuration for multi-tab view interface
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | **mode** | `Enum<'page' \| 'drawer' \| 'modal' \| 'split' \| 'popover' \| 'new_window' \| 'none'>` | optional (default: `"page"`) |  |
-| **view** | `string` | optional | Name of the form view to use for details (e.g. "summary_view", "edit_form") |
+| **view** | `string` | optional | [EXPERIMENTAL — not enforced] Intended as the name of a form view to open for details (e.g. "summary_view", "edit_form"), but no reader resolves an authored view name: the one read forwards this string into the renderer's navigation-ACTION argument (the slot that otherwise carries the mode token), where a consumer with a closed action vocabulary matches no branch and the row click does nothing. Authoring it selects no view — leave it unset until enforce-or-remove (ADR-0049) is decided for this key. |
 | **preventNavigation** | `boolean` | optional (default: `false`) | Disable standard navigation entirely |
 | **openNewTab** | `boolean` | optional (default: `false`) | Force open in new tab (applies to page mode) |
 | **size** | `Enum<'auto' \| 'sm' \| 'md' \| 'lg' \| 'xl' \| 'full'>` | optional (default: `"auto"`) | Overlay size bucket for drawer/modal detail: 'auto' (default — renderer derives from field count + viewport; AI writes nothing) or a coarse override sm/md/lg/xl/full. Prefer this over the pixel `width`; page mode ignores it. |
@@ -1310,7 +1310,7 @@ View filter rule
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | **mode** | `Enum<'page' \| 'drawer' \| 'modal' \| 'split' \| 'popover' \| 'new_window' \| 'none'>` | optional (default: `"page"`) |  |
-| **view** | `string` | optional | Name of the form view to use for details (e.g. "summary_view", "edit_form") |
+| **view** | `string` | optional | [EXPERIMENTAL — not enforced] Intended as the name of a form view to open for details (e.g. "summary_view", "edit_form"), but no reader resolves an authored view name: the one read forwards this string into the renderer's navigation-ACTION argument (the slot that otherwise carries the mode token), where a consumer with a closed action vocabulary matches no branch and the row click does nothing. Authoring it selects no view — leave it unset until enforce-or-remove (ADR-0049) is decided for this key. |
 | **preventNavigation** | `boolean` | optional (default: `false`) | Disable standard navigation entirely |
 | **openNewTab** | `boolean` | optional (default: `false`) | Force open in new tab (applies to page mode) |
 | **size** | `Enum<'auto' \| 'sm' \| 'md' \| 'lg' \| 'xl' \| 'full'>` | optional (default: `"auto"`) | Overlay size bucket for drawer/modal detail: 'auto' (default — renderer derives from field count + viewport; AI writes nothing) or a coarse override sm/md/lg/xl/full. Prefer this over the pixel `width`; page mode ignores it. |

--- a/packages/spec/src/ui/view.zod.ts
+++ b/packages/spec/src/ui/view.zod.ts
@@ -1595,8 +1595,24 @@ export const NavigationConfigSchema = lazySchema(() => strictObject({
 }, {
   mode: NavigationModeSchema.default('page'),
   
-  /** Target View Config */
-  view: z.string().optional().describe('Name of the form view to use for details (e.g. "summary_view", "edit_form")'),
+  /**
+   * [#16885] Target view config — DECLARED, NOT RESOLVED. The name promises
+   * view selection; nothing in the stack performs it. Measured at
+   * `.objectui-sha`: the single read is `useNavigationOverlay`
+   * (`packages/react/src/hooks/useNavigationOverlay.ts`), which passes the
+   * string as the SECOND argument of `onNavigate` — the slot whose other
+   * producers are mode tokens (`'new_window'`, `'view'`) — and re-exports it
+   * on `NavigationOverlayState.view`, which no consumer reads. Every
+   * `formViews` read in that tree is `formViews?.default`; none is keyed by
+   * an authored view name, so there is no path by which this could resolve.
+   * One shipped consumer types that argument `'view' | 'edit'` with no
+   * fallback branch, so an authored name there is a dead row click.
+   *
+   * Enforce-or-remove (ADR-0049) is undecided — #16885 carries the
+   * measurement. This description is corrected, not the accept set: the key
+   * still parses exactly as before.
+   */
+  view: z.string().optional().describe('[EXPERIMENTAL — not enforced] Intended as the name of a form view to open for details (e.g. "summary_view", "edit_form"), but no reader resolves an authored view name: the one read forwards this string into the renderer\'s navigation-ACTION argument (the slot that otherwise carries the mode token), where a consumer with a closed action vocabulary matches no branch and the row click does nothing. Authoring it selects no view — leave it unset until enforce-or-remove (ADR-0049) is decided for this key.'),
   
   /** Interaction Triggers */
   preventNavigation: z.boolean().default(false).describe('Disable standard navigation entirely'),


### PR DESCRIPTION
Part of #16885 — this round is **measure-and-report**. Both repairs triage named (honour `view`, or retire it under ADR-0049) are out of bounds for it, so the card stays open.

- **Clause-②: no** — this PR puts no new key on any published payload.

## What this changes

One `.describe()` string on `NavigationConfigSchema.view`, plus the three generated reference-doc rows that project from it, plus a changeset.

⛔ **No accept set moves.** `view` is still `z.string().optional()`. Every document that parsed before parses now, with identical issues and identical output. Nothing is retired, renamed, constrained, or newly resolved.

## The measurement

Declaration — `packages/spec/src/ui/view.zod.ts`, `NavigationConfigSchema` (unique in non-built source: `preventNavigation` occurs exactly once outside `dist/`, at that block).

Reads — re-measured against **source**, not the bundle the card quoted. Repo-local: zero (`git grep` over tracked files excluding `**/dist/**`; lit control — `navigation.mode` occurs 5×). `objectui` at the sha this repo pins in `.objectui-sha` (`53ded82b`, read with `git show SHA:PATH`; `dist/` is untracked at that sha, so the reading is reproducible):

| probe | result | control |
| :--- | :--- | :--- |
| `navigation?.view` read | **1** — `packages/react/src/hooks/useNavigationOverlay.ts:245` | `navigation?.mode` / `preventNavigation` / `openNewTab`: 13 sites |
| consumers of the hook's returned `.view` | **0** | siblings `width` / `isOverlay` / `mode` on the same returned object: ~20 sites |
| `formViews` read keyed by an authored view name | **0** — every read is `formViews?.default` | `formViews` reads overall: 23 sites |

The one read binds `const view = navigation?.view` and then passes it as the **second argument of `onNavigate`** at two branches (`:287` no-config, `:320` `page`) — the slot whose other producers in the same function are mode tokens (`onNavigate(id, 'new_window')` at `:278` and `:301`).

**A consumer with a closed vocabulary on that argument exists.** `packages/app-shell/src/views/ObjectView.tsx:2540` types it `(recordId: string | number, mode: 'view' | 'edit')` and branches on both values **with no fallback arm** — an authored name matches neither and the row click does nothing. The sibling consumer at `:1957` tolerates anything non-`new_window`, which is why the effect is invisible on some surfaces.

Authored instances in this repo — **zero**, and the space is not vacuous: `ListViewSchema.navigation` is set **nowhere** in-tree (every object-form `navigation: {` in tracked files, 21 sites, is an i18n translation map). The scanner was proven on a synthetic fixture that lights for both `view` and `mode` before that zero was accepted.

## Which exit triage's two the measurement supports

**Undetermined on the repair — and that is the finding.** Both exits keep live evidence, neither is discharged:

- *Meant to name a form view.* The declaration does not merely hint through the key's name — it **states the intent in a sentence**: "Name of the form view to use for details (e.g. `summary_view`, `edit_form`)", under a `/** Target View Config */` comment. Downstream, `useNavigationOverlay` promotes `view` to a first-class member of `NavigationOverlayState`, which reads as a slot built for renderers and never wired. And a maintainer comment at `ObjectView.tsx:1968` describes the forwarding path in so many words.
- *Residue to retire.* No resolution step exists anywhere, at any layer. No lint rule guards it (`lint-view-refs` resolves **app navigation `viewName` → `listViews`**, a different key on a different surface). The spec `CHANGELOG` never mentions it, while the sibling `size` work is mentioned 3×.

⚠️ One piece of apparent counter-evidence, read at the site rather than counted: `objectui`'s `view-navigation-config-spec-parity.test.ts:139` asserts `site.navigation?.view === 'summary_view'`. It uses `{ view: 'summary_view' }` only as a convenient **mode-less** config to pin type parity — it asserts the key is *accepted*, never that it *resolves*.

⇒ Choosing between them is the seat's act: honouring `view` is new capability, retiring it narrows a published schema. This PR takes neither.

## Verification

At `bec4767c` (the final commit).

- `pnpm --filter @objectstack/spec build` → `VERDICT command-exit 0` (shared verify lock), then `build-docs.ts` → `✅ Generated 222 files`.
- Gate families run green, each read from the gate's own verdict line: spec `check:authorable-surface` · `check:docs` · `check:generated` · `check:liveness` · `check:api-surface` · `check:skill-refs` · `check:skill-examples` · `check:llms-txt` · `check:variant-docs` · `check:empty-state` · `check:strictness-ledger` · `check:objectui-pin-citations` · `check:export-origins` · `check:duration-unit-keys` · `check:exported-any` · `check:dual-source-exports` · `check:entry-nameability` · `check:yaml-examples` · `check:browser-reachable-entries`; repo `check:doc-authoring` · `check:doc-anchors` · `check:docs-single-h1` · `check:docs-spec-enumerations` · `check:docs-audit-scope` · `check:docs-redirects` · `check:docs-transcript-drift` · `check:nul-bytes` · `check:quick-reference-counts` · `check:corpus-claim-drift` · `check:published-files` · `check:org-identifier` · `check:role-word` · `check:slot-lookup` · `check:watch-hint-literal` · `check:spec-parsed-alias` · `check:page-declaration-shape` · `check:pm-widening-tells` · `check:skill-identifier-liveness` · `check:published-readme-links` · `check:type-source-resolution` · `check:test-source-alias` · `check:cross-package-test-inputs` · `check-adr-0087-registration --base origin/main` · `check-changeset-no-major --base origin/main` · `check-closing-keyword-parity` · `check-comment-mask-adoption` · `check-comment-mask-corpus` · `check-registry-log-declared` · `check-section-landing-index` · `check-plugin-teardown-shape` · `check-platform-object-tenancy-census` · `check-reference-carrier-shape` · `check-ci-filter-parity` · `check-affected-docs` · `check-undeclared-dep-imports` · `check-system-context-census`.
- `pnpm --filter @objectstack/spec typecheck` → exit 0. Targeted tests `src/ui/view.test.ts` + `src/ui/interaction-config-retirement.test.ts` → **373 passed**.
- `eslint . --no-inline-config` over the whole repo → exit 0, no output. ⭐ Not a narrowing: the repo-level scan actually ran at this head, so no ratchet reading is deferred.
- `check:doc-authoring` caught a real defect mid-round: the first draft of the description carried the card id, which that gate forbids inside `.describe()` prose because the prose projects into published docs where the citation resolves to nothing. The id was moved to the adjacent TSDoc block and the gate went green.

**Changeset — measured, not assumed.** Owed. `@objectstack/spec`'s published `files[]` ships both `dist` and `src/**/*.zod.ts`. On the rebuilt artifact the corrected sentence is present in **22** built bundles and in the published source file; the old sentence is absent from **all** of them. Positive control: a sibling shipped `describe()` (`Disable standard navigation entirely`) lit the same probe at 22. Negative control: a test-only `it()` title lit `src` at 1 and `dist` at 0.

## 验收备注

- `noted, not filed` — the liveness ledger classifies `view/list/navigation` as **one `live` row with no `children`**, so its six sub-keys (`mode`, `view`, `preventNavigation`, `openNewTab`, `size`, `width`) are classified nowhere and `navigation.view` inherits `live` from its container. It is also absent from `undrilled-containers.baseline.json`, whose own `_containers` note claims to record every such gap. This is not a new card: it is exactly the defect **#17424** already describes (*"`check-liveness` drills exactly ONE level"*), whose stated fix includes migrating that baseline. **承接者: #17424** — `navigation.view` is a concrete, measured casualty for that round to cite.
- `noted, not filed` — `ObjectView.tsx:1968` (objectui, pinned sha) tells the next reader that a forwarded `navigation.view` name is *"resolved by RecordDetailView from its own config"*. RecordDetailView does resolve from its own config, but the forwarded name is dropped before it: the handler navigates to `record/:id` carrying only an `originState.from`. The sentence is therefore true about RecordDetailView and misleading about the name. **承接者: 无** in this repo — it is a comment in the read-only pinned checkout, and it belongs to whichever exit #16885 takes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MkQhmuuJAVDjmeWNixwDDH)_