### PR TITLE
fix(spec): guard three data lookups against Object.prototype fall-through

### DIFF
--- a/.changeset/17456-prototype-fallthrough-guards.md
+++ b/.changeset/17456-prototype-fallthrough-guards.md
@@ -1,0 +1,61 @@
+---
+'@objectstack/spec': patch
+---
+
+fix(spec): three more lookups refuse an off-vocabulary key instead of handing back an `Object.prototype` member
+
+`BASE_ALIASES` / `DIALECT_ALIASES` (`canonicalizeSqlType`),
+`DEFAULT_VALUE_TOKEN_SUGGESTIONS` (`suggestDefaultValueToken`) and
+`CONTEXT_TOKEN_SUGGESTIONS` (`classifyFilterToken`) are plain object literals, so
+all three inherit `Object.prototype`, and every lookup into them was a bare
+index. Measured by importing the BUILT artifact (`dist/data/index.mjs`) on the
+repo's Node 22 baseline (v22.22.2) and driving each function — the same way the
+two landed siblings in this family were measured — over a fixed population of
+five: `constructor`, `toString`, `valueOf`, `__proto__` and a plain unknown word.
+
+| call | before | after |
+|:--|:--|:--|
+| `canonicalizeSqlType('varchar')` | `'text'` | `'text'` — unmoved |
+| `canonicalizeSqlType('timestamptz', 'postgres')` | `'datetime'` | `'datetime'` — unmoved |
+| `canonicalizeSqlType('constructor')` | the `Object` **function**, out of a signature that admits only `CanonicalSqlType` string literals | `'unknown'` |
+| `canonicalizeSqlType('constructor', <any dialect>)` | the `Object` **function** | `'unknown'` |
+| `canonicalizeSqlType('__proto__')` | `'array'` | `'array'` — unmoved; the array-notation rule answers ahead of either table |
+| `canonicalizeSqlType('toString' / 'valueOf' / 'nope')` | `'unknown'` | `'unknown'` — unmoved |
+| `suggestFieldTypeForSqlType('constructor')` | **`TypeError: Cannot read properties of undefined (reading 'suggested')`** | `undefined` |
+| `isCompatible('constructor', 'text')` | **`TypeError: … (reading 'exact')`** | `'lossy'` |
+| `suggestDefaultValueToken('currentuser')` | `'current_user'` | `'current_user'` — unmoved |
+| `suggestDefaultValueToken('constructor')` | the `Object` **function** | `undefined` |
+| `suggestDefaultValueToken('__proto__')` | `Object.prototype` — an **object** | `undefined` |
+| `classifyFilterToken('{current_user}').suggestion` | `'current_user_id'` | `'current_user_id'` — unmoved |
+| `classifyFilterToken('{constructor}').suggestion` | the `Object` **function**, in a field declared `ContextToken` | `undefined` |
+| `classifyFilterToken('{__proto__}').suggestion` | `Object.prototype` | `undefined` |
+
+The two `TypeError` rows are the sharpest consequence and were not previously
+recorded: a non-`CanonicalSqlType` reaches `CANONICAL_TO_FIELD[canonical]`, which
+is `undefined`, so both published sibling accessors threw on the member read
+rather than merely returning something off-contract. `canonicalizeSqlType`'s
+`rawType` comes off live database introspection, which is where an
+attacker-free, entirely accidental `constructor` actually comes from.
+
+`classifyFilterToken`'s half is the one a type-checked consumer meets: the
+declared `suggestion?: ContextToken` was a compile-time guarantee that was false
+at runtime, and nothing in the type system would ever have flagged it. Its
+wrapped-token regex captures `[^{}]+` — anything but braces — so the reachable
+key set is not the identifier-shaped one; what bounds it is the `toLowerCase()`,
+which leaves exactly the lower-case-stable prototype members (`constructor`,
+`__proto__`) namable today. `toString` / `valueOf` were quiet by that casing
+accident alone, not by a guard.
+
+All three sites now go through an `Object.prototype.hasOwnProperty.call` check
+returning each function's own already-declared refusal value — `'unknown'`,
+`undefined`, and an absent `suggestion` respectively. No declared signature
+changes. This narrows and widens nothing an author can reach: every legal
+spelling is an own key of its table, so nothing accepted before is refused now,
+and only answers that were never inside the declared return types move.
+
+A null-prototype table was the other available shape and is not taken, for the
+reason the two landed siblings measured rather than assumed: a `__proto__: null`
+object literal does not type-check against the `Record<…>` annotation at all
+(TS2353), and the `Object.assign(Object.create(null), …)` spelling that does
+compile silently costs that annotation's exhaustiveness check (TS2741 stopped
+firing for a table missing a member). A quiet failure is worse than a loud one.

