### PR TITLE
docs(spec): state the authoring-surface jurisdiction retiredFromLoadPath actually has

### DIFF
--- a/.changeset/wild-jars-hammer.md
+++ b/.changeset/wild-jars-hammer.md
@@ -1,0 +1,29 @@
+---
+'@objectstack/spec': patch
+---
+
+Correct what `retiredFromLoadPath` declares about its own reach.
+
+The flag's docs said a retired conversion is "never at load" and that "the load
+seam never sets this — only `objectstack migrate meta` (and the fixture CI)
+replays it". Neither half held. Three data-at-rest call sites pass
+`includeRetired: true` on purpose — `applyConversionsToStoredItem` (which pins
+it rather than offering it), flow rehydration in the automation engine, and the
+artifact-ingestion door `applyArtifactForwardConversions` — and `migrate meta`
+does not reach the option at all: `applyMetaMigrations` looks each step's
+conversion up by id and calls `apply` directly.
+
+What the flag actually governs is the **authoring** surface: it keeps the entry
+off `normalizeStackInput`, the single funnel for `defineStack`, `validate`,
+`lint`, `compile`, `info` and `doctor`, so a live author meets the tombstone
+instead of a silent rewrite. That split is what ADR-0087's
+`## Addendum (2026-07-31)` and the artifact-door ruling both bought.
+
+Documentation only — no behaviour, no schema key and no export moves. The
+corrected text ships in `dist/*.d.ts`, and the split it describes is now pinned
+by a test that drives `normalizeStackInput` and `applyConversionsToStoredItem`
+over the same bytes, so the sentence and the behaviour cannot drift apart again.
+
+Authors setting this flag on a **default flip** (old and new shapes both legal,
+meaning different things) should read the corrected doc: the flag does not
+confine such a rewrite to history — the data-at-rest seams still apply it.

--- a/packages/spec/src/conversions/apply.ts
+++ b/packages/spec/src/conversions/apply.ts
@@ -7,8 +7,9 @@
  * against a normalized stack, threading the (immutably updated) stack through
  * each entry and turning each rewrite into a structured {@link ConversionNotice}.
  * It is wired into `normalizeStackInput`, so it fires on the single seam every
- * load path funnels through — `defineStack`, `objectstack validate`, `lint`,
- * `info`, and `doctor`.
+ * AUTHORING path funnels through — `defineStack`, `objectstack validate`,
+ * `lint`, `info`, and `doctor`. Data-at-rest load paths reach it by their own
+ * route and with `includeRetired` set; see that option below.
  */
 
 import { ALL_CONVERSIONS } from './registry.js';
