### PR TITLE
fix(gate): read a heading that denies a migration prescription as a denial

### DIFF
--- a/scripts/check-adr-0087-registration.mjs
+++ b/scripts/check-adr-0087-registration.mjs
@@ -393,6 +393,7 @@ const SELF_TEST_BATTERIES = Object.freeze({
   'R7: an unknown category is refused (the vocabulary is closed)': 3,
   'R8: an empty justification is refused': 2,
   'G5: the catch-all, on a changeset carrying no prescription': 1,
+  'D-E2E (#17357): the denial heading, END TO END through `scan()`': 6,
   'R9: two markers is ambiguous, not "the first one wins"': 2,
   'R10: THE #6419 SHAPE -- a REAL prescription, written in Chinese with -': 4,
   'R11: the same, framed by a HEADING instead of an inline label': 3,
@@ -420,6 +421,7 @@ const SELF_TEST_BATTERIES = Object.freeze({
   'Unit pins on the two pattern-shaped judgements': 29,
   'the floors: what the new vocabulary must refuse': 9,
   'the floors: labels that are NOT mentions, and mentions that ARE evidenced': 9,
+  'D1-D9 (#17357): a heading that DENIES a prescription is not evidence of one': 9,
   'P51-P60: the HARD-WRAPPED mention, and the floors that keep the cure from': 11,
   'P62-P68: the framed region closes at the same or a SHALLOWER heading, not': 7,
   'U1-U12 (#8299): unit pins on the runtime-interface-only primitives': 13,
@@ -1171,6 +1173,52 @@ const FRAMING_TAIL_RE =
   /(?:迁移|改写|改名|升级|migrat(?:e|es|ed|ing|ion|ions)|rename[sd]?|rewrit(?:e|es|ten|ing)|upgrade[sd]?)$/i;
 
 /**
+ * Does a NEGATOR directly govern the placeholder in this HEADING -- is the heading
+ * DENYING that a prescription exists rather than opening one? (#17357)
+ *
+ * A heading short-circuits the governance test below, because a heading is a label
+ * by construction and its words are a title rather than a sentence (P46). That is
+ * right for every heading which says what follows it, and exactly wrong for the one
+ * shape that says what does NOT follow it:
+ *
+ *     ## No FROM -> TO mapping, and why this section is not one
+ *
+ * Read as a label, that heading evidences the very prescription it denies, and the
+ * gate then refuses `not-required (no-migration-prescription)` on it -- offering as
+ * the remedy `registered <ENTRY_ID>`, which asserts the opposite of what the
+ * changeset says. Measured before the repair, through the real CLI on a real temp
+ * repo: the heading above is exit 1 with `Evidence (from-to-label)` naming the
+ * denial itself, and the IDENTICAL denial reworded off the token is exit 0. The
+ * detector was keying on the SPELLING rather than the meaning, and the only passing
+ * form was to avoid a word -- a gate shaping prose a human reads, in the direction
+ * of not naming the thing being denied.
+ *
+ * ⚠️ The rule is ADJACENCY, exactly as `GOVERNING_WORD_RE` is: the negator has to be
+ * the last word before the placeholder. "A negator appears somewhere in the heading"
+ * is a whole clause and a different claim -- `## 升级:不再支持的键的 FROM → TO` is a
+ * real prescription heading whose negator modifies a noun three words away, and a
+ * loose read turns it into a denial. The class is CLOSED for the same reason
+ * `WRAPPED_GOVERNOR_RE`'s is: an open read of "negative-sounding words" cannot be
+ * measured, and a false NEGATIVE here is the one direction this gate must not buy.
+ *
+ * ⚠️ A framing word between the negator and the placeholder is transparent, exactly
+ * as it is in-line (`FRAMING_TAIL_RE`): `## No migration FROM → TO` denies as
+ * plainly as `## No FROM → TO`, because `migration` FRAMES the placeholder rather
+ * than governing it. The second right-trim is what makes that composition work --
+ * stripping the framing tail leaves the space that preceded it.
+ *
+ * ⚠️ Direction, and the whole reason this cannot weaken the gate: a denying heading
+ * is NOT an exemption. It is demoted to exactly the status of a governed MENTION, so
+ * it falls through to `carriesConcreteRewrite` -- a body that denies in its heading
+ * and then SHOWS the goods anywhere is refused precisely as before -- and every
+ * other branch of `findMigrationPrescription` still reads the same body afterwards.
+ * The narrowing can only ever remove a hit whose SOLE evidence was a heading saying
+ * there was nothing to evidence.
+ */
+const HEADING_DENIAL_RE =
+  /(?:^|[^A-Za-z])(?:no|not|none|never|without|lacks?|lacking|zero)$|(?:无|没有|不|未|非)$/i;
+
+/**
  * A line whose sentence CANNOT run on into the line below it -- markdown structure
  * rather than prose. Consulted only by `labelPositioned`'s cross-line arm (#7094):
  * a placeholder opening the line under one of these is opening a segment, so it is
@@ -1263,6 +1311,14 @@ const VERTICAL_TO_RE = /^\s{0,3}(?:(?:\/\/|#|-|\*|>)\s*)*\**TO\**\s*(?::|—|-|$
  * short-circuits: `## 升级:翻译包键的 FROM → TO` is a title and not a sentence, and it
  * ends in the very particle the Chinese arm reads as governance.
  *
+ * ⚠️ With ONE exception, and it is a polarity one (#17357): a heading whose governing
+ * word DENIES the placeholder -- `## No FROM → TO mapping, and why this section is
+ * not one` -- is not opening a prescription, it is stating that there is none to
+ * open. Read as a label it evidenced the thing it denied, and the author was refused
+ * for saying so in the clearest available words. `HEADING_DENIAL_RE` above carries
+ * the closed class, the adjacency rule and why a denying heading is demoted to a
+ * mention rather than exempted.
+ *
  * ⚠️ Prose in this repo is HARD-WRAPPED at ~80 columns, so "starts its line" is NOT
  * the test and never could be -- `carry their\nFROM → TO migration` puts a mention
  * at column 0 with nothing at all to its left. #7078 left that as a stated blind
@@ -1306,8 +1362,15 @@ const VERTICAL_TO_RE = /^\s{0,3}(?:(?:\/\/|#|-|\*|>)\s*)*\**TO\**\s*(?::|—|-|$
  * @param {string} [prev] the line above it, when there is one (#7094)
  */
 function labelPositioned(line, col, prev) {
-  if (/^\s{0,3}#{1,6}\s/.test(line)) return true;
   const prefix = line.slice(0, col).replace(/\s+$/, '');
+  // A heading is a label by construction, whatever words it carries -- UNLESS the
+  // word governing the placeholder denies it (#17357). A denying heading is not
+  // granted an exemption here; it is demoted to the status of a governed mention and
+  // takes the `carriesConcreteRewrite` path below, so a body that shows the goods
+  // anywhere is refused exactly as it was.
+  if (/^\s{0,3}#{1,6}\s/.test(line)) {
+    return !HEADING_DENIAL_RE.test(prefix.replace(FRAMING_TAIL_RE, '').replace(/\s+$/, ''));
+  }
   if (prefix !== '') return !GOVERNING_WORD_RE.test(prefix.replace(FRAMING_TAIL_RE, ''));
   // The placeholder OPENS its line -- bare or merely indented, so a wrapped list
   // item counts. There is no character to its left, so the governing word, if there
@@ -4033,6 +4096,43 @@ function selfTest() {
     },
   })));
 
+  // ---- D-E2E (#17357): the denial heading, END TO END through `scan()` --------
+  //
+  // D1-D9 above pin the detector; these pin the VERDICT, because the detector is
+  // only half of what the author meets. Three cases, and the two REDs are the half
+  // that keeps this from being a weakening: an author who denies in plain words is
+  // admitted, an author who denies in the heading and ships the prescription anyway
+  // is still refused, and an author who says NOTHING at all is still refused.
+  battery('D-E2E (#17357): the denial heading, END TO END through `scan()`');
+  const DENIAL_HEADING = '## No FROM → TO mapping, and why this section is not one';
+  const DENIAL_WHY = 'a bare deletion on a non-strict schema refuses nothing and converts nothing';
+  green('D-E2E-G the plain-words denial is admitted', run(mk({
+    files: {
+      '.changeset/x.md': CS({
+        body: '**BREAKING** the `x` key is deleted outright.\n\n' + DENIAL_HEADING + '\n\n'
+          + 'No metadata upgrader has an edit and `os migrate meta` has nothing to list.\n\n'
+          + '<!-- adr-0087: not-required (no-migration-prescription) ' + DENIAL_WHY + ' -->\n',
+      }),
+    },
+  })));
+  red('D-E2E-R1 the same denial heading over a body that SHIPS the prescription still refuses', run(mk({
+    files: {
+      '.changeset/x.md': CS({
+        body: '**BREAKING** the `x` key is deleted outright.\n\n' + DENIAL_HEADING + '\n\n'
+          + '- `App.x` → `App.y`\n\n'
+          + '<!-- adr-0087: not-required (no-migration-prescription) ' + DENIAL_WHY + ' -->\n',
+      }),
+    },
+  })), [/contradicts the changeset's own body/, /Evidence \(from-to-label\)/]);
+  red('D-E2E-R2 a SILENT omission is still refused -- the denial is a reading, never an exemption', run(mk({
+    files: {
+      '.changeset/x.md': CS({
+        body: '**BREAKING** the `x` key is deleted outright.\n\n' + DENIAL_HEADING + '\n\n'
+          + 'No metadata upgrader has an edit and `os migrate meta` has nothing to list.\n',
+      }),
+    },
+  })), [/no `adr-0087:` disposition marker/]);
+
   // ---- R9: two markers is ambiguous, not "the first one wins" ---------------
   battery('R9: two markers is ambiguous, not "the first one wins"');
   red('R9 two disposition markers', run(mk({
@@ -5473,6 +5573,54 @@ function selfTest() {
   assert(
     findMigrationPrescription('prose that wraps at eighty columns and ends the line here\nFROM → TO:\n\n- `a.b` → `a.c`\n')?.line === 'FROM → TO:',
     'P50: the evidence line is the placeholder\'s OWN line -- the match may open on the newline that ends the line above, which used to be reported instead',
+  );
+
+  // --- D1-D9 (#17357): a heading that DENIES a prescription is not evidence of one.
+  //
+  // The heading short-circuit in `labelPositioned` had no polarity, so
+  // `## No FROM → TO mapping, and why this section is not one` evidenced the very
+  // prescription it denied and `not-required (no-migration-prescription)` was refused
+  // on it -- while the IDENTICAL denial reworded off the token passed. Both
+  // directions are pinned here, and the RED half is load-bearing: a narrowing that
+  // only proves the denial passes has made the gate weaker and measured nothing
+  // about it. D2/D4/D6 are the positive controls -- if any of them goes red the arm
+  // has stopped seeing rather than started discriminating.
+  battery('D1-D9 (#17357): a heading that DENIES a prescription is not evidence of one');
+  assert(
+    !hasMigrationPrescription('## No FROM → TO mapping, and why this section is not one\n\nA bare deletion on a non-strict schema refuses nothing and converts nothing.\n'),
+    'D1: THE #17357 SHAPE -- the denial heading verbatim, in a body that shows no goods',
+  );
+  assert(
+    findMigrationPrescription('## Migration — FROM → TO\n\ndelete the block\n')?.branch === 'from-to-label',
+    'D2: POSITIVE CONTROL -- an ordinary label heading, with NO concrete rewrite in the body to fall back on, still matches',
+  );
+  assert(
+    findMigrationPrescription('## No FROM → TO mapping, and why this section is not one\n\n- `a.b` → `a.c`\n')?.branch === 'from-to-label',
+    'D3: a denying heading is DEMOTED TO A MENTION, not exempted -- a body that denies and then SHOWS the goods is refused exactly as before',
+  );
+  assert(
+    findMigrationPrescription('## Upgrading the keys that are not yet removed, FROM → TO\n')?.branch === 'from-to-label',
+    'D4: POSITIVE CONTROL -- ADJACENCY is the rule; a negator three words away from the placeholder governs a different noun and denies nothing',
+  );
+  assert(
+    !hasMigrationPrescription('## 无 FROM → TO 映射,以及本节为什么不是一份映射\n\n直接删除,什么都不需要改写。\n'),
+    'D5: the Chinese spelling of the same denial -- `无` governs the placeholder',
+  );
+  assert(
+    findMigrationPrescription('## 升级:不再支持的键的 FROM → TO\n')?.branch === 'from-to-label',
+    'D6: POSITIVE CONTROL -- `不` modifies a noun three words away; the governing token is `的`, so this real prescription heading is untouched',
+  );
+  assert(
+    !hasMigrationPrescription('## No migration FROM → TO is prescribed by this change\n'),
+    'D7: a framing word between the negator and the placeholder is transparent -- `migration` FRAMES, it does not govern',
+  );
+  assert(
+    findMigrationPrescription('## No FROM → TO mapping, and why this section is not one\n\n**Migration (FROM → TO).** delete the block\n')?.line === '**Migration (FROM → TO).** delete the block',
+    'D8: only the DENYING occurrence is demoted -- a genuine label later in the same body still hits, and the evidence line is that label rather than the denial',
+  );
+  assert(
+    findMigrationPrescription('## Nonstandard keys, FROM → TO is how they are listed\n')?.branch === 'from-to-label',
+    'D9: POSITIVE CONTROL -- the closed class is WORD-anchored, so `Nonstandard` is not `no` and this heading keeps its label reading',
   );
 
   // --- P51-P60: the HARD-WRAPPED mention, and the floors that keep the cure from


### PR DESCRIPTION
Fixes #17357

Authored by the `os-dev` round of the `domain:spec` execution seat, session
`session_01MkQhmuuJAVDjmeWNixwDDH` — https://claude.ai/code/session_01MkQhmuuJAVDjmeWNixwDDH
(durable attribution in prose: the trailing footer block on this body is written by the
platform on every edit, so it carries no session).

Clause-②: no — a gate's evidence rule is corrected. No schema key, no closed-set member and no
published export moves; `CATEGORIES` is untouched and so is ADR-0087. The set of changesets the
gate ACCEPTS grows by exactly the ones that were being refused for denying a prescription in
plain words.

## The defect, reproduced two-legged before anything changed

`check-adr-0087-registration`'s branch-1 detector short-circuits on any markdown heading — a
heading is a label by construction — so a heading that **denies** the changeset carries a
FROM/TO mapping evidenced the very prescription it denied, and
`not-required (no-migration-prescription)` was refused on it. The remedy that refusal offers
(`registered` plus an entry id) asserts the opposite of what the changeset says.

Measured on `7f625364b0` through the **real CLI** on a **real temp git repo** — the two legs
differ only in the wording of one heading, and nothing else in the changeset:

| leg | heading | gate, before the fix | after |
|:---|:---|:---|:---|
| A · token present | `## No FROM → TO mapping, and why this section is not one` | **exit 1**, `Evidence (from-to-label)` naming the denial itself | **exit 0** |
| B · token absent | `## No old-to-new mapping, and why this section is not one` | **exit 0** | **exit 0** |

⇒ the gate was keying on the **spelling** rather than the meaning, and the only passing form was
to avoid a word. A one-legged reproduction would have proved nothing here; leg B is what shows
the refusal is about the token and not about the claim.

The reproduction driver is in the round's scratchpad, not in the tree — it copies the gate under
test plus its two sibling modules into a temp repo, builds the base/head commits, and runs
`node scripts/check-adr-0087-registration.mjs --base ...` from inside it, capturing `$?` before
any pipe. Its first run failed **both** legs on a 32-character justification (the 40-character
floor), which is why the exit codes above are quoted with the hits that produced them rather
than on their own.

## The repair

`labelPositioned`'s heading short-circuit now asks whether the word **governing** the
placeholder is a negator:

- **Adjacency is the rule**, exactly as `GOVERNING_WORD_RE` is. "A negator appears somewhere in
  the heading" is a whole clause and a different claim — `## 升级:不再支持的键的 FROM → TO` is a
  real prescription heading whose negator modifies a noun three words away.
- **The class is bounded**, for the same reason `WRAPPED_GOVERNOR_RE`'s is: an open read of
  "negative-sounding words" cannot be measured, and a false negative is the one direction this
  gate must not buy.
- **A framing word between the negator and the placeholder is transparent**, exactly as it is
  in-line: `## No migration FROM → TO` denies as plainly as `## No FROM → TO`.

**This cannot weaken the gate, and the mechanism is why.** A denying heading is **not** granted
an exemption — it is demoted to exactly the status of a governed MENTION, so it falls through to
`carriesConcreteRewrite`. A body that denies in its heading and then SHIPS the prescription is
refused precisely as before, every other branch of `findMigrationPrescription` still reads the
same body afterwards, and a silent omission is untouched.

## Both directions are pinned, in the gate's own `--self-test`

Extended, not bolted beside. Nine unit pins (`D1`-`D9`) and three end-to-end cases through
`scan()` (`D-E2E-*`), each registered in `SELF_TEST_BATTERIES` under its own floor:

| pin | direction |
|:---|:---|
| D1 · D5 · D7 | the denial heading is read as a denial (English, Chinese, and with a framing word between) |
| **D2 · D4 · D6 · D9** | **positive controls** — an ordinary label heading with no concrete rewrite to fall back on; a negator three words away; the Chinese real-prescription heading; a word merely beginning with the negator's letters. If any of these reds, the arm has stopped seeing rather than started discriminating |
| **D3** | **a denying heading over a body that SHOWS the goods is still a hit** — demoted to a mention, not exempted |
| **D8** | only the DENYING occurrence is demoted; a genuine label later in the same body still hits, and the evidence line is that label |
| **D-E2E-G** | the plain-words denial is admitted, end to end |
| **D-E2E-R1** | the same denial heading over a body that ships the prescription is **still refused**, on `contradicts the changeset's own body` |
| **D-E2E-R2** | a **silent omission** is **still refused**, on `no adr-0087: disposition marker` |

Self-test after: `exit 0`, 353 assertions over real temp git repos.

## Ablation

The fix reverted to `return true` with the pins left in place, restored afterwards:

- **On-disk proof read FIRST**, before anything ran: the fixed text `1 → 0`, the injected
  ablation marker `0 → 1`. The script refuses to run the self-test unless both counts move.
- **Result**: self-test `exit 1`, **5 failures** — `D1`, `D5`, `D7`, `D8`, `D-E2E-G`. The seven
  control pins stayed green under ablation, which is what makes them controls: they pin
  behaviour the repair must not change.
- **Restore proven by `git hash-object`** against the HEAD blob
  (`d78b2ddd94284f16a95ecbb77cfe75d758aebed6` both sides), never from an exit code, with
  `git diff HEAD` clean afterwards. `trap` on `EXIT INT TERM`, absolute paths throughout, and an
  empty hash treated as failure rather than as nothing to compare.

## Corpus reading — the narrowing removes no true positive

`findMigrationPrescription` run over the real changeset stock at `d87a6936ef`
(`objectstack-ai/objectstack`, this worktree), before and after:

- **238 changesets, 17 hits, byte-identical both sides** — `diff` of the two per-file verdict
  tables is empty. No row changes branch, evidence line or verdict.

## Verification

Gate families derived by `node scripts/pm/dispatch-gates.mjs --commands --repo objectstack-ai/objectstack`
(exit 0; change set derived by the tool itself from the merge base `7f625364b0`, not from a
hand-written diff):

- **35 derived families, 35 run, all exit 0**, every code captured before any pipe
  (`cmd > file 2>&1; EXIT=$?`). No family returned 3.
- Reconciled with `--ran` carrying the exit codes: **35 derived, 35 run, 0 NOT-MEASURED, 0 UNRUN**
  — a derived zero, not a claimed one.
- `node scripts/check-adr-0087-registration.mjs --base origin/main` — exit 0 on this PR's own diff.
- `pnpm lint` equivalent run **whole-tree, not narrowed**: `eslint . --no-inline-config --format json`
  over **6655 files** that eslint itself selects, **0 errors**, exit 0, at `d87a6936ef`. The
  narrowed run on the changed file alone is also 0/0/0. This repo never enables type-aware
  linting for any file, so neither reading can move a verdict on an untouched file.
- Diff touches no package, so there is no dependency closure to build and no package test suite
  is owed; the file's own test surface is its `--self-test`, which is in the derived set above.

## Changeset — not owed, measured rather than asserted

`@objectstack/spec` built first and confirmed finished (`34/34 declared declaration file(s)
present`, lock wrapper `VERDICT command-exit 0`), then `npm pack --dry-run --json`:

| reading | count |
|:---|:---|
| tarball entries | 2012 |
| **negative** — entries matching this round's file | **0** |
| **positive control** — `dist/*` entries, the built surface that does ship | **216** |
| second negative control — `src/**/*.test.ts`, present on disk, never shipped | 0 |
| lit control for the matcher itself — entries matching `package.json` | 1 |

Across the workspace: **70 published packages, 0** declaring a `files[]` entry that escapes its
own directory — so a repo-root `scripts/` file cannot appear in any tarball. No package source
imports the changed file (the only hits outside `scripts/` are CHANGELOG prose and one comment).
⇒ nothing published moves; `skip-changeset` applied on this PR.

## 验收备注

- **Filed as issue 17864, not fixed here** — the same detector reads a governed MENTION as a label
  whenever a framing word sits between the governor and the placeholder:
  `the Migration FROM → TO is documented elsewhere` returns `from-to-label`, while the identical
  sentence without `Migration` returns `null` and `Migration FROM → TO: delete the block` (no
  governor) returns `from-to-label`. Cause: `prefix.replace(FRAMING_TAIL_RE, '')` leaves the
  space the framing word sat behind, and `GOVERNING_WORD_RE` is end-anchored, so the word the
  strip exists to expose is never examined. It is the same false-positive direction this card is
  about but a **different arm with its own measured history** — the in-line rule's first draft
  took five real prescriptions with it — so repairing it needs its own stock measurement and is
  out of this card's declared file face.
- Noted, not filed: `labelPositioned` keeps its own inline copy of the ATX-heading pattern while
  `HEADING_RE` is hoisted a few hundred lines above for the framed-region arm. Carrier: the next
  author of this gate, who is the only reader either spelling has.
- The card's `path:line` citations were re-derived by symbol rather than trusted: every one of
  them had moved, which is the expected state.


---
_Generated by [Claude Code](https://claude.ai/code)_