--- a/packages/spec/src/data/context-tokens.test.ts
+++ b/packages/spec/src/data/context-tokens.test.ts
@@ -183,3 +183,67 @@ describe('classifyFilterToken — brace-wrapped by intent (#5586)', () => {
     expect(classifyFilterToken(value)).toBeNull();
   });
 });
+
+/**
+ * The Object.prototype fall-through pin. Its POPULATION is the point: the
+ * suite's other suggestion cases iterate the canonical near-miss vocabulary
+ * only — precisely the population that behaves — which is why this site sat
+ * green while `classifyFilterToken('{constructor}')` put the `Object` FUNCTION
+ * into `suggestion`, whose declared type is `ContextToken`.
+ */
+describe('classifyFilterToken — Object.prototype fall-through in `suggestion`', () => {
+  // Fixed at five. `toString` / `valueOf` are quiet only because the key is
+  // lower-cased first (`tostring` names nothing); they are in the population
+  // so that the accident is pinned as an outcome rather than trusted as a
+  // guard.
+  const POPULATION = ['constructor', 'toString', 'valueOf', '__proto__', 'nope'] as const;
+
+  it.each(POPULATION)('{%s} carries this branch\'s own declared refusal — an absent suggestion', (word) => {
+    // `suggestion` is optional in the declared return, so its absence IS the
+    // refusal value; ⛔ nothing was invented for the fix.
+    expect(classifyFilterToken(`{${word}}`)).toEqual({ kind: 'unknown', token: word, suggestion: undefined });
+    expect(classifyFilterToken(`\${${word}}`)).toEqual({ kind: 'unknown', token: word, suggestion: undefined });
+  });
+
+  it('no spelling reachable through the wrapped-token regex yields a non-ContextToken suggestion', () => {
+    // `FILTER_TOKEN_WRAPPED_RE` captures `[^{}]+` — anything but braces — so the
+    // reachable key set is NOT the identifier-shaped one objectui's narrower
+    // `[a-zA-Z0-9_]+` bounds. This sweep is over every own property name of
+    // `Object.prototype`, which is the set a bracket index can resolve, rather
+    // than over the two spellings that happen to be noisy today.
+    for (const name of Object.getOwnPropertyNames(Object.prototype)) {
+      const out = classifyFilterToken(`{${name}}`);
+      expect(out).not.toBeNull();
+      const suggestion = out && 'suggestion' in out ? out.suggestion : undefined;
+      // Pins the SILENCE: either absent, or a declared member of the union.
+      expect(suggestion === undefined || (CONTEXT_TOKENS as readonly string[]).includes(suggestion)).toBe(true);
+      expect(typeof suggestion).not.toBe('function');
+      expect(typeof suggestion).not.toBe('object');
+    }
+  });
+
+  it('lit control — a real near miss still gets its suggestion', () => {
+    // Without this, a guard that refused everything would pass the cases above.
+    expect(classifyFilterToken('{current_user}')).toEqual({
+      kind: 'unknown',
+      token: 'current_user',
+      suggestion: 'current_user_id',
+    });
+    expect(classifyFilterToken('{org_id}')).toEqual({
+      kind: 'unknown',
+      token: 'org_id',
+      suggestion: 'current_org_id',
+    });
+  });
+
+  it('lit control — the lookup table shadows no prototype member with an own key', () => {
+    // The reading the fix rests on: the table cannot be "already safe" by
+    // accident. If a row named `constructor` were ever added, the guard's
+    // meaning changes and this goes red first.
+    for (const name of Object.getOwnPropertyNames(Object.prototype)) {
+      expect(Object.prototype.hasOwnProperty.call(CONTEXT_TOKEN_SUGGESTIONS, name)).toBe(false);
+    }
+    // Lit control for the control: a row that IS present.
+    expect(Object.prototype.hasOwnProperty.call(CONTEXT_TOKEN_SUGGESTIONS, 'current_user')).toBe(true);
+  });
+});

