### PR TITLE
test(service-automation): characterize a config-less `wait` / `boundary_event` node at run time

### DIFF
--- a/packages/services/service-automation/src/builtin/absent-config-node-characterization.test.ts
+++ b/packages/services/service-automation/src/builtin/absent-config-node-characterization.test.ts
@@ -1,0 +1,326 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * ⚠️ CHARACTERIZATION — this file RECORDS what the executor does today with a
+ * node that carries **no config block at all**. It does **not** endorse it, and
+ * a green run here is **not** a statement that the behaviour is correct.
+ *
+ * A later reader: every `expect` below is a photograph, not a contract. If the
+ * behaviour is deliberately changed, **update the photograph** — a red here is
+ * "the recorded behaviour moved", which may be exactly what a fix intends. The
+ * one thing it must never do is drift *unnoticed*.
+ *
+ * **Why the photograph was taken (#17843).** `@objectstack/spec` ACCEPTS a
+ * `wait` node whose `waitEventConfig` block is absent entirely — that is the
+ * state a freshly created node is in — while it REFUSES a node whose block is
+ * present with `eventType` omitted. So "block absent" is a document an author
+ * can really save, and what it then DOES at run time had never been observed:
+ * the question was answered from source, and this file is the observed run that
+ * closes that gap. It measures both halves the card asked for, because they are
+ * different execution branches and neither predicts the other:
+ *
+ *  - **`wait`** — the executor defaults `eventType` to `'timer'` on purpose (the
+ *    `?? 'timer'` in `wait-node.ts` carries a comment saying a wait node without
+ *    a config block is a valid timer wait), and the timer branch with no
+ *    `timerDuration` computes no deadline: no wake-up job, no `waitUntil`, not
+ *    one log line, and `success: true, suspend: true`. The run parks there until
+ *    something external calls `resume(runId)`. ⭐ Recorded, not blessed:
+ *    whether a duration-less timer wait should warn or refuse is a product
+ *    question that belongs to a successor card, not to this file.
+ *  - **`boundary_event`** — ⭐ the opposite shape, and the reason extrapolating
+ *    from `wait` would have been wrong. No executor is registered for it at all
+ *    (`installBuiltinNodes` seeds twelve packs, none of them this one; the
+ *    README files it as BPMN *interop* representation rather than the native
+ *    authoring model), so the run fails LOUDLY with `NO_EXECUTOR` before the
+ *    config block is ever read — and it fails identically whether that block is
+ *    absent or fully populated.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { PluginContext } from '@objectstack/core';
+import { AutomationEngine } from '../engine.js';
+import type { NodeExecutionResult, NodeExecutor } from '../engine.js';
+import { InMemorySuspendedRunStore } from '../suspended-run-store.js';
+import { registerWaitNode } from './wait-node.js';
+import { FlowNodeSchema } from '@objectstack/spec/automation';
+import type { AutomationResult } from '@objectstack/spec/contracts';
+import type { IJobService, JobHandler, JobSchedule } from '@objectstack/spec/contracts';
+
+type LogLine = { level: string; text: string };
+
+/**
+ * Every level the `Logger` contract offers, funnelled into ONE ordered sink —
+ * the engine's logger and the plugin ctx's logger are the same recorder, so
+ * "did anything at all get logged" is answerable rather than "did the level I
+ * happened to spy on get logged".
+ */
+function recordingLogger(sink: LogLine[]): PluginContext['logger'] {
+  const at = (level: string) => (...args: unknown[]) => {
+    sink.push({ level, text: args.map((a) => (typeof a === 'string' ? a : JSON.stringify(a))).join(' ') });
+  };
+  const logger = { info: at('info'), warn: at('warn'), error: at('error'), debug: at('debug') };
+  return { ...logger, child: () => logger } as unknown as PluginContext['logger'];
+}
+
+/** A job service that records what was scheduled — the instrument for "was a wake-up armed". */
+function jobCtx(sink: LogLine[]) {
+  const scheduled: Array<{ name: string; schedule: JobSchedule }> = [];
+  const job: IJobService = {
+    async schedule(name: string, schedule: JobSchedule, _handler: JobHandler) {
+      scheduled.push({ name, schedule });
+    },
+    async cancel() {},
+    async trigger() {},
+  };
+  const ctx = {
+    logger: recordingLogger(sink),
+    getService: (id: string) => (id === 'job' ? job : undefined),
+  } as unknown as PluginContext;
+  return { ctx, scheduled };
+}
+
+/** Records the order nodes ran, so "the run never got past the node" is observed, not assumed. */
+function marker(ran: string[]): NodeExecutor {
+  return { type: 'mark', async execute(node) { ran.push(node.id); return { success: true }; } };
+}
+
+/**
+ * start → before(mark) → <the node under measurement> → after(mark) → end.
+ *
+ * `before` proves the run REACHED the node; `after` proves whether it got past
+ * it. Without those two the readings below would be compatible with a flow that
+ * never ran at all.
+ */
+const flowWith = (node: Record<string, unknown>) => ({
+  name: 'f',
+  label: 'F',
+  type: 'autolaunched',
+  nodes: [
+    { id: 'start', type: 'start', label: 'Start' },
+    { id: 'before', type: 'mark', label: 'Before' },
+    node,
+    { id: 'after', type: 'mark', label: 'After' },
+    { id: 'end', type: 'end', label: 'End' },
+  ],
+  edges: [
+    { id: 'e0', source: 'start', target: 'before' },
+    { id: 'e1', source: 'before', target: String(node.id) },
+    { id: 'e2', source: String(node.id), target: 'after' },
+    { id: 'e3', source: 'after', target: 'end' },
+  ],
+});
+
+/**
+ * One real, engine-driven run of a `wait` node, reporting every channel the
+ * measurement needs.
+ *
+ * The executor's own return value is captured by wrapping the executor
+ * `registerWaitNode` publishes — the value recorded is the one the ENGINE
+ * received from a genuine run, never a second invocation staged by the test.
+ */
+async function runWaitNode(node: Record<string, unknown>) {
+  const logs: LogLine[] = [];
+  const ran: string[] = [];
+  const engine = new AutomationEngine(recordingLogger(logs));
+  const store = new InMemorySuspendedRunStore();
+  engine.setSuspendedRunStore(store);
+  engine.registerNodeExecutor(marker(ran));
+
+  const { ctx, scheduled } = jobCtx(logs);
+  let returned: NodeExecutionResult | undefined;
+  const realRegister = engine.registerNodeExecutor.bind(engine);
+  const patchable = engine as unknown as { registerNodeExecutor: (e: NodeExecutor) => void };
+  patchable.registerNodeExecutor = (exec: NodeExecutor) => {
+    if (exec.type !== 'wait') return realRegister(exec);
+    const inner = exec.execute.bind(exec);
+    return realRegister({
+      ...exec,
+      async execute(n, v, c) { const r = await inner(n, v, c); returned = r; return r; },
+    });
+  };
+  registerWaitNode(engine, ctx);
+  delete (engine as unknown as Record<string, unknown>).registerNodeExecutor;
+
+  engine.registerFlow('f', flowWith(node));
+  // Production seals the vocabulary at `kernel:bootstrapped`
+  // (`AutomationServicePlugin`); sealing here keeps the engine's own
+  // "never sealed" warning out of the window, so a log line seen during the run
+  // is one the NODE produced.
+  engine.sealNodeTypeVocabulary();
+  const from = logs.length;
+  const result = await engine.execute('f');
+  return {
+    result,
+    returned,
+    scheduled,
+    suspended: engine.listSuspendedRuns(),
+    stored: await store.list(),
+    logsDuringRun: logs.slice(from),
+    ran,
+  };
+}
+
+/** One real, engine-driven run of a node whose type has no executor registered. */
+async function runUnexecutableNode(node: Record<string, unknown>) {
+  const logs: LogLine[] = [];
+  const ran: string[] = [];
+  const engine = new AutomationEngine(recordingLogger(logs));
+  engine.registerNodeExecutor(marker(ran));
+  registerWaitNode(engine, jobCtx(logs).ctx);
+  engine.registerFlow('f', flowWith(node));
+
+  const beforeSeal = logs.length;
+  engine.sealNodeTypeVocabulary();
+  const sealLogs = logs.slice(beforeSeal);
+
+  const from = logs.length;
+  const result = await engine.execute('f');
+  return { result, registeredTypes: engine.getRegisteredNodeTypes(), sealLogs, logsDuringRun: logs.slice(from), ran };
+}
+
+const nodeStatus = (result: AutomationResult, nodeId: string) =>
+  result.summary?.nodes?.find((n) => n.nodeId === nodeId)?.status;
+
+/**
+ * The premise, pinned: the documents measured below are ones an author can
+ * really save. Without this leg the readings are untethered — if the spec ever
+ * starts refusing a block-less node, this whole file characterizes a document
+ * that can no longer exist, and its reader must be told that rather than left
+ * reading run-time behaviour for an unreachable input.
+ */
+describe('premise (#17843) — the parse contract ACCEPTS a node with no config block', () => {
+  const parse = (node: Record<string, unknown>) => FlowNodeSchema.safeParse(node);
+
+  it('accepts a `wait` node with no `waitEventConfig` at all, and refuses one whose block omits `eventType`', () => {
+    expect(parse({ id: 'pause', type: 'wait', label: 'Wait' }).success).toBe(true);
+    // The boundary the measurement turns on: "omitted key inside a present
+    // block" and "block absent" are different documents with different verdicts.
+    expect(parse({ id: 'pause', type: 'wait', label: 'Wait', waitEventConfig: {} }).success).toBe(false);
+  });
+
+  it('accepts a `boundary_event` node with no `boundaryConfig` at all', () => {
+    expect(parse({ id: 'b', type: 'boundary_event', label: 'Boundary' }).success).toBe(true);
+  });
+});
+
+describe('characterization (#17843) — a `wait` node with NO config block at all · recorded, NOT endorsed', () => {
+  it('defaults to a timer, arms nothing, writes no deadline and says nothing — and the run parks there', async () => {
+    const m = await runWaitNode({ id: 'pause', type: 'wait', label: 'Wait' });
+
+    // The run really reached the node and really stopped at it.
+    expect(m.ran, 'the run must have reached the wait node').toEqual(['before']);
+    expect(m.result.status).toBe('paused');
+    expect(m.result.success).toBe(true);
+    expect(m.suspended).toHaveLength(1);
+
+    // ① The executor's return value, verbatim. ⚠️ `output` is a PRESENT key
+    //    carrying `undefined` — not an absent one (`toStrictEqual`, because a
+    //    plain `toEqual` cannot tell those two apart, and a JSON dump of this
+    //    object drops the key entirely and reads as the second).
+    expect(m.returned).toStrictEqual({
+      success: true, suspend: true, correlation: 'timer:pause', output: undefined,
+    });
+    expect(m.returned?.output, 'nothing to write: no deadline was computed').toBeUndefined();
+
+    // ② No wake-up job was scheduled, though a job service WAS available —
+    //    which is what makes the silence below unconditional rather than a
+    //    consequence of a job-less host.
+    expect(m.scheduled).toEqual([]);
+
+    // ③ No `waitUntil` is written, so a later cold boot's re-arm pass
+    //    (`rearmSuspendedWaitTimers`) skips this run as "not a timer wait".
+    const vars = (m.stored[0]?.variables ?? {}) as Record<string, unknown>;
+    expect(Object.keys(vars).filter((k) => k.endsWith('.waitUntil'))).toEqual([]);
+
+    // ④ ⭐ Not one log line — no `warn`, no `error`, nothing at any level.
+    expect(m.logsDuringRun, 'the node emits nothing an operator could see').toEqual([]);
+
+    // ⇒ the correlation is a bare `timer:<nodeId>`, which arms nothing and which
+    //    `onSuspensionReleased` deliberately does not treat as a job name. The
+    //    only exit from this pause is an external `resume(runId)`.
+    expect(m.suspended[0]).toMatchObject({ nodeId: 'pause', correlation: 'timer:pause' });
+  });
+
+  it('CONTROL — the same node WITH `eventType: timer` + `timerDuration` behaves differently on every channel', async () => {
+    const control = await runWaitNode({
+      id: 'pause', type: 'wait', label: 'Wait',
+      waitEventConfig: { eventType: 'timer', timerDuration: 'PT1H' },
+    });
+    const absent = await runWaitNode({ id: 'pause', type: 'wait', label: 'Wait' });
+
+    // A wake-up job IS armed, one shot, ~1h out.
+    expect(control.scheduled).toHaveLength(1);
+    expect(control.scheduled[0].schedule.type).toBe('once');
+
+    // …and the deadline IS persisted, under the key the re-arm pass reads.
+    const controlVars = (control.stored[0]?.variables ?? {}) as Record<string, unknown>;
+    expect(typeof controlVars['pause.waitUntil']).toBe('string');
+    expect(control.returned?.output).toEqual({ waitUntil: controlVars['pause.waitUntil'] });
+
+    // The correlation is the JOB's name here, the inert `timer:<nodeId>` there.
+    expect(control.returned?.correlation).toBe(control.scheduled[0].name);
+    expect(control.returned?.correlation).not.toBe(absent.returned?.correlation);
+
+    // ⇒ the instrument discriminates: every channel that read zero above reads
+    //    non-zero here, so the zeros are a reading of the absent-config path and
+    //    not of a harness that measures nothing.
+    expect([absent.scheduled.length, control.scheduled.length]).toEqual([0, 1]);
+    expect([
+      Object.keys((absent.stored[0]?.variables ?? {}) as Record<string, unknown>).some((k) => k.endsWith('.waitUntil')),
+      Object.keys(controlVars).some((k) => k.endsWith('.waitUntil')),
+    ]).toEqual([false, true]);
+
+    // Both halves park the run, so "paused" is the one thing that does NOT
+    // discriminate — recorded so a reader does not mistake it for a signal.
+    expect([absent.result.status, control.result.status]).toEqual(['paused', 'paused']);
+  });
+});
+
+describe('characterization (#17843) — a `boundary_event` node · a DIFFERENT branch from `wait`, measured separately', () => {
+  it('fails the run loudly with NO_EXECUTOR — nothing is registered for the type, silent suspension never enters it', async () => {
+    const m = await runUnexecutableNode({ id: 'b', type: 'boundary_event', label: 'Boundary' });
+
+    // The premise: the platform ships no `boundary_event` executor.
+    expect(m.registeredTypes).not.toContain('boundary_event');
+
+    // The run reached the node (`before` ran) and did NOT get past it.
+    expect(m.ran).toEqual(['before']);
+
+    // ⭐ Loud, not silent — the opposite of the `wait` half above.
+    expect(m.result.success).toBe(false);
+    expect(m.result.status).toBe('failed');
+    expect(m.result.error).toBe("No executor registered for node type 'boundary_event'");
+    expect(nodeStatus(m.result, 'b')).toBe('failure');
+
+    // Loud TWICE: sealing the vocabulary names the type before any run.
+    expect(m.sealLogs.some((l) => l.level === 'warn' && l.text.includes('boundary_event'))).toBe(true);
+    // …and the run itself is reported, rather than passing unremarked.
+    expect(m.logsDuringRun.some((l) => l.text.includes('status=failed'))).toBe(true);
+  });
+
+  it('CONTROL — a fully populated `boundaryConfig` fails identically ⇒ the config block is never consulted', async () => {
+    const populated = await runUnexecutableNode({
+      id: 'b', type: 'boundary_event', label: 'Boundary',
+      boundaryConfig: {
+        attachedToNodeId: 'before', eventType: 'timer', timerDuration: 'PT1H', interrupting: true,
+      },
+    });
+
+    expect(populated.result.success).toBe(false);
+    expect(populated.result.error).toBe("No executor registered for node type 'boundary_event'");
+    expect(populated.ran).toEqual(['before']);
+    // ⇒ presence or absence of the block changes NOTHING here: the dispatch
+    //    fails before any executor could read it. Which is exactly why the
+    //    `wait` reading could not have been extrapolated onto this type.
+  });
+
+  it('CONTROL — the identical flow with a REGISTERED type in that slot runs to completion', async () => {
+    const ok = await runUnexecutableNode({ id: 'b', type: 'mark', label: 'Marker in the boundary slot' });
+
+    expect(ok.result.success).toBe(true);
+    expect(ok.result.status).not.toBe('failed');
+    // ⇒ the flow shape and the harness are sound; the failure above is the
+    //    node type, not the fixture.
+    expect(ok.ran).toEqual(['before', 'b', 'after']);
+  });
+});


### PR DESCRIPTION
Fixes #17843

Clause-②: no

Refs objectstack-ai/objectui#9109 (that card's grade depends on the reading below; nothing over there gates this one).

## What this is

**A measurement, converted from a source reading into an observed run.** Executor behaviour is
deliberately unchanged — the card says so itself, and the `?? 'timer'` fallback in
`wait-node.ts` carries a comment declaring it intentional.

The triage seat answered the card from source (comment 5651444086). This PR runs it. The run
**agrees with that reading on the `wait` half**, so the p1 escalation on objectui#9109 stands and
needs no rollback. The `boundary_event` half — which triage explicitly did **not** measure — comes
out the **opposite** shape, which is exactly why the card refused to extrapolate.

## The four readings, as recorded

All four come from real `engine.execute()` runs through `AutomationEngine`, with the node-type
vocabulary sealed (what `AutomationServicePlugin` does at `kernel:bootstrapped`), a job service
present, an `InMemorySuspendedRunStore` attached, and one recording logger behind both the engine
and the plugin context so "any log line at any level" is answerable.

### 1. `wait`, no config block at all

```
node:                { id: 'pause', type: 'wait', label: 'Wait' }
executor return:     { success: true, suspend: true, correlation: 'timer:pause', output: undefined }
engine result:       { success: true, status: 'paused', runId: 'run_caa5b321-...' }
scheduled jobs:      []
stored variables:    { previous: null, $runId: 'run_caa5b321-...', $flowName: 'f', $flowLabel: 'F' }
                     -- no 'pause.waitUntil' key
log lines during run: []
nodes that ran:      [ 'before' ]        -- the run reached the node and never got past it
```

⇒ the `'timer'` default applies, the timer branch computes no deadline, **no wake-up job is armed
even though a job service was available**, **no `waitUntil` is persisted**, and **not one log line
is emitted at any level**. The run parks until something external calls `resume(runId)`.

⚠️ One correction to the source reading's rendering, found only by running it: `output` is a
**present key carrying `undefined`**, not an absent key. A JSON dump of the return value drops it
and reads as the second. The test pins it with `toStrictEqual` for that reason — `toEqual` cannot
tell those two apart.

### 2. CONTROL — the same node WITH `eventType: 'timer'` and `timerDuration: 'PT1H'`

```
executor return:     { success: true, suspend: true,
                       correlation: 'flow-wait:run_ab5a389c-...:pause',
                       output: { waitUntil: '2026-09-13T07:38:41.591Z' } }
scheduled jobs:      [ { name: 'flow-wait:run_ab5a389c-...:pause',
                         schedule: { type: 'once', at: '2026-09-13T07:38:41.591Z' } } ]
stored variables:    ... 'pause.waitUntil': '2026-09-13T07:38:41.591Z'
```

⇒ **every channel that read zero above reads non-zero here**, so the zeros are a reading of the
absent-config path and not of an inert harness. The one channel that does *not* discriminate is
`status: 'paused'` — both halves park the run — and the test records that too, so a later reader
does not mistake it for a signal.

### 3. `boundary_event`, no config block at all — measured separately, NOT extrapolated

```
registered node types: [ 'mark', 'wait' ]      -- nothing registers 'boundary_event'
engine result:       { success: false, status: 'failed',
                       error: "No executor registered for node type 'boundary_event'" }
summary node 'b':    { nodeType: 'boundary_event', status: 'failure', runs: 1, failures: 1 }
at vocabulary seal:  warn -- "Flow 'f' references node type(s) with no registered executor or
                     descriptor ... these nodes fail at execution time with NO_EXECUTOR."
                     meta: { unknownTypes: [ 'boundary_event' ], knownTypes: [...] }
during the run:      info -- "[automation] run flow=f run=... status=failed ... failed=1"
nodes that ran:      [ 'before' ]
```

⇒ ⭐ **the opposite of the `wait` half: loud, and loud twice.** The type has no executor at all
(`installBuiltinNodes` seeds twelve packs, none of them this one; the package README files
`boundary_event` as the BPMN *interop* representation rather than the native authoring model), so
the dispatch fails before any config block could be read. There is no silent suspension on this
branch to find.

### 4. CONTROL — `boundary_event` with a fully populated `boundaryConfig`

Fails **identically** (`success: false`, same `error` string, same step failure) ⇒ the block is
never consulted. A third control puts a **registered** type in the same slot in the same flow and
the run completes (`ran: [ 'before', 'b', 'after' ]`), so the failure above is the node type, not
the fixture.

## Premise check

The card's premise holds on the tip, verified rather than assumed, and is pinned in the test:
`FlowNodeSchema` **accepts** a `wait` node with no `waitEventConfig` at all, **refuses** one whose
block is present with `eventType` omitted, and **accepts** a `boundary_event` node with no
`boundaryConfig`. So the documents measured above are ones an author can really save.

## The durable form

`packages/services/service-automation/src/builtin/absent-config-node-characterization.test.ts` —
named, titled and headed as a **characterization**, with the header stating in as many words that
every assertion is a photograph and not an endorsement, that a red here means "the recorded
behaviour moved" (possibly on purpose), and that whether a duration-less timer wait should warn or
refuse is a product question for a successor card rather than anything this file blesses.

## Verification

- `pnpm --filter @objectstack/service-automation test` — **133 files, 1571 tests, all pass** (the
  new file is 7 of them).
- `pnpm --filter @objectstack/service-automation typecheck` — exit 0.
- `pnpm --filter @objectstack/service-automation build` — exit 0; dependency closure built first
  via `pnpm --filter '@objectstack/service-automation^...' build`.
- Gate families derived from the diff with `scripts/pm/dispatch-gates.mjs` and reconciled with
  `--ran`: **53 derived, 51 run green, 0 unrun, 2 NOT MEASURED** —
  `check:dual-build-cjs-loads` and `check:type-check-debt`, both exit **3**
  (`PREREQUISITE NOT MET`: each reads built output for the whole workspace, which `lint.yml` builds
  before invoking them). Neither is a finding, and this diff emits nothing into any `dist/` for
  them to read.
- `pnpm lint` (the repo-wide `eslint . --no-inline-config`) — exit 0, whole population, no
  narrowing claimed.
- `pnpm check:nul-bytes` green, plus a direct control-character scan of the added file
  (`grep -naP` over the C0 set plus DEL) — no matches.

Gate log and reconciliation taken at `d5e7d32c3`, the final commit.

## Changeset

`skip-changeset`, measured rather than assumed: the package publishes
`files: ["dist", "README.md", "CHANGELOG.md"]`, and after a real build a probe symbol unique to the
added file appears in **0** of those paths, while the positive control `rearmSuspendedWaitTimers`
appears in **2** files under `dist/`. Nothing already published moves.

**Clause-② re-derived from the delivered diff: `no`.** The diff is exactly one added file, a
`*.test.ts` under `src/`, outside `files[]` and unreachable from the published entry
(`exports: { "." }` resolves into `dist/`). It adds no exported symbol reachable from a published
entry and no key on an already-published payload — the file declares no exports at all, and in any
case the grading test is reachability, not the appearance of the word export in a diff.

## Acceptance notes

Out of scope for this card, noted rather than filed:

- **The silent permanent suspension itself is confirmed, and is deliberately not repaired here.**
  The card states it is not a request to change anything, and the dispatching seat reserved the
  successor question — should a duration-less timer wait warn or refuse? — for itself.
- `output` being a present-but-`undefined` key rather than an absent one is invisible to a JSON
  rendering of the return value. An observation about how the value reads, not a defect.
- A **paused** run emits no run-level log line at all, where a `completed` or `failed` run gets an
  `[automation] run flow=... status=...` line. Consistent with "paused is not terminal"; recorded
  because it is the other half of why the absent-config wait is silent end to end.
- `boundary_event` parses clean and then fails the run with `NO_EXECUTOR`. Not filed: the engine
  treats "a node type nothing registered" as a declared, handled state with a startup warning that
  names the type, and the package README declares this type interop-only. Loud by design, not a
  trap.

---
_Generated by [Claude Code](https://claude.ai/code/session_01URLHobLUJB9K1ABV6ofdjj)_