### PR TITLE
fix(spec): give the email-template locale bundle a stated en-US floor, and report one that has none

### DIFF
--- a/.changeset/email-template-locale-floor.md
+++ b/.changeset/email-template-locale-floor.md
@@ -1,0 +1,24 @@
+---
+'@objectstack/spec': minor
+---
+
+Email templates: say where the `en-US` fallback floor is, and report a bundle that has none.
+
+`IEmailService.sendTemplate` matches `(name, locale)` exactly and retries exactly one rung —
+the literal `en-US`. There is no language-subtag folding, so a bundle whose English row is
+tagged `en` is unreachable from `en-US` and from every other tag it does not itself carry;
+each such delivery raises `TEMPLATE_NOT_FOUND`, which classifies permanent, so it dead-letters
+with no retry. An app declaring `i18n.defaultLocale: 'en'` and authoring `locale: 'en'` has
+done the consistent thing throughout and still shipped a bundle with no floor — and it
+validated, built and installed clean.
+
+- `EmailTemplateDefinitionSchema.locale`'s `describe` and TSDoc now state the exact match, the
+  single literal `en-US` rung, the absence of folding, and that the stack's own declared default
+  locale is the wrong tag whenever it is not spelled `en-US`.
+- New exported `EMAIL_TEMPLATE_FLOOR_LOCALE` names that tag once: it is both the schema default
+  and the resolver's sole retry rung.
+- `defineStack` now reports (advisory `console.warn`, warn-once per bundle) an `emailTemplates`
+  bundle that carries rows for the stack's own `i18n.supportedLocales` but none tagged `en-US`.
+
+Advisory only — no accept set moves. The stack still parses and is returned unchanged; the
+resolver's ladder is unchanged.

--- a/content/docs/references/system/email-template.mdx
+++ b/content/docs/references/system/email-template.mdx
@@ -44,7 +44,7 @@ const result = EmailTemplateDefinitionSchema.parse(data);
 | **name** | `string` | ✅ | Template identifier (dotted snake_case) |
 | **label** | `string` | ✅ | Display label |
 | **category** | `Enum<'auth' \| 'notification' \| 'workflow' \| 'marketing' \| 'custom'>` | optional (default: `"custom"`) |  |
-| **locale** | `string` | optional (default: `"en-US"`) | BCP-47 locale (e.g. en-US, zh-CN) |
+| **locale** | `string` | optional (default: `"en-US"`) | BCP-47 locale (e.g. en-US, zh-CN) — the bundle key the resolver matches EXACTLY, with one retry rung: the literal `en-US`. No language-subtag folding, so `en` and `en-US` are different bundles and neither reaches the other. A bundle with no `en-US` row therefore has no fallback floor: any recipient locale it does not carry a row for raises TEMPLATE_NOT_FOUND, which is permanent — the delivery dead-letters with no retry. Your stack's own `i18n.defaultLocale` is the wrong tag here unless it is spelled `en-US`. |
 | **subject** | `string` | ✅ | Subject template |
 | **bodyHtml** | `string` | ✅ | HTML body template |
 | **bodyText** | `string` | optional | Plain-text body template (auto-derived from HTML when omitted) |

--- a/packages/spec/api-surface/system.json
+++ b/packages/spec/api-surface/system.json
@@ -200,6 +200,7 @@
     "Doc (type)",
     "DocSchema (const)",
     "DocTranslation (type)",
+    "EMAIL_TEMPLATE_FLOOR_LOCALE (const)",
     "ENVIRONMENT_ARTIFACT_SCHEMA_VERSION (const)",
     "EmailAddressConfig (type)",
     "EmailAddressConfigSchema (const)",

--- a/packages/spec/export-origins/system.json
+++ b/packages/spec/export-origins/system.json
@@ -194,6 +194,7 @@
     "Doc": "src/system/doc.zod.ts#Doc (type)",
     "DocSchema": "src/system/doc.zod.ts#DocSchema (const)",
     "DocTranslation": "src/system/doc.zod.ts#DocTranslation (type)",
+    "EMAIL_TEMPLATE_FLOOR_LOCALE": "src/system/email-template.zod.ts#EMAIL_TEMPLATE_FLOOR_LOCALE (const)",
     "ENVIRONMENT_ARTIFACT_SCHEMA_VERSION": "src/system/environment-artifact.zod.ts#ENVIRONMENT_ARTIFACT_SCHEMA_VERSION (const)",
     "EmailAddressConfig": "src/system/email-config.zod.ts#EmailAddressConfig (type)",
     "EmailAddressConfigSchema": "src/system/email-config.zod.ts#EmailAddressConfigSchema (const)",

