### PR TITLE
feat(spec): an app-declared capability token is not a platform system permission at the everyone anchor

### DIFF
--- a/.changeset/17189-app-capability-not-high-privilege.md
+++ b/.changeset/17189-app-capability-not-high-privilege.md
@@ -56,8 +56,26 @@ Both halves are phase ①; ⛔ neither lands without the other following.
 
 **This is shipped, which is why it carries a changeset rather than
 `skip-changeset`.** `@objectstack/spec`'s published `files[]` ships `dist`, and
-the new code reaches it — `declaredCapabilities` and `appDeclaredCapabilityNames`
-each occur in 2 built files under `packages/spec/dist` after the build, with
-`describeHighPrivilegeBits` itself at 2 as the positive control that ships. The
-ADR half does not ship: a phrase unique to the revision note occurs in 0 built
-files, and `docs/adr/**` is in no package's `files[]`.
+the new code reaches it.
+
+Counts below are taken on a **clean full build of this head** — an empty `dist`,
+then `pnpm --filter @objectstack/spec build` with both passes (JS and DTS): exit
+0, `check-dts-emitted` reporting 34/34 declaration files, and
+`dist/.build-input-hash` and `.build-input-hash-dts` both matching `src`. The
+build state is named because it changes the answer: on a JS-only `dist` — one
+still mid-DTS, or built under `OS_SKIP_DTS` — every declaration file is missing
+and each count below that reaches one is halved.
+
+| identifier | built files | where |
+|---|---|---|
+| `declaredCapabilities` | **4** | `security/index.js`, `index.mjs`, `index.d.ts`, `index.d.mts` |
+| `AnchorBindingContext` | **2** | `index.d.ts`, `index.d.mts` — a type, so the declarations are its whole published reach |
+| `appDeclaredCapabilityNames` | **2** | `index.js`, `index.mjs` — module-private, so it has no declaration presence at all |
+| `describeHighPrivilegeBits` | **4** | the positive control: a symbol already known to ship |
+
+Negative control: a sentence occurring **only** in the ADR revision — `As first
+written, the bullet above made` — occurs in **0** built files, and `docs/adr/**`
+is in no package's `files[]`. ⚠️ The control has to be a sentence the source
+does not also carry: `The platform floor is absolute` reads 2, not 0, because
+that sentence is in this predicate's JSDoc as well as in the ADR, and an emitted
+JSDoc reaches `index.d.ts` / `index.d.mts` like any other declaration text.

--- a/.changeset/17189-app-capability-not-high-privilege.md
+++ b/.changeset/17189-app-capability-not-high-privilege.md
@@ -1,0 +1,62 @@
+---
+'@objectstack/spec': minor
+---
+
+feat(spec): an app-declared capability token is not a platform system permission at the `everyone` anchor
+
+`describeHighPrivilegeBits` counted **any** non-empty `systemPermissions` as a
+high-privilege bit, so a permission set carrying the capability token its own
+app declared could not be bound to the `everyone` audience anchor:
+
+```
+FROM  describeHighPrivilegeBits({ systemPermissions: ['clm_requester.access'] })
+      -> 'system permissions'        // the app's own navigation gate, refused
+TO    describeHighPrivilegeBits({ systemPermissions: ['clm_requester.access'] },
+                                { declaredCapabilities: ['clm_requester.access'] })
+      -> null
+```
+
+One list carries two unlike things: the platform's own powers (`manage_users`
+and friends) and a capability a package **declared for itself** (ADR-0066 D1,
+entering `sys_capability` with `managed_by: 'package'` + `package_id`
+provenance). An app whose navigation gates on its own token therefore could not
+ship the set every employee holds — the set's own gate made it unbindable — and
+authors were pushed toward declaring no gates at all, the opposite of what
+ADR-0066 D1 exists to encourage.
+
+**The discriminator is provenance, not spelling.** Both predicates
+(`describeHighPrivilegeBits`, `describeAnchorForbiddenBits`) take a new optional
+`AnchorBindingContext` naming the capability names *this stack declared*; a
+token on that list is the app's own gate and is not counted. ⛔ A naming-syntax
+rule (dotted ⇒ app token) was considered and rejected: it misjudges in silence
+the first dotted platform permission — `setup.access` is one today — and the
+first undotted app token.
+
+**What is still refused**, each pinned in `high-privilege.test.ts`:
+
+- a platform capability name, **however it is declared** — a package declaring
+  `manage_users` cannot launder it past the gate (the platform floor);
+- any token absent from the declared list, and every token when no list is
+  passed — omission gets the pre-change verdict, so the narrowing fails closed;
+- a mixed set: one unexcused token still refuses the whole set;
+- the `guest` tier (ADR-0090 D9), which does not honour the excusal at all —
+  D5 speaks for authenticated members, and anonymous visitors are not that.
+
+**No shipped behaviour moves in this release.** Every current caller invokes the
+predicates with the old arity, and with no context the code path is identical —
+so this release widens the API, not any live anchor binding. The
+`@objectstack/plugin-security` boot refusal and the `@objectstack/lint`
+`security-anchor-high-privilege` rule pass the declared list in a follow-up, in
+the ruled order (protocol first).
+
+ADR-0090 D5's offending-bit list is revised to match, in the same PR: the
+offending bit is a `systemPermissions` entry naming a **platform** system
+permission.
+
+**This is shipped, which is why it carries a changeset rather than
+`skip-changeset`.** `@objectstack/spec`'s published `files[]` ships `dist`, and
+the new code reaches it — `declaredCapabilities` and `appDeclaredCapabilityNames`
+each occur in 2 built files under `packages/spec/dist` after the build, with
+`describeHighPrivilegeBits` itself at 2 as the positive control that ships. The
+ADR half does not ship: a phrase unique to the revision note occurs in 0 built
+files, and `docs/adr/**` is in no package's `files[]`.