--- a/packages/spec/src/data/context-tokens.zod.ts
+++ b/packages/spec/src/data/context-tokens.zod.ts
@@ -249,5 +249,33 @@ export function classifyFilterToken(
   const token = m[1];
   if (isContextToken(token)) return { kind: 'context', token: token as ContextToken };
   if (isDateMacroToken(token)) return { kind: 'date-macro', token };
-  return { kind: 'unknown', token, suggestion: CONTEXT_TOKEN_SUGGESTIONS[token.toLowerCase()] };
+  // Own-property guard: the table is a plain object literal, so a bare index
+  // resolves `Object.prototype`'s members for an off-vocabulary token —
+  // `{constructor}` put the `Object` FUNCTION and `{__proto__}`
+  // `Object.prototype` itself into `suggestion`, whose declared type is
+  // `ContextToken`. A TypeScript consumer holds a compile-time guarantee that
+  // is false at runtime, and nothing in the type system will ever flag it.
+  //
+  // The reach is not bounded by the identifier shapes: `FILTER_TOKEN_WRAPPED_RE`
+  // captures `[^{}]+`, anything but braces. What bounds it is that the key is
+  // lower-cased, so only the prototype members whose names are already
+  // lower-case are namable — `constructor` and `__proto__` today. `toString` /
+  // `valueOf` / `hasOwnProperty` are quiet by that casing accident alone, ⛔ not
+  // by a guard, and a future lower-case prototype member would join the noisy
+  // set silently.
+  //
+  // The refusal value is this branch's own declared one: `suggestion` is
+  // optional, so its absence — `undefined` — is what "resembles nothing" already
+  // means here. The guard narrows: every near-miss that answered before is an
+  // own key.
+  //
+  // ⛔ Not a null-prototype table (TS2353 against the `Readonly<Record<…>>`
+  // annotation, or a silent loss of its exhaustiveness check via
+  // `Object.assign(Object.create(null), …)`) and ⛔ not a list of prototype
+  // member names, which the next prototype member defeats.
+  const lower = token.toLowerCase();
+  const suggestion = Object.prototype.hasOwnProperty.call(CONTEXT_TOKEN_SUGGESTIONS, lower)
+    ? CONTEXT_TOKEN_SUGGESTIONS[lower]
+    : undefined;
+  return { kind: 'unknown', token, suggestion };
 }

--- a/packages/spec/src/data/default-value-shape.test.ts
+++ b/packages/spec/src/data/default-value-shape.test.ts
@@ -17,8 +17,10 @@ import {
   checkLiteralDefaultValue,
   discriminateDefaultValueShape,
   isExpressionEnvelopeDefault,
+  suggestDefaultValueToken,
   type DefaultValueShape,
 } from './default-value-shape';
+import { DEFAULT_VALUE_TOKENS } from './default-value-tokens';
 
 describe('#7127 discriminateDefaultValueShape — engine-parity classification', () => {
   const CASES: Array<{ label: string; dv: unknown; shape: DefaultValueShape }> = [
@@ -173,5 +175,42 @@ describe('#7127 checkLiteralDefaultValue — the shared stored-form literal chec
     expect(v.ok).toBe(false);
     expect(v.detail).toContain('ISO-8601 instant');
     expect(v.detail).not.toContain('Unrecognized key');
+  });
+});
+
+/**
+ * The Object.prototype fall-through pin. Its POPULATION is the point: the
+ * suite's other suggestion cases iterate the canonical near-miss vocabulary
+ * only — precisely the population that behaves — which is why this site sat
+ * green while `suggestDefaultValueToken('constructor')` returned the `Object`
+ * FUNCTION and `suggestDefaultValueToken('__proto__')` returned
+ * `Object.prototype`, out of a signature declared `DefaultValueToken |
+ * undefined`.
+ */
+describe('suggestDefaultValueToken — Object.prototype fall-through', () => {
+  // Fixed at five. `toString` / `valueOf` are quiet here only because the key
+  // is lower-cased first, which is an accident of casing and ⛔ not a guard —
+  // they belong in the population precisely so the day that stops being true
+  // is a red test and not a silent regression.
+  const POPULATION = ['constructor', 'toString', 'valueOf', '__proto__', 'nope'] as const;
+
+  it.each(POPULATION)('%s answers this function\'s own declared refusal value', (word) => {
+    // `undefined` is read from the declared return type, ⛔ not invented here.
+    expect(suggestDefaultValueToken(word)).toBeUndefined();
+  });
+
+  it.each(POPULATION)('%s never yields a non-string, whatever the answer is', (word) => {
+    // Pins the SILENCE rather than today's `undefined`: should a prototype
+    // member ever be shadowed by a real own key, this still holds; what it
+    // refuses is a function or an object escaping the string union.
+    const out = suggestDefaultValueToken(word);
+    expect(out === undefined || DEFAULT_VALUE_TOKENS.includes(out)).toBe(true);
+  });
+
+  it('lit control — the real near-miss vocabulary still answers', () => {
+    // Without this, a guard that refused everything would pass the cases above.
+    expect(suggestDefaultValueToken('currentuser')).toBe('current_user');
+    expect(suggestDefaultValueToken('{now}')).toBe('NOW()');
+    expect(suggestDefaultValueToken('current_time')).toBe('NOW()');
   });
 });

