### PR TITLE
docs(adr): ADR-0090 D5 offending bits are platform system permissions, not any systemPermissions

### DIFF
--- a/docs/adr/0090-permission-model-v2-concept-convergence.md
+++ b/docs/adr/0090-permission-model-v2-concept-convergence.md
@@ -237,8 +237,53 @@ Replaces both the `member_default` builtin-set fallback and ADR-0056 D7's defaul
   install-time prompt ("CRM suggests adding `crm_readonly` to Everyone — accept?"). It is **never**
   auto-bound: installing a package must not silently widen every tenant user's access.
 - **Lint (D7) hard-blocks high-privilege bits on `everyone` bindings**: `viewAllRecords`,
-  `modifyAllRecords`, `allowDelete`, `allowPurge`, `allowTransfer`, and `systemPermissions` are
-  rejected (or force a break-glass confirmation) on any set bound to `everyone`.
+  `modifyAllRecords`, `allowDelete`, `allowPurge`, `allowTransfer`, and a `systemPermissions`
+  entry naming a **platform** system permission are rejected (or force a break-glass
+  confirmation) on any set bound to `everyone`. An **app-declared capability token** — one a
+  package declared for itself under ADR-0066 D1, entering `sys_capability` with
+  `managed_by: 'package'` + `package_id` provenance — is **not** an offending bit: it gates
+  only what that same package's own resources require of it, so conferring it on the
+  authenticated audience widens nothing the package did not itself define. See the revision
+  note below.
+
+> **Revision (2026-09-12, #17189) — the offending bit is a `systemPermissions` entry naming a
+> PLATFORM permission, not `systemPermissions` at all.** [ruled]
+>
+> As first written, the bullet above made **any** non-empty `systemPermissions` an offending bit,
+> and `describeHighPrivilegeBits` (`@objectstack/spec/security`) implemented it literally.
+> `systemPermissions` carries two unlike kinds of token, though: the platform's own powers
+> (`manage_users` and friends), and a capability a package **declared for itself** (ADR-0066 D1).
+> An app whose navigation gates on its own token therefore could not ship the set every employee
+> holds — the set's own gate made it unbindable to `everyone` — so the app was pushed toward
+> declaring no gates at all, the opposite of what ADR-0066 D1 exists to encourage. Reported by a
+> named downstream consumer that had to fall back to binding its baseline set to each position by
+> hand, plus one manual grant per new hire, indefinitely.
+>
+> **What changed**: an offending `systemPermissions` bit is one naming a platform system
+> permission. A token this stack declared as a package capability is not counted. Three boundaries
+> hold the narrowing, and each fails closed:
+>
+> 1. **The platform floor is absolute.** A platform capability name stays high-privilege however it
+>    is declared, so a package cannot launder `manage_users` past the anchor gate by declaring a
+>    capability of that name.
+> 2. **The discriminator is provenance, never spelling.** The predicate is *told* which names this
+>    stack declared; it never infers "app token" from the shape of a name. ⛔ A naming-syntax rule
+>    (dotted ⇒ app token) was considered and rejected: it misjudges in silence the first dotted
+>    platform permission — `setup.access` is one today — and the first undotted app token.
+> 3. **Omission refuses.** A caller that cannot enumerate the stack's declarations gets the
+>    pre-revision verdict, so a missing input narrows nothing.
+>
+> **`guest` is untouched.** D9's strictest tier keeps refusing any non-empty `systemPermissions`:
+> D5 speaks for authenticated members, and conferring an app's own gate on anonymous visitors is a
+> different act, not decided here.
+>
+> Ruling: director seat, batch #110, 2026-09-10 — option (i), the predicate takes the declared
+> capability list as an input. The landing order is the maintainer's, verbatim:
+> 「我们的项目以objectstack 协议为准，文档应该以实际实现为准。协议不正确的应该先修改协议。」
+> ⇒ this revision and the `packages/spec` predicate land first; the `plugin-security` boot refusal
+> and the `@objectstack/lint` `security-anchor-high-privilege` rule follow. Until those callers
+> supply the declared list they keep the pre-revision behaviour — the predicate's default — so the
+> narrowing reaches a binding only where a caller can name what this stack declared.
 
 ### D6 — Explain engine is P0; access-matrix snapshots gate publishes
 


### PR DESCRIPTION
Part of #17189 — the **protocol half** of phase ①. ⛔ This PR does not discharge the card, and ⛔ carries no closing keyword: #17189 still owes step ②.

**Sibling**: #17811 carries the `packages/spec` predicate, its test, the changeset and the two regenerated surface snapshots. The two were one PR until the seat review of head `a21ad008`; they are split here on the ruling's own instruction.

## Why this is its own PR

The ruling (#17189 comment `5615806616`, director seat, batch #110) says it twice, verbatim:

> ADR-0090 D5 的 offending 清单相应收窄为「平台系统权限；带 package provenance 的应用声明 capability 令牌不计」，ADR 修订走独立受管 PR（draft、请审、人合）

> `Clause-②: yes`（放宽接受集）；**ADR-0090 修订单独受管 PR**

The triage seat had already ruled the same shape: 「那部分**必须是独立的受管 PR**，⛔ 不得与代码同 diff」.

Measured consequence, not style. `scripts/pm/check-governed-merges.mjs --test` on this PR's one-file list exits **3 = GOVERNED**; on the sibling's five-file list it exits **0 = NOT governed**. Bundled, one governed path made the predicate change human-merge-only too. Split, this half waits for its human and the code half takes ordinary landing.

## Why the revision is required

Both halves are phase ①, per the ordering note (#17189 comment `5617614086`) carrying the maintainer verbatim:

> 「我们的项目以objectstack 协议为准，文档应该以实际实现为准。协议不正确的应该先修改协议。」

D5's last bullet said **any** `systemPermissions` was an offending bit, and `describeHighPrivilegeBits` implemented that literally — so the protocol, not the implementation, was the half that was wrong. A predicate change without this revision would leave the ADR describing a rule the code no longer applies.

⚠️ **Merge order.** The maintainer's sentence puts the protocol first. This PR is human-merge-only and the sibling is not, so nothing mechanical keeps the code from landing first; if that order matters to you, merge this one before #17811 is enqueued. Flagging rather than deciding — a draft PR cannot enforce it.

## What changed

D5's last bullet now reads "a `systemPermissions` entry naming a **platform** system permission", and names an app-declared capability token — one a package declared for itself under ADR-0066 D1, entering `sys_capability` with `managed_by: 'package'` + `package_id` provenance — as **not** an offending bit.

A dated revision note records:

- the two unlike token kinds in one list, and the cost that motivated the narrowing (a named downstream consumer binding its baseline set to seven positions by hand, plus one manual grant per new hire);
- three boundaries, each failing closed — **the platform floor is absolute** (a platform capability name stays high-privilege however it is declared, so `manage_users` cannot be laundered by declaring it); **the discriminator is provenance, never spelling** (⛔ the dotted-name rule was considered and rejected: `setup.access` is a dotted *platform* capability today); **omission refuses** (a caller that cannot enumerate the declarations gets the pre-revision verdict);
- that the D9 `guest` tier is untouched — D5 speaks for authenticated members;
- the ruling's provenance and the landing order, quoted verbatim in the original Chinese;
- that the consuming callers keep the pre-revision behaviour until they supply the declared list.

The revision text is **byte-identical** to what stood on `a21ad008` before the split — verified by diffing this branch's file against that branch's. Removing the code hunks made no sentence of it false: nothing in the note claims the predicate ships in this PR.

## Clause ②

Recorded, not re-declared here: the card's declaration is `Clause-②: yes`（放宽接受集）per the ruling's 执行 line, and the `needs:contract-review` carrier is already hung by the seat on card #17189 and on the code PR #17811. This half is prose only — it puts no key on any published payload and moves no accept set by itself. Whether the carrier is also owed on this PR is the seat's call; ⛔ this round writes no labels.

## Verification

- Content: unchanged from the reviewed head, byte-for-byte (see above). The engineering behind it was accepted in the seat review of `a21ad008` and is ⛔ not re-litigated here.
- `check-governed-merges.mjs --test docs/adr/0090-permission-model-v2-concept-convergence.md` → exit **3 (GOVERNED)**. Control, the sibling's five-file list → exit **0 (NOT governed)**, so the 3 is a verdict about this file rather than an instrument that only ever says 3.
- ADR gate family on this branch: `check-adr-links`, `check-adr-symbol-anchors`, `check:adr-anchors`, `check-adr-0087-registration --base origin/main`, `check:nul-bytes`, `check:pm-governed-prose`, `check:doc-authoring` — exit codes captured before any pipe, reported in the round's report.
- No changeset: `docs/adr/**` is in no package's `files[]`, and a phrase unique to this revision note occurs in 0 built files under `packages/spec/dist` — the negative control measured in the sibling PR's changeset decision.

⚠️ **Governed surface** — `docs/adr/**`. Draft only, and it stays draft: ⛔ not flipped ready, ⛔ not enqueued, ⛔ no auto-merge, ⛔ no approving review. A human merge is the review record.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MkQhmuuJAVDjmeWNixwDDH)_