--- a/packages/spec/src/stack-email-template-locale-floor.test.ts
+++ b/packages/spec/src/stack-email-template-locale-floor.test.ts
@@ -120,8 +120,10 @@ describe('#17614 — and stays silent where the bundle HAS a floor (the controls
   });
 
   it('silent when the row omits `locale` entirely — the schema default already IS the floor', () => {
-    // This is the post-parse seam. Run pre-parse, the key is not there yet and
-    // this stack would be reported for a floor it actually has.
+    // Measured, by ablation: moving the call pre-parse does NOT break this —
+    // the reader mirrors the schema default for a missing key, so the two
+    // agree and the case is silent either way. The pin is the behaviour (an
+    // omitted `locale` is never reported), not the call site.
     const { warns, value } = warningsOf(stack([tpl(undefined)], THE_TRAP));
     expect(floorWarns(warns)).toEqual([]);
     expect(value.emailTemplates?.[0]?.locale).toBe(EMAIL_TEMPLATE_FLOOR_LOCALE);

--- a/packages/spec/src/stack-email-template-locale-floor.test.ts
+++ b/packages/spec/src/stack-email-template-locale-floor.test.ts
@@ -1,0 +1,146 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+//
+// #17614 — an `emailTemplates` bundle tagged with the stack's OWN
+// `i18n.defaultLocale` has no fallback floor.
+//
+// Measured before this landed, on an unmodified tree: a stack declaring
+// `defaultLocale: 'en'`, `supportedLocales: ['en','zh-CN','ja-JP','es-ES']`
+// and one row per those tags parsed with ZERO warnings and ZERO errors, and
+// the resolver then answered `TEMPLATE_NOT_FOUND` — which classifies
+// PERMANENT, so the delivery dead-letters with no retry — for `de-DE` and for
+// the literal `en-US`. The identical bundle with its English row tagged
+// `en-US` delivered for `de-DE`. `sendTemplate` matches `(name, locale)`
+// exactly and retries exactly one rung, the literal `en-US`; there is no
+// language-subtag folding, and that ladder's shape is a settled ruling this
+// change deliberately does not touch. The remedy is the bundle, so the
+// diagnostic is where the author is standing.
+//
+// These pin the diagnostic ADVISORY: every case asserts the parse still
+// succeeds and the stack comes back unchanged. The diagnostic narrows what
+// passes SILENTLY; it moves no accept set.
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { defineStack } from './stack.zod';
+import { EmailTemplateDefinitionSchema, EMAIL_TEMPLATE_FLOOR_LOCALE } from './system/email-template.zod';
+
+const MANIFEST = { id: 'acme', name: 'acme', version: '1.0.0', namespace: 'acme', type: 'app' as const };
+
+const tpl = (locale: string | undefined, name = 'acme.welcome') => ({
+  name,
+  label: `Welcome ${locale ?? '(default)'}`,
+  ...(locale === undefined ? {} : { locale }),
+  subject: `[${locale ?? 'default'}] Hi {{name}}`,
+  bodyHtml: `<p>[${locale ?? 'default'}] Hi {{name}}</p>`,
+});
+
+const stack = (tpls: unknown[], i18n?: unknown) => ({
+  manifest: MANIFEST,
+  ...(i18n === undefined ? {} : { i18n }),
+  emailTemplates: tpls,
+}) as never;
+
+const THE_TRAP = { defaultLocale: 'en', supportedLocales: ['en', 'zh-CN', 'ja-JP', 'es-ES'], fallbackLocale: 'en' };
+
+/** Run `defineStack` capturing every `console.warn` it emits. */
+function warningsOf(config: unknown): { warns: string[]; value: ReturnType<typeof defineStack> } {
+  const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  try {
+    const value = defineStack(config as never);
+    return { warns: spy.mock.calls.map((c) => c.map(String).join(' ')), value };
+  } finally {
+    spy.mockRestore();
+  }
+}
+
+const floorWarns = (warns: string[]) => warns.filter((w) => w.includes('no fallback floor'));
+
+afterEach(() => {
+  // The reporter is warn-once per (bundle, tags); each test authors its own
+  // tag set so the cache cannot mask a case, but keep runs independent.
+  vi.restoreAllMocks();
+});
+
+describe('#17614 — the floor tag is one named constant, not two spellings', () => {
+  it('is the schema default for `locale`, so a row that omits the key HAS the floor', () => {
+    expect(EMAIL_TEMPLATE_FLOOR_LOCALE).toBe('en-US');
+    const parsed = EmailTemplateDefinitionSchema.parse({
+      name: 'acme.welcome', label: 'W', subject: 's', bodyHtml: '<p>b</p>',
+    });
+    expect(parsed.locale).toBe(EMAIL_TEMPLATE_FLOOR_LOCALE);
+  });
+
+  it("states the two facts an author needs in the published `describe` — the floor tag and what a miss costs", () => {
+    // The `describe` is the authoring surface (it lands in the generated
+    // reference docs). The rule used to live only in a docstring two packages
+    // away, under a heading about a different subject — which is the finding.
+    const text = String(EmailTemplateDefinitionSchema.shape.locale.description ?? '');
+    expect(text).toContain('en-US');
+    expect(text).toContain('TEMPLATE_NOT_FOUND');
+  });
+});
+
+describe('#17614 — defineStack reports a bundle with no `en-US` floor', () => {
+  it('reports the trap: every supportedLocales tag authored, none of them the floor', () => {
+    const { warns, value } = warningsOf(stack(['en', 'zh-CN', 'ja-JP', 'es-ES'].map((l) => tpl(l)), THE_TRAP));
+    const hits = floorWarns(warns);
+    expect(hits).toHaveLength(1);
+    expect(hits[0]).toContain("emailTemplates 'acme.welcome'");
+    expect(hits[0]).toContain("none tagged 'en-US'");
+    expect(hits[0]).toContain('TEMPLATE_NOT_FOUND');
+    // ADVISORY — the accept set did not move: the stack parsed and came back
+    // carrying exactly the tags the author wrote.
+    expect(value.emailTemplates?.map((t) => t.locale)).toEqual(['en', 'zh-CN', 'ja-JP', 'es-ES']);
+  });
+
+  it('reports a single-row bundle tagged with the stack default — the consistent thing an author writes', () => {
+    const { warns, value } = warningsOf(stack([tpl('en')], THE_TRAP));
+    expect(floorWarns(warns)).toHaveLength(1);
+    expect(value.emailTemplates).toHaveLength(1);
+  });
+
+  it('reports each bundle separately, by name', () => {
+    const { warns } = warningsOf(stack(
+      [tpl('en', 'acme.welcome'), tpl('zh-CN', 'acme.welcome'), tpl('en', 'acme.reset')],
+      THE_TRAP,
+    ));
+    const hits = floorWarns(warns);
+    expect(hits).toHaveLength(2);
+    expect(hits.some((w) => w.includes("'acme.welcome'"))).toBe(true);
+    expect(hits.some((w) => w.includes("'acme.reset'"))).toBe(true);
+  });
+});
+
+describe('#17614 — and stays silent where the bundle HAS a floor (the controls)', () => {
+  it('silent when the bundle carries an en-US row beside the supported tags', () => {
+    const { warns, value } = warningsOf(stack(
+      ['en-US', 'zh-CN', 'ja-JP', 'es-ES'].map((l) => tpl(l)), THE_TRAP,
+    ));
+    expect(floorWarns(warns)).toEqual([]);
+    expect(value.emailTemplates).toHaveLength(4);
+  });
+
+  it('silent when the row omits `locale` entirely — the schema default already IS the floor', () => {
+    // This is the post-parse seam. Run pre-parse, the key is not there yet and
+    // this stack would be reported for a floor it actually has.
+    const { warns, value } = warningsOf(stack([tpl(undefined)], THE_TRAP));
+    expect(floorWarns(warns)).toEqual([]);
+    expect(value.emailTemplates?.[0]?.locale).toBe(EMAIL_TEMPLATE_FLOOR_LOCALE);
+  });
+
+  it('silent when the stack declares no supportedLocales to measure against', () => {
+    const { warns } = warningsOf(stack([tpl('en')]));
+    expect(floorWarns(warns)).toEqual([]);
+  });
+
+  it('silent when no authored tag is one this stack claims to support', () => {
+    const { warns } = warningsOf(stack([tpl('fr-CA')], { defaultLocale: 'en', supportedLocales: ['en'] }));
+    expect(floorWarns(warns)).toEqual([]);
+  });
+
+  it('warns once for one bundle, however many times the same stack is defined', () => {
+    const first = warningsOf(stack([tpl('pt-BR')], { defaultLocale: 'pt-BR', supportedLocales: ['pt-BR'] }));
+    const second = warningsOf(stack([tpl('pt-BR')], { defaultLocale: 'pt-BR', supportedLocales: ['pt-BR'] }));
+    expect(floorWarns(first.warns)).toHaveLength(1);
+    expect(floorWarns(second.warns)).toEqual([]);
+  });
+});

--- a/packages/spec/src/stack.zod.ts
+++ b/packages/spec/src/stack.zod.ts
@@ -2697,8 +2697,10 @@ const warnedEmailTemplateFloors = new Set<string>();
  * resolver's ladder is fenced by a standing ruling and is NOT touched here: the
  * remedy this points at is the bundle.
  *
- * Runs post-parse on purpose — `locale` defaults to `en-US`, so a row that
- * omits the key entirely already has the floor and must not be reported.
+ * Runs post-parse, on the value the schema produced. `locale` defaults to
+ * `en-US`, so a row that omits the key entirely already has the floor and must
+ * not be reported — the reader below mirrors that default rather than relying
+ * on the call site for it, so the two agree wherever this is called from.
  * Warn-once per bundle, keyed by name plus the tags it actually carries.
  */
 function warnEmailTemplateLocaleFloor(data: ObjectStackDefinition): void {

--- a/packages/spec/src/stack.zod.ts
+++ b/packages/spec/src/stack.zod.ts
@@ -60,7 +60,7 @@ import { CubeSchema } from './data/analytics.zod';
 import { WebhookSchema } from './automation/webhook.zod';
 
 // System Protocol (additional)
-import { EmailTemplateDefinitionSchema } from './system/email-template.zod';
+import { EmailTemplateDefinitionSchema, EMAIL_TEMPLATE_FLOOR_LOCALE } from './system/email-template.zod';
 import { DocSchema } from './system/doc.zod';
 import { BookSchema } from './system/book.zod';
 
@@ -2663,6 +2663,84 @@ function warnUnknownAuthoringKeys(raw: unknown): void {
   }
 }
 
+const warnedEmailTemplateFloors = new Set<string>();
+
+/**
+ * Report an `emailTemplates` bundle that carries rows for this stack's own
+ * `i18n.supportedLocales` but none tagged {@link EMAIL_TEMPLATE_FLOOR_LOCALE}.
+ *
+ * ## What goes wrong without this
+ *
+ * `IEmailService.sendTemplate` matches `(name, locale)` EXACTLY and retries
+ * exactly one rung — the literal `en-US`. There is no language-subtag folding,
+ * so a bundle whose English row is tagged `en` is unreachable from `en-US` and
+ * from every other tag it does not itself carry: each such delivery raises
+ * `TEMPLATE_NOT_FOUND`, which classifies **permanent**, so it dead-letters with
+ * no retry. `sys_user.locale` is user-editable free-text BCP-47 and is NOT
+ * constrained to `supportedLocales`, so the locales that can reach the lookup
+ * are not the ones the author enumerated — a recipient can break their own mail
+ * by setting a legal tag.
+ *
+ * ⭐ The trap is that the author does the CONSISTENT thing: a stack declaring
+ * `defaultLocale: 'en'` whose English row says `locale: 'en'` agrees with
+ * itself everywhere, validates, builds and installs clean, and still ships a
+ * bundle with no floor. The stack's own declared default locale is the wrong
+ * answer whenever it is not spelled `en-US`.
+ *
+ * ## Posture — advisory, and deliberately so
+ *
+ * Same seam and same posture as {@link warnUnknownAuthoringKeys}: this only
+ * WARNS. It moves no accept set — the parse above already succeeded and its
+ * result is returned unchanged — because refusing an `emailTemplates` shape
+ * that ships today would be a behaviour change on an authoring surface, which
+ * is a scheduled migration rather than something to slip in behind a lint. The
+ * resolver's ladder is fenced by a standing ruling and is NOT touched here: the
+ * remedy this points at is the bundle.
+ *
+ * Runs post-parse on purpose — `locale` defaults to `en-US`, so a row that
+ * omits the key entirely already has the floor and must not be reported.
+ * Warn-once per bundle, keyed by name plus the tags it actually carries.
+ */
+function warnEmailTemplateLocaleFloor(data: ObjectStackDefinition): void {
+  const supported = data.i18n?.supportedLocales;
+  if (!Array.isArray(supported) || supported.length === 0) return;
+  const templates = data.emailTemplates;
+  if (!Array.isArray(templates) || templates.length === 0) return;
+
+  const supportedSet = new Set(supported.map((l) => String(l)));
+
+  /** name → the locale tags that bundle carries, in authored order. */
+  const bundles = new Map<string, string[]>();
+  for (const tpl of templates) {
+    const name = typeof tpl?.name === 'string' ? tpl.name : '';
+    if (!name) continue;
+    const locale = typeof tpl?.locale === 'string' ? tpl.locale : EMAIL_TEMPLATE_FLOOR_LOCALE;
+    const tags = bundles.get(name);
+    if (tags) tags.push(locale);
+    else bundles.set(name, [locale]);
+  }
+
+  for (const [name, tags] of bundles) {
+    if (tags.includes(EMAIL_TEMPLATE_FLOOR_LOCALE)) continue;
+    const declared = tags.filter((t) => supportedSet.has(t));
+    if (declared.length === 0) continue;
+
+    const key = `${name} ${tags.join(',')}`;
+    if (warnedEmailTemplateFloors.has(key)) continue;
+    warnedEmailTemplateFloors.add(key);
+    console.warn(
+      `defineStack: emailTemplates '${name}' carries rows for ${declared.map((t) => `'${t}'`).join(', ')} ` +
+      `but none tagged '${EMAIL_TEMPLATE_FLOOR_LOCALE}', so this bundle has no fallback floor. ` +
+      `sendTemplate matches (name, locale) exactly and retries only the literal ` +
+      `'${EMAIL_TEMPLATE_FLOOR_LOCALE}' — there is no language-subtag folding, so every recipient ` +
+      `locale this bundle does not carry a row for raises TEMPLATE_NOT_FOUND, which is permanent ` +
+      `(dead-letter, no retry). Your stack's own i18n.defaultLocale is the wrong tag here unless ` +
+      `it is spelled '${EMAIL_TEMPLATE_FLOOR_LOCALE}': tag the English row '${EMAIL_TEMPLATE_FLOOR_LOCALE}' ` +
+      `and keep the other tags beside it.`,
+    );
+  }
+}
+
 export function defineStack(
   config: ObjectStackDefinitionInput,
   options?: DefineStackOptions,
@@ -2756,6 +2834,11 @@ export function defineStack(
     const lines = triggerErrors.map((e) => `  ✗ ${e}`);
     throw new StackTriggerCapabilityRequiredError(`${header}\n\n${lines.join('\n')}`, triggerErrors);
   }
+
+  // Post-parse and advisory: the stack is valid and is returned unchanged.
+  // `locale` carries a default, so this has to run AFTER the parse or a row
+  // that omits the key would read as a missing floor it actually has.
+  warnEmailTemplateLocaleFloor(data);
 
   return mergeActionsIntoObjects(data);
 }

--- a/packages/spec/src/system/email-template-floor-locale-parity.pin.test.ts
+++ b/packages/spec/src/system/email-template-floor-locale-parity.pin.test.ts
@@ -1,0 +1,89 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * [#17614] `EMAIL_TEMPLATE_FLOOR_LOCALE`'s docblock may say "the two must stay
+ * equal" only while something holds them equal. This is that something.
+ *
+ * `packages/spec/src/system/email-template.zod.ts` publishes, in TSDoc an
+ * author reads at the moment they type `locale:`, that
+ * `@objectstack/plugin-email` spells the same value as its own
+ * `DEFAULT_TEMPLATE_LOCALE` and that the two must stay equal. Both constants
+ * are PUBLISHED — `EMAIL_TEMPLATE_FLOOR_LOCALE` from this package, and
+ * `DEFAULT_TEMPLATE_LOCALE` from `plugin-email`'s `email-service.ts` via its
+ * `index.ts` re-export — so that sentence is a cross-package claim on two
+ * published surfaces with, until this file, nothing behind it.
+ *
+ * `position-delegatable-enforcer.pin.test.ts` in this package exists for the
+ * identical shape and states the hazard in general terms: *"prose costs nothing
+ * to add and no compiler checks it."* A published "must stay equal" nobody
+ * checks reads, to the next author, as an invariant that is being watched.
+ *
+ * ## Why this reads TEXT instead of importing
+ *
+ * `packages/spec` does not depend on `@objectstack/plugin-email` (its
+ * dependencies are `pg-connection-string` and `zod`), and it must not start —
+ * the spec is the contract both ends of that relationship are written against.
+ * So the value is read out of the other package's SOURCE, which is what the
+ * `repo` vitest project exists for; this file is registered in
+ * `packages/spec/vitest.repo-tests.json` so `check:cross-package-test-inputs`
+ * and turbo's input hashing both see the escape.
+ *
+ * ⛔ Scope: the VALUE, not the resolver. This asserts two literals agree. It
+ * asserts nothing about the ladder's shape — the exact `(name, locale)` match
+ * and its single retry rung are a settled ruling, and changing them is not this
+ * pin's business. Renaming either constant turns this red on purpose: the
+ * docblock names `DEFAULT_TEMPLATE_LOCALE` specifically, so a rename is an edit
+ * to the published claim and has to be made in both places.
+ *
+ * ⛔ A missing or unreadable declaration is a FAILURE, never a silent pass —
+ * that is the whole failure mode a text-reading pin has to defend against.
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, it, expect } from 'vitest';
+
+import { EMAIL_TEMPLATE_FLOOR_LOCALE } from './email-template.zod';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+/** …/packages/spec/src/system → repo root */
+const REPO_ROOT = resolve(HERE, '../../../..');
+const EMAIL_SERVICE_SOURCE = join(REPO_ROOT, 'packages', 'plugins', 'plugin-email', 'src', 'email-service.ts');
+const EMAIL_INDEX_SOURCE = join(REPO_ROOT, 'packages', 'plugins', 'plugin-email', 'src', 'index.ts');
+
+/** `export const DEFAULT_TEMPLATE_LOCALE = '…';` — how plugin-email declares it. */
+const DECLARATION = /^export const DEFAULT_TEMPLATE_LOCALE = '([^']*)';\s*$/m;
+
+describe('#17614 — the published "must stay equal" claim, held', () => {
+  it("plugin-email's DEFAULT_TEMPLATE_LOCALE literal equals EMAIL_TEMPLATE_FLOOR_LOCALE", () => {
+    const source = readFileSync(EMAIL_SERVICE_SOURCE, 'utf8');
+    const match = DECLARATION.exec(source);
+
+    // An absent declaration is the vacuous-pass trap this pin exists to avoid:
+    // fail loudly and name what was looked for, rather than skipping.
+    expect(
+      match,
+      `no 'export const DEFAULT_TEMPLATE_LOCALE = ...' declaration found in ${EMAIL_SERVICE_SOURCE}. `
+        + 'It was renamed, moved or reshaped — update this pin and the "must stay equal" sentence '
+        + 'in packages/spec/src/system/email-template.zod.ts together.',
+    ).not.toBeNull();
+
+    expect(match?.[1]).toBe(EMAIL_TEMPLATE_FLOOR_LOCALE);
+  });
+
+  it('is a claim about a PUBLISHED constant — plugin-email still re-exports it', () => {
+    // If it stopped being published the docblock's framing would be wrong even
+    // while the literals still agreed.
+    const index = readFileSync(EMAIL_INDEX_SOURCE, 'utf8');
+    expect(index).toContain('DEFAULT_TEMPLATE_LOCALE');
+  });
+
+  it('the sentence this pin backs is still the one being published', () => {
+    // Reworded freely; what may not vanish silently is the claim itself.
+    const spec = readFileSync(join(HERE, 'email-template.zod.ts'), 'utf8');
+    expect(spec).toContain('DEFAULT_TEMPLATE_LOCALE');
+    expect(spec).toContain('must stay equal');
+  });
+});