--- a/packages/spec/src/data/default-value-shape.ts
+++ b/packages/spec/src/data/default-value-shape.ts
@@ -294,5 +294,25 @@ export function suggestDefaultValueToken(dv: unknown): DefaultValueToken | undef
   // guard is a type error, not just awkward.
   const key = dv.trim().toLowerCase();
   if (isRuntimeDefaultToken(dv)) return undefined;
+  // Own-property guard: the table is a plain object literal, so a bare index
+  // resolves `Object.prototype`'s members for an off-vocabulary `dv` —
+  // `constructor` handed back the `Object` FUNCTION and `__proto__`
+  // `Object.prototype` itself, out of a signature that admits only a
+  // `DefaultValueToken` string or `undefined`. `toString` / `valueOf` are quiet
+  // here only because `key` is lower-cased first (`tostring` names nothing),
+  // which is an accident of casing and ⛔ not a guard — it does not cover the
+  // two prototype members whose names are already lower-case, and it would not
+  // cover a future one.
+  //
+  // The refusal value is this function's own declared one, `undefined`, read
+  // from the return type. The guard narrows: every suggestion that answered
+  // before is an own key.
+  //
+  // ⛔ Not a null-prototype table (TS2353 against the annotation, or a silent
+  // loss of its exhaustiveness check via `Object.assign(Object.create(null), …)`;
+  // measured in `src/data/driver/config-registry.zod.ts`'s sibling guard) and
+  // ⛔ not a list of prototype member names, which the next prototype member
+  // defeats.
+  if (!Object.prototype.hasOwnProperty.call(DEFAULT_VALUE_TOKEN_SUGGESTIONS, key)) return undefined;
   return DEFAULT_VALUE_TOKEN_SUGGESTIONS[key];
 }

--- a/packages/spec/src/data/type-compat.test.ts
+++ b/packages/spec/src/data/type-compat.test.ts
@@ -5,6 +5,7 @@ import {
   canonicalizeSqlType,
   suggestFieldTypeForSqlType,
   isCompatible,
+  type SqlDialect,
 } from './type-compat';
 import { suggestFieldType } from '../shared/suggestions.zod';
 