@@ -29,9 +30,32 @@ export interface ApplyConversionsOptions {
   onNotice?: (notice: ConversionNotice) => void;
   /**
    * Also apply conversions marked `retiredFromLoadPath` (default `false`).
-   * The load seam never sets this — a retired entry is chain history, not a
-   * live window. The migration chain and the fixture CI set it so graduated
-   * transforms stay replayable forever (ADR-0087 D3).
+   *
+   * **Retirement is an AUTHORING-SURFACE event**, and the default posture is
+   * that surface: `normalizeStackInput` — the single funnel for `defineStack`,
+   * `validate`, `lint`, `compile`, `info`, `doctor`, i18n extraction and
+   * scaffold validation — never sets this, so a live author meets the
+   * tombstone and is taught the canonical spelling instead of having the old
+   * shape silently rewritten. That funnel is the whole jurisdiction the flag
+   * has; it is not a claim about every load path.
+   *
+   * **Data-at-rest load paths set it deliberately** — three call sites today:
+   * `applyConversionsToStoredItem` (`./stored.js`), where it is *pinned*
+   * rather than offered (`StoredConversionOptions` omits the key, so no caller
+   * can turn it off); flow rehydration in the automation engine; and the
+   * artifact-ingestion door (`applyArtifactForwardConversions` in
+   * `@objectstack/metadata-core`, reached from two callers), which opens the
+   * window by comparing the artifact's declared `engines.protocol` floor with
+   * the running spec version. A stored row, a stored flow and a built artifact
+   * have no author to teach, so each replays the FULL chain, retired entries
+   * included — ADR-0087's `## Addendum (2026-07-31)` for the first two, the
+   * #12772 ruling for the third. The fixture CI sets it as well, so graduated
+   * transforms stay covered forever (ADR-0087 D3).
+   *
+   * `objectstack migrate meta` is NOT one of these callers: `applyMetaMigrations`
+   * (`../migrations/chain.js`) looks each step's conversion up in
+   * `ALL_CONVERSIONS` by id and calls its `apply` directly, so it never reaches
+   * this option at all.
    */
   includeRetired?: boolean;
   /**
@@ -65,8 +89,11 @@ export function applyConversions(
 
   for (const conversion of ALL_CONVERSIONS) {
     // A retired entry is graduated chain history (ADR-0087 D2 window, second
-    // half): the loader no longer accepts its old shape — only `migrate meta`
-    // (and the fixture CI) replays it, via `includeRetired`.
+    // half): the AUTHORING funnel (`normalizeStackInput`) no longer replays it,
+    // so the tombstone teaches the author instead. The data-at-rest seams —
+    // stored-row rehydration, flow rehydration, the artifact-ingestion door —
+    // opt back in via `includeRetired`, as do the fixture CI and any caller
+    // rehydrating rows nobody can be taught (see `includeRetired` above).
     if (conversion.retiredFromLoadPath && !includeRetired) continue;
     const retiresIn = conversion.toMajor + 1;
     const context: ConversionContext = {

--- a/packages/spec/src/conversions/conversions.test.ts
+++ b/packages/spec/src/conversions/conversions.test.ts
@@ -391,6 +391,43 @@ describe('conversion layer (ADR-0087 D2)', () => {
       expect(flows[0].name).toBe('my_flow'); // map key injected
       expect(flows[0].nodes[0].type).toBe('http'); // converted
     });
+
+    /**
+     * The jurisdiction pin for `retiredFromLoadPath` (#16864).
+     *
+     * `apply.ts` and `types.ts` now declare that retirement is an AUTHORING
+     * surface event: the flag keeps an entry off `normalizeStackInput`, while
+     * data-at-rest seams replay it on purpose. Both halves are asserted here,
+     * through the real doors rather than through `applyConversions` directly
+     * — the cases elsewhere in this file drive the primitive, so they would
+     * all stay green if `normalizeStackInput` ever started passing
+     * `includeRetired`, and the declaration would go stale unnoticed. This is
+     * the test that fails first when either half moves.
+     */
+    it('⛔ does NOT replay a RETIRED entry, while the stored-row door does', () => {
+      const entry = ALL_CONVERSIONS.find((c) => c.id === 'app-hidden-to-unpublished');
+      // Premise: without this the assertions below would pass vacuously.
+      expect(entry?.retiredFromLoadPath, 'premise: the entry under test is retired').toBe(true);
+
+      const authored = { name: 'account', label: 'Account', hidden: true, navigation: [] };
+
+      // Authoring funnel: the old shape survives verbatim, nothing is reported.
+      const notices: ConversionNotice[] = [];
+      const out = normalizeStackInput(
+        { apps: [structuredClone(authored)] },
+        { onConversionNotice: (n) => notices.push(n) },
+      );
+      expect((out.apps as any[])[0]).toEqual(authored);
+      expect(notices).toEqual([]);
+
+      // Data at rest: the SAME bytes through the stored-row door DO convert.
+      const stored = applyConversionsToStoredItem('app', structuredClone(authored)) as Record<
+        string,
+        unknown
+      >;
+      expect(stored.hidden).toBeUndefined();
+      expect(stored._unpublished).toBe(true);
+    });
   });
 
   describe('flow-node-wait-timeout-keys-removed (#4158)', () => {

--- a/packages/spec/src/conversions/types.ts
+++ b/packages/spec/src/conversions/types.ts
@@ -142,13 +142,30 @@ export interface MetadataConversion {
   /** The protocol major that introduced the canonical shape. */
   toMajor: number;
   /**
-   * When `true`, this conversion is **retired from the load path**: the loader
-   * no longer accepts the old shape (the schema rejects or tombstones it), and
-   * the entry exists purely as graduated migration-chain history — replayed by
-   * `objectstack migrate meta` against *source* metadata, never at load. This
-   * is the ADR-0087 D2 window's second half ("retired in N+1 — but never
-   * deleted"), and it is also how a pre-launch one-step rename (which never had
-   * a load window at all) is preserved in the chain.
+   * When `true`, this conversion is **retired from the AUTHORING surface**: the
+   * authoring funnel (`normalizeStackInput` — `defineStack`, `validate`,
+   * `lint`, `compile`, `info`, `doctor`) no longer replays it, so an author
+   * writing the old shape meets the schema's rejection or its tombstone and is
+   * taught the canonical spelling. This is the ADR-0087 D2 window's second half
+   * ("retired in N+1 — but never deleted"), and it is also how a pre-launch
+   * one-step rename (which never had a load window at all) is preserved in the
+   * chain.
+   *
+   * ⚠️ The flag's name says "load path", but its reach is the authoring surface
+   * only — **data-at-rest load paths replay retired entries on purpose**:
+   * stored-row rehydration (`applyConversionsToStoredItem`, which pins
+   * `includeRetired: true` rather than offering it), flow rehydration in the
+   * automation engine, and the artifact-ingestion door
+   * (`applyArtifactForwardConversions`, inside its declared-floor window). A
+   * row, a stored flow or a built artifact has no author for a tombstone to
+   * teach, and refusing a shape that once worked would only break data — see
+   * ADR-0087's `## Addendum (2026-07-31)` and the #12772 ruling. `objectstack
+   * migrate meta` replays it too, against *source* metadata, but by id through
+   * `applyMetaMigrations` rather than through this flag.
+   *
+   * ⇒ Setting this does NOT confine a rewrite to history. For a conversion
+   * whose old and new shapes are both legal and mean different things (a
+   * default flip, not a rename), the data-at-rest seams will still apply it.
    */
   retiredFromLoadPath?: boolean;
   /** Dotted surface, e.g. `flow.node.type`, `page.kind`, `flow.node.config`. */


### PR DESCRIPTION
Fixes #16864

Clause-②: no — declaration prose only. No schema key moves, no accepted-set change, no export change, no behaviour change.

## What this changes

`retiredFromLoadPath` declared a jurisdiction it does not have. Two carriers in
`packages/spec/src/conversions/` said a retired conversion is "never at load" and that
"the load seam never sets this — the migration chain and the fixture CI set it". This PR
corrects both to what the tree actually does, and pins the split with a test so the
sentence and the behaviour cannot drift apart again.

Nothing about behaviour changes. The flag is **live**, not inert, and it is not narrowed,
removed or re-flagged here.

## The corrected declaration

> Retirement is an **authoring-surface** event. The flag keeps the entry off
> `normalizeStackInput` — the authoring funnel for `defineStack`, `validate`, `lint`,
> `compile`, `info` and `doctor` — so a live author meets the tombstone instead of a
> silent rewrite. **Data-at-rest load paths replay it deliberately**: stored-row
> rehydration, flow rehydration in the automation engine, and the artifact-ingestion
> door. Per ADR-0087's `## Addendum (2026-07-31)` and the artifact-door ruling on #12772.

Three files:

- `packages/spec/src/conversions/apply.ts` — the `includeRetired` option docblock, the
  inline comment in the conversion loop, and the module docblock's claim that
  `normalizeStackInput` is "the single seam every load path funnels through" (it is the
  single seam every **authoring** path funnels through).
- `packages/spec/src/conversions/types.ts` — the `MetadataConversion.retiredFromLoadPath`
  field doc.
- `packages/spec/src/conversions/conversions.test.ts` — the pin.

## Seam inventory, re-measured on this branch's base

`git grep -n "includeRetired" -- '*.ts' ':!*.test.ts'` returns **3** `includeRetired: true`
literals; the set of runtime callers reaching them is **4**, because
`applyArtifactForwardConversions` has two non-test callers.

| literal | what it is | non-test callers |
|:--|:--|:--|
| `packages/spec/src/conversions/stored.ts:75` | `applyConversionsToStoredItem` — `includeRetired` is PINNED, not a caller's choice (`StoredConversionOptions` omits the key) | every stored-row rehydration seam: `metadata-protocol/src/protocol.ts`, `metadata/src/loaders/database-loader.ts`, `objectql/src/plugin.ts`, `services/service-datasource/src/datasource-admin-plugin.ts` |
| `packages/services/service-automation/src/engine.ts:3710` | flow rehydration, at runtime | 1 (the engine itself) |
| `packages/metadata-core/src/artifact-forward-conversion.ts:291` | the artifact-ingestion door, inside its declared-floor window | 2 — `metadata/src/plugin.ts:763` and `runtime/src/app-plugin.ts:907` |

Control for that count: the same grep **without** the `':!*.test.ts'` exclusion returns
strictly more lines, including test paths — so the exclusion is really excluding rather
than silently swallowing the corpus, and a count of 3 could have come back otherwise.

The second half of the old sentence is false in its own way, verified here rather than
carried over: **`objectstack migrate meta` never passes `includeRetired` anywhere.**
`applyMetaMigrations` (`packages/spec/src/migrations/chain.ts`) builds `CONVERSION_BY_ID`
from `ALL_CONVERSIONS` and calls each step's `conversion.apply(...)` directly — it does not
call `applyConversions` at all, so it never reaches the option. The "fixture CI" half of the
old sentence IS true (`conversions.test.ts` passes `includeRetired: true` for the fixture
pairs) and is kept.

## The pin, and why the existing tests were not one

The three tests in the `normalizeStackInput integration (the load seam)` block all drive
**live** entries. Every existing assertion about the retired split drives `applyConversions`
directly with and without `includeRetired`. So if `normalizeStackInput` ever began passing
`includeRetired: true`, every one of them would stay green and the corrected sentence would
go stale exactly the way the old one did.

The new case drives the two **real doors** over the same bytes: `normalizeStackInput` leaves
an authored `hidden: true` app verbatim with zero notices, while
`applyConversionsToStoredItem` over the same object returns `_unpublished: true` with
`hidden` gone. It opens with a premise assertion that the entry under test is in fact
`retiredFromLoadPath`, so it cannot pass vacuously if someone un-retires it.

## Out of scope, named here so they are not lost

This round is the `packages/spec` share only. Three other carriers of the same false claim
are **not** touched:

1. **`docs/adr/0087-metadata-protocol-upgrade-contract.md`** — still carries the
   pre-addendum claim that a retired entry is skipped by the loader, superseded by its own
   `## Addendum (2026-07-31)` some 35 lines below; and the artifact-ingestion door has **no**
   addendum there at all, so a reader of the ADR sees the stored-row policy and nothing
   about the boot seam. `docs/adr/**` is a governed surface: a separate draft-only PR with a
   human merge.
2. **`.claude/skills/spec-property-retirement/SKILL.md`** — teaches future retirement
   authors a guarantee the seams do not give, and cites `field-required-notnull-explicit` as
   its worked example, an entry #16693 removed from the registry. `.claude/**` is governed
   and belongs to the `domain:skills` lane.
3. **`docs/protocol-upgrade-guide.md`** — generated by
   `packages/spec/scripts/build-upgrade-guide.ts`, which walks `MIGRATIONS_BY_MAJOR` steps
   and therefore renders only 50 of the 75 retired entries; the within-major 17.x
   retirements are wired to no step and are absent from the guide entirely. Not "fixed" here.

Separately: **#17885** carries the default-flip question this correction does not answer —
whether the artifact door should keep replaying entries whose old and new shapes are both
legal and mean different things. This PR only stops the flag from *claiming* it prevents
that.

## Verification

All readings below were taken in a dedicated worktree at base `be5c60291c`, and the final
commit is `4c82fc7c49`.

**Both spec vitest projects, on the final commit** (CI runs both):

| command | project | result |
|:--|:--|:--|
| `pnpm --filter @objectstack/spec test` | `local` | **exit 0** — 472 files, 13435 tests passed |
| `pnpm --filter @objectstack/spec test:repo` | `repo` (cross-corpus scanners) | **exit 0** — 30 files passed |
| `pnpm --filter @objectstack/spec typecheck` | — | **exit 0** |
| `pnpm --filter @objectstack/spec check:generated` | — | **exit 0** — all 15 generated artifacts up to date, nothing to regenerate |

`test:repo` was run *after* the final commit, since a prose diff is exactly what those
scanners read. Heavy runs went through `scripts/pm/os-verify-lock.sh`
(`VERDICT command-exit 0`).

**Gate families**: `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack`
derived 79 families for this change set. All 79 are accounted for with recorded exit codes:
**75 exit 0**, and **4 NOT MEASURED** — `check:doc-formula-expressions`,
`check:dual-build-cjs-loads`, `check:lean-entry-closure` and `check:type-check-debt` each
exited **3**, the code a gate uses when refusing its own prerequisite (they need builds of
packages this diff does not touch). Exit 3 is not a red and is not reported as one; CI builds
the tree first and runs them for real.

**Ablation of the new pin** (mutate on disk, prove it landed, RED, restore, prove the
restore, GREEN). The mutation is the exact drift the pin exists to catch: make
`normalizeStackInput` pass `includeRetired: true`.

```
anchor occurrences BEFORE = 1   injected occurrences BEFORE = 0
anchor occurrences AFTER  = 0   injected occurrences AFTER  = 1
HEAD blob     3456f9d4ecff3e5109ddf5b19b2649d661c0f251
mutated blob  df88fd0081df1bd7cd83c87bdbe700654a9b03ab   (differs -> the mutation landed)
RED   leg: vitest exit 1 — "does NOT replay a RETIRED entry, while the stored-row door does" FAILS
          (1 failed | 194 passed — the mutation is aimed, not a blanket break)
restored blob 3456f9d4ecff3e5109ddf5b19b2649d661c0f251   (== HEAD -> restore proven by hash)
          git diff HEAD: empty · git status --porcelain: empty
GREEN leg: vitest exit 0 — 195 passed
```

The ablation needs no rebuild: the test reaches its subjects through same-package relative
specifiers (`../shared/metadata-collection.zod.js`, `./stored.js`), which vitest resolves to
`src/`, not to `dist/`. Restore is `git checkout HEAD -- PATH` (never a bare checkout, which
reads the index), under an `EXIT INT TERM` trap with an absolute path, and it is proven by
blob hash rather than by an exit code.

**Changeset**: owed, and measured rather than asserted. `packages/spec` `files[]` ships
`dist` plus `src/**/*.zod.ts` — neither edited file is a `.zod.ts`, so the sources themselves
do **not** publish (negative control: both are absent from `npm pack --dry-run --json`, whose
tarball has 2012 entries including 200 `.zod.ts` sources, so the list is selective rather than
empty). What does publish is the TSDoc: after a real build the corrected text appears in two
shipped declaration files, `dist/index.d.ts` and `dist/types-DBIjqK7N.d.ts`, both confirmed
present in the pack listing. Controls: an untouched TSDoc line (`Stable, kebab-case id`)
reaches `.d.ts` too, while a function-**body** comment from the same edit
(`graduated chain history`) reaches **0** `.d.ts` files and the exact corrected phrase reaches
**0** `dist/*.js` files. So a `patch` changeset is owed for text an upgrading author reads in
their editor, and `skip-changeset` would be wrong.

**Lint**: narrowed to the three changed files and declared as such —
`eslint --no-inline-config --format json` over them reports **3 files, 0 errors, 0 warnings**
(file count read from the JSON, not estimated). The universe read from ESLint's own config
rather than guessed: its API selects **6670** files at the repo root. Invariance: this repo's
single `eslint.config.mjs` never enables type-aware linting for any file — no
`parserOptions.project`, no typed `@typescript-eslint` rules (the config says so at its own
line 328 and cites the positive control it was measured with) — so a comment-and-test diff in
three files cannot move the verdict on any file it does not touch. The repo-wide run is CI's.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MkQhmuuJAVDjmeWNixwDDH)_