--- a/packages/spec/src/system/email-template.zod.ts
+++ b/packages/spec/src/system/email-template.zod.ts
@@ -23,6 +23,24 @@ import { strictObject } from '../shared/strict-object';
  */
 
 /**
+ * The one locale tag with standing in an email-template bundle: the schema
+ * default for {@link EmailTemplateDefinitionSchema}.`locale` AND the sole rung
+ * `IEmailService.sendTemplate` retries after an exact `(name, locale)` miss.
+ *
+ * Named because those two roles are the same fact and authors keep reading it
+ * as neither: the resolver does no language-subtag folding, so this literal —
+ * not the stack's `i18n.defaultLocale`, not a bare `en` — is what makes a
+ * bundle reachable from a recipient locale nobody authored a row for. A bundle
+ * without a row at this tag has no fallback floor at all.
+ *
+ * ⚠️ `@objectstack/plugin-email` spells the same value as its own
+ * `DEFAULT_TEMPLATE_LOCALE` (that package implements the ladder; this one only
+ * declares the contract). The two must stay equal — the ladder's shape is a
+ * settled ruling, so this constant tracks it rather than the other way round.
+ */
+export const EMAIL_TEMPLATE_FLOOR_LOCALE = 'en-US';
+
+/**
  * Logical grouping; surfaces as a filter facet in Studio listings.
  */
 export const EmailTemplateDefinitionCategorySchema = lazySchema(() => z.enum([
@@ -79,11 +97,39 @@ export const EmailTemplateDefinitionSchema = lazySchema(() => strictObject({
   category: EmailTemplateDefinitionCategorySchema.default('custom'),
 
   /**
-   * IETF BCP-47 locale tag. Multiple rows with the same `name` but
-   * different `locale` form an i18n bundle; the service picks the
-   * best match for the recipient's locale, falling back to `en-US`.
+   * IETF BCP-47 locale tag — the second half of the bundle key.
+   *
+   * Multiple rows sharing one `name` form an i18n bundle. The resolver
+   * (`IEmailService.sendTemplate`) matches `(name, locale)` **exactly** and
+   * then retries exactly one rung: the **literal** string
+   * {@link EMAIL_TEMPLATE_FLOOR_LOCALE}. There is no language-subtag folding
+   * on that path — `en-US` does not fall back to `en`, and `en` is not
+   * reachable from `en-US`.
+   *
+   * ⚠️ So `en-US` is the bundle's FLOOR, and a bundle carrying no `en-US` row
+   * has none: every recipient locale the bundle does not itself carry a row
+   * for raises `TEMPLATE_NOT_FOUND`, which classifies **permanent** — the
+   * delivery dead-letters with no retry. The reachable locale set is not the
+   * set the author enumerated either: `sys_user.locale` is user-editable
+   * free-text BCP-47, unconstrained by the stack's `i18n.supportedLocales`,
+   * so a recipient can select a legal tag nobody authored.
+   *
+   * ⛔ The stack's own declared `i18n.defaultLocale` is the WRONG tag here
+   * whenever it is not spelled `en-US`. An app that declares
+   * `defaultLocale: 'en'` and then authors `locale: 'en'` has done the
+   * consistent thing throughout and still shipped a bundle with no floor —
+   * it validates, builds and installs clean. Author the English row at the
+   * `en-US` default and add the other tags beside it; `defineStack` reports a
+   * bundle that carries `supportedLocales` rows without an `en-US` one.
    */
-  locale: z.string().default('en-US').describe('BCP-47 locale (e.g. en-US, zh-CN)'),
+  locale: z.string().default(EMAIL_TEMPLATE_FLOOR_LOCALE).describe(
+    'BCP-47 locale (e.g. en-US, zh-CN) — the bundle key the resolver matches EXACTLY, with one '
+    + 'retry rung: the literal `en-US`. No language-subtag folding, so `en` and `en-US` are '
+    + 'different bundles and neither reaches the other. A bundle with no `en-US` row therefore has '
+    + 'no fallback floor: any recipient locale it does not carry a row for raises '
+    + 'TEMPLATE_NOT_FOUND, which is permanent — the delivery dead-letters with no retry. Your '
+    + "stack's own `i18n.defaultLocale` is the wrong tag here unless it is spelled `en-US`.",
+  ),
 
   /** Subject line; supports `{{var.path}}` placeholders. */
   subject: z.string().describe('Subject template'),

--- a/packages/spec/vitest.repo-tests.json
+++ b/packages/spec/vitest.repo-tests.json
@@ -28,5 +28,6 @@
   "src/shared/retired-key-migrate-sentence.test.ts",
   "src/system/compliance-families-retirement.test.ts",
   "src/system/constants/platform-object-names.test.ts",
+  "src/system/email-template-floor-locale-parity.pin.test.ts",
   "src/ui/action-requires-confirmation-docblock.pin.test.ts"
 ]


### PR DESCRIPTION
Fixes #17614

Clause-②: yes

Triage ruled BOTH remedies in, with an order (comment 5642916137): **「do both, option 1 first.」** Both land here.

## The trap, reproduced on this branch's own head before anything changed

An app declares `i18n: { defaultLocale: 'en', supportedLocales: ['en','zh-CN','ja-JP','es-ES'] }` and authors its English `emailTemplates` row as `locale: 'en'` — the consistent thing. Measured on an unmodified tree:

| probe | reading |
|---|---|
| `defineStack` on that stack | `parsed-ok=true warnings=0`, stored locales `["en","zh-CN","ja-JP","es-ES"]` |
| `sendTemplate({ locale: 'de-DE' })` | `TEMPLATE_NOT_FOUND: acme.welcome (locale=de-DE)` |
| `sendTemplate({ locale: 'en-US' })` | `TEMPLATE_NOT_FOUND: acme.welcome (locale=en-US)` |
| **lit control** — same bundle, English row tagged `en-US` | **DELIVERED**, `subject=[en-US] Hi` |

The control is aimed at the resolver ladder itself: it proves the probe can come back "delivered", so the two `TEMPLATE_NOT_FOUND` readings are readings and not a broken harness. A second lit control covers the `defineStack` half — an `objectz` typo on the same stack is refused, so `warnings=0` is a measurement rather than a dead capture.

`TEMPLATE_NOT_FOUND` classifies **permanent**, so each of those dead-letters with no retry. `sys_user.locale` is user-editable free-text BCP-47 and is not constrained to `supportedLocales`, so the locales that can reach the lookup are not the ones the author enumerated.

## Premise re-read on today's tree, not on the card

The card measured against installed 17.4.0. Re-read at this branch's base: the ladder in `packages/plugins/plugin-email/src/email-service.ts` is byte-for-byte what the card quotes — exact `(name, locale)`, one retry rung at the literal `DEFAULT_TEMPLATE_LOCALE = 'en-US'`, no folding — and `EmailTemplateDefinitionSchema.locale` was still `z.string().default('en-US').describe('BCP-47 locale (e.g. en-US, zh-CN)')`. **The premise holds; the trap is open.** Its TSDoc was also actively misleading — "the service picks the best match for the recipient's locale" reads as folding, which does not exist on that path.

## ① Say it where the author is standing

`EmailTemplateDefinitionSchema.locale`'s `describe` and TSDoc now state the exact match, the single literal `en-US` rung, the absence of language-subtag folding, that a bundle with no `en-US` row has no floor, and that the stack's own declared default locale is the wrong tag whenever it is not spelled `en-US`. The `describe` is the published authoring surface — it lands in `content/docs/references/system/email-template.mdx`, regenerated here.

New exported `EMAIL_TEMPLATE_FLOOR_LOCALE` names the tag once, in the one place that is both the schema default and the resolver's sole retry rung.

## ② The author-time diagnostic

`defineStack` now reports an `emailTemplates` bundle that carries rows for the stack's own `i18n.supportedLocales` but none tagged `en-US`. Advisory `console.warn`, warn-once per bundle, post-parse — the same seam and posture as the existing `warnUnknownAuthoringKeys` reporter.

## ⛔ The fence held

Language-subtag folding was not added, no third rung was added, and `EmailService.resolveAndRenderTemplate` is not touched — the diff contains no file under `packages/plugins/plugin-email`. The ladder's shape stays as #13881 settled it; the remedy this points at is the bundle.

## Clause-② self-check — `yes`, and the rationale is corrected

**`yes` is right, and it is a mechanical call, not a measurement.** The carrier that fires is the **new exported symbol** `EMAIL_TEMPLATE_FLOOR_LOCALE` — a new export on a published surface is always `yes`, decided by looking at the export list. It is registered at `packages/spec/api-surface/system.json` and `packages/spec/export-origins/system.json`; a changed published `describe` moves `content/docs/references/system/email-template.mdx` alongside it.

⚠️ Correcting the rationale this PR shipped with: the dispatch and this body's first version justified `yes` on the ground that remedy ② *narrows* what passes silently, and **that rule does not exist** — the lane text says the opposite, that narrowing is still a semantic surface and does not trip clause ②. The declaration was over-determined: the right answer reached through a limb that does not fire.

The accept-set measurement below stands and is **not** the basis for the `yes`; it is reported because it is true and reviewable. The final diff **moves no accept set**: same probe, same tree, before and after, `parsed-ok=true` on both sides and the returned stack carries the identical tags `["en","zh-CN","ja-JP","es-ES"]`; only the warning count goes 0 to 1. No Zod refinement added, no schema key added or removed, no closed set narrowed.

Carrier state: PR and card both carry `needs:contract-review`; `scripts/pm/check-clause2-carriers.mjs --pair 17884` exits 0, both carriers agree. Draft, not enqueued, auto-merge not armed — the seat lands it.

## Contract review — C1 resolved, option (a)

Review verdict: PASS WITH CONDITIONS (comment 5647795889). C1 said the new constant's docblock **publishes** an invariant — that `@objectstack/plugin-email`'s `DEFAULT_TEMPLATE_LOCALE` and `EMAIL_TEMPLATE_FLOOR_LOCALE` "must stay equal" — with nothing holding them equal, the same shape as this package's existing `position-delegatable-enforcer.pin.test.ts` and its own words, "prose costs nothing to add and no compiler checks it."

**Chose (a), add the pin, over (b), delete the sentence.** The sentence is *true and useful*: both constants are published (`plugin-email` re-exports `DEFAULT_TEMPLATE_LOCALE` from its `index.ts`), they are genuinely one settled value in two packages, and an author or a future round needs to know they are coupled. Deleting it would buy honesty by removing information, leaving the drift seam just as real and now undocumented. (a) keeps the claim and makes it checkable, and it costs nothing this PR was not already allowed to spend — so (b) is the retreat, not the equal.

`packages/spec/src/system/email-template-floor-locale-parity.pin.test.ts` reads `packages/plugins/plugin-email/src/email-service.ts` **as text** and asserts its `DEFAULT_TEMPLATE_LOCALE` literal equals `EMAIL_TEMPLATE_FLOOR_LOCALE`. `packages/spec` cannot import `plugin-email` (its dependencies are `zod` and `pg-connection-string`) and must not start to; the `repo` vitest project exists for exactly this, and the path is registered in `packages/spec/vitest.repo-tests.json`. A missing or renamed declaration fails loudly rather than passing vacuously.

⛔ **The fence is still intact.** The delivered diff contains no file under `packages/plugins/plugin-email`; no rung was added, nothing folds, and `EmailService.resolveAndRenderTemplate` is untouched. The pin only reads that package.

## Successor-card seed (C2) — the second silent, floorless case

`packages/spec/src/stack.zod.ts`, the `declared.length === 0` branch of `warnEmailTemplateLocaleFloor`. A stack that **does** declare `i18n.supportedLocales` but whose bundle tags **none** of them is equally floorless and equally silent — `supportedLocales: ['en']` with a lone `fr-CA` row. This PR's own test pins that green ("silent when no authored tag is one this stack claims to support"), so the gap is deliberate and recorded rather than accidental. ⛔ Not fixed here: widening the condition is a second decision about who gets warned, and it is left as the seed of a successor card together with the no-`i18n`-block case already noted below.

A third, named by the review and recorded here for the same successor: a `console.warn` at `defineStack` is heard only by whoever runs the build and reads stdout, while this card's own premise is that the trap survives because people do not read. The stronger rung that stays inside the fence is an `os lint` / `os validate` rule — a separate card, not this one.

## Tests, and the ablation that proves each one could fail

New: `packages/spec/src/stack-email-template-locale-floor.test.ts` (10 tests). Every case asserts the parse still succeeds and the stack returns unchanged, so the pins are on the advisory posture too.

Proven by on-disk mutation, each with its injected-text count verified before the run and the restore verified by `git hash-object` against the HEAD blob:

| mutation | result |
|---|---|
| MUT-1 — the diagnostic never reports | **RED**, 4 failed / 6 passed |
| MUT-2 — the `describe` loses `TEMPLATE_NOT_FOUND` | **RED**, 1 failed / 9 passed |
| MUT-3 — call the diagnostic pre-parse on raw input | **GREEN, 10 passed — reported, not hidden** |
| restored (hashes MATCH both files) | **GREEN**, 10 passed |

MUT-3 falsified a claim I had written into the test: the reader mirrors the schema default for a missing `locale`, so pre-parse and post-parse agree and the call site is not what that case pins. The comment and the function's rationale were corrected to say what was actually measured, rather than the reverse.

### C1 parity pin — ablated, because an un-ablated pin is not a pin

Mutated `plugin-email`'s literal on disk from `en-US` to `en-GB` (restored immediately; the delivered diff does not touch that file):

| leg | evidence |
|---|---|
| landed on disk | original literal occurrences 1 to 0, injected literal 1, and the blob hash moved off the HEAD blob (`0198f7ac` to `108eb1b8`) |
| RED | exit 1 — `AssertionError: expected 'en-GB' to be 'en-US'`, 1 failed / 2 passed |
| restored + GREEN | hash back to `0198f7ac`, MATCHES the HEAD blob, `git diff HEAD` empty; re-run exit 0, 3 passed |

`pnpm check:cross-package-test-inputs` exits 0 with the new escape declared. That zero is a reading, not a dead gate: unregistering the path from `vitest.repo-tests.json` reds it (exit 1) naming this exact file, and it was then re-registered.

### Commands and exit codes

Both `packages/spec` vitest projects were run and their exit codes captured **separately** (the wrapper's own verdict line covers only the last part, so each was captured inside the run):

| command | reading |
|---|---|
| `pnpm --filter @objectstack/spec test` (project `local`) | `LOCAL_EXIT=0` — 473 files / 13444 tests passed |
| `pnpm --filter @objectstack/spec test:repo` (project `repo`) | `REPO_EXIT=0` — 30 files / 520 tests passed |
| `pnpm --filter @objectstack/spec typecheck` | `TC_EXIT=0` |
| `pnpm --filter @objectstack/spec check:generated` | all 15 artifacts up to date after `--fix` |
| `eslint . --no-inline-config --format json` | exit 0 — 6660 files (eslint's own population), 0 errors, 0 warnings, at `d81bcb4ae2` |

24 of the 107 gate families `scripts/pm/dispatch-gates.mjs` derives for this change set were run locally, all exit 0; the remaining 83 are declared to CI rather than run on the shared box. This is a **declared** narrowing, not a skipped one.

## Changeset

`.changeset/email-template-locale-floor.md`, `minor` on `@objectstack/spec`. One is owed and is not skippable: ① changes a published `describe` (it moves `content/docs/references/`) and the diff adds a published export.

## Corpus census

No in-repo stack begins warning. The one example app that declares both halves — `examples/app-showcase` (`defaultLocale: 'en'`, `supportedLocales: ['en','zh-CN']`) — already tags its bundle `en-US`, and its own header comment explains why. That is the "one careful reading" triage named as the only thing standing between this trap and a live outage; it is now the schema's job instead.

## Acceptance notes (out of scope, noted, not filed)

- `@objectstack/plugin-email` spells the floor as its own `DEFAULT_TEMPLATE_LOCALE`; this PR adds a second spelling in spec rather than making the two one constant, because collapsing them means editing the ladder's own file, which the fence puts out of reach for this round. The new constant's docblock states the dependency direction. No parity pin is added here. Successor: whoever next opens `email-service.ts` under a ruling that lifts the fence.
- The diagnostic's condition is the ruling's wording verbatim — it requires `i18n.supportedLocales` to be declared. A stack that declares no `i18n` block and authors a lone `en` row is equally floorless and stays silent. Named as a deliberate boundary, not widened here.

---
_Generated by [Claude Code](https://claude.ai/code)_