@@ -152,5 +153,90 @@ describe('isCompatible', () => {
     expect(isCompatible('geometry', 'text')).toBe('lossy');
     expect(isCompatible('geometry', 'json')).toBe('lossy');
     expect(isCompatible('geometry', 'number')).toBe(false);
+  });
+});
+
+/**
+ * The Object.prototype fall-through pin. Its POPULATION is the point: the
+ * suite's other cases iterate the canonical vocabulary only, which is
+ * precisely the population that behaves, and that is why this site sat green
+ * while `canonicalizeSqlType('constructor')` returned the `Object` FUNCTION
+ * out of a signature that admits only `CanonicalSqlType` string literals.
+ *
+ * `rawType` is uncontrolled — it arrives from live database introspection —
+ * so the population below is the reachable one, not a contrived one.
+ */
+describe('canonicalizeSqlType — Object.prototype fall-through', () => {
+  // Fixed at five: the three prototype members a lower-cased key can name or
+  // nearly name, the assignment-shaped one, and a plain unknown word that
+  // names nothing at all. Four is not four-fifths of this pin.
+  const POPULATION = ['constructor', 'toString', 'valueOf', '__proto__', 'nope'] as const;
+  // Every member of the declared `SqlDialect` union, so the dialect half of the
+  // guarded line is covered for each table it can select — including the two
+  // the union declares but `DIALECT_ALIASES` does not populate, which fall
+  // through to the base map and must answer just as safely.
+  const DIALECTS: readonly SqlDialect[] = [
+    'postgres', 'mysql', 'sqlite', 'snowflake', 'bigquery', 'mongo',
+  ];
+
+  // The declared return type is a private union, so the pin names it here.
+  // ⛔ This list pins the SIGNATURE, not today's answers: a member added to
+  // `CanonicalSqlType` belongs here too.
+  const CANONICAL: readonly string[] = [
+    'text', 'integer', 'bigint', 'decimal', 'float', 'boolean', 'date', 'time',
+    'datetime', 'json', 'uuid', 'binary', 'enum', 'array', 'vector', 'unknown',
+  ];
+
+  it.each(POPULATION)('%s resolves to a declared CanonicalSqlType, never a prototype member', (word) => {
+    // The assertion is on the SHAPE of the answer, not on which word it is:
+    // what the defect produced was a `function`, and pinning "is a declared
+    // member of the union" survives a vocabulary change that pinning the
+    // string `'unknown'` would break.
+    expect(typeof canonicalizeSqlType(word)).toBe('string');
+    expect(CANONICAL).toContain(canonicalizeSqlType(word));
+    for (const dialect of DIALECTS) {
+      expect(typeof canonicalizeSqlType(word, dialect)).toBe('string');
+      expect(CANONICAL).toContain(canonicalizeSqlType(word, dialect));
+    }
+  });
+
+  it('`constructor` is refused with this function\'s own declared refusal value', () => {
+    // `'unknown'` is the trailing `return` of the function itself, ⛔ not a
+    // value invented for the fix.
+    expect(canonicalizeSqlType('constructor')).toBe('unknown');
+    for (const dialect of DIALECTS) expect(canonicalizeSqlType('constructor', dialect)).toBe('unknown');
+  });
+
+  it('`__proto__` answers `array` from the array-notation rule, ahead of either table', () => {
+    // Not a fall-through: `__proto__` starts with `_`, which is Postgres array
+    // notation (`_int4`), and that branch returns before any lookup. Recorded
+    // so a later reader does not mistake a legitimate declared answer for the
+    // defect, and so the array rule cannot be quietly dropped.
+    expect(canonicalizeSqlType('__proto__')).toBe('array');
+    expect(canonicalizeSqlType('_int4')).toBe('array');
+  });
+
+  it('the published sibling accessors stay total over the same population', () => {
+    // The defect was not confined to this function's own return: a
+    // non-`CanonicalSqlType` reaches `CANONICAL_TO_FIELD[canonical]`, which is
+    // `undefined`, and both accessors below threw a TypeError on the member
+    // read. That is the consequence a plain-JS caller actually meets.
+    for (const word of POPULATION) {
+      expect(() => suggestFieldTypeForSqlType(word)).not.toThrow();
+      expect(() => isCompatible(word, 'text')).not.toThrow();
+      for (const dialect of DIALECTS) {
+        expect(() => suggestFieldTypeForSqlType(word, dialect)).not.toThrow();
+        expect(() => isCompatible(word, 'text', dialect)).not.toThrow();
+      }
+    }
+  });
+
+  it('lit control — the canonical vocabulary is untouched by the guard', () => {
+    // If the guard narrowed anything it should not, these go red. Both halves
+    // of the guarded line are represented: the base map and a dialect map.
+    expect(canonicalizeSqlType('varchar')).toBe('text');
+    expect(canonicalizeSqlType('numeric(10,2)')).toBe('decimal');
+    expect(canonicalizeSqlType('timestamptz', 'postgres')).toBe('datetime');
+    expect(canonicalizeSqlType('objectid', 'mongo')).toBe('text');
   });
 });

--- a/packages/spec/src/data/type-compat.ts
+++ b/packages/spec/src/data/type-compat.ts
@@ -217,9 +217,36 @@ export function canonicalizeSqlType(rawType: string, dialect?: SqlDialect): Cano
 
   // `timestamp with time zone` collapsed to `timestamp` above; `timestamptz`
   // handled via alias.
+  // Own-property guard on BOTH halves. Either table is a plain object literal,
+  // so a bare index resolves `Object.prototype`'s members for an off-vocabulary
+  // `rawType`: `constructor` handed the `Object` FUNCTION out of a signature
+  // that admits only `CanonicalSqlType` string literals, and it passed the
+  // `if (...)` truthiness test on the way. `rawType` is uncontrolled here — it
+  // arrives from live database introspection — so the reach is real for a
+  // plain-JS caller, which has no compile-time narrowing at all.
+  //
+  // The refusal value is this function's own declared one, `'unknown'` (the
+  // trailing `return`), reached by simply not taking the alias branch. The
+  // guard narrows: every alias that answered before is an own key.
+  //
+  // ⛔ Not a null-prototype table, for the reason the sibling guards in
+  // `src/shared/value-domain.zod.ts` and `src/data/driver/config-registry.zod.ts`
+  // record: a `__proto__: null` object literal does not type-check against the
+  // `Record<…>` annotation at all (TS2353), and the
+  // `Object.assign(Object.create(null), …)` spelling that does compile silently
+  // COSTS the annotation's exhaustiveness check (TS2741 stopped firing for a
+  // table missing a member). A quiet failure is worse than a loud one.
+  //
+  // ⛔ Not a list of prototype member names either — a guard that names words
+  // does not survive the next prototype member, and `toString` / `valueOf` are
+  // quiet here only by the accident that `t` is lower-cased first.
   const dialectMap = dialect ? DIALECT_ALIASES[dialect] : undefined;
