### PR TITLE
fix(spec): register plugin-approvals as a second emitter of RESUME_FAILED

### DIFF
--- a/.changeset/17909-approvals-resume-failed-provenance.md
+++ b/.changeset/17909-approvals-resume-failed-provenance.md
@@ -1,0 +1,15 @@
+---
+"@objectstack/spec": minor
+---
+
+`@objectstack/plugin-approvals` is now registered as a second emitter of the already-registered `RESUME_FAILED` in `ERROR_CODE_LEDGER`, so the only correct implementation of `ResumeFailureReport.code` stops being refused by `check:error-code-provenance`.
+
+**The contradiction this closes.** `ResumeFailureReport` (`contracts/approval-service.ts`) declares `code: ErrorCode` as **required** — "a success answer has no envelope `code` to fall back on" — and its docblock prescribes `RESUME_FAILED` for a run that could not be advanced. But the ledger listed that code only under `@objectstack/rest`, so the first producer to fill the slot stamped a registered code its own owner key did not list, which the provenance gate refuses. The declaration shipped in a state where satisfying it tripped a sibling gate.
+
+**Measured, not derived.** With PR #17908's stamp site present and the ledger unchanged, the guard answers exit 1 and names it: `@objectstack/plugin-approvals stamps 'RESUME_FAILED' (objlit) at packages/plugins/plugin-approvals/src/approval-service.ts:3370 — not listed under its own owner key`. With this row, the same tree answers exit 0 with the site counted as listed.
+
+**A row, not a waiver — the precedent's own predicate decides it.** The `EXTERNAL_IMPORT_ERROR` waiver records "the door stamps this code itself for every throw and never reads the producer's declaration". Both halves fail for `resumeFailure`: it rides a **success** answer, which the REST approvals door serves with `res.json(out)` verbatim, and `packages/rest/src` spells `resumeFailure` nowhere. The producer's literal *is* the wire value, so the door names no vocabulary to waive it under.
+
+**One code, not the three the docblock names.** `RESUME_TARGET_LOST` is a thrown message prefix mapped by rest's catch and stays under rest's row; `RESUME_IN_PROGRESS` is compared and never constructed in this package, and is emitted by `@objectstack/service-automation`, which carries its own row. A row for a code the package does not stamp would be the dead weight this file's gate refuses.
+
+⛔ **No wire byte moves and no accept set widens.** `RESUME_FAILED` was already in the registered union, so no response can now carry a code it could not carry before; the per-package rows are provenance, not identity. No exported symbol is added and no published payload gains a key.

