### PR TITLE
fix(spec): refuse a declared def rename that would collapse two baseline keys onto one

### DIFF
--- a/packages/spec/scripts/build-schemas-check-mode.test.ts
+++ b/packages/spec/scripts/build-schemas-check-mode.test.ts
@@ -975,6 +975,11 @@ const DELETED_AGED = `data/Object:${DELETED_AGED_LEAF} [RETIRED]`;
  *  fixture vacuous. */
 const DELETED_BY_RENAME_SOURCE_DEF = 'integration/FieldMapping';
 const DELETED_BY_RENAME = `${DELETED_BY_RENAME_SOURCE_DEF}:source`;
+/** The SAME property under the rename's TARGET def. The committed surface is the
+ *  post-rename snapshot, so it records this one and not `DELETED_BY_RENAME`; an
+ *  upstream anchor from before the rename is the mirror image, and holding both
+ *  at once is the #17383 collision. */
+const CARRIED_BY_RENAME = `${RENAMED_DEFS[DELETED_BY_RENAME_SOURCE_DEF]}:source`;
 
 describe('build-schemas.ts — deleted baseline lines must prove themselves (#4650)', () => {
   beforeAll(() => {
@@ -1266,13 +1271,80 @@ describe('build-schemas.ts — deleted baseline lines must prove themselves (#46
       expect(pristineSurface).toContain(
         `${RENAMED_DEFS[DELETED_BY_RENAME_SOURCE_DEF]}:source`,
       );
-      seedBase((s) => [...s, DELETED_BY_RENAME].sort());
+      // ⚠️ The old key is INJECTED and the carried one REMOVED, which is what an
+      // upstream anchor from before the rename really looks like: the property
+      // is recorded under the OLD def and not yet under the new one. Injecting
+      // alone left the base recording `source` under BOTH defs — a shape no
+      // real landing produces, and one #17383's collision guard now refuses
+      // outright (measured: the run exits 1 before this check is reached), so
+      // the fixture would have been asserting about a build that never got here.
+      seedBase((s) => [...s.filter((k) => k !== CARRIED_BY_RENAME), DELETED_BY_RENAME].sort());
       seedSurface((s) => s);
 
       const { status, output } = run(['--check']);
 
       expect(output).not.toContain('deleted without proof');
       expect(output).not.toContain('carry their own proof');
+      expect(status).toBe(0);
+    },
+  );
+
+  // ─── #17383 — a rename may MOVE keys, it may never MERGE two onto one ─────
+  // `checkRenameTable` validates the table against the defs the build EMITS, so
+  // this shape is invisible to it: one well-formed rename, source unemitted,
+  // target emitted. The damage is in the BASELINE, where the carry's plain
+  // `Map.set` collapses the two entries and drops one side's recorded retired
+  // state and default — before any ratchet below runs.
+
+  it(
+    'refuses a rename whose baseline records the same property under BOTH defs, and writes nothing',
+    { timeout: SPAWN_TIMEOUT_MS },
+    () => {
+      // The target keeps `CARRIED_BY_RENAME`, so the base records `source` under
+      // the source def AND the target def. That is the collision.
+      seedBase((s) => [...s, DELETED_BY_RENAME].sort());
+      const surfaceBytes = seedSurface((s) => s);
+
+      const { status, output } = run(['--check']);
+
+      expect(status).toBe(1);
+      expect(output).toContain('would COLLAPSE keys of the upstream baseline');
+      expect(output).toContain(
+        `${DELETED_BY_RENAME_SOURCE_DEF} → ${RENAMED_DEFS[DELETED_BY_RENAME_SOURCE_DEF]}`,
+      );
+      expect(output).toContain('under the TARGET def — source');
+      // The remedy is the one the two-sources rule already prescribes.
+      expect(output).toContain('retiredKey()');
+      // A check reports; it does not write (#4711).
+      expect(readSurface()).toBe(surfaceBytes);
+    },
+  );
+
+  it(
+    'does NOT refuse a rename into a populated target when no property name is shared',
+    { timeout: SPAWN_TIMEOUT_MS },
+    () => {
+      // The cost this guard can impose, pinned: the target def is populated in
+      // the base (six other keys survive the filter below), and the carried
+      // property name is not one of them. `Map.set` collapses only entries that
+      // are the SAME key, so this merge writes every key exactly once and loses
+      // nothing. Refusing a populated target as such would redden most of the
+      // committed table.
+      const baseKeys = [
+        ...pristineSurface.filter((k) => k !== CARRIED_BY_RENAME),
+        DELETED_BY_RENAME,
+      ].sort();
+      const targetDef = RENAMED_DEFS[DELETED_BY_RENAME_SOURCE_DEF];
+      expect(
+        baseKeys.filter((k) => k.startsWith(`${targetDef}:`)).length,
+        'the target def must still hold keys in the base, or this pins nothing',
+      ).toBeGreaterThan(0);
+      seedBase(() => baseKeys);
+      seedSurface((s) => s);
+
+      const { status, output } = run(['--check']);
+
+      expect(output).not.toContain('would COLLAPSE keys');
       expect(status).toBe(0);
     },
   );

--- a/packages/spec/scripts/build-schemas.ts
+++ b/packages/spec/scripts/build-schemas.ts
@@ -17,7 +17,12 @@ import {
   formatDefKeyCollisions,
   type EmittedDef,
 } from './lib/def-key-collisions';
-import { RENAMED_DEFS, carryAuthorableKey, checkRenameTable } from './lib/renamed-defs';
+import {
+  RENAMED_DEFS,
+  carryAuthorableKey,
+  checkRenameBaselineCollisions,
+  checkRenameTable,
+} from './lib/renamed-defs';
 // The Zod-graph walkers the authorable-surface reachability BFS runs on. Extracted
 // at #5317 so the pipe-direction rule (#4488) is assertable without running the
 // whole generator — see scripts/zod-graph.test.ts.
@@ -871,10 +876,40 @@ try {
   process.exit(1);
 }
 
+/**
+ * Refuse a declared rename that would COLLAPSE two of a baseline's own keys
+ * (#17383). Every carry below is a plain `Map.set` keyed by the carried key, so
+ * a rename whose source and target both hold the same property name in this
+ * baseline loses one of the two recorded facts — its retired state and its
+ * default — before any comparison runs. `checkRenameTable` cannot see this: it
+ * validates the table against the defs this build EMITS, and the damage lives
+ * in the baseline. Called once per baseline this script carries, because the
+ * in-tree snapshot and the upstream anchor are different documents and a
+ * collision can exist in either alone.
+ */
+function assertNoRenameBaselineCollisions(label: string, baselineKeys: Iterable<string>): void {
+  const problems = checkRenameBaselineCollisions(baselineKeys);
+  if (problems.length === 0) return;
+  console.error(
+    `\n❌ ${problems.length} declared def rename(s) would COLLAPSE keys of the ${label}:`,
+  );
+  for (const p of problems) console.error(`     - ${p}`);
+  console.error(
+    `\n   A rename may MOVE keys; it may never merge two of them onto one name. The carry\n` +
+    `   runs before every ratchet below, so a collapsed key makes the diff they report a\n` +
+    `   diff against input this script already corrupted — in both directions: a real\n` +
+    `   default change on the merged key can read as no change, and a key whose default\n` +
+    `   never moved can read as changed. See scripts/lib/renamed-defs.ts (#4684, #17383).`,
+  );
+  process.exit(1);
+}
+
 if (surfaceDoc) {
   const snapshot = new Map<string, boolean>(
     surfaceDoc.keys.map((e) => [e.replace(RETIRED_MARK, ''), e.endsWith(RETIRED_MARK)]),
   );
+
+  assertNoRenameBaselineCollisions(`committed ${SURFACE_FILE_NAME}`, snapshot.keys());
 
   // Carry the snapshot through any declared def rename FIRST, so every check
   // below compares like with like. A rename moves keys between defs; it must
@@ -2137,6 +2172,10 @@ let gitResolvedAnchor: { rev: string; keys: string[] } | null = null;
   if (base) {
     // Carry base keys through declared def renames first — same discipline as
     // the snapshot carry above — so a rename is never misread as a deletion.
+    assertNoRenameBaselineCollisions(
+      `upstream baseline ${base.rev.slice(0, 12)}`,
+      (base.doc.keys ?? []).map((entry) => entry.replace(RETIRED_MARK, '')),
+    );
     const baseSnapshot = new Map<string, boolean>();
     for (const entry of base.doc.keys ?? []) {
       const key = entry.replace(RETIRED_MARK, '');

--- a/packages/spec/scripts/lib/renamed-defs.ts
+++ b/packages/spec/scripts/lib/renamed-defs.ts
@@ -245,6 +245,87 @@ export function carryAuthorableKey(
  * The last two rules are about entries *interacting*, and only bind once the
  * table holds more than one entry — which #4703 is the first change to do.
  */
+/**
+ * Property names a recorded baseline holds under BOTH a rename's source def and
+ * its target def — the keys the carry would silently collapse (#17383).
+ *
+ * ## Why this is a separate rule from the four in {@link checkRenameTable}
+ *
+ * That function validates the table against the defs a build EMITS, which is
+ * all it can see at its call site. The damage here is not visible there at all:
+ * it lives in the BASELINE, and it is reached by a single, perfectly well-formed
+ * rename. `A → B` where the baseline already records `B:mode` is not two sources
+ * onto one target, so the merge rule never sees it; the source is gone and the
+ * target is emitted, so the decay rules pass; and every carry in
+ * `build-schemas.ts` is a plain `Map.set` keyed by the CARRIED key, so
+ * `A:mode` and `B:mode` land on the same entry and the later write wins.
+ *
+ * The damage is the same one the two-sources rule already refuses, reached by
+ * one rename instead of two: the surviving entry keeps only one of the two
+ * recorded RETIRED states and only one of the two recorded DEFAULTS, and the
+ * loss happens INSIDE the carry, before any comparison runs. So every gate
+ * downstream — check (b)'s live → retired transition, the deletion gate, the
+ * authorable-defaults differ — adjudicates against already-clobbered input, in
+ * both directions: a genuine default change on the merged key can read as no
+ * change at all, and a key whose default never moved can read as `changed`.
+ *
+ * ## What it deliberately does NOT refuse
+ *
+ * A rename onto a def that already exists is a legitimate, in-tree shape —
+ * `cloud/Sha256Digest → system/Sha256Digest` is one, and 24 of the committed
+ * entries have a target that already holds baseline keys once the surface
+ * snapshot has been regenerated under the new name. None of that loses
+ * anything: `Map.set` can only collapse two entries that are the SAME key, so a
+ * merge whose source and target share no property NAME writes every key exactly
+ * once. Refusing a populated target as such would redden the committed table;
+ * the collision — the intersection — is the whole of the damage and the whole
+ * of what is refused.
+ *
+ * Returns one problem line per colliding entry; empty means this baseline
+ * survives the carry intact.
+ */
+export function checkRenameBaselineCollisions(
+  baselineKeys: Iterable<string>,
+  renames: Readonly<Record<string, string>> = RENAMED_DEFS,
+): string[] {
+  const propsByDef = new Map<string, Set<string>>();
+  for (const key of baselineKeys) {
+    const sep = key.indexOf(':');
+    // A bare def key names no property, so it cannot collide with one.
+    if (sep < 0) continue;
+    const def = key.slice(0, sep);
+    let props = propsByDef.get(def);
+    if (props === undefined) propsByDef.set(def, (props = new Set<string>()));
+    props.add(key.slice(sep + 1));
+  }
+  const problems: string[] = [];
+  for (const [from, to] of Object.entries(renames)) {
+    // A self-rename collides with itself on every key; rule 1 of
+    // `checkRenameTable` already names it, and a second line would bury it.
+    if (from === to) continue;
+    const source = propsByDef.get(from);
+    const target = propsByDef.get(to);
+    if (source === undefined || target === undefined) continue;
+    const collisions = [...source].filter((prop) => target.has(prop)).sort();
+    if (collisions.length === 0) continue;
+    problems.push(
+      `${from} → ${to}: the baseline already records ${collisions.length} of this ` +
+        `rename's property name(s) under the TARGET def — ${collisions.join(', ')}. ` +
+        `Carrying the rename collapses each pair onto one key (last write wins), and ` +
+        `takes the losing side's recorded retired state and recorded default with it. ` +
+        `That is the same damage the two-sources-onto-one-target rule refuses, reached ` +
+        `by one rename instead of two, and it happens INSIDE the carry — before any ` +
+        `comparison runs — so the diff this build reports is computed against clobbered ` +
+        `input. Converging two defs on a shared property name is a real change: keep the ` +
+        `rename, and retire the losing side explicitly with \`retiredKey()\` plus its ` +
+        `registered ADR-0087 conversion, exactly as a retirement without a rename would ` +
+        `require. A merge whose two defs share no property name is lossless and is not ` +
+        `refused here.`,
+    );
+  }
+  return problems;
+}
+
 export function checkRenameTable(
   emittedDefs: ReadonlySet<string>,
   renames: Readonly<Record<string, string>> = RENAMED_DEFS,

--- a/packages/spec/scripts/renamed-defs.test.ts
+++ b/packages/spec/scripts/renamed-defs.test.ts
@@ -18,6 +18,7 @@ import { describe, it, expect } from 'vitest';
 import {
   RENAMED_DEFS,
   carryAuthorableKey,
+  checkRenameBaselineCollisions,
   checkRenameTable,
 } from './lib/renamed-defs';
 
@@ -134,6 +135,112 @@ describe('checkRenameTable', () => {
         'integration/FieldMapping': 'integration/ConnectorFieldMapping',
       }),
     ).toEqual([]);
+  });
+});
+
+describe('checkRenameBaselineCollisions — a rename may MOVE keys, never MERGE them (#17383)', () => {
+  const renames = { 'integration/Old': 'integration/New' } as const;
+
+  // The shape the four rules of `checkRenameTable` cannot see. It is ONE rename,
+  // so the two-sources rule never fires; the source is unemitted and the target
+  // is emitted, so both decay rules pass. The damage is in the BASELINE, and
+  // every carry in build-schemas.ts is a plain `Map.set` on the carried key.
+  it('refuses a rename whose target already holds the same property name, and names it', () => {
+    const problems = checkRenameBaselineCollisions(
+      ['integration/New:mode', 'integration/Old:mode'],
+      renames,
+    );
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toContain('integration/Old → integration/New');
+    expect(problems[0]).toContain('under the TARGET def — mode');
+    // The remedy must be the one the two-sources rule already prescribes.
+    expect(problems[0]).toContain('retiredKey()');
+  });
+
+  it('is silent where checkRenameTable is loud, and loud where it is silent', () => {
+    // The discriminator, stated as one assertion: the SAME baseline damage is
+    // invisible to the emitted-def rules, which is why this rule exists.
+    const baseline = ['integration/New:mode', 'integration/Old:mode'];
+    expect(checkRenameTable(new Set(['integration/New']), renames)).toEqual([]);
+    expect(checkRenameBaselineCollisions(baseline, renames)).toHaveLength(1);
+  });
+
+  it('reports EVERY colliding property, sorted, not just the first', () => {
+    const problems = checkRenameBaselineCollisions(
+      [
+        'integration/New:alpha', 'integration/New:beta', 'integration/New:gamma',
+        'integration/Old:beta', 'integration/Old:alpha', 'integration/Old:delta',
+      ],
+      renames,
+    );
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toContain('2 of this');
+    expect(problems[0]).toContain('alpha, beta');
+  });
+
+  // ─── What it must NOT refuse — the cost this rule can impose ─────────────
+  // A `Map.set` can only collapse two entries that are the SAME key, so a merge
+  // whose two defs share no property NAME writes every key exactly once and
+  // loses nothing. Refusing a populated target as such would redden 24 of the
+  // committed entries, whose targets all hold keys once the surface snapshot has
+  // been regenerated under the new name — and it would forbid the in-tree
+  // `cloud/Sha256Digest → system/Sha256Digest` shape outright.
+
+  it('ACCEPTS a merge into a populated target whose property names are disjoint', () => {
+    expect(
+      checkRenameBaselineCollisions(
+        ['integration/New:kept', 'integration/Old:moved'],
+        renames,
+      ),
+    ).toEqual([]);
+  });
+
+  it('ACCEPTS the landing shape: the baseline holds the keys under the SOURCE only', () => {
+    // The real `authorable-surface.base.json` shape while a rename lands — the
+    // upstream anchor predates it, so the target has no keys there at all.
+    expect(
+      checkRenameBaselineCollisions(['integration/Old:mode', 'integration/Old:other'], renames),
+    ).toEqual([]);
+  });
+
+  it('ACCEPTS the settled shape: the baseline holds the keys under the TARGET only', () => {
+    // The committed `authorable-surface/` shape after regeneration — the entry is
+    // inert against the snapshot but still enforces the hygiene invariants.
+    expect(
+      checkRenameBaselineCollisions(['integration/New:mode', 'integration/New:other'], renames),
+    ).toEqual([]);
+  });
+
+  it('matches the def exactly — a def that merely shares a prefix is not the target', () => {
+    expect(
+      checkRenameBaselineCollisions(['integration/NewThing:mode', 'integration/Old:mode'], renames),
+    ).toEqual([]);
+  });
+
+  it('ignores bare def keys, which name no property and so can collide with none', () => {
+    expect(checkRenameBaselineCollisions(['integration/New', 'integration/Old'], renames)).toEqual([]);
+  });
+
+  it('splits on the FIRST separator, so a property containing ":" still collides', () => {
+    const problems = checkRenameBaselineCollisions(
+      ['integration/New:a:b', 'integration/Old:a:b'],
+      renames,
+    );
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toContain('a:b');
+  });
+
+  it('leaves a self-rename to checkRenameTable rather than reporting it twice', () => {
+    // Every key of a self-rename collides with itself; rule 1 already names the
+    // entry, and a second line would bury the real diagnosis.
+    expect(
+      checkRenameBaselineCollisions(['integration/Old:mode'], {
+        'integration/Old': 'integration/Old',
+      }),
+    ).toEqual([]);
+    expect(
+      checkRenameTable(new Set(['integration/Old']), { 'integration/Old': 'integration/Old' }),
+    ).toHaveLength(1);
   });
 });
 


### PR DESCRIPTION
Fixes #17383

Clause-②: no

`checkRenameTable` validates `RENAMED_DEFS` against the defs a build **emits** — that
is all its call site can see. A single rename `A -> B` where the recorded **baseline**
already holds a property name under both `A` and `B` is invisible to it: it is not two
sources onto one target, the source is unemitted and the target is emitted, so all of
the existing rules pass. Every carry in `build-schemas.ts` is a plain `Map.set` keyed
by the carried key, so the two entries collapse and the later write wins.

## The premise this PR did not inherit

The card places `checkRenameTable` in `packages/spec/scripts/lib/authorable-defaults.ts`.
It is not there. Re-derived by symbol on `origin/main`:

- the guard is `packages/spec/scripts/lib/renamed-defs.ts`, consumed once in
  `build-schemas.ts`;
- there are **five** clobbering carry sites, not two — four in `build-schemas.ts`
  (the surface gate's `prev`, the deletion gate's `baseSnapshot`, and both
  `baselineKeys` builders of the defaults gate) plus `carryDefaultsThroughRenames`;
- a sixth carry site, `registeredRetiredKeys()`, is **not** affected: it merges
  deliberately (earliest major wins) instead of clobbering.

A second correction: the card and the dispatch both say `checkRenameTable` refuses
"exactly four shapes". It refuses **five** — the chained-rename rule (`A -> B -> C`)
is a separate pass at the end of the function.

## The gap, reproduced with a lit control

Against the real carry code, one rename `integration/Old -> integration/New`, with the
baseline holding `mode` under both defs:

| leg | reading |
| --- | --- |
| the guard today | `checkRenameTable` returns `[]` — no diagnostic |
| **lit control** | the *same* collapse reached by two sources returns 1 problem — `the TARGET def is already claimed by …` |
| key side | `prev` collapses 2 baseline entries to 1; the surviving retired flag is whichever sorted last |
| defaults side | `carryDefaultsThroughRenames` collapses 2 fingerprints to 1 |
| **acceptance bar** | target default `"b"`, this build emits `"a"` — a genuine change — and `diffAuthorableDefaults` reports `[]`. **Swallowed.** |
| mirror | target default `"b"`, this build emits `"b"` — no change at all — and the differ reports `changed: "a" -> "b"`. **Manufactured.** |

The corruption is bidirectional, which is what decides the disposition below.

## The choice: REFUSE — and refuse the intersection, not the populated target

The card offers two shapes and specifies neither. This PR refuses, for three reasons,
and narrows *what* is refused for a fourth.

1. **The damage is identical to the two-sources rule's**, not merely similar: the same
   maps, the same `Map.set`, the same lost retired state and lost default. Where the
   damage is identical, the disposition should be too.
2. **Report-and-allow cannot work here**, because the clobber happens *inside the
   carry, before any comparison runs*. The rows a reviewer would read are themselves
   computed against corrupted input — and per the table above the gate both swallows
   real changes and manufactures false ones, so a reviewer holding an advisory
   "collision" line beside a `changed` row cannot tell which of the two is real.
   Refusal is the only disposition that keeps the reported diff honest.
3. The remedy is available and is the one the two-sources rule already prescribes:
   keep the rename, and retire the losing side explicitly with `retiredKey()` plus its
   registered ADR-0087 conversion.

4. ⚠️ **But the card's literal predicate is falsified by measurement.** "Refuse a rename
   whose target already carries keys in the baseline" would redden `main` immediately:

   - **24 of the 39** committed entries have a target that already holds baseline keys
     in the committed `authorable-surface/` (that snapshot is the *post*-rename one, so
     the keys sit under the new name and the source has none);
   - the in-tree `cloud/Sha256Digest -> system/Sha256Digest` entry is documented as
     "a rename onto a def that already existed", so rename-into-an-existing-target is
     an already-sanctioned shape.

   `Map.set` can only collapse entries that are the **same key**, so a merge whose two
   defs share no property **name** writes every key exactly once and loses nothing. The
   refusal is therefore the **intersection** — the property names the baseline records
   under both defs — which is exactly the damage and nothing more. Measured on
   `origin/main`: **0 collisions** in the committed `authorable-surface/` and **0** in
   `authorable-surface.base.json`.

Both baselines are guarded, because they are different documents: the upstream anchor
is the *pre*-rename snapshot (source populated, target empty) and the in-tree snapshot
is the *post*-rename one. A real merge-into-populated-target shows up in the anchor
first, so guarding only the in-tree snapshot would have missed the card's own case.

## Ablation — both directions, on-disk proof, hash restore

Each leg: unique-anchor check, occurrence counts before and after, `git hash-object`
against the `HEAD` blob, `trap … EXIT INT TERM`, and restore verified byte-identical
plus an empty `git diff HEAD`.

**Leg A — disable the guard.** Blob `f32305e7` -> `addc4481`.

- 4 unit pins RED: *refuses a rename whose target already holds the same property
  name*; *is silent where checkRenameTable is loud*; *reports EVERY colliding
  property*; *splits on the FIRST separator*
- 1 wiring pin RED: *refuses a rename whose baseline records the same property under
  BOTH defs, and writes nothing*
- 25 unit pins stayed green — the mutation is targeted, not a blanket break
- restored: `f32305e7`, byte-identical, `git diff HEAD` empty

**Leg B — make the guard over-fire** (refuse when BOTH sides are populated, ignoring the
intersection). Blob `f32305e7` -> `4f87b2b5`. This is the cost this change can impose.

- the over-refusal pins RED, exactly as designed: *ACCEPTS a merge into a populated
  target whose property names are disjoint*, and the wiring pin *does NOT refuse a
  rename into a populated target when no property name is shared*
- one extra, honestly reported: *reports EVERY colliding property, sorted* also went
  RED, because the over-firing rule reports 3 properties where the real rule reports 2
- 27 unit pins stayed green; restored `f32305e7`, byte-identical, `git diff HEAD` empty

⚠️ Note what Leg B means: under that mutation the **real build stays green**, because
every committed entry has an empty source side in the in-tree snapshot. The over-refusal
is caught *only* by these pins. That is why they exist.

⭐ **Correction, from the at-tier contract review of this PR.** An earlier revision of this
section said Leg B "is the leg the card's literal predicate would have shipped" while also
saying the real build stays green under it. **Those cannot both be true**, and the review
separated them by measurement:

- **Leg B (above, blob `4f87b2b5`)** — refuse when both sides are populated. Real
  `check:authorable-surface` **exit 0**; caught by the pins alone.
- **The card's literal predicate** — refuse ANY populated target — is a *different*
  mutation (the review's B2, blob `4a3848b9`). Wired into the real build it exits **1**
  with **24 problem lines**: `❌ 24 declared def rename(s) would COLLAPSE keys of the
  committed authorable-surface/`.

⇒ The card's predicate is caught by the real build, loudly. The narrower over-fire is the
one only the pins catch. Both readings stand; only the sentence conflating them was wrong.

## One fixture corrected, and why it is in scope

`build-schemas-check-mode.test.ts` seeded its carry fixture by **injecting** the old key
into the base while leaving the carried key in place — so the anchor recorded `source`
under both defs at once. That is the collision, and the new guard refuses it: measured,
the run now exits 1 *before* the check the fixture was written for is reached, so it
would have been asserting about a build that never got there. No real landing produces
that anchor (a pre-rename anchor holds the property under the old def only), so the
fixture now removes the carried key as well. It is a faithfulness fix, not an
accommodation — and it doubles as the over-refusal pin, since the target def still holds
six other keys in that base.

## Verification

| run | exit | result |
| --- | ---: | --- |
| `vitest run --project local scripts/renamed-defs.test.ts` | 0 | 29 passed |
| `vitest run --project repo build-schemas-check-mode.test.ts -t 'deleted baseline lines must prove themselves'` | 0 | 11 passed, 63 skipped |
| `pnpm --filter @objectstack/spec typecheck` | 0 | `tsc` + `check:scripts-typecheck` + `check:test-typecheck` all green |
| `pnpm --filter @objectstack/spec run check:authorable-surface` | 0 | the real `build-schemas.ts --check` accepts the committed table |
| derived gate families (`scripts/pm/dispatch-gates.mjs --commands`) | 0 | see the report; 3 of them read `dist/` and were re-run after a build |

## No changeset — `skip-changeset`

Measured rather than assumed. `packages/spec`'s `files[]` ships `dist`, `json-schema`,
`liveness`, `prompts`, `llms.txt`, `README.md`, `src/**/*.zod.ts`, `CHANGELOG.md`,
`api-surface`, `spec-changes.json`. This diff touches only `packages/spec/scripts/**`.

- positive control — `ConnectorSchema`, a published symbol: **4** published paths hit
- `checkRenameBaselineCollisions` (new): **0**
- `checkRenameTable` and `carryAuthorableKey`, siblings in the same build-script module
  that have shipped through many releases: **0**

The sibling control is the load-bearing half: build-script symbols have never reached a
published path, so this is a measurement across releases rather than an argument from
construction. Nothing published moves. ⚠️ The dispatch's declared file surface listed
"a changeset"; this deviates from it deliberately and is flagged in the round report so
the seat can reverse it in one step.

## 验收备注

范围外发现,均未立卡:

- 卡片与派发词都称 `checkRenameTable` "refuses exactly four shapes",实为**五条** ——
  链式改名(`A -> B -> C`)是函数末尾独立的一遍。属于卡片表述,不是代码缺陷。
- 两来源规则(guard four)即使在两个来源的属性名**完全不相交**时也拒绝,比它自己
  陈述的损害更宽;本次新规则只拒交集。这是一处不对称,但方向偏严、不违反任何契约,
  因此记录不立卡。承接者:下一个向 `RENAMED_DEFS` 添加合并型条目的 PR。
- `registeredRetiredKeys()`(`build-schemas.ts`)是第六个 carry 站点,它**刻意合并**
  (取最早的 major)而非覆盖,不受本次影响。记录以免下次读成遗漏。

## 维护者速读(草稿)

**改了什么** —— `packages/spec` 的构建期闸门新增一条规则:声明的 def 改名,如果基线
快照在**源 def 和目标 def 下记录了同一个属性名**,构建直接失败。新增
`checkRenameBaselineCollisions`,在 `build-schemas.ts` 的两处基线(in-tree 快照与
upstream 锚点)各调用一次。只动构建脚本,不动任何已发布内容。

**为什么改** —— 现有的 `checkRenameTable` 只能看到"这次构建发出了哪些 def",看不到
基线。所以单条改名 `A -> B` 撞上一个基线里已有 keys 的 `B` 时,五条现有规则全部放行,
而所有 carry 都是 `Map.set`,两条记录塌成一条、后写的赢。丢掉的是属性的 retired 状态
与 default 指纹,而且塌陷发生在**任何比较之前**,因此下游每个 ratchet 都在已被污染的
输入上判案 —— 双向出错:真实的 default 变更会被吞掉,没变的会被报成 `changed`。
⚠️ 今天树里没有这种改名,这是**潜在**而非现行缺陷:修它的理由是闸门的保证比它读起来
更窄,不是现在坏了。

**风险与代价(含回滚)** —— 代价是闸门可能**误拒**一次合法改名。卡片建议的字面判据
("目标在基线里已有 keys 就拒绝")实测会当场让 `main` 变红:39 条已提交条目里有 24 条
的目标在 in-tree 快照下已有 keys,而且 `cloud/Sha256Digest -> system/Sha256Digest`
这条在树里就是"改名到一个已存在的 def"。所以本次只拒**交集**(两边同名的属性),
不相交的合并逐字节无损、照常放行,并由 Leg B 消融钉死。实测 `main` 两份基线的交集
均为 0,`check:authorable-surface` 绿。回滚成本极低:整个改动是构建脚本加一条规则,
`git revert` 即可,不涉及任何已发布载荷、导出符号或生成产物。

**席位意见** —— (留空,待席位定稿)

**你要做的** —— 两件。① 裁一下方向:卡片把"拒绝"与"带碰撞报告放行"并列且不指定,
本 PR 选了**拒绝**并收窄到交集,理由与证据在正文;若你要"报告放行",需要先回答
guard four 为什么对同一损害判了拒绝。② 确认 `skip-changeset` 这一路:实测没有任何
已发布内容移动(带正控),但派发词的文件面写了"a changeset",两者冲突,由你定。

---
_Generated by [Claude Code](https://claude.ai/code)_