-  if (dialectMap && dialectMap[t]) return dialectMap[t];
-  if (BASE_ALIASES[t]) return BASE_ALIASES[t];
+  if (dialectMap && Object.prototype.hasOwnProperty.call(dialectMap, t) && dialectMap[t]) {
+    return dialectMap[t];
+  }
+  if (Object.prototype.hasOwnProperty.call(BASE_ALIASES, t) && BASE_ALIASES[t]) {
+    return BASE_ALIASES[t];
+  }
 
   // `timestamp with time zone` may survive as `timestamp` already mapped;
   // anything else is unknown.


### PR DESCRIPTION
Fixes #17456
Fixes #17762

**Clause-②: no** — the diff adds no exported symbol, no key on a published payload and no registration; it narrows three existing implementations onto the signatures they already declare. Checked mechanically, not asserted: `node scripts/pm/check-widening-tells.mjs --declaration no --diff …` exits **0** — «7 changed file(s) — 3 judged against a declared surface (no widening tell), 4 NOT MEASURED» (the 4 being the changeset and the three test files, neither of which declares a contract). The known T1 false positive on a re-declared key line did not fire.

> Note: generic type brackets are written with **square** brackets in this body (`Record[string, X]` stands for the angle-bracket spelling) so it survives GitHub's body sanitiser intact.

## What was wrong

Three lookups indexed a plain object literal with a runtime key, so an off-vocabulary key resolved an **inherited** `Object.prototype` member and was handed out through a signature that admits only declared values:

- `canonicalizeSqlType` — `packages/spec/src/data/type-compat.ts`, **both halves** of its alias line (`dialectMap[t]` and `BASE_ALIASES[t]`)
- `suggestDefaultValueToken` — `packages/spec/src/data/default-value-shape.ts`
- `classifyFilterToken` — `packages/spec/src/data/context-tokens.zod.ts`, where the index sits in a **property position inside an object literal**, which is why #17456's `return TABLE[key];`-keyed survey could not reach it

## Premise falsification, first — all three faces

Every claim in either card was re-checked rather than inherited.

**Action face.** All three sites were read on `origin/main` (`2eab3beb7f`, fetched) and all three still lacked a guard. Each symbol was located by name; the three `path:line` readings the cards carry (`type-compat.ts:222`, `default-value-shape.ts:297`, `context-tokens.zod.ts:252`) all re-derived to the same lines at this head, but the pins and this body cite symbols, not line numbers. `git log --oneline -20` over each file returns one commit in this checkout — ⚠️ the checkout is **shallow** (`git rev-parse --is-shallow-repository` → `true`), so that is a depth artefact and no ancestry claim rests on it.

**Card-reference face.** Read live rather than as the cards describe them: **#15315** — state `completed`, no longer open; **#16903** — state `completed`, no longer open; **#17715** — open; **objectui#9129** — open. All four match what the cards say. (The words for the not-open state are spelled around deliberately: GitHub's reference parser matches a keyword plus a number and ignores the surrounding prose, so a status sentence must not put one near a card number it has no business touching.)

**Work-item face.** Each site independently confirmed unguarded in the tree before being touched. ⛔ The two excluded siblings were re-confirmed and **not** touched: `numericColumnFor` is guarded by a `Set` membership test above the index, and `currencyFractionDigits` upper-cases its key.

## ⭐ The measurement this round owed

#17762's filer states plainly that they did **not** import and drive the built `classifyFilterToken` — their table came from a minimal literal with the same prototype. That reading is delivered here, against the **BUILT artifact** (`packages/spec/dist/data/index.mjs`) on the repo's Node 22 baseline (v22.22.2), for all three functions, before and after. Population fixed at five, every zero carrying a control that could have come back the other way.