--- a/packages/spec/src/api/error-code-ledger.zod.ts
+++ b/packages/spec/src/api/error-code-ledger.zod.ts
@@ -1062,6 +1062,26 @@ export const ERROR_CODE_LEDGER = {
   '@objectstack/plugin-approvals': [
     'FORBIDDEN',
     'RECORD_LOCKED',
+    // [#17909] Second EMITTER of the code — `@objectstack/rest` already
+    // registers it for the THROW path, where the approvals door's
+    // `handleApprovalError` catch maps a `RESUME_FAILED:`-prefixed message to
+    // a 500 whose body names that same code, and the producer's declaration is
+    // never read. This row is the OTHER moment, and it is not that one: the
+    // `resumeFailure` member `ResumeFailureReport` declares
+    // (`contracts/approval-service.ts`) rides a SUCCESS answer, where the door
+    // has no envelope to stamp — `decide` / `recall` are served by
+    // `res.json(out)` (rest-server.ts), which copies the service's result
+    // verbatim, and `packages/rest/src` spells `resumeFailure` nowhere. So the
+    // wire value IS this package's own literal, reachable end to end (the
+    // #8035 test), and the door names no vocabulary here to waive it under.
+    // One code, not three: the member's docblock also names
+    // `RESUME_TARGET_LOST` and `RESUME_IN_PROGRESS`, and this package stamps
+    // neither in a scanned position — `RESUME_TARGET_LOST` is a thrown message
+    // prefix served under rest's row, `RESUME_IN_PROGRESS` is compared, never
+    // constructed, and is emitted by `@objectstack/service-automation`, which
+    // carries its own row. A row for a code this package does not stamp would
+    // be the dead weight this file's gate refuses.
+    'RESUME_FAILED',
   ],
   '@objectstack/plugin-security': [
     // [#7474] `controlled_by_parent` declared with no `master_detail` relation.


### PR DESCRIPTION
Fixes #17909

Clause-②: yes

`packages/spec` declared `ResumeFailureReport.code: ErrorCode` as **required** and prescribed `RESUME_FAILED` in its docblock, but the provenance ledger listed that code only under `@objectstack/rest`. So the only correct implementation stamps a registered code its own owner key does not list, and `check:error-code-provenance` refuses it. This adds the missing provenance row under `@objectstack/plugin-approvals`.

## The measurement the card declared NOT MEASURED

The card recorded its causal link as *derived from the guard's stated rule, not from the guard's own output* — a fresh worktree answered `tsx: not found`. Dependencies installed, the guard run, and here is its own text.

**Before** — branch base `5741ff10c30`, ledger unchanged, PR #17908's stamp site injected from its head `109c9ce13`:

```
scanned 2301 files; 336 registered-code stamp site(s): 318 listed, 17 waived

FAIL — 1 stamp site(s) of a registered code with no provenance row:
  @objectstack/plugin-approvals stamps 'RESUME_FAILED' (objlit) at packages/plugins/plugin-approvals/src/approval-service.ts:3370 — not listed under its own owner key
```

`VERDICT guard-exit=1`. Exactly one violation, exactly the site the card names.

**After** — this PR's row, same injected stamp site:

```
scanned 2301 files; 336 registered-code stamp site(s): 319 listed, 17 waived
OK — every registered-code stamp site is listed under its own owner key or carries a recorded waiver (10 waiver(s), all live)
```

`VERDICT guard-exit=0`, and the listed count moves 318 to 319 — the site is admitted as listed, not waived.

## The card frames this as one code; it is three, and only one is stamped

The member's docblock names `RESUME_FAILED`, `RESUME_TARGET_LOST` and `RESUME_IN_PROGRESS`. Measured on the tree, not inherited:

| code | ledger owner | who stamps it in a scanned position |
|---|---|---|
| `RESUME_FAILED` | `@objectstack/rest` (`:287`) | rest's catch maps the message prefix to a status, via a variable — not a literal the scan sees. plugin-approvals stamps the literal, once, at `approval-service.ts:3370` (new in #17908). **The row this PR adds.** |
| `RESUME_TARGET_LOST` | `@objectstack/rest` (`:288`) | nobody, in a scanned position. plugin-approvals throws it as a message prefix (`approval-service.ts:3189`); rest's catch maps that prefix. No row owed. |
| `RESUME_IN_PROGRESS` | `@objectstack/service-automation` (`:1044`) — **not** rest, correcting the dispatch's open premise | `service-automation/src/engine.ts:5795` and `:6165`, which its own owner key already lists. plugin-approvals only *compares* it (`:3304`). No row owed. |

## Why a row and not a waiver — the precedent's own predicate, applied

The `EXTERNAL_IMPORT_ERROR` waiver states the test plainly: the door's catch *"stamps this code itself for EVERY importObject throw and never reads the producer's declaration — the door names the wire vocabulary."* Both halves fail here, and the second decisively:

- `resumeFailure` rides a **success** answer. The REST approvals door serves `decide` / `recall` with `res.json(out)` (`rest-server.ts`), which copies the service's result verbatim — there is no envelope for the door to stamp on that path.
- `git grep resumeFailure packages/rest/src` matches **nothing**. The door neither stamps nor reads it. The producer's literal *is* the wire value.

The door's `handleApprovalError` catch is a real second moment, and it is the *throw* path — already covered by rest's existing row. This PR does not touch it.

⛔ The gate is not evaded. The literal stays exactly where it is; nothing is hoisted into a constant to dodge the textual scan.

## Ablation and cost direction

Each leg mutates on disk, proves the mutation landed by occurrence count, runs the guard, and restores under a `trap` verified by `git hash-object` against the `HEAD` blob plus an empty `git diff HEAD`. The guard is a `tsx` script importing `../src/api/error-code-ledger.zod` — source, no `dist` interposed, so no build sits between the edit and the reading.

| leg | mutation | expected | measured |
|---|---|---|---|
| ablation | remove the row, keep the stamp site | reds, same site | `exit=1`, `@objectstack/plugin-approvals stamps 'RESUME_FAILED' … at …:3370`, listed back to 318 |
| cost direction | keep the row, stamp `RESUME_TARGET_LOST` instead | still reds — the row must not over-permit | `exit=1`, names `RESUME_TARGET_LOST` at `:3290`. The row admits exactly the one code measured |
| #15970 coverage | keep the row, stamp `RESUME_FAILED` at **two** sites | green — a row is package-scoped | `exit=0`, 320 listed |

## Does this unblock #15970?

**Yes, conditionally, and the condition is measured rather than asserted.** The guard reconciles on `(package, code)`, not on line number, so any number of `RESUME_FAILED` sites inside `@objectstack/plugin-approvals` are admitted by this one row — the third leg above proves it with two sites. `ApprovalRecallResult.resumeFailure` is the same member type in the same package, so an implementation that stamps `RESUME_FAILED` is covered with no further ledger edit.

⚠️ It is **not** covered if #15970's implementation stamps `RESUME_TARGET_LOST` for a lost run: the cost-direction leg is exactly that case, and it reds. That is the intended narrowness, not a gap — that code's wire emission belongs to rest's catch, and if a producer ever stamps it on a success answer it owes its own reading, not a pre-emptive row.

## Clause ② and the changeset level

Declared **`Clause-②: yes`**, measured rather than argued: `node scripts/pm/check-widening-tells.mjs --declaration no` answers `exit=4` with `✗ T4 … a new registration in a registry / catalog` at `error-code-ledger.zod.ts:1084`; with `--declaration yes` it answers `exit=0`. The ledger's own header agrees — *"Registering a code widens this face and is therefore a Clause-② change, door or no door."* The changeset is `minor` accordingly.

⚠️ Worth a reviewer's eye, and stated rather than hidden: nothing an implementation may now *emit* actually changes. `RESUME_FAILED` was already in the registered union under rest, so no response can carry a code it could not carry before — the per-package rows are provenance, not identity, as this file's header says. The `yes` is the conservative direction, not a claim that the accept set grew.

`needs:contract-review` is hung on this PR.

## Verification

| check | verdict |
|---|---|
| `pnpm --filter @objectstack/spec check:error-code-provenance` | `exit=0` |
| `pnpm --filter @objectstack/spec test` (`--project local`) | `exit=0` — 473 files passed, 1 skipped; 13483 tests passed, 1 skipped |
| `pnpm --filter @objectstack/spec test:repo` (`--project repo`) | `exit=0` — 31 files, 523 tests passed |
| `pnpm --filter @objectstack/spec typecheck` | `exit=0` |
| `pnpm check:nul-bytes` | `exit=0` — 8541 text files scanned |
| `pnpm check:error-code-casing` | `exit=0` |
| `pnpm check:dispatcher-error-vocabulary` | `exit=0` |
| spec gate family (`check:liveness`, `check:duration-unit-keys`, `check:empty-state`, `check:variant-docs`, `check:llms-txt`, `check:skill-refs`, `check:strictness-ledger`, `check:yaml-examples`, `check:objectui-pin-citations`, `check:export-origins`) | all `exit=0` |

| `pnpm --filter @objectstack/spec build` + `check:api-surface` / `check:authorable-surface` / `check:docs` / `check:exported-any` / `check:dual-source-exports` / `check:entry-nameability` / `check:browser-reachable-entries` / `check:generated` | all `exit=0` — no generated artifact moves |
| derived gate sweep (`node scripts/pm/dispatch-gates.mjs --commands`, all 78 families, reconciled with `--ran`) | 75 `exit=0`, 3 `exit=3` **NOT MEASURED** |

The three NOT-MEASURED families are `check:doc-formula-expressions`, `check:dual-build-cjs-loads` and `check:lean-entry-closure` — each exits 3 with `PREREQUISITE NOT MET`, wanting a repo-wide `pnpm build` this diff does not otherwise need. CI's *Build Core* supplies it; recorded as not measured, ⛔ not as green.

Heavy steps ran through `scripts/pm/os-verify-lock.sh` on a shared box; verdicts are read from each command's own exit code captured before any pipe.

## 维护者速读(草稿)

**改了什么。** `packages/spec/src/api/error-code-ledger.zod.ts` 里,在 `'@objectstack/plugin-approvals'` 的 owner key 下加了一行 `'RESUME_FAILED'`,附带记录 wire 路径的注释;外加一份 `minor` changeset。一个数据表条目,没有新导出符号,没有已发布载荷上的新键。

**为什么改。** spec 自己把 `ResumeFailureReport.code` 声明成必填并在 docblock 里点名 `RESUME_FAILED`,却没给会填它的那个包登记 provenance 行 —— 于是"照声明实现"这件事本身会被姊妹门禁 `check:error-code-provenance` 拒收。第一个来填槽的实现者只是第一个发现的人。这一行把声明补齐。

**风险与代价(含回滚)。** 风险低:`RESUME_FAILED` 本来就在已注册并集里(挂在 rest 名下),这一行只改 provenance 归属,不让任何响应能带上它此前带不了的码。代价是一条 `minor` changeset(条款② 的机械判据命中 T4,按保守方向申报 `yes`)。回滚 = 删掉这一行加这份 changeset,单文件 revert,无迁移、无数据、无 wire 影响。

**席位意见。** (留空,待席位定稿)

**你要做的。** 确认两件事:(1) 同意这里走"加行"而不是"加 waiver" —— 判据是先例那句可测的话("门自己 stamp 且从不读生产者的声明")在成功路径上两半都不成立,证据在上面的 `res.json(out)` 与 `packages/rest/src` 零命中;(2) 条款② 申报为 `yes` 属于保守方向,而非真的放宽了接受集 —— 若你认为这类"已注册码的第二 emitter 行"不该触发契约复核,那是门禁 T4 的判据问题,值得单独立卡,⛔ 不在本 PR 处理。

## Unblocks

- **PR #17908 (#15556)** — blocked on this; its only failing step was *Error-code provenance guard*. `#15556 is not addressed here.`
- **#15970** — covered for a `RESUME_FAILED` stamp, measured above. `#15970 remains open.`

---
_Generated by [Claude Code](https://claude.ai/code/session_01MkQhmuuJAVDjmeWNixwDDH)_