--- a/.changeset/17189-app-capability-not-high-privilege.md
+++ b/.changeset/17189-app-capability-not-high-privilege.md
@@ -49,9 +49,10 @@ so this release widens the API, not any live anchor binding. The
 `security-anchor-high-privilege` rule pass the declared list in a follow-up, in
 the ruled order (protocol first).
 
-ADR-0090 D5's offending-bit list is revised to match, in the same PR: the
-offending bit is a `systemPermissions` entry naming a **platform** system
-permission.
+ADR-0090 D5's offending-bit list is revised to match in its own governed PR
+(objectstack#17814), per the ruling's 「ADR-0090 修订单独受管 PR」: the offending
+bit is a `systemPermissions` entry naming a **platform** system permission.
+Both halves are phase ①; ⛔ neither lands without the other following.
 
 **This is shipped, which is why it carries a changeset rather than
 `skip-changeset`.** `@objectstack/spec`'s published `files[]` ships `dist`, and

--- a/docs/adr/0090-permission-model-v2-concept-convergence.md
+++ b/docs/adr/0090-permission-model-v2-concept-convergence.md
@@ -237,53 +237,8 @@ Replaces both the `member_default` builtin-set fallback and ADR-0056 D7's defaul
   install-time prompt ("CRM suggests adding `crm_readonly` to Everyone — accept?"). It is **never**
   auto-bound: installing a package must not silently widen every tenant user's access.
 - **Lint (D7) hard-blocks high-privilege bits on `everyone` bindings**: `viewAllRecords`,
-  `modifyAllRecords`, `allowDelete`, `allowPurge`, `allowTransfer`, and a `systemPermissions`
-  entry naming a **platform** system permission are rejected (or force a break-glass
-  confirmation) on any set bound to `everyone`. An **app-declared capability token** — one a
-  package declared for itself under ADR-0066 D1, entering `sys_capability` with
-  `managed_by: 'package'` + `package_id` provenance — is **not** an offending bit: it gates
-  only what that same package's own resources require of it, so conferring it on the
-  authenticated audience widens nothing the package did not itself define. See the revision
-  note below.
-
-> **Revision (2026-09-12, #17189) — the offending bit is a `systemPermissions` entry naming a
-> PLATFORM permission, not `systemPermissions` at all.** [ruled]
->
-> As first written, the bullet above made **any** non-empty `systemPermissions` an offending bit,
-> and `describeHighPrivilegeBits` (`@objectstack/spec/security`) implemented it literally.
-> `systemPermissions` carries two unlike kinds of token, though: the platform's own powers
-> (`manage_users` and friends), and a capability a package **declared for itself** (ADR-0066 D1).
-> An app whose navigation gates on its own token therefore could not ship the set every employee
-> holds — the set's own gate made it unbindable to `everyone` — so the app was pushed toward
-> declaring no gates at all, the opposite of what ADR-0066 D1 exists to encourage. Reported by a
-> named downstream consumer that had to fall back to binding its baseline set to each position by
-> hand, plus one manual grant per new hire, indefinitely.
->
-> **What changed**: an offending `systemPermissions` bit is one naming a platform system
-> permission. A token this stack declared as a package capability is not counted. Three boundaries
-> hold the narrowing, and each fails closed:
->
-> 1. **The platform floor is absolute.** A platform capability name stays high-privilege however it
->    is declared, so a package cannot launder `manage_users` past the anchor gate by declaring a
->    capability of that name.
-> 2. **The discriminator is provenance, never spelling.** The predicate is *told* which names this
->    stack declared; it never infers "app token" from the shape of a name. ⛔ A naming-syntax rule
->    (dotted ⇒ app token) was considered and rejected: it misjudges in silence the first dotted
->    platform permission — `setup.access` is one today — and the first undotted app token.
-> 3. **Omission refuses.** A caller that cannot enumerate the stack's declarations gets the
->    pre-revision verdict, so a missing input narrows nothing.
->
-> **`guest` is untouched.** D9's strictest tier keeps refusing any non-empty `systemPermissions`:
-> D5 speaks for authenticated members, and conferring an app's own gate on anonymous visitors is a
-> different act, not decided here.
->
-> Ruling: director seat, batch #110, 2026-09-10 — option (i), the predicate takes the declared
-> capability list as an input. The landing order is the maintainer's, verbatim:
-> 「我们的项目以objectstack 协议为准，文档应该以实际实现为准。协议不正确的应该先修改协议。」
-> ⇒ this revision and the `packages/spec` predicate land first; the `plugin-security` boot refusal
-> and the `@objectstack/lint` `security-anchor-high-privilege` rule follow. Until those callers
-> supply the declared list they keep the pre-revision behaviour — the predicate's default — so the
-> narrowing reaches a binding only where a caller can name what this stack declared.
+  `modifyAllRecords`, `allowDelete`, `allowPurge`, `allowTransfer`, and `systemPermissions` are
+  rejected (or force a break-glass confirmation) on any set bound to `everyone`.
 
 ### D6 — Explain engine is P0; access-matrix snapshots gate publishes
 

--- a/docs/adr/0090-permission-model-v2-concept-convergence.md
+++ b/docs/adr/0090-permission-model-v2-concept-convergence.md
@@ -237,8 +237,53 @@ Replaces both the `member_default` builtin-set fallback and ADR-0056 D7's defaul
   install-time prompt ("CRM suggests adding `crm_readonly` to Everyone — accept?"). It is **never**
   auto-bound: installing a package must not silently widen every tenant user's access.
 - **Lint (D7) hard-blocks high-privilege bits on `everyone` bindings**: `viewAllRecords`,
-  `modifyAllRecords`, `allowDelete`, `allowPurge`, `allowTransfer`, and `systemPermissions` are
-  rejected (or force a break-glass confirmation) on any set bound to `everyone`.
+  `modifyAllRecords`, `allowDelete`, `allowPurge`, `allowTransfer`, and a `systemPermissions`
+  entry naming a **platform** system permission are rejected (or force a break-glass
+  confirmation) on any set bound to `everyone`. An **app-declared capability token** — one a
+  package declared for itself under ADR-0066 D1, entering `sys_capability` with
+  `managed_by: 'package'` + `package_id` provenance — is **not** an offending bit: it gates
+  only what that same package's own resources require of it, so conferring it on the
+  authenticated audience widens nothing the package did not itself define. See the revision
+  note below.
+
+> **Revision (2026-09-12, #17189) — the offending bit is a `systemPermissions` entry naming a
+> PLATFORM permission, not `systemPermissions` at all.** [ruled]
+>
+> As first written, the bullet above made **any** non-empty `systemPermissions` an offending bit,
+> and `describeHighPrivilegeBits` (`@objectstack/spec/security`) implemented it literally.
+> `systemPermissions` carries two unlike kinds of token, though: the platform's own powers
+> (`manage_users` and friends), and a capability a package **declared for itself** (ADR-0066 D1).
+> An app whose navigation gates on its own token therefore could not ship the set every employee
+> holds — the set's own gate made it unbindable to `everyone` — so the app was pushed toward
+> declaring no gates at all, the opposite of what ADR-0066 D1 exists to encourage. Reported by a
+> named downstream consumer that had to fall back to binding its baseline set to each position by
+> hand, plus one manual grant per new hire, indefinitely.
+>
+> **What changed**: an offending `systemPermissions` bit is one naming a platform system
+> permission. A token this stack declared as a package capability is not counted. Three boundaries
+> hold the narrowing, and each fails closed:
+>
+> 1. **The platform floor is absolute.** A platform capability name stays high-privilege however it
+>    is declared, so a package cannot launder `manage_users` past the anchor gate by declaring a
+>    capability of that name.
+> 2. **The discriminator is provenance, never spelling.** The predicate is *told* which names this
+>    stack declared; it never infers "app token" from the shape of a name. ⛔ A naming-syntax rule
+>    (dotted ⇒ app token) was considered and rejected: it misjudges in silence the first dotted
+>    platform permission — `setup.access` is one today — and the first undotted app token.
+> 3. **Omission refuses.** A caller that cannot enumerate the stack's declarations gets the
+>    pre-revision verdict, so a missing input narrows nothing.
+>
+> **`guest` is untouched.** D9's strictest tier keeps refusing any non-empty `systemPermissions`:
+> D5 speaks for authenticated members, and conferring an app's own gate on anonymous visitors is a
+> different act, not decided here.
+>
+> Ruling: director seat, batch #110, 2026-09-10 — option (i), the predicate takes the declared
+> capability list as an input. The landing order is the maintainer's, verbatim:
+> 「我们的项目以objectstack 协议为准，文档应该以实际实现为准。协议不正确的应该先修改协议。」
+> ⇒ this revision and the `packages/spec` predicate land first; the `plugin-security` boot refusal
+> and the `@objectstack/lint` `security-anchor-high-privilege` rule follow. Until those callers
+> supply the declared list they keep the pre-revision behaviour — the predicate's default — so the
+> narrowing reaches a binding only where a caller can name what this stack declared.
 
 ### D6 — Explain engine is P0; access-matrix snapshots gate publishes
 

--- a/packages/spec/api-surface/security.json
+++ b/packages/spec/api-surface/security.json
@@ -10,6 +10,7 @@
     "AdminScope (type)",
     "AdminScopeParsed (type)",
     "AdminScopeSchema (const)",
+    "AnchorBindingContext (interface)",
     "AuthzPosture (type)",
     "AuthzPostureSchema (const)",
     "CapabilityDeclaration (type)",

--- a/packages/spec/export-origins/security.json
+++ b/packages/spec/export-origins/security.json
@@ -10,6 +10,7 @@
     "AdminScope": "src/security/permission.zod.ts#AdminScope (type)",
     "AdminScopeParsed": "src/security/permission.zod.ts#AdminScopeParsed (type)",
     "AdminScopeSchema": "src/security/permission.zod.ts#AdminScopeSchema (const)",
+    "AnchorBindingContext": "src/security/high-privilege.ts#AnchorBindingContext (interface)",
     "AuthzPosture": "src/security/explain.zod.ts#AuthzPosture (type)",
     "AuthzPostureSchema": "src/security/explain.zod.ts#AuthzPostureSchema (const)",
     "CapabilityDeclaration": "src/security/capabilities.ts#CapabilityDeclaration (type)",

--- a/packages/spec/src/security/high-privilege.test.ts
+++ b/packages/spec/src/security/high-privilege.test.ts
@@ -1,0 +1,164 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * [#17189] `systemPermissions` carries two unlike kinds of token, and only one
+ * of them may block an `everyone` anchor binding (ADR-0090 D5).
+ *
+ * Every acceptance below is paired with the SAME definition judged without the
+ * declaration list, which refuses — so no pin here can pass because the
+ * predicate went blind. The platform floor is pinned against
+ * `PLATFORM_CAPABILITY_NAMES` itself rather than a transcribed name, so a
+ * renamed platform capability cannot leave the floor testing nothing.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { PLATFORM_CAPABILITY_NAMES } from './capabilities';
+import { describeHighPrivilegeBits, describeAnchorForbiddenBits } from './high-privilege';
+
+/** The app token from the filing consumer: declared by the app, gates its own nav. */
+const APP_TOKEN = 'clm_requester.access';
+/** A platform system permission — the other kind. */
+const PLATFORM_TOKEN = 'manage_users';
+/**
+ * A platform capability that is spelled like an app token (dotted). It is the
+ * reason the discriminator may not be a spelling rule: a name-shape heuristic
+ * would hand this one to `everyone`.
+ */
+const DOTTED_PLATFORM_TOKEN = 'setup.access';
+
+describe('describeHighPrivilegeBits — app-declared capability vs platform system permission (#17189)', () => {
+  it('pins the platform names this suite reasons about (else the floor tests nothing)', () => {
+    expect(PLATFORM_CAPABILITY_NAMES.has(PLATFORM_TOKEN)).toBe(true);
+    expect(PLATFORM_CAPABILITY_NAMES.has(DOTTED_PLATFORM_TOKEN)).toBe(true);
+    // The app token must NOT be a platform capability, or "newly accepted"
+    // below would be measuring the floor instead of the excusal.
+    expect(PLATFORM_CAPABILITY_NAMES.has(APP_TOKEN)).toBe(false);
+  });
+
+  // ---- STILL REFUSED: the pre-#17189 verdict is the default ----
+
+  it('still refuses an app token when no declaration list is supplied', () => {
+    expect(describeHighPrivilegeBits({ systemPermissions: [APP_TOKEN] })).toMatch(/system permissions/);
+    expect(describeHighPrivilegeBits({ systemPermissions: [APP_TOKEN] }, {})).toMatch(/system permissions/);
+    expect(describeHighPrivilegeBits({ systemPermissions: [APP_TOKEN] }, { declaredCapabilities: [] }))
+      .toMatch(/system permissions/);
+  });
+
+  it('still refuses a token this stack did not declare', () => {
+    expect(
+      describeHighPrivilegeBits({ systemPermissions: ['other_app.access'] }, { declaredCapabilities: [APP_TOKEN] }),
+    ).toMatch(/system permissions/);
+  });
+
+  // ---- NEWLY ACCEPTED: a token the stack declared is the app's own gate ----
+
+  it('accepts a set whose only system permission is a capability this stack declared', () => {
+    expect(
+      describeHighPrivilegeBits({ systemPermissions: [APP_TOKEN] }, { declaredCapabilities: [APP_TOKEN] }),
+    ).toBeNull();
+  });
+
+  it('accepts declaration/registry rows as well as bare names', () => {
+    expect(
+      describeHighPrivilegeBits(
+        { systemPermissions: [APP_TOKEN] },
+        { declaredCapabilities: [{ name: APP_TOKEN, scope: 'org' }] },
+      ),
+    ).toBeNull();
+    // An entry carrying no usable name excuses nothing.
+    expect(
+      describeHighPrivilegeBits({ systemPermissions: [APP_TOKEN] }, { declaredCapabilities: [{}, { name: 42 }] }),
+    ).toMatch(/system permissions/);
+  });
+
+  it('accepts the `sys_permission_set` JSON-string column shape too', () => {
+    const row = { system_permissions: JSON.stringify([APP_TOKEN]) };
+    expect(describeHighPrivilegeBits(row)).toMatch(/system permissions/);
+    expect(describeHighPrivilegeBits(row, { declaredCapabilities: [APP_TOKEN] })).toBeNull();
+  });
+
+  it('accepts the filing consumer’s real shape: read grants plus its own nav token', () => {
+    const clmRequester = {
+      isDefault: true,
+      objects: { contract: { allowRead: true, allowCreate: true, allowEdit: true } },
+      systemPermissions: [APP_TOKEN],
+    };
+    expect(describeHighPrivilegeBits(clmRequester)).toMatch(/system permissions/);
+    expect(describeHighPrivilegeBits(clmRequester, { declaredCapabilities: [APP_TOKEN] })).toBeNull();
+  });
+
+  // ---- THE PLATFORM FLOOR: declaring a platform name laundered nothing ----
+
+  it('still refuses a platform system permission even when a package declares that name', () => {
+    expect(
+      describeHighPrivilegeBits({ systemPermissions: [PLATFORM_TOKEN] }, { declaredCapabilities: [PLATFORM_TOKEN] }),
+    ).toMatch(/system permissions/);
+  });
+
+  it('is provenance, not spelling: a DOTTED platform capability is still refused when declared', () => {
+    expect(
+      describeHighPrivilegeBits(
+        { systemPermissions: [DOTTED_PLATFORM_TOKEN] },
+        { declaredCapabilities: [DOTTED_PLATFORM_TOKEN] },
+      ),
+    ).toMatch(/system permissions/);
+  });
+
+  it('still refuses a mixed set — one unexcused token is enough', () => {
+    expect(
+      describeHighPrivilegeBits(
+        { systemPermissions: [APP_TOKEN, PLATFORM_TOKEN] },
+        { declaredCapabilities: [APP_TOKEN, PLATFORM_TOKEN] },
+      ),
+    ).toMatch(/system permissions/);
+  });
+
+  it('never excuses a non-string entry, however the list is declared', () => {
+    expect(
+      describeHighPrivilegeBits(
+        { systemPermissions: [{ name: APP_TOKEN }] },
+        { declaredCapabilities: [APP_TOKEN, { name: APP_TOKEN }] },
+      ),
+    ).toMatch(/system permissions/);
+  });
+
+  // ---- THE REST OF THE D5 LIST IS UNTOUCHED ----
+
+  it('leaves every other D5 bit refusing, declaration list or not', () => {
+    const ctx = { declaredCapabilities: [APP_TOKEN] };
+    expect(describeHighPrivilegeBits({ systemPermissions: [APP_TOKEN], objects: { a: { viewAllRecords: true } } }, ctx))
+      .toMatch(/View\/Modify All/);
+    expect(describeHighPrivilegeBits({ systemPermissions: [APP_TOKEN], objects: { a: { modifyAllRecords: true } } }, ctx))
+      .toMatch(/View\/Modify All/);
+    expect(describeHighPrivilegeBits({ systemPermissions: [APP_TOKEN], objects: { a: { allowDelete: true } } }, ctx))
+      .toMatch(/delete\/purge\/transfer/);
+    expect(describeHighPrivilegeBits({ systemPermissions: [APP_TOKEN], objects: { a: { allowTransfer: true } } }, ctx))
+      .toMatch(/delete\/purge\/transfer/);
+    expect(describeHighPrivilegeBits({ systemPermissions: [APP_TOKEN], objects: { a: { allowExport: true } } }, ctx))
+      .toMatch(/bulk export/);
+  });
+});
+
+describe('describeAnchorForbiddenBits — the excusal is the `everyone` tier’s alone (ADR-0090 D9)', () => {
+  const declaredOnly = { systemPermissions: [APP_TOKEN] };
+  const ctx = { declaredCapabilities: [APP_TOKEN] };
+
+  it('lets a declared app token bind to `everyone`', () => {
+    expect(describeAnchorForbiddenBits(declaredOnly, 'everyone')).toMatch(/system permissions/);
+    expect(describeAnchorForbiddenBits(declaredOnly, 'everyone', ctx)).toBeNull();
+  });
+
+  it('still refuses it for `guest` — the strictest tier does not honour the D5 excusal', () => {
+    expect(describeAnchorForbiddenBits(declaredOnly, 'guest', ctx)).toMatch(/system permissions/);
+    // Lit control: the guest tier CAN return null, so the line above is a
+    // verdict about the token and not about the tier refusing everything.
+    expect(describeAnchorForbiddenBits({ objects: { a: { allowRead: true } } }, 'guest')).toBeNull();
+  });
+
+  it('leaves the guest tier’s own rules exactly as they were', () => {
+    expect(describeAnchorForbiddenBits({ objects: { '*': { allowRead: true } } }, 'guest', ctx)).toMatch(/wildcard/);
+    expect(describeAnchorForbiddenBits({ objects: { a: { allowEdit: true } } }, 'guest', ctx)).toMatch(/read-only/);
+    expect(describeAnchorForbiddenBits({ objects: { a: { allowEdit: true } } }, 'everyone', ctx)).toBeNull();
+  });
+});

--- a/packages/spec/src/security/high-privilege.ts
+++ b/packages/spec/src/security/high-privilege.ts
@@ -14,6 +14,8 @@
  * `system_permissions` JSON-string columns) — callers pass whatever they have.
  */
 
+import { PLATFORM_CAPABILITY_NAMES } from './capabilities';
+
 /** Tolerant JSON access: value may be the parsed object or a JSON string column. */
 function coerceRecord(v: unknown): Record<string, unknown> | undefined {
   if (typeof v === 'string') {
@@ -23,13 +25,65 @@ function coerceRecord(v: unknown): Record<string, unknown> | undefined {
 }
 
 /**
+ * [#17189, ADR-0066 D1] What the anchor predicates need to know about the
+ * stack they are judging a set FOR.
+ *
+ * The predicates are pure and synchronous — they read one permission-set
+ * definition and nothing else — so the one fact they cannot discover for
+ * themselves is which capability names this stack DECLARED. The caller holds
+ * it: at boot from the `sys_capability` rows carrying `managed_by: 'package'`
+ * provenance, at authoring time from the stack's own `capabilities` array.
+ *
+ * ⛔ Never synthesize this from the set under test. The point of the input is
+ * that a set cannot vouch for its own tokens; a "declared" list derived from
+ * `systemPermissions` would excuse every token by construction and turn the
+ * gate off.
+ */
+export interface AnchorBindingContext {
+  /**
+   * Capability names declared by the packages installed in this stack — plain
+   * names, or declarations/registry rows carrying a `name`. Omit it (or pass an
+   * empty list) and the predicates refuse exactly as they did before the input
+   * existed.
+   */
+  declaredCapabilities?: Iterable<string | { name?: unknown }>;
+}
+
+/**
+ * The app-declared names that may be excused, with the platform floor applied.
+ *
+ * Returns `undefined` when nothing is excusable, so the caller keeps the
+ * pre-#17189 code path verbatim rather than filtering against an empty set.
+ */
+function appDeclaredCapabilityNames(
+  context: AnchorBindingContext | undefined,
+): ReadonlySet<string> | undefined {
+  const declared = context?.declaredCapabilities;
+  if (!declared) return undefined;
+  const names = new Set<string>();
+  for (const entry of declared) {
+    const name = typeof entry === 'string'
+      ? entry
+      : (entry && typeof entry === 'object' ? (entry as { name?: unknown }).name : undefined);
+    if (typeof name !== 'string' || name.length === 0) continue;
+    // THE PLATFORM FLOOR. A platform capability stays high-privilege no matter
+    // who declares a capability of that name — otherwise declaring
+    // `manage_users` would launder it past the anchor gate, and the widening
+    // would be a bypass rather than a distinction.
+    if (PLATFORM_CAPABILITY_NAMES.has(name)) continue;
+    names.add(name);
+  }
+  return names.size > 0 ? names : undefined;
+}
+
+/**
  * Does a permission-set definition carry bits too dangerous for an audience
  * anchor (`everyone` / `guest`)? Returns a human-readable description of the
  * first offending bit, or `null` when the set is anchor-safe.
  *
- * Offending bits — the ADR-0090 D5 list: any `systemPermissions`,
- * View/Modify All Data (VAMA), or delete/purge/transfer on any object, plus
- * bulk `export` (#3544).
+ * Offending bits — the ADR-0090 D5 list: a `systemPermissions` entry naming a
+ * PLATFORM system permission, View/Modify All Data (VAMA), or
+ * delete/purge/transfer on any object, plus bulk `export` (#3544).
  * A plain `'*'` wildcard grant is NOT high-privilege by itself (D5 permits a
  * read — or read/create/edit-own — baseline to cover all objects; the
  * platform's own `viewer_readonly` is exactly that shape, and `member_default`
@@ -49,14 +103,53 @@ function coerceRecord(v: unknown): Record<string, unknown> | undefined {
  * not a baseline right, and never something an anchor should confer wholesale.
  * (`member_default` deliberately carries no `allowExport`, so the platform's
  * own baseline stays anchor-bindable.)
+ *
+ * ## [#17189] `systemPermissions` carries TWO unlike kinds of token
+ *
+ * One list, two things: the platform's own powers (`manage_users` and friends
+ * — the curated `PLATFORM_CAPABILITIES`), and a capability an APP declared for
+ * itself (ADR-0066 D1 `defineCapability`, entering the `sys_capability`
+ * registry at boot with `managed_by: 'package'` + `package_id` provenance).
+ * Until `context` existed the predicate saw only a list of NAMES and judged
+ * both alike, so an app could not ship the "every employee holds this" set its
+ * own navigation gates on: the set's own token made it unbindable to
+ * `everyone`, and the app was pushed toward not declaring gates at all.
+ *
+ * {@link AnchorBindingContext.declaredCapabilities} supplies the missing half —
+ * the capability names THIS stack declared. A name on that list is the app's
+ * own gate and is not counted as a system permission. The discriminator is
+ * **provenance**, not spelling: ⛔ never infer "app token" from the shape of a
+ * name (a dotted segment, a prefix). A spelling rule misjudges in silence the
+ * first platform permission that is dotted or the first app token that is not,
+ * and it is the CALLER — which can read what this stack declared — that holds
+ * the fact, never the string.
+ *
+ * Two properties keep the widening honest, both fail-CLOSED:
+ *
+ *  - **The platform floor is absolute.** A name in
+ *    {@link PLATFORM_CAPABILITY_NAMES} is high-privilege however it is
+ *    declared, so an app cannot launder `manage_users` past the anchor gate by
+ *    declaring a capability of that name.
+ *  - **Omission refuses.** With no `context` — or with a token absent from it —
+ *    the verdict is exactly the pre-parameter one: a non-empty
+ *    `systemPermissions` offends. A caller that cannot enumerate the stack's
+ *    declarations errs toward REFUSING a binding, never toward granting one.
  */
-export function describeHighPrivilegeBits(def: any): string | null {
+export function describeHighPrivilegeBits(def: any, context?: AnchorBindingContext): string | null {
   if (!def || typeof def !== 'object') return null;
   const sysRaw = def.systemPermissions ?? def.system_permissions;
   const sys = typeof sysRaw === 'string'
     ? (() => { try { return JSON.parse(sysRaw); } catch { return undefined; } })()
     : sysRaw;
-  if (Array.isArray(sys) && sys.length > 0) return 'system permissions';
+  if (Array.isArray(sys) && sys.length > 0) {
+    const declared = appDeclaredCapabilityNames(context);
+    // A non-string entry is never excused: only a name can be matched against a
+    // declaration, so anything else stays on the offending side.
+    const unexcused = declared
+      ? sys.filter((token: unknown) => typeof token !== 'string' || !declared.has(token))
+      : sys;
+    if (unexcused.length > 0) return 'system permissions';
+  }
   const objects = coerceRecord(def.objects ?? def.object_permissions);
   if (objects) {
     for (const [objName, rawPerm] of Object.entries(objects)) {
@@ -90,8 +183,15 @@ export function describeHighPrivilegeBits(def: any): string | null {
 export function describeAnchorForbiddenBits(
   def: any,
   anchor: 'everyone' | 'guest',
+  context?: AnchorBindingContext,
 ): string | null {
-  const high = describeHighPrivilegeBits(def);
+  // [#17189] The D5 app-capability excusal is the `everyone` tier's alone. D9
+  // gives `guest` the STRICTEST tier, and an app token handed to `guest` is
+  // handed to anonymous visitors — a different act from handing it to the
+  // authenticated members D5 speaks for, and one this ruling did not decide.
+  // So the guest tier asks the question with NO context and keeps refusing any
+  // non-empty `systemPermissions`.
+  const high = describeHighPrivilegeBits(def, anchor === 'guest' ? undefined : context);
   if (high) return high;
   if (anchor !== 'guest') return null;
   const objects = coerceRecord(def?.objects ?? def?.object_permissions);

--- a/packages/spec/src/security/high-privilege.ts
+++ b/packages/spec/src/security/high-privilege.ts
@@ -42,11 +42,12 @@ function coerceRecord(v: unknown): Record<string, unknown> | undefined {
 export interface AnchorBindingContext {
   /**
    * Capability names declared by the packages installed in this stack — plain
-   * names, or declarations/registry rows carrying a `name`. Omit it (or pass an
-   * empty list) and the predicates refuse exactly as they did before the input
-   * existed.
+   * names, or declarations/`sys_capability` rows carrying a `name` (every other
+   * field on such a row is ignored, so a caller hands over what it already has
+   * and never transcribes). Omit it (or pass an empty list) and the predicates
+   * refuse exactly as they did before the input existed.
    */
-  declaredCapabilities?: Iterable<string | { name?: unknown }>;
+  declaredCapabilities?: Iterable<string | { name?: unknown; [key: string]: unknown }>;
 }
 
 /**


### PR DESCRIPTION
Part of #17189 — step ① of the ruled order only. ⛔ This PR does not discharge the card and ⛔ carries no closing keyword: the `plugin-security` boot refusal and the `@objectstack/lint` `security-anchor-high-privilege` rule are step ②, deliberately untouched here.

**Sibling**: #17814 carries the ADR-0090 D5 revision alone, as its own governed draft PR. The two were one PR until the seat review of head `a21ad008`; they are split on the ruling's own instruction — 「ADR-0090 修订单独受管 PR」 and 「ADR 修订走独立受管 PR（draft、请审、人合）」 (#17189 comment `5615806616`), which the triage seat had already spelled 「⛔ 不得与代码同 diff」. Measured: `check-governed-merges --test` on this PR's five-file list exits **0 (NOT governed)**; add the ADR back and the same predicate exits **3 (GOVERNED)**. Bundled, one governed path made the predicate change human-merge-only too. ⭐ Both halves are phase ① and ⛔ neither is dropped.

⚠️ **Merge order.** The maintainer's ordering note (#17189 comment `5617614086`) puts the protocol first: 「协议不正确的应该先修改协议。」 The ADR half is human-merge-only and this half is not, so nothing mechanical keeps this one from landing first. If that order matters, merge #17814 before this is enqueued — flagging rather than deciding, since a draft PR cannot enforce it.

- **Clause-②: yes** — 放宽接受集. Corrected on seat review: the ruling (#17189 comment `5615806616`) declared this value in advance, in its 执行 line, and a declaration made in advance is not overruled by a reading of the diff. My earlier `no` applied a narrower test ("no new key on a published payload") than clause ② asks. The diff agrees with the ruling three ways: a permission set that was refused is now accepted; `packages/spec/api-surface/security.json` and `export-origins/security.json` were regenerated, so the published-surface snapshots moved; and the changeset's own rationale says "a widened accept set".

## The defect

`describeHighPrivilegeBits` counted **any** non-empty `systemPermissions` as a high-privilege bit, so a permission set carrying the capability token its own app declared could not be bound to the `everyone` audience anchor.

```
describeHighPrivilegeBits({ systemPermissions: ['manage_users'] })          -> 'system permissions'
describeHighPrivilegeBits({ systemPermissions: ['clm_requester.access'] })  -> 'system permissions'
```

Re-confirmed on this branch's own base (`482d34d60c`) against a freshly built `dist`, with a lit control: `{ objects: { a: { allowRead: true } } }` and `{ systemPermissions: [] }` both returned `null` in the same run, so the instrument could have come back the other way. The shipped predicate's arity was `1` — there was no channel through which the distinction could have arrived.

## The change

Both predicates take a new optional `AnchorBindingContext` naming the capability names **this stack declared** (ADR-0066 D1: `defineCapability`, entering `sys_capability` with `managed_by: 'package'` + `package_id` provenance). A token on that list is the app's own gate and is not counted as a system permission.

**The discriminator is provenance, not spelling, and that is the point rather than a convenience.** The rejected alternative was a naming-syntax rule (dotted ⇒ app token). It misjudges in silence in both directions: `setup.access` is a *platform* capability that is dotted today, and nothing stops an app declaring an undotted token. A syntax rule guesses; the declared list is a fact the caller can read, and only the caller can read it — the predicate is pure and synchronous by contract, and a set may never vouch for its own tokens.

Two properties keep the widening honest, both fail-closed:

- **The platform floor is absolute.** A name in `PLATFORM_CAPABILITY_NAMES` stays high-privilege however it is declared, so a package cannot launder `manage_users` past the gate by declaring a capability of that name.
- **Omission refuses.** With no context — or with a token absent from it — the verdict is byte-identical to the pre-change one. Every current caller uses the old arity, so **no live anchor binding moves in this PR**; the narrowing reaches a binding only once step ② supplies the list.

`guest` (ADR-0090 D9) does not honour the excusal at all: D5 speaks for authenticated members, and conferring an app's own gate on anonymous visitors is a different act that ruling (i) did not decide.

## Both directions tested

`packages/spec/src/security/high-privilege.test.ts`, 15 cases. Newly **accepted**: a set whose only system permission is a declared token, in the authored shape, the `sys_permission_set` JSON-string column shape, declaration/registry row entries, and the filing consumer's real shape. Still **refused**: a platform permission even when a package declares that name; `setup.access` — dotted, declared, still refused; any undeclared token; every token when no list is passed; a mixed set (one unexcused token refuses the whole set); non-string entries; every other D5 bit (VAMA, delete/transfer, bulk export); and the whole `guest` tier.

**Ablation** (both legs: mutate, prove it reached disk with an occurrence count on the mutated text, run, restore; restore verified byte-identical to the `HEAD` blob with `git diff HEAD` empty):

| mutation | expected | observed |
|---|---|---|
| delete the excusal (`unexcused = sys`) | the acceptance pins go red | **6 red / 9 green** |
| delete the platform floor | only the floor pins go red | **3 red / 12 green** — exactly the three named |

The first leg reddened one test more than predicted: `leaves every other D5 bit refusing` carries both a declared token and an object bit, so without the excusal the `systemPermissions` branch answers before the object branch is reached. Reported as observed, not as predicted.

## ADR-0090 D5

The revision is not optional here. D5's last bullet said **any** `systemPermissions`, and the code implemented that literally — so the protocol, not the implementation, was the thing that was wrong. Per the maintainer's ordering, verbatim:

> 「我们的项目以objectstack 协议为准，文档应该以实际实现为准。协议不正确的应该先修改协议。」

The bullet now reads "a `systemPermissions` entry naming a **platform** system permission", with a dated revision note recording the two token kinds, the three fail-closed boundaries, why the spelling rule was rejected, that `guest` is untouched, and that the callers keep the pre-revision behaviour until they supply the list. **That change now lives in #17814**, byte-identical to what stood here on `a21ad008` — verified by diffing the two branches' copies of the file. Removing the code hunks from it made no sentence of it false: nothing in the note ever claimed the predicate ships alongside it. ⚠️ Until #17814 merges, this file's own JSDoc describes a D5 list narrower than the published ADR still states; that window is the split's cost, and the merge-order note above is how to close it.

## Verification

- `pnpm --filter @objectstack/spec test` — 472 files / 13365 tests passed.
- `pnpm --filter @objectstack/spec typecheck` — passed (`tsc --noEmit`, scripts, and the test-layer ledger; the new test file compiles clean and is **not** added to `test-typecheck-debt.json`).
- Consumers of the changed surface, **unedited**: `plugin-security` `audience-anchors.test.ts` + `audience-anchor-set-claims.pin.test.ts` (20 passed — including the pin that reads this very JSDoc block), `@objectstack/lint` `validate-security-posture*.test.ts` (139 passed).
- Derived gate family, **re-derived on the split head** (`scripts/pm/dispatch-gates.mjs --commands --repo objectstack-ai/objectstack`): 83 commands — 79 exit 0, and four exit **3 = PREREQUISITE NOT MET** (`check:dual-build-cjs-loads`, `check:lean-entry-closure`, `check:type-check-debt`, `check:doc-formula-expressions`). All four read a whole-repo build; the closure build was OOM-killed on this shared box at 11m52s. They are **NOT MEASURED**, ⛔ not green, and are declared to CI. Exactly six commands left this PR's family when the ADR did — `check-adr-links`, `check-adr-symbol-anchors` (each with its `--self-test`), `check:adr-anchors` and `check:pm-governed-merges` — and all six are run green on #17814 instead, which derives 18 commands of its own (17 green, the same `check:doc-formula-expressions` at 3).
- The engineering the seat accepted is untouched by the split, proven rather than asserted: `git diff a21ad008 HEAD -- packages/spec` is **empty**. Only the ADR file and one changeset sentence moved (the sentence said the revision landed "in the same PR", which the split made false; it now names #17814).
- `eslint . --no-inline-config` over the whole repo — exit 0, measured on `a21ad008`, whose `packages/spec` tree is byte-identical to this head. No narrowing claimed.
- Generated baselines regenerated on a fresh build, not by hand: `api-surface/security.json`, `export-origins/security.json` (one line each, the new interface). `check:generated` green.
- Changeset owed, **measured — and re-measured after the at-tier review found the first reading wrong** (F3). The counts are taken on a **clean full build of this head**: empty `dist`, then `pnpm --filter @objectstack/spec build` with both passes, exit 0, `check-dts-emitted` 34/34, and both `dist/.build-input-hash*` matching `src`. `declaredCapabilities` reaches **4** files (`security/index.js`, `index.mjs`, `index.d.ts`, `index.d.mts`) and the positive control `describeHighPrivilegeBits` **4**; `AnchorBindingContext` **2** (declarations only - it is a type) and `appDeclaredCapabilityNames` **2** (JS only - it is module-private). Negative control: a sentence occurring only in the ADR revision reads **0**, and `docs/adr/**` is in no package's `files[]`.
  ⚠️ my first reading said "2" for everything. Every figure in it was the **JS-only** reading: a background build was rebuilding the package while I grepped, and it had emitted JS but not DTS. That also silently broke the negative control - `The platform floor is absolute` is in this predicate's own JSDoc as well as in the ADR, so it was never ADR-unique and reads **2**, not 0, once declarations exist. Both the number and the control are corrected, and the changeset now names the build state, because the build state is what changes the answer. The conclusion it supports - that a changeset is owed - never moved.
- Step ② is byte-unchanged: `git diff` over `packages/plugins/plugin-security` and `packages/lint` against the merge base is empty.

## 维护者速读（草稿）

**改了什么** — 应用自己声明的「门牌」不再被当成平台系统权限。应用现在可以把「全体员工都持有」的权限集绑到 `everyone`，即使这个集合带着它自己导航要读的那张门牌。平台权限（`manage_users` 一类）的保护一点没松。本 PR 同时按裁决修订了 ADR-0090 D5 的清单——协议先改，实现跟上。

**为什么改** — 具名下游 `objectstack-ai/hotclm` 被这条规则挡住：它无法表达「全体员工」，只能把权限集逐一绑到七个岗位，再由管理员为每个没有岗位的员工手工授予；每一个新入职都是一次手工步骤，永远。该仓维护者已裁定保留这个 workaround 等本修。

**风险与代价（含回滚）** — 本次发布**没有任何已有行为变化**：所有调用方仍用旧参数调用，不传名单时判定与改前逐字一致。风险集中在第二步（`plugin-security` 与 `lint` 开始传名单）落地时，而不是现在。误判方向是「多拒」不是「多放」：名单缺失即拒绝。平台权限有绝对下限——应用声明一个叫 `manage_users` 的能力也洗不白它。`guest`（匿名访客）这一档完全不放宽。回滚成本低：本 PR 是一个可选参数加一份文档修订，`git revert` 即可，无数据迁移、无存储格式变化。

**席位意见** — （留给维护者）

**你要做的** — 一、确认 D5 修订的措辞就是您要的协议（这是受管面，需要您人工合并）。二、确认「应用声明过的能力可以发给全体员工」这条安全姿态判断——本 PR 只按已声明的出处区分，**不**按 `scope: 'org'` 再收窄一层；若您要求更窄的判据，说一声，第二步的调用方过滤一下名单即可，谓词不用改。

---

⚠️ **Governed surface — this footer described the PRE-SPLIT PR and is now false; corrected in place rather than deleted, because the reading it reports is the reason the split happened.** When this PR still carried `docs/adr/0090-…`, `check-governed-merges --test` on its file list exited **3 (GOVERNED)**. It no longer carries it: re-measured on the five-file list at 2026-09-12T09:5xZ the same predicate exits **0 — NOT governed**, with the ADR appended as the control exiting **3**. ⇒ ordinary queue landing applies to this PR, and the human-merge rule applies to **#17814** instead. ⛔ Still not armed, for a different reason: the maintainer's ordering note puts the protocol first, so the seat holds this PR until #17814 is merged by hand.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MkQhmuuJAVDjmeWNixwDDH)_

---
_Generated by [Claude Code](https://claude.ai/code)_