| call | BEFORE | AFTER |
|:--|:--|:--|
| `canonicalizeSqlType('varchar')` — lit control | `'text'` | `'text'` |
| `canonicalizeSqlType('timestamptz', 'postgres')` — lit control | `'datetime'` | `'datetime'` |
| `canonicalizeSqlType('constructor')` | the `Object` **function** | `'unknown'` |
| `canonicalizeSqlType('constructor', d)` — every `SqlDialect` `d` | the `Object` **function** | `'unknown'` |
| `canonicalizeSqlType('__proto__')` | `'array'` | `'array'` |
| `canonicalizeSqlType('toString' / 'valueOf' / 'nope')` | `'unknown'` | `'unknown'` |
| `suggestFieldTypeForSqlType('constructor')` | **`TypeError: Cannot read properties of undefined (reading 'suggested')`** | `undefined` |
| `isCompatible('constructor', 'text')` | **`TypeError: … (reading 'exact')`** | `'lossy'` |
| `suggestDefaultValueToken('currentuser')` — lit control | `'current_user'` | `'current_user'` |
| `suggestDefaultValueToken('constructor')` | the `Object` **function** | `undefined` |
| `suggestDefaultValueToken('__proto__')` | `Object.prototype` | `undefined` |
| `suggestDefaultValueToken('toString' / 'valueOf' / 'nope')` | `undefined` | `undefined` |
| `classifyFilterToken('{current_user}').suggestion` — lit control | `'current_user_id'` | `'current_user_id'` |
| `classifyFilterToken('{constructor}').suggestion` | the `Object` **function** | `undefined` |
| `classifyFilterToken('{__proto__}').suggestion` | `Object.prototype` | `undefined` |
| `classifyFilterToken('{toString}' / '{valueOf}' / '{nope}').suggestion` | `undefined` | `undefined` |

Three readings neither card carries:

1. ⭐ **The `__proto__` row on site 1 is not a fall-through.** `'__proto__'` starts with `_`, which is Postgres array notation (`_int4`), and that branch returns `'array'` — a legitimate declared member — before either table is consulted. #17456's table reports `'array'` correctly but does not say why; a reader could mistake it for the defect. A pin now records it so the array rule cannot be quietly dropped either.
2. ⭐ **The defect was not confined to the function's own return.** A non-`CanonicalSqlType` reaches `CANONICAL_TO_FIELD[canonical]`, which is `undefined`, so the two **published sibling accessors** that read the result — `suggestFieldTypeForSqlType` and `isCompatible` — **threw a `TypeError`** on `rawType = 'constructor'`. That is a crash on a published surface, from a `rawType` that arrives off live database introspection.
3. ⭐ **The wider-regex question #17762 asks (its acceptance item 4) is answered, and bounded.** `FILTER_TOKEN_WRAPPED_RE` captures `[^{}]+` — anything but braces — so the reachable key set is *not* the identifier-shaped one objectui's narrower `[a-zA-Z0-9_]+` bounds. What bounds it here is the `toLowerCase()`: of `Object.prototype`'s twelve own property names, exactly **two** are lower-case-stable and therefore namable — `constructor` and `__proto__`. The other ten (`hasOwnProperty`, `toLocaleString`, `isPrototypeOf`, `propertyIsEnumerable`, `toString`, `valueOf`, and the four `__define*` / `__lookup*` accessors) are quiet by that casing accident alone, ⛔ not by a guard. One pin sweeps all twelve so the day a lower-case prototype member is added is a red test rather than a silent regression.

## The fix

An `Object.prototype.hasOwnProperty.call` guard at each lookup, returning **that function's own already-declared refusal value** read from its signature — `'unknown'` (site 1's own trailing `return`), `undefined` (site 2's declared return type), and an absent `suggestion` (site 3's optional field). ⛔ No declared return type changes, and no value was invented for this round. The spelling is copied from the two landed siblings in `src/shared/value-domain.zod.ts` and `src/data/driver/config-registry.zod.ts`.

⛔ **No null-prototype table**, per the binding carry-over: the annotation either stops compiling (TS2353) or, in the `Object.assign(Object.create(null), …)` spelling, silently loses its exhaustiveness check (TS2741 stopped firing for a table missing a member). ⛔ **No special-casing of `constructor`** — a guard that names words does not survive the next prototype member.

## The pins, and the ablation that proves they can fail

Each site gains a pin whose population is exactly **`constructor`, `toString`, `valueOf`, `__proto__` and a plain unknown word**, plus a lit control proving the real vocabulary still answers. The pre-existing pins are green today because they iterate the canonical vocabulary only — precisely the population that behaves.

⭐ **Ablation, run from the committed state, on-disk proof read first.** All three guards were removed from source; the removal was proven on disk by `grep -c` on each guard's exact text (`1 → 0` for each, against a lit control on a string still present reading `2`) and by three changed blob hashes, ⛔ not by any editor's exit code. The script carried `trap … EXIT INT TERM` with absolute paths.

- **mutated** — `Test Files 3 failed (3)` · `Tests 10 failed | 89 passed (99)`. The ten are exactly the prototype-member cases across all three files; **every lit control stayed green**, so the ablation did not simply break the suite.
- **restored** — `git checkout HEAD -- …`, proven by an empty `git diff HEAD`, an empty **whole-tree** `git status --porcelain`, and all three blob hashes back at their `HEAD` values (matched, not empty). Then: `Test Files 3 passed (3)` · `Tests 99 passed (99)`.

⭐ No rebuild is involved, and that is a measured fact rather than a shortcut: these tests import their subject by **relative source path**, so vitest resolves `src/`. Had they been consuming `dist/`, a mutation to `src` alone would have left them green — that they moved *is* the proof of the resolution path.

## Changeset — measured

`npm pack --dry-run --json` on the **built** package (built first):

- **positive control** `dist/data/index.mjs` → **SHIPS**; `dist/data/index.js` → **SHIPS**
- **negative controls** `src/data/type-compat.ts`, `src/data/default-value-shape.ts`, `src/data/type-compat.test.ts`, `src/data/context-tokens.test.ts` → **do NOT ship**
- `src/data/context-tokens.zod.ts` → **SHIPS** as source too (the manifest's `files` carries `src/**/*.zod.ts`)

And the guard text itself reaches the packed artifact: 4 occurrences in each of `dist/data/index.mjs` and `dist/data/index.js`, against a control marker reading 0.

⇒ **A changeset is owed.** Grade **`patch`**: a bug fix in a released package, with no declared signature moved and nothing an author can write removed or renamed. `.changeset/17456-prototype-fallthrough-guards.md`.

⚠️ One sub-premise of the dispatch is falsified and recorded rather than acted on differently: the `issue-N-` filename spelling has **four** precedents in this tree, not zero (`issue-17400-…`, `issue-17461-…`, `issue-17574-…`, `issue-17595-…`). The directive's substance still holds — `card-slug` is the prevailing *numbered* spelling at 48 files — so the filename is unchanged.

## Verification

- `pnpm --filter @objectstack/spec typecheck` — **OK**, including `check:test-typecheck` («54 file(s) / 259 error(s) / 144 pinned signature(s)» held, none of them in the three files this PR touches — a zero with a lit control: the same grep over the same log reads 259 for other test files).
- `pnpm --filter @objectstack/spec test` — **`Test Files 470 passed | 1 skipped (471)` · `Tests 13378 passed | 1 skipped (13379)`**.
- `pnpm lint` (`eslint . --no-inline-config`, repo-wide, ⛔ not narrowed) — **exit 0** at `b280ae299a`, the final commit.
- **All 81 derived gate families** (`node scripts/pm/dispatch-gates.mjs`) — exit code captured **before any pipe** for every one. Reconciled: «81 derived, 81 run, **0 NOT-MEASURED**, 0 UNRUN … a DERIVED zero — all 81 recorded an exit code and none of them is 3». Eight needed a prerequisite first — one exit 3 and four exit 1 on a stale `dist`, plus three more exit 3 — and ⛔ none was folded into the green count: the closures were built (`turbo run build`, including the full `packages/*` sweep `lint.yml` performs before those steps) and each was re-run to a real exit 0.

## 验收备注 — out of scope, noted and filed

⭐ **The triage comment on #17456 asked this round to re-run the survey keyed on the index expression itself rather than on the `return TABLE[key]` spelling, and to report the count. Done, and the count is not five.** Keyed on «a table annotated `Record[string, X]` — the widest key type — that is a plain object literal, indexed with a non-literal key», over 944 non-test files in `packages/spec/src`: **76** such tables, **44** with at least one runtime-key index site.

Four of those were driven against the built artifact. **Three are live and off-contract** — `normalizeFilterOperator` (`ui/view.zod.ts`, which indexes **twice**, raw and lower-cased, so it has no case-folding accident protecting it and returns the `Object` function for `constructor`, `toString` **and** `valueOf`), `resolveDiscoveryEnvironment` (`api/discovery.zod.ts`, whose docblock promises «a value guaranteed to satisfy DiscoveryEnvironmentSchema») and `pluralToSingular` (`meta-spelling/manifest-collection-spelling.ts`). One is **safe** and is the discriminating control: `suggestFieldType` reaches the inherited member but only truthiness-tests it before wrapping, so nothing off-contract escapes.

⛔ Not fixed here — the scope fence on both cards is exact and the triage comment states it. Filed as **#17818**, unassigned and unlabelled, carrying the survey method, the measured tables with their lit controls, and an explicit NOT MEASURED on the remaining 41 tables.

Nothing else is withheld: no other finding was noted and not filed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MkQhmuuJAVDjmeWNixwDDH)_

---
_Generated by [Claude Code](https://claude.ai/code)_